### PR TITLE
Add doc preview CI

### DIFF
--- a/.github/actions/doc_preview/action.yml
+++ b/.github/actions/doc_preview/action.yml
@@ -1,0 +1,99 @@
+name: Preview docs built from PRs
+
+inputs:
+  source-folder:
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    # The steps below are executed only when testing in a PR.
+    # Note: the PR previews will be removed once merged to main (see below)
+    - name: Get PR info
+      if: ${{ github.ref_name != 'main' }}
+      uses: nv-gha-runners/get-pr-info@main
+      id: get-pr-info
+    
+    - name: Extract PR number from info
+      if: ${{ github.ref_name != 'main' }}
+      run: |
+        PR_NUMBER="${{ fromJSON(steps.get-pr-info.outputs.pr-info).number }}"
+        if [[ "$PR_NUMBER" == "" ]]; then
+          echo "cannot extract PR number"
+          exit 1
+        else
+          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+        fi
+    
+    - name: Deploy doc preview
+      if: ${{ github.ref_name != 'main' }}
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        git-config-name: cuda-python-bot
+        git-config-email: cuda-python-bot@users.noreply.github.com
+        folder: ${{ inputs.source-folder }}
+        target-folder: docs/pr-preview/pr-${{ env.PR_NUMBER }}/
+        commit-message: "Deploy doc preview for PR ${{ env.PR_NUMBER }} (${{ github.sha }})"
+    
+    - name: Leave a comment after deployment
+      if: ${{ github.ref_name != 'main' }}
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: pr-preview
+        number: ${{ env.PR_NUMBER }}
+        skip_unchanged: true
+        message: |
+          Doc Preview CI
+          :---:
+          | <p></p> :rocket: View preview at <br> https://nvidia.github.io/cuda-python/pr-preview/pr-${{ env.PR_NUMBER }}/ <br><br>
+          | <h6><br> Preview will be ready when the GitHub Pages deployment is complete. <br><br></h6>
+    
+    # The steps below are executed only when building on main.
+    - name: Get PR data
+      if: ${{ github.ref_name == 'main' }}
+      uses: actions/github-script@v7
+      id: get-pr-data
+      with:
+        script: |
+          return (
+            await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              commit_sha: context.sha,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })
+          ).data[0];
+    
+    - name: Extract PR number from data
+      if: ${{ github.ref_name == 'main' }}
+      run: |
+        PR_NUMBER="${{ fromJSON(steps.get-pr-data.outputs.result).number }}"
+        if [[ "$PR_NUMBER" == "" ]]; then
+          echo "cannot extract PR number"
+          exit 1
+        else
+          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+        fi
+    
+    - name: Remove doc preview
+      if: ${{ github.ref_name == 'main' }}
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        git-config-name: cuda-python-bot
+        git-config-email: cuda-python-bot@users.noreply.github.com
+        folder: ${{ inputs.source-folder }}
+        target-folder: docs/pr-preview/pr-${{ env.PR_NUMBER }}/
+        commit-message: "Clean up doc preview for PR ${{ env.PR_NUMBER }} (${{ github.sha }})"
+    
+    - name: Leave a comment after removal
+      if: ${{ github.ref_name == 'main' }}
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: pr-preview
+        number: ${{ env.PR_NUMBER }}
+        hide_and_recreate: true
+        hide_classify: "OUTDATED"
+        message: |
+          Doc Preview CI
+          :---:
+          Preview removed because the pull request was closed or merged.

--- a/.github/actions/doc_preview/action.yml
+++ b/.github/actions/doc_preview/action.yml
@@ -1,4 +1,6 @@
-name: Preview docs built from PRs
+name: Preview or clean up docs built from PRs
+
+# A re-implementation based on the logic of https://github.com/rossjrw/pr-preview-action/blob/41a957c44a456a34718e9bcf825363194db5e6d5/README.md, due to limitations illustrated in NVIDIA/cuda-python#380.
 
 inputs:
   source-folder:

--- a/.github/actions/doc_preview/action.yml
+++ b/.github/actions/doc_preview/action.yml
@@ -17,6 +17,7 @@ runs:
     
     - name: Extract PR number from info
       if: ${{ github.ref_name != 'main' }}
+      shell: bash --noprofile --norc -xeuo pipefail {0}
       run: |
         PR_NUMBER="${{ fromJSON(steps.get-pr-info.outputs.pr-info).number }}"
         if [[ "$PR_NUMBER" == "" ]]; then
@@ -66,6 +67,7 @@ runs:
     
     - name: Extract PR number from data
       if: ${{ github.ref_name == 'main' }}
