### PR TITLE
Docstrings for cuda.core

### DIFF
--- a/cuda_core/cuda/core/experimental/_device.py
+++ b/cuda_core/cuda/core/experimental/_device.py
@@ -116,7 +116,7 @@ class Device:
     @property
     def name(self) -> str:
         """Return the device name."""
-        # CUDA Runtime uses up to 256 characters, use the same for consistency
+        # Use 256 characters to be consistent with CUDA Runtime
         name = handle_return(cuda.cuDeviceGetName(256, self._id))
         name = name.split(b'\0')[0]
         return name.decode()

--- a/cuda_core/cuda/core/experimental/_device.py
+++ b/cuda_core/cuda/core/experimental/_device.py
@@ -19,10 +19,37 @@ _tls_lock = threading.Lock()
 
 
 class Device:
+    """Represents a GPU and acts as an entry point for cuda.core features.
 
+    This is a singleton object that helps ensure interoperability
+    across multiple libraries imported in the process to both see
+    and use the same GPU device.
+
+    While acting as the entry point, many other CUDA resources can be
+    allocated such as streams and buffers. Any :obj:`Context` dependent
+    resource created through this device, will continue to refer to
+    this device's context.
+
+    """
     __slots__ = ("_id", "_mr", "_has_inited")
 
     def __new__(cls, device_id=None):
+        """Create and return a singleton :obj:`Device` object.
+
+        Creates and returns a thread-local singleton :obj:`Device` object
+        corresponding to a specific device.
+
+        Note
+        ----
+        Will not initialize the GPU.
+
+        Parameters
+        ----------
+        device_id : int, optional
+            Device ordinal to return a :obj:`Device` object for.
+            Default value of `None` return the currently used device.
+
+        """
         # important: creating a Device instance does not initialize the GPU!
         if device_id is None:
             device_id = handle_return(cudart.cudaGetDevice())
@@ -54,15 +81,24 @@ class Device:
 
     @property
     def device_id(self) -> int:
+        """Returns device ordinal."""
         return self._id
 
     @property
     def pci_bus_id(self) -> str:
+        """Returns a PCI Bus Id string for this device."""
         bus_id = handle_return(cudart.cudaDeviceGetPCIBusId(13, self._id))
         return bus_id[:12].decode()
 
     @property
     def uuid(self) -> str:
+        """Returns a UUID for the device.
+
+        Returns 16-octets identifying the device. If the device is in
+        MIG mode, returns its MIG UUID which uniquely identifies the
+        subscribed MIG compute instance.
+
+        """
         driver_ver = handle_return(cuda.cuDriverGetVersion())
         if driver_ver >= 11040:
             uuid = handle_return(cuda.cuDeviceGetUuid_v2(self._id))
@@ -74,19 +110,21 @@ class Device:
 
     @property
     def name(self) -> str:
-        # assuming a GPU name is less than 128 characters...
-        name = handle_return(cuda.cuDeviceGetName(128, self._id))
+        """Returns the device name."""
+        # CUDA Runtime uses up to 256 characters, use the same for consistency
+        name = handle_return(cuda.cuDeviceGetName(256, self._id))
         name = name.split(b'\0')[0]
         return name.decode()
 
     @property
     def properties(self) -> dict:
+        """Returns information about the compute-device."""
         # TODO: pythonize the key names
         return handle_return(cudart.cudaGetDeviceProperties(self._id))
 
     @property
     def compute_capability(self) -> ComputeCapability:
