### PR TITLE
Include pyx/pyd files in the wheel's root cuda directory

### DIFF
--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -37,7 +37,7 @@ Repository = "https://github.com/NVIDIA/cuda-python"
 Documentation = "https://nvidia.github.io/cuda-python/"
 
 [tool.setuptools.packages.find]
-include = ["cuda.bindings*"]
+include = ["cuda*"]
 
 [tool.versioneer]
 VCS = "git"


### PR DESCRIPTION
With this change the `.pxd` and friends files are included in the wheel under "cuda" as well as "cuda/bindings"

You can test with: `python -m pip wheel -vvv .` and unzip the wheel.

CC @leofang 