### PR TITLE
Fix doc ci permissions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -339,8 +339,7 @@ jobs:
     # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
     permissions:
       id-token: write
-      pages: write
-      contents: read
+      contents: write
     needs:
       - build
     secrets: inherit


### PR DESCRIPTION
The CI on main failed: https://github.com/NVIDIA/cuda-python/actions/runs/12587535835/job/35083892418, because it needs a write permission for content: https://github.com/JamesIves/github-pages-deploy-action#getting-started-airplane