### PR TITLE
Update to use the new NVKS runners

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -38,7 +38,7 @@ jobs:
     # The build stage could fail but we want the CI to keep moving.
     if: ${{ github.repository_owner == 'nvidia' && !cancelled() }}
     # WAR: Building the doc currently requires a GPU (NVIDIA/cuda-python#326,327)
-    runs-on: linux-amd64-gpu-t4-latest-1-testing
+    runs-on: linux-amd64-gpu-t4-latest-1
     #runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/test-wheel.yml
+++ b/.github/workflows/test-wheel.yml
@@ -28,7 +28,7 @@ jobs:
     if: ${{ github.repository_owner == 'nvidia' && !cancelled() }}
     runs-on: ${{ (inputs.runner == 'default' && inputs.host-platform == 'linux-64' && 'linux-amd64-gpu-v100-latest-1') ||
                  (inputs.runner == 'default' && inputs.host-platform == 'linux-aarch64' && 'linux-arm64-gpu-a100-latest-1') ||
-                 (inputs.runner == 'H100' && 'linux-amd64-gpu-h100-latest-1-testing') }}
+                 (inputs.runner == 'H100' && 'linux-amd64-gpu-h100-latest-1') }}
     # Our self-hosted runners require a container
     # TODO: use a different (nvidia?) container
     container:


### PR DESCRIPTION
The old runners are removed, so all CIs are blocked due to lack of runners.