### PR TITLE
Make `cuda-core` (tentatively) depend on `cuda-python`

### DIFF
--- a/cuda_core/pyproject.toml
+++ b/cuda_core/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 dependencies = [
     "numpy",
     # TODO: change this once cuda-bindings is packaged, see NVIDIA/cuda-python#105
-    "cuda-python <=12.7.*",
+    "cuda-python <13",
 ]
 
 

--- a/cuda_core/pyproject.toml
+++ b/cuda_core/pyproject.toml
@@ -43,6 +43,8 @@ classifiers = [
 ]
 dependencies = [
     "numpy",
+    # TODO: change this once cuda-bindings is packaged, see NVIDIA/cuda-python#105
+    "cuda-python <=12.7.*",
 ]
 
 


### PR DESCRIPTION
Close #190.

Blocked by #188. (After it's merged, we'll support both CUDA 11 & 12, and the simple constraint added in this PR will be safe.)

This change should be revisited once we start working on #105. Right now, it's a way to ensure the bindings are available in the user environment.