### PR TITLE
Add `ObjectCode` ptx constructor

### DIFF
--- a/cuda_core/cuda/core/experimental/_module.py
+++ b/cuda_core/cuda/core/experimental/_module.py
@@ -285,7 +285,7 @@ class ObjectCode:
         Parameters
         ----------
         module : Union[bytes, str]
-            Either a bytes object containing the in-memory cubin to load, or
+            Either a bytes object containing the in-memory ptx code to load, or
             a file path string pointing to the on-disk ptx file to load.
         symbol_mapping : Optional[dict]
             A dictionary specifying how the unmangled symbol names (as keys)

--- a/cuda_core/cuda/core/experimental/_module.py
+++ b/cuda_core/cuda/core/experimental/_module.py
@@ -279,7 +279,7 @@ class ObjectCode:
 
     @staticmethod
     def from_ptx(module: Union[bytes, str], *, symbol_mapping: Optional[dict] = None) -> "ObjectCode":
-        """Create an :class:`ObjectCode` instance from an existing cubin.
+        """Create an :class:`ObjectCode` instance from an existing PTX.
 
         Parameters
         ----------

--- a/cuda_core/cuda/core/experimental/_module.py
+++ b/cuda_core/cuda/core/experimental/_module.py
@@ -293,7 +293,6 @@ class ObjectCode:
             them (default to no mappings).
         """
         obj = ObjectCode._init(module, "cubin", symbol_mapping=symbol_mapping)
-        breakpoint()
         obj._code_type = "ptx"
         return obj
 

--- a/cuda_core/cuda/core/experimental/_module.py
+++ b/cuda_core/cuda/core/experimental/_module.py
@@ -291,7 +291,7 @@ class ObjectCode:
             should be mapped to the mangled names before trying to retrieve
             them (default to no mappings).
         """
-        return ObjectCode._init(module, "ptx")  # , symbol_mapping=symbol_mapping)
+        return ObjectCode._init(module, "ptx", symbol_mapping=symbol_mapping)
 
     # TODO: do we want to unload in a finalizer? Probably not..
 

--- a/cuda_core/cuda/core/experimental/_module.py
+++ b/cuda_core/cuda/core/experimental/_module.py
@@ -223,9 +223,9 @@ class ObjectCode:
 
     Note
     ----
-    This class has no default constructor. If you already have a cubin that you would
-    like to load, use the :meth:`from_cubin` alternative constructor. For all other
-    possible code types (ex: "ptx"), only :class:`~cuda.core.experimental.Program`
+    This class has no default constructor. If you already have a cubin or ptx file that you would
+    like to load, use the :meth:`from_cubin` or :meth:`from_ptx` alternative constructors.
+    For all other possible code types (ex: "fatbin"), only :class:`~cuda.core.experimental.Program`
     accepts them and returns an :class:`ObjectCode` instance with its
     :meth:`~cuda.core.experimental.Program.compile` method.
 
@@ -277,6 +277,25 @@ class ObjectCode:
             them (default to no mappings).
         """
         return ObjectCode._init(module, "cubin", symbol_mapping=symbol_mapping)
+
+    @staticmethod
+    def from_ptx(module: Union[bytes, str], *, symbol_mapping: Optional[dict] = None) -> "ObjectCode":
+        """Create an :class:`ObjectCode` instance from an existing cubin.
+
+        Parameters
+        ----------
+        module : Union[bytes, str]
+            Either a bytes object containing the in-memory cubin to load, or
+            a file path string pointing to the on-disk ptx file to load.
+        symbol_mapping : Optional[dict]
+            A dictionary specifying how the unmangled symbol names (as keys)
+            should be mapped to the mangled names before trying to retrieve
+            them (default to no mappings).
+        """
+        obj = ObjectCode._init(module, "cubin", symbol_mapping=symbol_mapping)
+        breakpoint()
+        obj._code_type = "ptx"
+        return obj
 
     # TODO: do we want to unload in a finalizer? Probably not..
 

--- a/cuda_core/cuda/core/experimental/_module.py
+++ b/cuda_core/cuda/core/experimental/_module.py
@@ -223,11 +223,10 @@ class ObjectCode:
 
     Note
     ----
-    This class has no default constructor. If you already have a cubin or ptx file that you would
-    like to load, use the :meth:`from_cubin` or :meth:`from_ptx` alternative constructors.
-    For all other possible code types (ex: "fatbin"), only :class:`~cuda.core.experimental.Program`
-    accepts them and returns an :class:`ObjectCode` instance with its
-    :meth:`~cuda.core.experimental.Program.compile` method.
+    This class has no default constructor. If you already have a cubin that you would
+    like to load, use the :meth:`from_cubin` alternative constructor. Constructing directly
+    from all other possible code types should be avoided in favor of compilation through
+    :class:`~cuda.core.experimental.Program`
 
     Note
     ----
@@ -292,9 +291,7 @@ class ObjectCode:
             should be mapped to the mangled names before trying to retrieve
             them (default to no mappings).
         """
-        obj = ObjectCode._init(module, "cubin", symbol_mapping=symbol_mapping)
-        obj._code_type = "ptx"
-        return obj
+        return ObjectCode._init(module, "ptx")  # , symbol_mapping=symbol_mapping)
 
     # TODO: do we want to unload in a finalizer? Probably not..
 

--- a/cuda_core/cuda/core/experimental/_program.py
+++ b/cuda_core/cuda/core/experimental/_program.py
@@ -425,7 +425,8 @@ class Program:
             self._linker.close()
         self._mnff.close()
 
-    def _can_load_generated_ptx(self):
+    @staticmethod
+    def _can_load_generated_ptx():
         driver_ver = handle_return(driver.cuDriverGetVersion())
         nvrtc_major, nvrtc_minor = handle_return(nvrtc.nvrtcVersion())
         return nvrtc_major * 1000 + nvrtc_minor * 10 <= driver_ver

--- a/cuda_core/tests/test_linker.py
+++ b/cuda_core/tests/test_linker.py
@@ -34,11 +34,6 @@ def compile_ptx_functions(init_cuda):
 
 
 @pytest.fixture(scope="function")
-def compile_ptx_functions_raw(compile_ptx_functions):
-    return tuple(obj.code for obj in compile_ptx_functions)
-
-
-@pytest.fixture(scope="function")
 def compile_ltoir_functions(init_cuda):
     object_code_a_ltoir = Program(kernel_a, "c++", ProgramOptions(link_time_optimization=True)).compile("ltoir")
     object_code_b_ltoir = Program(device_function_b, "c++", ProgramOptions(link_time_optimization=True)).compile(

--- a/cuda_core/tests/test_module.py
+++ b/cuda_core/tests/test_module.py
@@ -116,6 +116,8 @@ def test_object_code_load_ptx(get_saxpy_kernel_ptx):
     sym_map = mod._sym_map
     mod_obj = ObjectCode.from_ptx(ptx, symbol_mapping=sym_map)
     assert mod.code == ptx
+    if not Program._can_load_generated_ptx():
+        pytest.skip("PTX version too new for current driver")
     mod_obj.get_kernel("saxpy<double>")  # force loading
 
 


### PR DESCRIPTION
Adds the ability to link multiple PTX files with one linker instance. 