### PR TITLE
Some CI tweaks

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -2,3 +2,6 @@
 # https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/
 
 enabled: true
+# always require manual CI triggering, ignoring signed commits
+auto_sync_draft: false
+auto_sync_ready: false

--- a/.github/workflows/gh-build-and-test.yml
+++ b/.github/workflows/gh-build-and-test.yml
@@ -27,9 +27,11 @@ jobs:
     with:
       client-repo: ${{ github.event.repository.name }}
       target-device: ${{ inputs.target-device }}
-      runs-on: ${{ (inputs.host-platform == 'linux-x64' && 'linux-amd64-cpu16') || (inputs.host-platform == 'linux-aarch64' && 'linux-arm64-cpu16') || (inputs.host-platform == 'mac' && 'macos-latest') }}
+      runs-on: ${{ (inputs.host-platform == 'linux-x64' && 'linux-amd64-cpu8') ||
+                   (inputs.host-platform == 'linux-aarch64' && 'linux-arm64-cpu8') }}
       build-type: ${{ inputs.build-type }}
-      use-container: ${{ inputs.host-platform == 'linux-x64' || inputs.host-platform == 'linux-aarch64'}}
+      use-container: ${{ inputs.host-platform == 'linux-x64' ||
+                         inputs.host-platform == 'linux-aarch64'}}
       host-platform: ${{ inputs.host-platform }}
       dependencies-file: ""
       build-mode: ${{ inputs.build-mode }}


### PR DESCRIPTION
- use a smaller CPU runner for building the packages (closes #264)
- enforce manual CI triggering for all cases