### PR TITLE
Use Ruff to do import sorting

### DIFF
--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -44,6 +44,7 @@ version = { attr = "cuda.bindings._version.__version__" }
 
 [tool.ruff]
 line-length = 120
+extend = "../pyproject.toml"
 
 [tool.ruff.format]
 docstring-code-format = true
@@ -98,3 +99,6 @@ exclude = ["cuda/bindings/_version.py"]
   "UP022",
   "E402", # module level import not at top of file
   "F841"] # F841 complains about unused variables, but some assignments have side-effects that could be useful for tests (func calls for example)
+
+[tool.ruff.lint.isort]
+known-first-party = ["cuda.parallel"]

--- a/cuda_core/pyproject.toml
+++ b/cuda_core/pyproject.toml
@@ -66,6 +66,7 @@ readme = { file = ["DESCRIPTION.rst"], content-type = "text/x-rst" }
 
 [tool.ruff]
 line-length = 120
+extend = "../pyproject.toml"
 
 [tool.ruff.format]
 docstring-code-format = true
@@ -103,3 +104,6 @@ exclude = ["cuda/core/_version.py"]
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "setup.py" = ["F401"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["cuda.core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+
+[tool.ruff]
+target-version = "py310"
+
+[tool.ruff.lint]
+extend-select = ["I"]


### PR DESCRIPTION
Sort imports using Ruff (invoking `ruff linter` will now sort imports in addition to existing linting).

It looks like so far, imports have been kept sorted by manual invocations of `ruff` (or `isort`). This PR makes it so that the existing pre-commit hook will also take care of sorting imports. 

This PR is based on the feedback/discussion in https://github.com/NVIDIA/cccl/pull/3230/.  