### PR TITLE
Improve doc CI comment 

### DIFF
--- a/.github/actions/doc_preview/action.yml
+++ b/.github/actions/doc_preview/action.yml
@@ -49,7 +49,9 @@ runs:
         message: |
           Doc Preview CI
           :---:
-          | <p></p> :rocket: View preview at <br> https://nvidia.github.io/cuda-python/pr-preview/pr-${{ env.PR_NUMBER }}/ <br><br>
+          | <p></p> :rocket: View preview at <br> https://nvidia.github.io/cuda-python/pr-preview/pr-${{ env.PR_NUMBER }}/ <br>
+          | <br> https://nvidia.github.io/cuda-python/pr-preview/pr-${{ env.PR_NUMBER }}/cuda-core/ <br>
+          | <br> https://nvidia.github.io/cuda-python/pr-preview/pr-${{ env.PR_NUMBER }}/cuda-bindings/ <br><br>
           | <h6><br> Preview will be ready when the GitHub Pages deployment is complete. <br><br></h6>
     
     # The steps below are executed only when building on main.


### PR DESCRIPTION
Follow-up of #395. This is needed because the way we build component docs could make it a bit hard to navigate when previewing the changes.