### PR TITLE
Add pre-commit.ci config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,13 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ci:
+    autofix_commit_msg: |
+      [pre-commit.ci] auto code formatting
+    autofix_prs: false
+    autoupdate_branch: ''
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: quarterly
+    skip: []
+    submodules: false
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
Closes #255 

This PR adds a `ci:` section to the pre-commit config. [pre-commit.ci](https://pre-commit.ci/) has been enabled for this repository.

