### PR TITLE
rectify the supported types for ObjectCode and Program 

### DIFF
--- a/cuda_core/cuda/core/experimental/_module.py
+++ b/cuda_core/cuda/core/experimental/_module.py
@@ -93,7 +93,7 @@ class ObjectCode:
         a file path string containing that module for loading.
     code_type : Any
         String of the compiled type.
-        Supported options are "ptx", "cubin" and "fatbin".
+        Supported options are "ptx", "cubin", "ltoir" "fatbin".
     jit_options : Optional
         Mapping of JIT options to use during module loading.
         (Default to no options)
@@ -105,7 +105,7 @@ class ObjectCode:
     """
 
     __slots__ = ("_handle", "_code_type", "_module", "_loader", "_sym_map")
-    _supported_code_type = ("cubin", "ptx", "fatbin")
+    _supported_code_type = ("cubin", "ptx", "ltoir", "fatbin") #This list must include, but is not limited to, all supported target types for Program
 
     def __init__(self, module, code_type, jit_options=None, *,
                  symbol_mapping=None):

--- a/cuda_core/cuda/core/experimental/_program.py
+++ b/cuda_core/cuda/core/experimental/_program.py
@@ -26,7 +26,7 @@ class Program:
 
     __slots__ = ("_handle", "_backend", )
     _supported_code_type = ("c++", )
-    _supported_target_type = ("ptx", "cubin", "ltoir", )
+    _supported_target_type = ("cubin", "ptx", "ltoir") #OptiXIR also supported by nvrtc
 
     def __init__(self, code, code_type):
         self._handle = None


### PR DESCRIPTION
Program's supported target_types should be a subset of ObjectCode's. Based on the nvrtc API, the supported target_types should be LTOIR, PTX and CUBIN. 

If someone used nvcc to compile some.cu file with the -fatbin flag, they should be able to construct an ObjectCode object from that data. Therefore ObjectCode's supported types should not be limited to Program's target_types.

#closes 212