### PR TITLE
Add event timing

### DIFF
--- a/cuda_core/cuda/core/experimental/_event.py
+++ b/cuda_core/cuda/core/experimental/_event.py
@@ -117,7 +117,12 @@ class Event:
 
     def __sub__(self, other):
         # return self - other (in milliseconds)
-        timing = handle_return(driver.cuEventElapsedTime(other.handle, self.handle))
+        try:
+            timing = handle_return(driver.cuEventElapsedTime(other.handle, self.handle))
+        except CUDAError as e:
+            raise RuntimeError(
+                "Timing capability must be enabled in order to subtract two Events; timing is disabled by default."
+            ) from e
         return timing
 
     @property

--- a/cuda_core/cuda/core/experimental/_event.py
+++ b/cuda_core/cuda/core/experimental/_event.py
@@ -48,7 +48,8 @@ class Event:
 
     Events can be used to monitor device's progress, query completion
     of work up to event's record, help establish dependencies
-    between GPU work submissions, and record the elapsed time on GPU:
+    between GPU work submissions, and record the elapsed time (in milliseconds)
+    on GPU:
 
     .. code-block:: python
 
@@ -58,14 +59,14 @@ class Event:
         # ... run some GPU works ...
         e2 = s.record(options={"enable_timing": True})
         e2.sync()
-        print(f"time = {e2 - e1}")
+        print(f"time = {e2 - e1} milliseconds")
 
         # Or, if events are already created:
         s.record(e1)
         # ... run some more GPU works ...
         s.record(e2)
         e2.sync()
-        print(f"time = {e2 - e1}")
+        print(f"time = {e2 - e1} milliseconds")
 
     Directly creating an :obj:`~_event.Event` is not supported due to ambiguity,
     and they should instead be created through a :obj:`~_stream.Stream` object.
@@ -120,7 +121,7 @@ class Event:
         return NotImplemented
 
     def __sub__(self, other):
-        # return self - other
+        # return self - other (in milliseconds)
         timing = handle_return(driver.cuEventElapsedTime(other.handle, self.handle))
         return timing
 

--- a/cuda_core/cuda/core/experimental/_event.py
+++ b/cuda_core/cuda/core/experimental/_event.py
@@ -54,16 +54,11 @@ class Event:
     .. code-block:: python
 
         # To create events and record the timing:
-        s = Device(0).create_stream()
-        e1 = s.record(options={"enable_timing": True})
-        # ... run some GPU works ...
-        e2 = s.record(options={"enable_timing": True})
-        e2.sync()
-        print(f"time = {e2 - e1} milliseconds")
-
-        # Or, if events are already created:
+        s = Device().create_stream()
+        e1 = Device().create_event({"enable_timing": True})
+        e2 = Device().create_event({"enable_timing": True})
         s.record(e1)
-        # ... run some more GPU works ...
+        # ... run some GPU works ...
         s.record(e2)
         e2.sync()
         print(f"time = {e2 - e1} milliseconds")

--- a/cuda_core/docs/source/release/0.2.0-notes.rst
+++ b/cuda_core/docs/source/release/0.2.0-notes.rst
@@ -25,6 +25,7 @@ New features
 - Expose :class:`ObjectCode` as a public API, which allows loading cubins from memory or disk. For loading other kinds of code types, please continue using :class:`Program`.
 - A C++ helper function ``get_cuda_native_handle()`` is provided in the new ``include/utility.cuh`` header to retrive the underlying CUDA C objects (ex: ``CUstream``) from a Python object returned by the ``.handle`` attribute (ex: :attr:`Stream.handle`).
 - For objects such as :class:`Program` and :class:`Linker` that could dispatch to different backends, a new ``.backend`` attribute is provided to query this information.
+- Support CUDA event timing.
 
 Limitations
 -----------

--- a/cuda_core/docs/source/release/0.2.0-notes.rst
+++ b/cuda_core/docs/source/release/0.2.0-notes.rst
@@ -28,7 +28,7 @@ New features
 - A C++ helper function ``get_cuda_native_handle()`` is provided in the new ``include/utility.cuh`` header to retrive the underlying CUDA C objects (ex: ``CUstream``) from a Python object returned by the ``.handle`` attribute (ex: :attr:`Stream.handle`).
 - For objects such as :class:`Program` and :class:`Linker` that could dispatch to different backends, a new ``.backend`` attribute is provided to query this information.
 - Support CUDA event timing.
-- An :class:`~_event.Event` may now be created without recording it to a :class:`Stream` using the :meth:`Device.create_event`` method.
+- An :class:`~_event.Event` may now be created without recording it to a :class:`~_stream.Stream` using the :meth:`Device.create_event` method.
 
 Limitations
 -----------

--- a/cuda_core/tests/test_event.py
+++ b/cuda_core/tests/test_event.py
@@ -12,7 +12,6 @@ import pytest
 
 import cuda.core.experimental
 from cuda.core.experimental import Device, EventOptions
-from cuda.core.experimental._utils import CUDAError
 
 
 def test_event_init_disabled():
@@ -36,9 +35,11 @@ def test_timing(init_cuda, enable_timing):
         assert isinstance(elapsed_time_ms, float)
         assert delay_seconds * 1000 <= elapsed_time_ms < delay_seconds * 1000 + 2  # tolerance 2 ms
     else:
-        with pytest.raises(CUDAError) as e:
+        with pytest.raises(RuntimeError) as e:
             elapsed_time_ms = e2 - e1
-            assert "CUDA_ERROR_INVALID_HANDLE" in str(e)
+            msg = str(e)
+            assert "disabled by default" in msg
+            assert "CUDA_ERROR_INVALID_HANDLE" in msg
 
 
 def test_is_sync_busy_waited(init_cuda):


### PR DESCRIPTION
When working on #475 (68c93652eb4037af9c5755745668800566413689) I noticed we surprisingly haven't implemented event-based timing...  Looks like an oversight to me because we did spend a lot of time discussing the default of the `enabling_timing` option and how to retrieve the timing result. This PR adds the implementation, which is also aligned with the `cuda::experimental::timed_event` treatment: 
https://github.com/NVIDIA/cccl/blob/096596b3580d6cb2042fff692e8162d2a0ea356b/cudax/include/cuda/experimental/__event/timed_event.cuh#L90