### PR TITLE
Add barebones tests to repo to start a pipeline

### DIFF
--- a/cuda_core/tests/test_compiler.py
+++ b/cuda_core/tests/test_compiler.py
@@ -1,0 +1,7 @@
+from cuda.py._compiler import Compiler
+
+def test_compiler_initialization():
+    code = "__device__ int test_func() { return 0; }"
+    compiler = Compiler(code, "c++")
+    assert compiler._handle is not None
+    assert compiler._backend == "nvrtc"

--- a/cuda_core/tests/test_context.py
+++ b/cuda_core/tests/test_context.py
@@ -1,4 +1,4 @@
-from cuda.py._context import Context
+from cuda.core._context import Context
 
 def test_context_initialization():
     try:

--- a/cuda_core/tests/test_context.py
+++ b/cuda_core/tests/test_context.py
@@ -1,0 +1,9 @@
+from cuda.py._context import Context
+
+def test_context_initialization():
+    try:
+        context = Context()
+    except NotImplementedError as e:
+        assert True
+    else:
+        assert False, "Expected NotImplementedError was not raised"

--- a/cuda_core/tests/test_device.py
+++ b/cuda_core/tests/test_device.py
@@ -1,4 +1,4 @@
-from cuda.py._device import Device
+from cuda.core._device import Device
 
 def test_device_initialization():
     device = Device()

--- a/cuda_core/tests/test_device.py
+++ b/cuda_core/tests/test_device.py
@@ -1,0 +1,5 @@
+from cuda.py._device import Device
+
+def test_device_initialization():
+    device = Device()
+    assert device is not None

--- a/cuda_core/tests/test_event.py
+++ b/cuda_core/tests/test_event.py
@@ -1,0 +1,9 @@
+from cuda.py._event import Event
+
+def test_event_initialization():
+    try:
+        event = Event()
+    except NotImplementedError as e:
+        assert True
+    else:
+        assert False, "Expected NotImplementedError was not raised"

--- a/cuda_core/tests/test_event.py
+++ b/cuda_core/tests/test_event.py
@@ -1,4 +1,4 @@
-from cuda.py._event import Event
+from cuda.core._event import Event
 
 def test_event_initialization():
     try:

--- a/cuda_core/tests/test_launcher.py
+++ b/cuda_core/tests/test_launcher.py
@@ -1,0 +1,11 @@
+from cuda.py._launcher import LaunchConfig
+
+def kernel():
+    pass
+
+def test_launch_initialization():
+    config = LaunchConfig(grid=(1, 1, 1), block=(1, 1, 1), stream=None, shmem_size=0)
+    
+    assert config.grid == (1, 1, 1)
+    assert config.block == (1, 1, 1)
+    assert config.shmem_size == 0

--- a/cuda_core/tests/test_launcher.py
+++ b/cuda_core/tests/test_launcher.py
@@ -1,8 +1,5 @@
 from cuda.py._launcher import LaunchConfig
 
-def kernel():
-    pass
-
 def test_launch_initialization():
     config = LaunchConfig(grid=(1, 1, 1), block=(1, 1, 1), stream=None, shmem_size=0)
     

--- a/cuda_core/tests/test_launcher.py
+++ b/cuda_core/tests/test_launcher.py
@@ -1,4 +1,4 @@
-from cuda.py._launcher import LaunchConfig
+from cuda.core._launcher import LaunchConfig
 
 def test_launch_initialization():
     config = LaunchConfig(grid=(1, 1, 1), block=(1, 1, 1), stream=None, shmem_size=0)

--- a/cuda_core/tests/test_memory.py
+++ b/cuda_core/tests/test_memory.py
@@ -1,4 +1,4 @@
-from cuda.py._memory import Buffer, MemoryResource
+from cuda.core._memory import Buffer, MemoryResource
 
 class DummyMemoryResource(MemoryResource):
     def __init__(self):