+      shell: bash --noprofile --norc -xeuo pipefail {0}
       run: |
         PR_NUMBER="${{ fromJSON(steps.get-pr-data.outputs.result).number }}"
         if [[ "$PR_NUMBER" == "" ]]; then

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -263,6 +263,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      pull-requests: write
     needs:
       - build
     secrets: inherit

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -126,40 +126,30 @@ jobs:
           mkdir -p artifacts/docs
           mv cuda_python/docs/build/html/* artifacts/docs/
 
-      # TODO: remove this step
+          # create an empty folder for removal use
+          mkdir -p artifacts/empty_docs
+
+      # TODO: Consider removing this step?
       - name: Upload doc artifacts
         uses: actions/upload-pages-artifact@v3
         with:
           path: artifacts/
           retention-days: 3
 
-      # Note: the PR previews will be removed once merged to main (see below)
-      - uses: rossjrw/pr-preview-action@v1
-        if: ${{ github.ref_name != 'main' && success() }}
+      - name: Deploy or clean up doc preview
+        uses: ./.github/actions/doc_preview
+        continue-on-error: false
         with:
-          source-dir: artifacts/docs/
-          preview-branch: gh-pages
-          umbrella-dir: docs/pr-preview
-          pages-base-path: docs
-          action: deploy
+          source-folder: ${{ (github.ref_name != 'main' && 'artifacts/docs') ||
+                              'artifacts/empty_docs' }}
 
-      # The steps below are not executed unless when building on main.
       - name: Deploy doc update
-        if: ${{ github.ref_name == 'main' && success() }}
+        if: ${{ github.ref_name == 'main' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          folder: artifacts/docs/
           git-config-name: cuda-python-bot
           git-config-email: cuda-python-bot@users.noreply.github.com
+          folder: artifacts/docs/
           target-folder: docs/
           commit-message: "Deploy latest docs: ${{ github.sha }}"
           clean: false
-
-      - uses: rossjrw/pr-preview-action@v1
-        if: ${{ github.ref_name == 'main' && success() }}
-        with:
-          source-dir: artifacts/docs/
-          preview-branch: gh-pages
-          umbrella-dir: docs/pr-preview
-          pages-base-path: docs
-          action: remove

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -50,7 +50,6 @@ jobs:
       # WAR: Building the doc currently requires CTK installed (NVIDIA/cuda-python#326,327)
       - name: Set up mini CTK
         uses: ./.github/actions/fetch_ctk
-        continue-on-error: false
         with:
           host-platform: linux-64
           cuda-version: ${{ inputs.build-ctk-ver }}
@@ -138,7 +137,6 @@ jobs:
 
       - name: Deploy or clean up doc preview
         uses: ./.github/actions/doc_preview
-        continue-on-error: false
         with:
           source-folder: ${{ (github.ref_name != 'main' && 'artifacts/docs') ||
                               'artifacts/empty_docs' }}

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -126,15 +126,24 @@ jobs:
           mkdir -p artifacts/docs
           mv cuda_python/docs/build/html/* artifacts/docs/
 
-      # Note: currently this is only for manual inspection. This step will become
-      # required once we switch to use GHA for doc deployment (see the bottom).
+      # TODO: remove this step
       - name: Upload doc artifacts
         uses: actions/upload-pages-artifact@v3
         with:
           path: artifacts/
           retention-days: 3
 
-      # The step below is not executed unless when building on main.
+      # Note: the PR previews will be removed once merged to main (see below)
+      - uses: rossjrw/pr-preview-action@v1
+        if: ${{ github.ref_name != 'main' && success() }}
+        with:
+          source-dir: artifacts/docs/
+          preview-branch: gh-pages
+          umbrella-dir: docs/pr-preview
+          pages-base-path: docs
+          action: deploy
+
+      # The steps below are not executed unless when building on main.
       - name: Deploy doc update
         if: ${{ github.ref_name == 'main' && success() }}
         uses: JamesIves/github-pages-deploy-action@v4
@@ -145,3 +154,12 @@ jobs:
           target-folder: docs/
           commit-message: "Deploy latest docs: ${{ github.sha }}"
           clean: false
+
+      - uses: rossjrw/pr-preview-action@v1
+        if: ${{ github.ref_name == 'main' && success() }}
+        with:
+          source-dir: artifacts/docs/
+          preview-branch: gh-pages
+          umbrella-dir: docs/pr-preview
+          pages-base-path: docs
+          action: remove


### PR DESCRIPTION
Close #346.

This PR adds a new `doc_preview` action that deploys docs built in each PR to 
```
https://nvidia.github.io/cuda-python/pr-preview/pr-<id>/
```
and post a message. Upon PR merge, the action would clean up the pushed files to remove the preview.

The `doc_preview` largely follows the logic of [`pr-preview-action`](https://github.com/rossjrw/pr-preview-action/), but has to be re-implemented to cope with two limitations:
1. Our copy-pr-bot can only be triggered by a `push` event, not by `pull_request` or `pull_request_target` events as required by `pr-preview-action`
2. The upstream `pr-preview-action` has no plan to support taking a PR number as an input parameter to bypass the first limitation (see https://github.com/NVIDIA/cuda-python/pull/380#issuecomment-2588834001)
  
It is understandable why `pull_request*` events are preferred, because with `push` events it is very tricky to get the PR number robustly, both during the PR test stage and during the merge to the main branch, and in the end this is what we need:
- PR test stage: 
   - use `get-pr-info` provided by nv-gha-runners to get the PR number
   - deploy the preview
- Merge to main:
   - use the [`listPullRequestsAssociatedWithCommit` GitHub API](https://github.com/orgs/community/discussions/27071#discussioncomment-8008688) to get the PR number 
   - clean up the preview