### PR TITLE
Stop tracking cached files and Jupyter notebook hashes in doc builds

### DIFF
--- a/cuda_bindings/docs/build_docs.sh
+++ b/cuda_bindings/docs/build_docs.sh
@@ -23,7 +23,7 @@ if [[ -z "${SPHINX_CUDA_BINDINGS_VER}" ]]; then
 fi
 
 # build the docs (in parallel)
-SPHINXOPTS="-j 4" make html
+SPHINXOPTS="-j 4 -d build/.doctrees" make html
 
 # for debugging/developing (conf.py), please comment out the above line and
 # use the line below instead, as we must build in serial to avoid getting

--- a/cuda_bindings/docs/source/overview.md
+++ b/cuda_bindings/docs/source/overview.md
@@ -1,12 +1,3 @@
----
-jupytext:
-  text_representation:
-    format_name: myst
-kernelspec:
-  display_name: Python 3
-  name: python3
----
-
 # Overview
 
 <p style="font-size: 14px; color: grey; text-align: right;">by <a

--- a/cuda_core/docs/build_docs.sh
+++ b/cuda_core/docs/build_docs.sh
@@ -19,7 +19,7 @@ if [[ -z "${SPHINX_CUDA_CORE_VER}" ]]; then
 fi
 
 # build the docs (in parallel)
-SPHINXOPTS="-j 4" make html
+SPHINXOPTS="-j 4 -d build/.doctrees" make html
 
 # for debugging/developing (conf.py), please comment out the above line and
 # use the line below instead, as we must build in serial to avoid getting

--- a/cuda_python/docs/build_docs.sh
+++ b/cuda_python/docs/build_docs.sh
@@ -23,7 +23,7 @@ if [[ -z "${SPHINX_CUDA_PYTHON_VER}" ]]; then
 fi
 
 # build the docs (in parallel)
-SPHINXOPTS="-j 4" make html
+SPHINXOPTS="-j 4 -d build/.doctrees" make html
 
 # for debugging/developing (conf.py), please comment out the above line and
 # use the line below instead, as we must build in serial to avoid getting


### PR DESCRIPTION
close #351

- `.doctrees` contain cached build files and don't impact html rendering. Store them outside of html build path.
- `overview.md` has page settings that triggers Jupyter notebook execution. Since the settings have minimal impact on displayed page, remove them to avoid hash regeneration.