### PR TITLE
CI: Fix the latest docs with more fine-grained warning banners

### DIFF
--- a/.github/actions/get_pr_number/action.yml
+++ b/.github/actions/get_pr_number/action.yml
@@ -21,6 +21,7 @@ runs:
           exit 1
         fi
         echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+        echo "BUILD_PREVIEW=1" >> $GITHUB_ENV
 
     - name: Get PR data (main branch)
       if: ${{ github.ref_name == 'main' }}
@@ -50,3 +51,4 @@ runs:
           exit 1
         fi
         echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+        echo "BUILD_LATEST=1" >> $GITHUB_ENV

--- a/cuda_bindings/docs/source/conf.py
+++ b/cuda_bindings/docs/source/conf.py
@@ -71,11 +71,11 @@ html_theme_options = {
     # ],
 }
 if os.environ.get("CI"):
-    if int(os.environ.get("BUILD_PREVIEW")):
+    if int(os.environ.get("BUILD_PREVIEW", 0)):
         PR_NUMBER = f"{os.environ['PR_NUMBER']}"
         PR_TEXT = f'<a href="https://github.com/NVIDIA/cuda-python/pull/{PR_NUMBER}">PR {PR_NUMBER}</a>'
         html_theme_options["announcement"] = f"<em>Warning</em>: This documentation is only a preview for {PR_TEXT}!"
-    elif int(os.environ.get("BUILD_LATEST")):
+    elif int(os.environ.get("BUILD_LATEST", 0)):
         html_theme_options["announcement"] = (
             "<em>Warning</em>: This documentation is built from the development branch!"
         )

--- a/cuda_bindings/docs/source/conf.py
+++ b/cuda_bindings/docs/source/conf.py
@@ -71,9 +71,14 @@ html_theme_options = {
     # ],
 }
 if os.environ.get("CI"):
-    PR_NUMBER = f"{os.environ['PR_NUMBER']}"
-    PR_TEXT = f'<a href="https://github.com/NVIDIA/cuda-python/pull/{PR_NUMBER}">PR {PR_NUMBER}</a>'
-    html_theme_options["announcement"] = f"<em>Warning</em>: This documentation is only a preview for {PR_TEXT}!"
+    if int(os.environ.get("BUILD_PREVIEW")):
+        PR_NUMBER = f"{os.environ['PR_NUMBER']}"
+        PR_TEXT = f'<a href="https://github.com/NVIDIA/cuda-python/pull/{PR_NUMBER}">PR {PR_NUMBER}</a>'
+        html_theme_options["announcement"] = f"<em>Warning</em>: This documentation is only a preview for {PR_TEXT}!"
+    elif int(os.environ.get("BUILD_LATEST")):
+        html_theme_options["announcement"] = (
+            "<em>Warning</em>: This documentation is built from the development branch!"
+        )
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/cuda_core/docs/source/conf.py
+++ b/cuda_core/docs/source/conf.py
@@ -76,9 +76,14 @@ html_theme_options = {
     # ],
 }
 if os.environ.get("CI"):
-    PR_NUMBER = f"{os.environ['PR_NUMBER']}"
-    PR_TEXT = f'<a href="https://github.com/NVIDIA/cuda-python/pull/{PR_NUMBER}">PR {PR_NUMBER}</a>'
-    html_theme_options["announcement"] = f"<em>Warning</em>: This documentation is only a preview for {PR_TEXT}!"
+    if int(os.environ.get("BUILD_PREVIEW")):
+        PR_NUMBER = f"{os.environ['PR_NUMBER']}"
+        PR_TEXT = f'<a href="https://github.com/NVIDIA/cuda-python/pull/{PR_NUMBER}">PR {PR_NUMBER}</a>'
+        html_theme_options["announcement"] = f"<em>Warning</em>: This documentation is only a preview for {PR_TEXT}!"
+    elif int(os.environ.get("BUILD_LATEST")):
+        html_theme_options["announcement"] = (
+            "<em>Warning</em>: This documentation is built from the development branch!"
+        )
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/cuda_core/docs/source/conf.py
+++ b/cuda_core/docs/source/conf.py
@@ -76,11 +76,11 @@ html_theme_options = {
     # ],
 }
 if os.environ.get("CI"):