-        """Returns a named tuple with 2 fields: major and minor. """
+        """Returns a named tuple with 2 fields: major and minor."""
         major = handle_return(cudart.cudaDeviceGetAttribute(
             cudart.cudaDeviceAttr.cudaDevAttrComputeCapabilityMajor, self._id))
         minor = handle_return(cudart.cudaDeviceGetAttribute(
@@ -96,12 +134,20 @@ class Device:
     @property
     @precondition(_check_context_initialized)
     def context(self) -> Context:
+        """Returns the current :obj:`Context` associated with this device.
+
+        Note
+        ----
+        Device must be initialized.
+
+        """
         ctx = handle_return(cuda.cuCtxGetCurrent())
         assert int(ctx) != 0
         return Context._from_ctx(ctx, self._id)
 
     @property
     def memory_resource(self) -> MemoryResource:
+        """Returns :obj:`MemoryResource` associated with this device."""
         return self._mr
 
     @memory_resource.setter
@@ -112,27 +158,50 @@ class Device:
 
     @property
     def default_stream(self) -> Stream:
+        """Returns default CUDA :obj:`Stream` associated with this device.
+
+        Returns per-thread default stream if environment is set with
+        CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM, otherwise return a legacy stream.
+
+        """
         return default_stream()
 
     def __int__(self):
+        """Returns device_id."""
         return self._id
 
     def __repr__(self):
         return f"<Device {self._id} ({self.name})>"
 
     def set_current(self, ctx: Context=None) -> Union[Context, None]:
-        """
-        Entry point of this object. Users always start a code by
+        """Set device to be used for GPU executions.
+
+        Initializes CUDA and sets the calling thread to a valid CUDA
+        context. By default the primary context is used, but optional `ctx`
+        parameter can be used to explicitly supply a :obj:`Context` object.
+
+        Providing a `ctx` causes the previous set context to be popped and returned.
+
+        Parameters
+        ----------
+        ctx : Context, optional
+            Optional context to push onto this device's current thread stack
+
+        Returns
+        -------
+        Union[Context, None], optional
+            Popped context
+
+        Examples
+        --------
+        Acts as an entry point of this object. Users always start a code by
         calling this method, e.g.
-        
+
         >>> from cuda.core.experimental import Device
         >>> dev0 = Device(0)
         >>> dev0.set_current()
         >>> # ... do work on device 0 ...
-        
-        The optional ctx argument is for advanced users to bind a
-        CUDA context with the device. In this case, the previously
-        set context is popped and returned to the user.
+
         """
         if ctx is not None:
             if not isinstance(ctx, Context):
@@ -163,25 +232,94 @@ class Device:
             self._has_inited = True
 
     def create_context(self, options: ContextOptions = None) -> Context:
-        # Create a Context object (but do NOT set it current yet!).
-        # ContextOptions is a dataclass for setting e.g. affinity or CIG
-        # options. 
+        """Create a new :obj:`Context` object.
+
+        Note
+        ----
+        The newly context will not be set as current.
+
+        Parameters
+        ----------
+        options : ContextOptions, optional
+            Customizable dataclass for context creation options
+
+        Returns
+        -------
+        :obj:`Context`
+            Newly created Context object
+
+        """
         raise NotImplementedError("TODO")
 
     @precondition(_check_context_initialized)
     def create_stream(self, obj=None, options: StreamOptions=None) -> Stream:
-        # Create a Stream object by either holding a newly created
-        # CUDA stream or wrapping an existing foreign object supporting
-        # the __cuda_stream__ protocol. In the latter case, a reference
-        # to obj is held internally so that its lifetime is managed.
+        """Create a Stream object.
+
+        New stream objects can be created in two different ways:
+
+        1) Create a new CUDA stream with customizable `options`.
+        2) Wrap an existing foreign `obj` supporting the __cuda_stream__ protocol.
+
+        Option (2) internally holds a reference to the foreign object
+        such that the lifetime is managed.
+
+        Note
+        ----
+        Device must be initialized.
+
+        Parameters
+        ----------
+        obj : Any, optional
+            Any object supporting the __cuda_stream__ protocol.
+        options : :obj:`StreamOptions`, optional
+            Customizable dataclass for stream creation options
+
+        Returns
+        -------
+        :obj:`Stream`
+            Newly created Stream object
+
+        """
         return Stream._init(obj=obj, options=options)
 
     @precondition(_check_context_initialized)
     def allocate(self, size, stream=None) -> Buffer:
+        """Allocate device memory from a specified stream.
+
+        Allocates device memory of `size` bytes on the specified `stream`
+        using the memory resource currently associated with this Device.
+
+        Parameter `stream` is optional, using a default stream by default.
+
+        Note
+        ----
+        Device must be initialized.
+
+        Parameters
+        ----------
+        size : int
+            Number of bytes to allocate.
+        stream : :obj:`Stream`, optional
+            The stream establishing the stream ordering semantic.
+            Default value of `None` uses default stream.
+
+        Returns
+        -------
+        :obj:`Buffer`
+            Newly created Buffer object
+
+        """
         if stream is None:
             stream = default_stream()
         return self._mr.allocate(size, stream)
 
     @precondition(_check_context_initialized)
     def sync(self):
+        """Synchronize the device.
+
+        Note
+        ----
+        Device must be initialized.
+
+        """
         handle_return(cudart.cudaDeviceSynchronize())

--- a/cuda_core/cuda/core/experimental/_device.py
+++ b/cuda_core/cuda/core/experimental/_device.py
@@ -160,8 +160,11 @@ class Device:
     def default_stream(self) -> Stream:
         """Return default CUDA :obj:`Stream` associated with this device.
 
-        Returns per-thread default stream if environment is set with
-        CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM, otherwise return a legacy stream.
+        The type of default stream returned depends on if the environment
+        variable CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM is set.
+
+        If set, returns a per-thread default stream. Otherwise returns
+        the legacy stream.
 
         """
         return default_stream()
@@ -184,13 +187,13 @@ class Device:
 
         Parameters
         ----------
-        ctx : Context, optional
-            Optional context to push onto this device's current thread stack
+        ctx : :obj:`Context`, optional
+            Optional context to push onto this device's current thread stack.
 
         Returns
         -------
-        Union[Context, None], optional
-            Popped context
+        Union[:obj:`Context`, None], optional
+            Popped context.
 
         Examples
         --------
@@ -240,13 +243,13 @@ class Device:
 
         Parameters
         ----------
-        options : ContextOptions, optional
-            Customizable dataclass for context creation options
+        options : :obj:`ContextOptions`, optional
+            Customizable dataclass for context creation options.
 
         Returns
         -------
         :obj:`Context`
-            Newly created Context object
+            Newly created Context object.
 
         """
         raise NotImplementedError("TODO")
@@ -272,12 +275,12 @@ class Device:
         obj : Any, optional
             Any object supporting the __cuda_stream__ protocol.
         options : :obj:`StreamOptions`, optional
-            Customizable dataclass for stream creation options
+            Customizable dataclass for stream creation options.
 
         Returns
         -------
         :obj:`Stream`
-            Newly created Stream object
+            Newly created stream object.
 
         """
         return Stream._init(obj=obj, options=options)
@@ -306,7 +309,7 @@ class Device:
         Returns
         -------
         :obj:`Buffer`
-            Newly created Buffer object
+            Newly created Buffer object.
 
         """
         if stream is None:

--- a/cuda_core/cuda/core/experimental/_device.py
+++ b/cuda_core/cuda/core/experimental/_device.py
@@ -98,6 +98,11 @@ class Device:
         MIG mode, returns its MIG UUID which uniquely identifies the
         subscribed MIG compute instance.
 
