### PR TITLE
cuda-python: fix module name and version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+# See the docstring in versioneer.py for instructions. Note that you must
+# re-run 'versioneer.py setup' after changing this section, and commit the
+# resulting files.
+
+[versioneer]
+VCS = git
+style = pep440
+versionfile_source = cuda/_version.py
+versionfile_build = cuda/_version.py
+tag_prefix = v
+parentdir_prefix = cuda-python-

--- a/setup.py
+++ b/setup.py
@@ -239,6 +239,7 @@ cmdclass = versioneer.get_cmdclass(cmdclass)
 # Setup
 
 setup(
+    name="cuda-python",
     version=versioneer.get_version(),
     ext_modules=extensions,
     packages=find_packages(include=["cuda", "cuda.*"]),


### PR DESCRIPTION
This PR fixes #63 

Kindly see the logs below 

```
nvidia@tegra-ubuntu:~/cuda-python$ python3 setup.py bdist_wheel --verbose --dist-dir ./dist
Parsing headers in "['/usr/local/cuda-12.4/include']" (Caching False)
Parsing driver headers
Parsing runtime headers
Parsing nvrtc headers
...
running bdist_wheel
running build
running build_py
...
UPDATING build/lib.linux-aarch64-3.10/cuda/_version.py
set build/lib.linux-aarch64-3.10/cuda/_version.py to '12.4.0+0.g2be0aac.dirty'
...
running build_ext
...
adding 'cuda_python-12.4.0+0.g2be0aac.dirty.dist-info/LICENSE'
adding 'cuda_python-12.4.0+0.g2be0aac.dirty.dist-info/METADATA'
adding 'cuda_python-12.4.0+0.g2be0aac.dirty.dist-info/WHEEL'
adding 'cuda_python-12.4.0+0.g2be0aac.dirty.dist-info/top_level.txt'
adding 'cuda_python-12.4.0+0.g2be0aac.dirty.dist-info/RECORD'
removing build/bdist.linux-aarch64/wheel
nvidia@tegra-ubuntu:~/cuda-python$
```