### PR TITLE
CI: Fix backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -34,4 +34,3 @@ jobs:
           copy_requested_reviewers: true
           label_pattern: to-be-backported
           target_branches: ${{ env.OLD_BRANCH }}
-          conflict_resolution: draft_commit_conflicts

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,7 +14,8 @@ jobs:
   backport:
     name: Backport pull request
     if: ${{ github.repository_owner == 'nvidia' &&
-            github.event.pull_request.merged == true
+            github.event.pull_request.merged == true &&
+            contains( github.event.pull_request.labels.*.name, 'to-be-backported')
          }}
     runs-on: ubuntu-latest
     steps:
@@ -32,5 +33,4 @@ jobs:
           copy_assignees: true
           copy_labels_pattern: true
           copy_requested_reviewers: true
-          label_pattern: to-be-backported
           target_branches: ${{ env.OLD_BRANCH }}


### PR DESCRIPTION
This PR contains 2 fixes, both due to me misreading the documentation 😛 

1. I noticed the `conflict_resolution` argument causes a warning because it's an experimental feature of the backport action, and it should not be passed directly as a input argument, but as a part of json.
https://github.com/korthout/backport-action#conflict_resolution
2. I've noticed the backport workflow went nuts in a few recently-merged PRs, where the backport step is triggered even if the PR does not have the `to-be-backported` label, ex: https://github.com/NVIDIA/cuda-python/pull/372#issuecomment-2591809508. It turns out that `label_pattern` is meant to be used [as a way to find the backport branch](https://github.com/korthout/backport-action#how-it-works) (for which we already set `target_branch`), not the way I intend it to (add a label to trigger backport upon merge). This is now fixed.