+        Note
+        ----
+        MIG UUID is only returned when device is in MIG mode and the
+        driver is older than CUDA 11.4.
+
         """
         driver_ver = handle_return(cuda.cuDriverGetVersion())
         if driver_ver >= 11040:

--- a/cuda_core/cuda/core/experimental/_device.py
+++ b/cuda_core/cuda/core/experimental/_device.py
@@ -81,18 +81,18 @@ class Device:
 
     @property
     def device_id(self) -> int:
-        """Returns device ordinal."""
+        """Return device ordinal."""
         return self._id
 
     @property
     def pci_bus_id(self) -> str:
-        """Returns a PCI Bus Id string for this device."""
+        """Return a PCI Bus Id string for this device."""
         bus_id = handle_return(cudart.cudaDeviceGetPCIBusId(13, self._id))
         return bus_id[:12].decode()
 
     @property
     def uuid(self) -> str:
-        """Returns a UUID for the device.
+        """Return a UUID for the device.
 
         Returns 16-octets identifying the device. If the device is in
         MIG mode, returns its MIG UUID which uniquely identifies the
@@ -110,7 +110,7 @@ class Device:
 
     @property
     def name(self) -> str:
-        """Returns the device name."""
+        """Return the device name."""
         # CUDA Runtime uses up to 256 characters, use the same for consistency
         name = handle_return(cuda.cuDeviceGetName(256, self._id))
         name = name.split(b'\0')[0]
@@ -118,13 +118,13 @@ class Device:
 
     @property
     def properties(self) -> dict:
-        """Returns information about the compute-device."""
+        """Return information about the compute-device."""
         # TODO: pythonize the key names
         return handle_return(cudart.cudaGetDeviceProperties(self._id))
 
     @property
     def compute_capability(self) -> ComputeCapability:
-        """Returns a named tuple with 2 fields: major and minor."""
+        """Return a named tuple with 2 fields: major and minor."""
         major = handle_return(cudart.cudaDeviceGetAttribute(
             cudart.cudaDeviceAttr.cudaDevAttrComputeCapabilityMajor, self._id))
         minor = handle_return(cudart.cudaDeviceGetAttribute(
@@ -134,7 +134,7 @@ class Device:
     @property
     @precondition(_check_context_initialized)
     def context(self) -> Context:
-        """Returns the current :obj:`Context` associated with this device.
+        """Return the current :obj:`Context` associated with this device.
 
         Note
         ----
@@ -147,7 +147,7 @@ class Device:
 
     @property
     def memory_resource(self) -> MemoryResource:
-        """Returns :obj:`MemoryResource` associated with this device."""
+        """Return :obj:`MemoryResource` associated with this device."""
         return self._mr
 
     @memory_resource.setter
@@ -158,7 +158,7 @@ class Device:
 
     @property
     def default_stream(self) -> Stream:
-        """Returns default CUDA :obj:`Stream` associated with this device.
+        """Return default CUDA :obj:`Stream` associated with this device.
 
         Returns per-thread default stream if environment is set with
         CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM, otherwise return a legacy stream.
@@ -167,7 +167,7 @@ class Device:
         return default_stream()
 
     def __int__(self):
-        """Returns device_id."""
+        """Return device_id."""
         return self._id
 
     def __repr__(self):

--- a/cuda_core/cuda/core/experimental/_device.py
+++ b/cuda_core/cuda/core/experimental/_device.py
@@ -19,7 +19,7 @@ _tls_lock = threading.Lock()
 
 
 class Device:
-    """Represents a GPU and acts as an entry point for cuda.core features.
+    """Represent a GPU and act as an entry point for cuda.core features.
 
     This is a singleton object that helps ensure interoperability
     across multiple libraries imported in the process to both see
@@ -30,26 +30,23 @@ class Device:
     resource created through this device, will continue to refer to
     this device's context.
 
+    Newly returend :obj:`Device` object are is a thread-local singleton
+    for a specified device.
+
+    Note
+    ----
+    Will not initialize the GPU.
+
+    Parameters
+    ----------
+    device_id : int, optional
+        Device ordinal to return a :obj:`Device` object for.
+        Default value of `None` return the currently used device.
+
     """
     __slots__ = ("_id", "_mr", "_has_inited")
 
     def __new__(cls, device_id=None):
-        """Create and return a singleton :obj:`Device` object.
-
-        Creates and returns a thread-local singleton :obj:`Device` object
-        corresponding to a specific device.
-
-        Note
-        ----
-        Will not initialize the GPU.
-
-        Parameters
-        ----------
-        device_id : int, optional
-            Device ordinal to return a :obj:`Device` object for.
-            Default value of `None` return the currently used device.
-
-        """
         # important: creating a Device instance does not initialize the GPU!
         if device_id is None:
             device_id = handle_return(cudart.cudaGetDevice())

--- a/cuda_core/cuda/core/experimental/_device.py
+++ b/cuda_core/cuda/core/experimental/_device.py
@@ -254,7 +254,7 @@ class Device:
         Returns
         -------
         :obj:`Context`
-            Newly created Context object.
+            Newly created context object.
 
         """
         raise NotImplementedError("TODO")
@@ -314,7 +314,7 @@ class Device:
         Returns
         -------
         :obj:`Buffer`
-            Newly created Buffer object.
+            Newly created buffer object.
 
         """
         if stream is None:

--- a/cuda_core/cuda/core/experimental/_event.py
+++ b/cuda_core/cuda/core/experimental/_event.py
@@ -13,17 +13,48 @@ from cuda.core.experimental._utils import handle_return
 
 @dataclass
 class EventOptions:
+    """Customizable :obj:`Event` options.
+
+    Attributes
+    ----------
+    enable_timing : bool, optional
+        Event will record timing data. (Default to False)
+    busy_waited_sync : bool, optional
+        If True, event will use blocking synchronization. When a CPU
+        thread calls synchronize, the call will block until the event
+        has actually been completed.
+        Otherwise, the CPU thread will busy-wait until the event has
+        been completed. (Default to False)
+    support_ipc : bool, optional
+        Event will be suitable for interprocess use.
+        Note that enable_timing must be False. (Default to False)
+
+    """
     enable_timing: Optional[bool] = False
     busy_waited_sync: Optional[bool] = False
     support_ipc: Optional[bool] = False
 
 
 class Event:
+    """Represents a record of a specific point of execution within a CUDA stream.
 
+    Applications can asynchronously record events at any point in
+    the program. An event keeps a record of all previous work withinq
+    the last recorded stream.
+
+    Events can be used to monitor device's progress, query completion
+    of work up to event's record, and help establish dependencies
+    between GPU work submissions.
+
+    """
     __slots__ = ("_handle", "_timing_disabled", "_busy_waited")
 
     def __init__(self):