-    if int(os.environ.get("BUILD_PREVIEW")):
+    if int(os.environ.get("BUILD_PREVIEW", 0)):
         PR_NUMBER = f"{os.environ['PR_NUMBER']}"
         PR_TEXT = f'<a href="https://github.com/NVIDIA/cuda-python/pull/{PR_NUMBER}">PR {PR_NUMBER}</a>'
         html_theme_options["announcement"] = f"<em>Warning</em>: This documentation is only a preview for {PR_TEXT}!"
-    elif int(os.environ.get("BUILD_LATEST")):
+    elif int(os.environ.get("BUILD_LATEST", 0)):
         html_theme_options["announcement"] = (
             "<em>Warning</em>: This documentation is built from the development branch!"
         )

--- a/cuda_python/docs/source/conf.py
+++ b/cuda_python/docs/source/conf.py
@@ -72,11 +72,11 @@ html_theme_options = {
     # ],
 }
 if os.environ.get("CI"):
-    if int(os.environ.get("BUILD_PREVIEW")):
+    if int(os.environ.get("BUILD_PREVIEW", 0)):
         PR_NUMBER = f"{os.environ['PR_NUMBER']}"
         PR_TEXT = f'<a href="https://github.com/NVIDIA/cuda-python/pull/{PR_NUMBER}">PR {PR_NUMBER}</a>'
         html_theme_options["announcement"] = f"<em>Warning</em>: This documentation is only a preview for {PR_TEXT}!"
-    elif int(os.environ.get("BUILD_LATEST")):
+    elif int(os.environ.get("BUILD_LATEST", 0)):
         html_theme_options["announcement"] = (
             "<em>Warning</em>: This documentation is built from the development branch!"
         )

--- a/cuda_python/docs/source/conf.py
+++ b/cuda_python/docs/source/conf.py
@@ -72,11 +72,14 @@ html_theme_options = {
     # ],
 }
 if os.environ.get("CI"):
-    PR_NUMBER = f"{os.environ['PR_NUMBER']}"
-    PR_TEXT = f'<a href="https://github.com/NVIDIA/cuda-python/pull/{PR_NUMBER}">PR {PR_NUMBER}</a>'
-    html_theme_options["announcement"] = (
-        f"<em>Warning</em>: This documentation is only a preview for {PR_TEXT}!"
-    )
+    if int(os.environ.get("BUILD_PREVIEW")):
+        PR_NUMBER = f"{os.environ['PR_NUMBER']}"
+        PR_TEXT = f'<a href="https://github.com/NVIDIA/cuda-python/pull/{PR_NUMBER}">PR {PR_NUMBER}</a>'
+        html_theme_options["announcement"] = f"<em>Warning</em>: This documentation is only a preview for {PR_TEXT}!"
+    elif int(os.environ.get("BUILD_LATEST")):
+        html_theme_options["announcement"] = (
+            "<em>Warning</em>: This documentation is built from the development branch!"
+        )
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -86,9 +89,7 @@ html_static_path = ["_static"]
 # Allow overwriting CUDA Python's domain name for local development. See:
 #   - https://stackoverflow.com/a/61694897/2344149
 #   - https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-rst_epilog
-CUDA_PYTHON_DOMAIN = os.environ.get(
-    "CUDA_PYTHON_DOMAIN", "https://nvidia.github.io/cuda-python"
-)
+CUDA_PYTHON_DOMAIN = os.environ.get("CUDA_PYTHON_DOMAIN", "https://nvidia.github.io/cuda-python")
 rst_epilog = f"""
 .. _cuda.core: {CUDA_PYTHON_DOMAIN}/cuda-core/latest
 .. _cuda.bindings: {CUDA_PYTHON_DOMAIN}/cuda-bindings/latest

--- a/cuda_python/pyproject.toml
+++ b/cuda_python/pyproject.toml
@@ -39,3 +39,6 @@ homepage = "https://nvidia.github.io/cuda-python/"
 documentation = "https://nvidia.github.io/cuda-python/"
 repository = "https://github.com/NVIDIA/cuda-python/"
 issues = "https://github.com/NVIDIA/cuda-python/issues/"
+
+[tool.ruff]
+line-length = 120


### PR DESCRIPTION
Follow-up of #410. Turns out we broke the latest docs https://nvidia.github.io/cuda-python/latest/. This PR adds more fine-grained warning banners to fix it:
- When building the PR previews, the warning banner links back to the PR (this was done in #410)
- When merging into `main` and updating the latest docs, a new warning banner is added 