### PR TITLE
Use pyproject for auto discovery of packages and data

### DIFF
--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -36,18 +36,8 @@ dependencies = [
 Repository = "https://github.com/NVIDIA/cuda-python"
 Documentation = "https://nvidia.github.io/cuda-python/"
 
-# BETA
-# [tool.setuptools]
-# zip-safe = false
-
-# BETA
-# [tool.setuptools.packages.find]
-# where = ["cuda"]
-# include = ["cuda", "cuda.*"]
-
-# BETA
-# [tool.setuptools.package-data]
-# "*" = ["*.pxd", "*.pyx", "*.h", "*.cpp"]
+[tool.setuptools.packages.find]
+include = ["cuda.bindings*"]
 
 [tool.versioneer]
 VCS = "git"

--- a/cuda_bindings/setup.py
+++ b/cuda_bindings/setup.py
@@ -258,11 +258,6 @@ cmdclass = versioneer.get_cmdclass(cmdclass)
 setup(
     version=versioneer.get_version(),
     ext_modules=do_cythonize(extensions),
-    packages=find_packages(include=["cuda", "cuda.*", "cuda.bindings", "cuda.bindings._bindings", "cuda.bindings._lib", "cuda.bindings._lib.cyruntime"]),
-    package_data=dict.fromkeys(
-        find_packages(include=["cuda", "cuda.*", "cuda.bindings", "cuda.bindings._bindings", "cuda.bindings._lib", "cuda.bindings._lib.cyruntime"]),
-        ["*.pxd", "*.pyx", "*.py", "*.h", "*.cpp"],
-    ),
     cmdclass=cmdclass,
     zip_safe=False,
 )


### PR DESCRIPTION
This PR adopts the same auto-discovery style as the cuda.core counterpart. This amendment is assured to expose the same data file as the posted Linux 11.8.5 patch. The change in style assist in getting most of the Windows files through.

Know issue: Windows builds can't auto-discover the trampoline files and they remain omitted from the final distributable. Note that Linux with this change does not face the same issue.