### PR TITLE
add nvjitlink to bindings documentation

### DIFF
--- a/cuda_bindings/docs/source/api.rst
+++ b/cuda_bindings/docs/source/api.rst
@@ -9,3 +9,4 @@ CUDA Python API Reference
    module/driver
    module/runtime
    module/nvrtc
+   module/nvjitlink

--- a/cuda_bindings/docs/source/module/nvjitlink.rst
+++ b/cuda_bindings/docs/source/module/nvjitlink.rst
@@ -1,0 +1,84 @@
+nvjitlink
+=========
+
+Functions
+---------
+
+NvJitLink defines the following functions for linking code objects and querying the info and error logs.
+
+.. autofunction:: cuda.bindings.nvjitlink.create
+.. autofunction:: cuda.bindings.nvjitlink.destroy
+.. autofunction:: cuda.bindings.nvjitlink.add_data
+.. autofunction:: cuda.bindings.nvjitlink.add_file
+.. autofunction:: cuda.bindings.nvjitlink.complete
+.. autofunction:: cuda.bindings.nvjitlink.get_linked_cubin_size
+.. autofunction:: cuda.bindings.nvjitlink.get_linked_cubin
+.. autofunction:: cuda.bindings.nvjitlink.get_linked_ptx_size
+.. autofunction:: cuda.bindings.nvjitlink.get_linked_ptx
+.. autofunction:: cuda.bindings.nvjitlink.get_error_log_size
+.. autofunction:: cuda.bindings.nvjitlink.get_error_log
+.. autofunction:: cuda.bindings.nvjitlink.get_info_log_size
+.. autofunction:: cuda.bindings.nvjitlink.get_info_log
+.. autofunction:: cuda.bindings.nvjitlink.version
+
+Types
+---------
+.. autoclass:: cuda.bindings.nvjitlink.Result
+
+    .. autoattribute:: cuda.bindings.nvjitlink.Result.SUCCESS
+
+
+    .. autoattribute:: cuda.bindings.nvjitlink.Result.ERROR_UNRECOGNIZED_OPTION
+
+
+    .. autoattribute:: cuda.bindings.nvjitlink.Result.ERROR_MISSING_ARCH
+
+
+    .. autoattribute:: cuda.bindings.nvjitlink.Result.ERROR_INVALID_INPUT
+
+
+    .. autoattribute:: cuda.bindings.nvjitlink.Result.ERROR_PTX_COMPILE
+
+
+    .. autoattribute:: cuda.bindings.nvjitlink.Result.ERROR_NVVM_COMPILE
+
+
+    .. autoattribute:: cuda.bindings.nvjitlink.Result.ERROR_INTERNAL
+
+
+    .. autoattribute:: cuda.bindings.nvjitlink.Result.ERROR_THREADPOOL
+
+
+    .. autoattribute:: cuda.bindings.nvjitlink.Result.ERROR_UNRECOGNIZED_INPUT
+
+
+    .. autoattribute:: cuda.bindings.nvjitlink.Result.ERROR_FINALIZE
+
+
+.. autoclass:: cuda.bindings.nvjitlink.InputType
+
+    .. autoattribute:: cuda.bindings.nvjitlink.InputType.NONE
+
+
+    .. autoattribute:: cuda.bindings.nvjitlink.InputType.CUBIN
+
+
+    .. autoattribute:: cuda.bindings.nvjitlink.InputType.PTX
+
+
+    .. autoattribute:: cuda.bindings.nvjitlink.InputType.LTOIR
+
+
+    .. autoattribute:: cuda.bindings.nvjitlink.InputType.FATBIN
+
+
+    .. autoattribute:: cuda.bindings.nvjitlink.InputType.OBJECT
+
+
+    .. autoattribute:: cuda.bindings.nvjitlink.InputType.LIBRARY
+
+
+    .. autoattribute:: cuda.bindings.nvjitlink.InputType.INDEX
+
+
+    .. autoattribute:: cuda.bindings.nvjitlink.InputType.ANY


### PR DESCRIPTION
#close 251

Add the nvjitlink rst. 

There are some formatting issues on the cybind side, that I plan to address in https://gitlab-master.nvidia.com/leof/cybind/-/issues/101. See the docstring for version() Return 