-        # minimal requirements for the destructor
+        """Unsupported function due to ambiguity.
+
+        New events should instead be created through a :obj:`Stream` object.
+
+        """
         self._handle = None
         raise NotImplementedError(
             "directly creating an Event object can be ambiguous. Please call "
@@ -51,37 +82,45 @@ class Event:
         return self
 
     def __del__(self):
+        """Destroys the event."""
         self.close()
 
     def close(self):
-        # Destroy the event.
+        """Destroys the event."""
         if self._handle:
             handle_return(cuda.cuEventDestroy(self._handle))
             self._handle = None
 
     @property
     def is_timing_disabled(self) -> bool:
-        # Check if this instance can be used for the timing purpose.
+        """Return True if the event does not record timing data, otherwise False."""
         return self._timing_disabled
 
     @property
     def is_sync_busy_waited(self) -> bool:
-        # Check if the event synchronization would keep the CPU busy-waiting.
+        """Return True if the event synchronization would keep the CPU busy-waiting, otherwise False."""
         return self._busy_waited
 
     @property
     def is_ipc_supported(self) -> bool:
-        # Check if this instance can be used for IPC.
+        """Return True if this event can be used as an interprocess event, otherwise False."""
         raise NotImplementedError("TODO")
 
     def sync(self):
-        # Sync over the event.
+        """Synchronize until the event completes.
+
+        If the event was created with busy_waited_sync, then the
+        calling CPU thread will block until the event has been
+        completed by the device.
+        Otherwise the CPU thread will busy-wait until the event
+        has been completed.
+
+        """
         handle_return(cuda.cuEventSynchronize(self._handle))
 
     @property
     def is_done(self) -> bool:
-        # Return True if all captured works have been completed,
-        # otherwise False.
+        """Return True if all captured works have been completed, otherwise False."""
         result, = cuda.cuEventQuery(self._handle)
         if result == cuda.CUresult.CUDA_SUCCESS:
             return True
@@ -92,4 +131,5 @@ class Event:
 
     @property
     def handle(self) -> int:
+        """Return event memory address."""
         return int(self._handle)

--- a/cuda_core/cuda/core/experimental/_event.py
+++ b/cuda_core/cuda/core/experimental/_event.py
@@ -36,7 +36,7 @@ class EventOptions:
 
 
 class Event:
-    """Represents a record of a specific point of execution within a CUDA stream.
+    """Represent a record at a specific point of execution within a CUDA stream.
 
     Applications can asynchronously record events at any point in
     the program. An event keeps a record of all previous work within
@@ -46,15 +46,13 @@ class Event:
     of work up to event's record, and help establish dependencies
     between GPU work submissions.
 
+    Directly creating an :obj:`Event` is not supported due to ambiguity,
+    and they should instead be created through a :obj:`Stream` object.
+
     """
     __slots__ = ("_handle", "_timing_disabled", "_busy_waited")
 
     def __init__(self):
-        """Unsupported function due to ambiguity.
-
-        New events should instead be created through a :obj:`Stream` object.
-
-        """
         self._handle = None
         raise NotImplementedError(
             "directly creating an Event object can be ambiguous. Please call "

--- a/cuda_core/cuda/core/experimental/_event.py
+++ b/cuda_core/cuda/core/experimental/_event.py
@@ -39,7 +39,7 @@ class Event:
     """Represents a record of a specific point of execution within a CUDA stream.
 
     Applications can asynchronously record events at any point in
-    the program. An event keeps a record of all previous work withinq
+    the program. An event keeps a record of all previous work within
     the last recorded stream.
 
     Events can be used to monitor device's progress, query completion

--- a/cuda_core/cuda/core/experimental/_event.py
+++ b/cuda_core/cuda/core/experimental/_event.py
@@ -86,7 +86,7 @@ class Event:
         self.close()
 
     def close(self):
-        """Destroys the event."""
+        """Destroy the event."""
         if self._handle:
             handle_return(cuda.cuEventDestroy(self._handle))
             self._handle = None

--- a/cuda_core/cuda/core/experimental/_event.py
+++ b/cuda_core/cuda/core/experimental/_event.py
@@ -82,7 +82,7 @@ class Event:
         return self
 
     def __del__(self):
-        """Destroys the event."""
+        """Return close(self)"""
         self.close()
 
     def close(self):
@@ -131,5 +131,5 @@ class Event:
 
     @property
     def handle(self) -> int:
-        """Return event memory address."""
+        """Return the underlying cudaEvent_t pointer address as Python int."""
         return int(self._handle)

--- a/cuda_core/cuda/core/experimental/_launcher.py
+++ b/cuda_core/cuda/core/experimental/_launcher.py
@@ -37,7 +37,23 @@ def _lazy_init():
 
 @dataclass
 class LaunchConfig:
-    """
+    """Customizable launch options.
+
+    Attributes
+    ----------
+    grid : Union[tuple, int]
+        Collection of threads that will execute a kernel function.
+    block : Union[tuple, int]
+        Group of threads (Thread Block) that will execute on the same
+        multiprocessor. Threads within a thread blocks have access to
+        shared memory and can be explicitly synchronized.
+    stream : :obj:`Stream`
+        The stream establishing the stream ordering semantic of a
+        launch.
+    shmem_size : int, optional
+        Dynamic shared-memory size per thread block in bytes.
+        (Default to size 0)
+
     """
     # TODO: expand LaunchConfig to include other attributes
     grid: Union[tuple, int] = None
@@ -87,6 +103,21 @@ class LaunchConfig:
 
 
 def launch(kernel, config, *kernel_args):
+    """Launches a :obj:`Kernel` object with launch-time configuration.
+
+    Invokes a :obj:`Kernel` object with specified launch-time
+    configurations.
+
+    Parameters
+    ----------
+    config : Any
+        Launch configurations inline with options provided by
+        :obj:`LaunchConfig` dataclass.
+    *kernel_args : Any
+        Variable length argument list that is provided to the
+        launching kernel.
+
+    """
     if not isinstance(kernel, Kernel):
         raise ValueError
     config = check_or_create_options(LaunchConfig, config, "launch config")

--- a/cuda_core/cuda/core/experimental/_launcher.py
+++ b/cuda_core/cuda/core/experimental/_launcher.py
@@ -110,6 +110,8 @@ def launch(kernel, config, *kernel_args):
 
     Parameters
     ----------
+    kernel : :obj:`Kernel`
+        Kernel to launch.
     config : Any
         Launch configurations inline with options provided by
         :obj:`LaunchConfig` dataclass.

--- a/cuda_core/cuda/core/experimental/_launcher.py
+++ b/cuda_core/cuda/core/experimental/_launcher.py
@@ -103,16 +103,14 @@ class LaunchConfig:
 
 
 def launch(kernel, config, *kernel_args):
-    """Launches a :obj:`Kernel` object with launch-time configuration.
-
-    Invokes a :obj:`Kernel` object with specified launch-time
-    configurations.
+    """Launches a :obj:`~cuda.core.experimental._module.Kernel`
+    object with launch-time configuration.
 
     Parameters
     ----------
-    kernel : :obj:`Kernel`
+    kernel : :obj:`~cuda.core.experimental._module.Kernel`
         Kernel to launch.
-    config : Any
+    config : :obj:`LaunchConfig`
         Launch configurations inline with options provided by
         :obj:`LaunchConfig` dataclass.
     *kernel_args : Any

--- a/cuda_core/cuda/core/experimental/_memory.py
+++ b/cuda_core/cuda/core/experimental/_memory.py
@@ -81,7 +81,7 @@ class Buffer:
 
     @property
     def handle(self):
-        """Return buffer handle object."""
+        """Return the buffer handle object."""
         return self._ptr
 
     @property

--- a/cuda_core/cuda/core/experimental/_memory.py
+++ b/cuda_core/cuda/core/experimental/_memory.py
@@ -22,19 +22,56 @@ PyCapsule = TypeVar("PyCapsule")
 
 
 class Buffer:
+    """Represents a handle to allocated memory.
+
+    This generic object provides a unified representation for how
+    different memory resources are to give access to their memory
+    allocations.
+
+    Support for data interchange mechanisms are provided by
+    establishing both the DLPack and the Python-level buffer
+    protocols.
+
+    """
 
     # TODO: handle ownership? (_mr could be None)
     __slots__ = ("_ptr", "_size", "_mr",)
 
     def __init__(self, ptr, size, mr: MemoryResource=None):
+        """Initialize a new buffer object.
+
+        Parameters
+        ----------
+        ptr : Any
+            Allocated buffer handle object
+        size : Any
+            Memory size of the buffer
+        mr : :obj:`MemoryResource`, optional
+            Memory resource associated with the buffer
+
+        """
         self._ptr = ptr
         self._size = size
         self._mr = mr
 
     def __del__(self):
-        self.close(default_stream())
+        """Return close(self)."""
+        self.close()
 
     def close(self, stream=None):
+        """Deallocate this buffer asynchronously on the given stream.
+
+        This buffer is released back to their memory resource
+        asynchronously on the given stream.
+
+        Parameters
+        ----------
+        stream : Any, optional
+            The stream object with a __cuda_stream__ protocol to
+            use for asynchronous deallocation. Defaults to using
+            the default stream.
+
+        """
         if self._ptr and self._mr is not None:
             if stream is None:
                 stream = default_stream()
@@ -44,42 +81,56 @@ class Buffer:
 
     @property
     def handle(self):
+        """Return buffer handle object."""
         return self._ptr
 
     @property
     def size(self):
+        """Return the memory size of this buffer."""
         return self._size
 
     @property
     def memory_resource(self) -> MemoryResource:
-        # Return the memory resource from which this buffer was allocated.
+        """Return the memory resource associated with this buffer."""
         return self._mr
 
     @property
     def is_device_accessible(self) -> bool:
-        # Check if this buffer can be accessed from GPUs.
+        """Return True if this buffer can be accessed by the GPU, otherwise False."""
         if self._mr is not None:
             return self._mr.is_device_accessible
         raise NotImplementedError
 
     @property
     def is_host_accessible(self) -> bool:
-        # Check if this buffer can be accessed from CPUs.
+        """Return True if this buffer can be accessed by the CPU, otherwise False."""
         if self._mr is not None:
             return self._mr.is_host_accessible
         raise NotImplementedError
 
     @property
     def device_id(self) -> int:
+        """Return the device ordinal of this buffer."""
         if self._mr is not None:
             return self._mr.device_id
         raise NotImplementedError
 
     def copy_to(self, dst: Buffer=None, *, stream) -> Buffer:
-        # Copy from this buffer to the dst buffer asynchronously on the
-        # given stream. The dst buffer is returned. If the dst is not provided,
-        # allocate one from self.memory_resource. Raise an exception if the
-        # stream is not provided.
+        """Copy from this buffer to the dst buffer asynchronously on the given stream.
+
+        Copies the data from this buffer to the provided dst buffer.
+        If the dst buffer is not provided, then a new buffer is first
+        allocated using the associated memory resource before the copy.
+
+        Parameters
+        ----------
+        dst : :obj:`Buffer`
+            Source buffer to copy data from
+        stream : Any
+            Keyword argument specifying the stream for the
+            asynchronous copy
+
+        """
         if stream is None:
             raise ValueError("stream must be provided")
         if dst is None:
@@ -93,8 +144,17 @@ class Buffer:
         return dst
 
     def copy_from(self, src: Buffer, *, stream):
-        # Copy from the src buffer to this buffer asynchronously on the
-        # given stream. Raise an exception if the stream is not provided. 
+        """Copy from the src buffer to this buffer asynchronously on the given stream.
+
+        Parameters
+        ----------
+        src : :obj:`Buffer`
+            Source buffer to copy data from
+        stream : Any
+            Keyword argument specifying the stream for the
+            asynchronous copy
+
+        """
         if stream is None:
             raise ValueError("stream must be provided")
         if src._size != self._size:
@@ -141,7 +201,7 @@ class Buffer:
         raise NotImplementedError("TODO")
 
     def __release_buffer__(self, buffer: memoryview, /):
-        # Supporting methond paired with __buffer__.
+        # Supporting method paired with __buffer__.
         raise NotImplementedError("TODO")
 
 

--- a/cuda_core/cuda/core/experimental/_memory.py
+++ b/cuda_core/cuda/core/experimental/_memory.py
@@ -22,7 +22,7 @@ PyCapsule = TypeVar("PyCapsule")
 
 
 class Buffer:
-    """Represents a handle to allocated memory.
+    """Represent a handle to allocated memory.
 
     This generic object provides a unified representation for how
     different memory resources are to give access to their memory
@@ -32,24 +32,21 @@ class Buffer:
     establishing both the DLPack and the Python-level buffer
     protocols.
 
+    Parameters
+    ----------
+    ptr : Any
+        Allocated buffer handle object
+    size : Any
+        Memory size of the buffer
+    mr : :obj:`MemoryResource`, optional
+        Memory resource associated with the buffer
+
     """
 
     # TODO: handle ownership? (_mr could be None)
     __slots__ = ("_ptr", "_size", "_mr",)
 
     def __init__(self, ptr, size, mr: MemoryResource=None):
-        """Initialize a new buffer object.
-
-        Parameters
-        ----------
-        ptr : Any
-            Allocated buffer handle object
-        size : Any
-            Memory size of the buffer
-        mr : :obj:`MemoryResource`, optional
-            Memory resource associated with the buffer
-
-        """
         self._ptr = ptr
         self._size = size
         self._mr = mr

--- a/cuda_core/cuda/core/experimental/_module.py
+++ b/cuda_core/cuda/core/experimental/_module.py
@@ -100,7 +100,7 @@ class ObjectCode:
             a file path string containing that module for loading.
         code_type : Any
             String of the compiled type.
-            Supported options are "ptx", "cubin" and "ltoir".
+            Supported options are "ptx", "cubin" and "fatbin".
         jit_options : Optional
             Mapping of JIT options to use during module loading.
             (Default to no options)

--- a/cuda_core/cuda/core/experimental/_module.py
+++ b/cuda_core/cuda/core/experimental/_module.py
@@ -48,8 +48,8 @@ def _lazy_init():
 class Kernel:
     """Represent a compiled kernel that had been loaded onto the device.
 
-    Kernel instances can execution when passed directly into a
-    launch function.
+    Kernel instances can execution when passed directly into the
+    :func:`~cuda.core.experimental.launch` function.
 
     Directly creating a :obj:`Kernel` is not supported, and they
     should instead be created through a :obj:`ObjectCode` object.

--- a/cuda_core/cuda/core/experimental/_module.py
+++ b/cuda_core/cuda/core/experimental/_module.py
@@ -46,17 +46,19 @@ def _lazy_init():
 
 
 class Kernel:
-    """Represents a compiled kernel that had been loaded onto the device.
+    """Represent a compiled kernel that had been loaded onto the device.
 
     Kernel instances can execution when passed directly into a
     launch function.
+
+    Directly creating a :obj:`Kernel` is not supported, and they
+    should instead be created through a :obj:`ObjectCode` object.
 
     """
 
     __slots__ = ("_handle", "_module",)
 
     def __init__(self):
-        """Unsupported function whose creation is intended through an :obj:`ObjectCode` object."""
         raise NotImplementedError("directly constructing a Kernel instance is not supported")
 
     @staticmethod
@@ -72,10 +74,33 @@ class Kernel:
 
 
 class ObjectCode:
-    """Represents the compiled program loaded onto the device.
+    """Represent a compiled program that was loaded onto the device.
 
     This object provides a unified interface for different types of
     compiled programs that are loaded onto the device.
+
+    Loads the module library with specified module code and JIT options.
+
+    Note
+    ----
+    Usage under CUDA 11.x will only load to the current device
+    context.
+
+    Parameters
+    ----------
+    module : Union[bytes, str]
+        Either a bytes object containing the module to load, or
+        a file path string containing that module for loading.
+    code_type : Any
+        String of the compiled type.
+        Supported options are "ptx", "cubin" and "fatbin".
+    jit_options : Optional
+        Mapping of JIT options to use during module loading.
+        (Default to no options)
+    symbol_mapping : Optional
+        Keyword argument dictionary specifying how symbol names
+        should be mapped before trying to retrieve them.
+        (Default to no mappings)
 
     """
 
@@ -84,37 +109,6 @@ class ObjectCode:
 
     def __init__(self, module, code_type, jit_options=None, *,
                  symbol_mapping=None):
-        """Create and return a compiled program as an instance of an :obj:`ObjectCode`.
-
-        Loads the module library with specified module code and JIT options.
-
-        Note
-        ----
-        Usage under CUDA 11.x will only load to the current device
-        context.
-
-        Parameters
-        ----------
-        module : Union[bytes, str]
-            Either a bytes object containing the module to load, or
-            a file path string containing that module for loading.
-        code_type : Any
-            String of the compiled type.
-            Supported options are "ptx", "cubin" and "fatbin".
-        jit_options : Optional
-            Mapping of JIT options to use during module loading.
-            (Default to no options)
-        symbol_mapping : Optional
-            Keyword argument dictionary specifying how symbol names
-            should be mapped before trying to retrieve them.
-            (Default to no mappings)
-
-        Returns
-        -------
-        :obj:`ObjectCode`
-            Newly created :obj:`ObjectCode`.
-
-        """
         if code_type not in self._supported_code_type:
             raise ValueError
         _lazy_init()

--- a/cuda_core/cuda/core/experimental/_program.py
+++ b/cuda_core/cuda/core/experimental/_program.py
@@ -56,7 +56,7 @@ class Program:
         self.close()
 
     def close(self):
-        """Destroys this program."""
+        """Destroy this program."""
         if self._handle is not None:
             handle_return(nvrtc.nvrtcDestroyProgram(self._handle))
             self._handle = None

--- a/cuda_core/cuda/core/experimental/_program.py
+++ b/cuda_core/cuda/core/experimental/_program.py
@@ -8,12 +8,34 @@ from cuda.core.experimental._module import ObjectCode
 
 
 class Program:
+    """Represents the compilation machinery for processing programs into :obj:`ObjectCode`.
+
+    This object provides a unified interface to multiple underlying
+    compiler libraries. Compilation support is enabled for a wide
+    range of code types and compilation types.
+
+    """
 
     __slots__ = ("_handle", "_backend", )
     _supported_code_type = ("c++", )
     _supported_target_type = ("ptx", "cubin", "ltoir", )
 
     def __init__(self, code, code_type):
+        """Create an instance of a :obj:`Program` object.
+
+        Parameters
+        ----------
+        code : Any
+            String of the CUDA Runtime Compilation program.
+        code_type : Any
+            String of the code type. Only "c++" is currently supported.
+
+        Returns
+        -------
+        :obj:`Program`
+            Newly created program object.
+
+        """
         self._handle = None
         if code_type not in self._supported_code_type:
             raise NotImplementedError
@@ -30,14 +52,40 @@ class Program:
             raise NotImplementedError
 
     def __del__(self):
+        """Return close(self)."""
         self.close()
 
     def close(self):
+        """Destroys this program."""
         if self._handle is not None:
             handle_return(nvrtc.nvrtcDestroyProgram(self._handle))
             self._handle = None
 
     def compile(self, target_type, options=(), name_expressions=(), logs=None):
+        """Compile the program with a specific compilation type.
+
+        Parameters
+        ----------
+        target_type : Any
+            String of the targeted compilation type.
+            Supported options are "ptx", "cubin" and "ltoir".
+        options : Union[List, Tuple], optional
+            List of compilation options associated with the backend
+            of this :obj:`Program`. (Default to no options)
+        name_expressions : Union[List, Tuple], optional
+            List of explicit name expressions to become accessible.
+            (Default to no expressions)
+        logs : Any, optional
+            Object with a write method to receive the logs generated
+            from compilation.
+            (Default to no logs)
+
+        Returns
+        -------
+        :obj:`ObjectCode`
+            Newly created code object.
+
+        """
         if target_type not in self._supported_target_type:
             raise NotImplementedError
 
@@ -80,8 +128,10 @@ class Program:
 
     @property
     def backend(self):
+        """Return the backend type string associated with this program."""
         return self._backend
 
     @property
     def handle(self):
+        """Return the program handle object."""
         return self._handle

--- a/cuda_core/cuda/core/experimental/_program.py
+++ b/cuda_core/cuda/core/experimental/_program.py
@@ -8,7 +8,8 @@ from cuda.core.experimental._module import ObjectCode
 
 
 class Program:
-    """Represent a compilation machinery to process programs into :obj:`ObjectCode`.
+    """Represent a compilation machinery to process programs into
+    :obj:`~cuda.core.experimental._module.ObjectCode`.
 
     This object provides a unified interface to multiple underlying
     compiler libraries. Compilation support is enabled for a wide
@@ -19,7 +20,7 @@ class Program:
     code : Any
         String of the CUDA Runtime Compilation program.
     code_type : Any
-        String of the code type. Only "c++" is currently supported.
+        String of the code type. Currently only ``"c++"`` is supported.
 
     """
 
@@ -74,7 +75,7 @@ class Program:
 
         Returns
         -------
-        :obj:`ObjectCode`
+        :obj:`~cuda.core.experimental._module.ObjectCode`
             Newly created code object.
 
         """

--- a/cuda_core/cuda/core/experimental/_program.py
+++ b/cuda_core/cuda/core/experimental/_program.py
@@ -8,11 +8,18 @@ from cuda.core.experimental._module import ObjectCode
 
 
 class Program:
-    """Represents the compilation machinery for processing programs into :obj:`ObjectCode`.
+    """Represent a compilation machinery to process programs into :obj:`ObjectCode`.
 
     This object provides a unified interface to multiple underlying
     compiler libraries. Compilation support is enabled for a wide
     range of code types and compilation types.
+
+    Parameters
+    ----------
+    code : Any
+        String of the CUDA Runtime Compilation program.
+    code_type : Any
+        String of the code type. Only "c++" is currently supported.
 
     """
 
@@ -21,21 +28,6 @@ class Program:
     _supported_target_type = ("ptx", "cubin", "ltoir", )
 
     def __init__(self, code, code_type):
-        """Create an instance of a :obj:`Program` object.
-
-        Parameters
-        ----------
-        code : Any
-            String of the CUDA Runtime Compilation program.
-        code_type : Any
-            String of the code type. Only "c++" is currently supported.
-
-        Returns
-        -------
-        :obj:`Program`
-            Newly created program object.
-
-        """
         self._handle = None
         if code_type not in self._supported_code_type:
             raise NotImplementedError

--- a/cuda_core/cuda/core/experimental/_stream.py
+++ b/cuda_core/cuda/core/experimental/_stream.py
@@ -127,7 +127,7 @@ class Stream:
     def close(self):
         """Destroy the stream.
 
-        Destroys the stream if we own it. Borrowed foreign stream
+        Destroy the stream if we own it. Borrowed foreign stream
         object will instead have their references released.
 
         """

--- a/cuda_core/cuda/core/experimental/_stream.py
+++ b/cuda_core/cuda/core/experimental/_stream.py
@@ -28,7 +28,7 @@ class StreamOptions:
         Stream does not synchronize with the NULL stream. (Default to True)
     priority : int, optional
         Stream priority where lower number represents a
-        higher priority. (Default to highest priority)
+        higher priority. (Default to lowest priority)
 
     """
     nonblocking: bool = True

--- a/cuda_core/cuda/core/experimental/_stream.py
+++ b/cuda_core/cuda/core/experimental/_stream.py
@@ -36,7 +36,7 @@ class StreamOptions:
 
 
 class Stream:
-    """Represents a queue of GPU operations that are executed in a specific order.
+    """Represent a queue of GPU operations that are executed in a specific order.
 
     Applications use streams to control the order of execution for
     GPU work. Work within a single stream are executed sequentially.
@@ -46,19 +46,17 @@ class Stream:
     Advanced users can utilize default streams for enforce complex
     implicit synchronization behaviors.
 
+    Directly creating a :obj:`Stream` is not supported due to ambiguity.
+    New streams should instead be created through a :obj:`Device`
+    object, or created directly through using an existing handle
+    using Stream.from_handle().
+
     """
 
     __slots__ = ("_handle", "_nonblocking", "_priority", "_owner", "_builtin",
                  "_device_id", "_ctx_handle")
 
     def __init__(self):
-        """Unsupported function due to ambiguity.
-
-        New streams should instead be created through a :obj:`Device`
-        object, or created directly through using an existing handle
-        using Stream.from_handle()
-
-        """
         # minimal requirements for the destructor
         self._handle = None
         self._owner = None

--- a/cuda_core/cuda/core/experimental/_stream.py
+++ b/cuda_core/cuda/core/experimental/_stream.py
@@ -235,7 +235,7 @@ class Stream:
 
     @property
     def device(self) -> Device:
-        """Return :obj:`Device` singleton associated with this stream.
+        """Return the :obj:`Device` singleton associated with this stream.
 
         Note
         ----

--- a/cuda_core/docs/source/_templates/autosummary/class.rst
+++ b/cuda_core/docs/source/_templates/autosummary/class.rst
@@ -1,0 +1,26 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+   {% block methods %}
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   {% for item in methods %}
+   .. automethod:: {{ item }}
+   {%- endfor %}
+
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   {% for item in attributes %}
+   .. autoattribute:: {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/cuda_core/docs/source/_templates/autosummary/dataclass.rst
+++ b/cuda_core/docs/source/_templates/autosummary/dataclass.rst
@@ -1,0 +1,10 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+   {% block methods %}
+   .. automethod:: __init__
+   {% endblock %}
+

--- a/cuda_core/docs/source/_templates/autosummary/namedtuple.rst
+++ b/cuda_core/docs/source/_templates/autosummary/namedtuple.rst
@@ -1,0 +1,8 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members: __new__
+   :special-members: __new__
+   :exclude-members: count, index, __reduce__, __reduce_ex__, __repr__, __hash__, __str__, __getnewargs__

--- a/cuda_core/docs/source/api.rst
+++ b/cuda_core/docs/source/api.rst
@@ -3,6 +3,11 @@
 ``cuda.core.experimental`` API Reference
 ========================================
 
+All of the APIs listed (or cross-referenced from) below are considered *experimental*
+and subject to future changes without deprecation notice. Once stablized they will be
+moved out of the ``experimental`` namespace.
+
+
 CUDA runtime
 ------------
 
@@ -10,6 +15,14 @@ CUDA runtime
    :toctree: generated/
 
    Device
+   launch
+
+   :template: dataclass.rst
+
+   EventOptions
+   StreamOptions
+   LaunchConfig
+
 
 CUDA compilation toolchain
 --------------------------

--- a/cuda_core/docs/source/api_private.rst
+++ b/cuda_core/docs/source/api_private.rst
@@ -1,0 +1,28 @@
+:orphan:
+
+.. This page is to generate documentation for private classes exposed to users,
+   i.e., users cannot instantiate it by themselves but may use it's properties
+   or methods via returned values from public APIs. These classes must be referred
+   in public APIs returning their instances.
+
+.. currentmodule:: cuda.core.experimental
+
+CUDA runtime
+------------
+
+.. autosummary::
+   :toctree: generated/
+
+   _memory.Buffer
+   _stream.Stream
+   _event.Event
+
+
+CUDA compilation toolchain
+--------------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   _module.Kernel
+   _module.ObjectCode

--- a/cuda_core/docs/source/conf.py
+++ b/cuda_core/docs/source/conf.py
@@ -34,7 +34,8 @@ extensions = [
     'sphinx.ext.autosummary',
 	'sphinx.ext.napoleon',
 	'myst_nb',
-	'enum_tools.autoenum'
+	'enum_tools.autoenum',
+    'sphinx_copybutton',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -77,3 +78,6 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+# skip cmdline prompts
+copybutton_exclude = '.linenos, .gp'

--- a/cuda_core/docs/source/install.md
+++ b/cuda_core/docs/source/install.md
@@ -5,25 +5,19 @@
 `cuda.core` is supported on all platforms that CUDA is supported. Specific
 dependencies are as follows:
 
-* Driver: Linux (450.80.02 or later) Windows (456.38 or later)
-* CUDA Toolkit 12.0 to 12.6
+|                   | CUDA 11      | CUDA 12     |
+|------------------ | ------------ | ----------- |
+| CUDA Toolkit [^1] | 11.2 - 11.8  | 12.0 - 12.6 |
+| Driver            | 450.80.02+ (Linux), 452.39+ (Windows) | 525.60.13+ (Linux), 527.41+ (Windows) |
 
-
-## Installing from PyPI
-
-Coming soon!
-
-
-## Installing from Conda
-
-Coming soon!
+[^1]: Including `cuda-python`.
 
 
 ## Installing from Source
 
-```shell
+```console
 $ git clone https://github.com/NVIDIA/cuda-python
 $ cd cuda-python/cuda_core
 $ pip install .
 ```
-For now `cuda-python` (`cuda-bindings` later) is a required dependency.
+For now `cuda-python` (`cuda-bindings` later) 11.x or 12.x is a required dependency.

--- a/cuda_core/docs/source/release/0.1.0-notes.md
+++ b/cuda_core/docs/source/release/0.1.0-notes.md
@@ -1,15 +1,17 @@
-# ``cuda.core`` Release notes
+# `cuda.core` Release notes
 
-Released on Oct XX, 2024
+Released on Nov XX, 2024
 
 ## Hightlights
-- Initial beta 1 release
+- Initial EA1 (early access) release
 - Supports all platforms that CUDA is supported
-- Supports all CUDA 12.x drivers
-- Supports all CUDA 12.x Toolkits
+- Supports all CUDA 11.x/12.x drivers
+- Supports all CUDA 11.x/12.x Toolkits
 - Pythonic CUDA runtime and other core functionalities
 
 ## Limitations
 
-- Source code release only; Python packages coming in a future release
-- Support for CUDA 11.x coming in the next release
+- All APIs are currently *experimental* and subject to change without deprecation notice.
+  Please kindly share your feedbacks with us so that we can make `cuda.core` better!
+- Source code release only; `pip`/`conda` support is coming in a future release
+- Windows TCC mode is [not yet supported](https://github.com/NVIDIA/cuda-python/issues/206)

--- a/cuda_python/docs/environment-docs.yml
+++ b/cuda_python/docs/environment-docs.yml
@@ -11,6 +11,7 @@ dependencies:
   - pytest
   - scipy
   - sphinx
+  - sphinx-copybutton
   - pip:
     - furo
     - myst-nb


### PR DESCRIPTION
Use [NumPy Style Python Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) to maintain consistency with cuda-bindings.

Edit:
Close #96 
Close #207