--- a/cuda_core/tests/test_memory.py
+++ b/cuda_core/tests/test_memory.py
@@ -1,0 +1,30 @@
+from cuda.py._memory import Buffer, MemoryResource
+
+class DummyMemoryResource(MemoryResource):
+    def __init__(self):
+        pass
+
+    def allocate(self, size, stream=None) -> Buffer:
+        pass
+
+    def deallocate(self, ptr, size, stream=None):
+        pass
+
+    @property
+    def is_device_accessible(self) -> bool:
+        return True
+
+    @property
+    def is_host_accessible(self) -> bool:
+        return True
+
+    @property
+    def device_id(self) -> int:
+        return 0
+
+def test_buffer_initialization():
+    dummy_mr = DummyMemoryResource()
+    buffer = Buffer(ptr=1234, size=1024, mr=dummy_mr)
+    assert buffer._ptr == 1234
+    assert buffer._size == 1024
+    assert buffer._mr == dummy_mr

--- a/cuda_core/tests/test_module.py
+++ b/cuda_core/tests/test_module.py
@@ -1,0 +1,11 @@
+from cuda.py._module import Module
+
+def test_module_initialization():
+    module_code = b"dummy_code"
+    code_type = "ptx"
+    module = Module(module=module_code, code_type=code_type)
+    assert module._handle is not None
+    assert module._code_type == code_type
+    assert module._module == module_code
+    assert module._loader is not None
+    assert module._sym_map == {}

--- a/cuda_core/tests/test_module.py
+++ b/cuda_core/tests/test_module.py
@@ -1,9 +1,9 @@
-from cuda.py._module import Module
+from cuda.core._module import ObjectCode
 
 def test_module_initialization():
     module_code = b"dummy_code"
     code_type = "ptx"
-    module = Module(module=module_code, code_type=code_type)
+    module = ObjectCode(module=module_code, code_type=code_type)
     assert module._handle is not None
     assert module._code_type == code_type
     assert module._module == module_code

--- a/cuda_core/tests/test_program.py
+++ b/cuda_core/tests/test_program.py
@@ -1,0 +1,7 @@
+from cuda.core._program import Program
+
+def test_program_initialization():
+    code = "__device__ int test_func() { return 0; }"
+    program = Program(code, "c++")
+    assert program._handle is not None
+    assert program._backend == "nvrtc"

--- a/cuda_core/tests/test_stream.py
+++ b/cuda_core/tests/test_stream.py
@@ -1,0 +1,9 @@
+from cuda.py._stream import Stream
+
+def test_stream_initialization():
+    try:
+        stream = Stream()
+    except NotImplementedError as e:
+        assert True
+    else:
+        assert False, "Expected NotImplementedError was not raised"

--- a/cuda_core/tests/test_stream.py
+++ b/cuda_core/tests/test_stream.py
@@ -1,4 +1,4 @@
-from cuda.py._stream import Stream
+from cuda.core._stream import Stream
 
 def test_stream_initialization():
     try:


### PR DESCRIPTION
This change adds a minimal testsuite to the repo so we can establish pipeline, and develop the tests alongside the cuda.core object model. It uses a pytest tree structure. 

Example:

python -m pytest tests/
===================================================== test session starts ======================================================
platform linux -- Python 3.12.7, pytest-8.3.3, pluggy-1.5.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /home/ksimpson/cuda-python/cuda-python/cuda_core
configfile: pyproject.toml
plugins: benchmark-4.0.0
collected 8 items

tests/test_context.py .                                                                                                  [ 12%]
tests/test_device.py .                                                                                                   [ 25%]
tests/test_event.py .                                                                                                    [ 37%]
tests/test_launcher.py .                                                                                                 [ 50%]
tests/test_memory.py .                                                                                                   [ 62%]
tests/test_module.py .                                                                                                   [ 75%]
tests/test_program.py .                                                                                                  [ 87%]
tests/test_stream.py .                                                                                                   [100%]

====================================================== 8 passed in 2.11s =======================================================