### PR TITLE
NEW: Create an Event without recording to Stream

### DIFF
--- a/cuda_core/cuda/core/experimental/_device.py
+++ b/cuda_core/cuda/core/experimental/_device.py
@@ -3,12 +3,13 @@
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 import threading
-from typing import Union
+from typing import Union, Optional
 
 from cuda.core.experimental._context import Context, ContextOptions
 from cuda.core.experimental._memory import Buffer, MemoryResource, _DefaultAsyncMempool, _SynchronousMemoryResource
 from cuda.core.experimental._stream import Stream, StreamOptions, default_stream
 from cuda.core.experimental._utils import ComputeCapability, CUDAError, driver, handle_return, precondition, runtime
+from cuda.core.experimental._event import Event, EventOptions
 
 _tls = threading.local()
 _lock = threading.Lock()
@@ -1197,6 +1198,27 @@ class Device:
 
         """
         return Stream._init(obj=obj, options=options)
+
+    @precondition(_check_context_initialized)
+    def create_event(self, options: Optional[EventOptions] = None) -> Event:
+        """Create an Event object without recording it to a Stream.
+
+        Note
+        ----
+        Device must be initialized.
+
+        Parameters
+        ----------
+        options : :obj:`EventOptions`, optional
+            Customizable dataclass for event creation options.
+
+        Returns
+        -------
+        :obj:`~_event.Event`
+            Newly created event object.
+
+        """
+        return Event._init(options)
 
     @precondition(_check_context_initialized)
     def allocate(self, size, stream=None) -> Buffer:

--- a/cuda_core/cuda/core/experimental/_device.py
+++ b/cuda_core/cuda/core/experimental/_device.py
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 import threading
-from typing import Union, Optional
+from typing import Optional, Union
 
 from cuda.core.experimental._context import Context, ContextOptions
+from cuda.core.experimental._event import Event, EventOptions
 from cuda.core.experimental._memory import Buffer, MemoryResource, _DefaultAsyncMempool, _SynchronousMemoryResource
 from cuda.core.experimental._stream import Stream, StreamOptions, default_stream
 from cuda.core.experimental._utils import ComputeCapability, CUDAError, driver, handle_return, precondition, runtime
-from cuda.core.experimental._event import Event, EventOptions
 
 _tls = threading.local()
 _lock = threading.Lock()

--- a/cuda_core/docs/source/release/0.2.0-notes.rst
+++ b/cuda_core/docs/source/release/0.2.0-notes.rst
@@ -27,6 +27,7 @@ New features
 - Expose :class:`ObjectCode` as a public API, which allows loading cubins from memory or disk. For loading other kinds of code types, please continue using :class:`Program`.
 - A C++ helper function ``get_cuda_native_handle()`` is provided in the new ``include/utility.cuh`` header to retrive the underlying CUDA C objects (ex: ``CUstream``) from a Python object returned by the ``.handle`` attribute (ex: :attr:`Stream.handle`).
 - For objects such as :class:`Program` and :class:`Linker` that could dispatch to different backends, a new ``.backend`` attribute is provided to query this information.
+- An :class:`Event` may now be created without recording it to a :class:`Stream` using the :class:`Device` ``create_stream()`` method.
 
 Limitations
 -----------

--- a/cuda_core/docs/source/release/0.2.0-notes.rst
+++ b/cuda_core/docs/source/release/0.2.0-notes.rst
@@ -27,7 +27,7 @@ New features
 - Expose :class:`ObjectCode` as a public API, which allows loading cubins from memory or disk. For loading other kinds of code types, please continue using :class:`Program`.
 - A C++ helper function ``get_cuda_native_handle()`` is provided in the new ``include/utility.cuh`` header to retrive the underlying CUDA C objects (ex: ``CUstream``) from a Python object returned by the ``.handle`` attribute (ex: :attr:`Stream.handle`).
 - For objects such as :class:`Program` and :class:`Linker` that could dispatch to different backends, a new ``.backend`` attribute is provided to query this information.
-- An :class:`Event` may now be created without recording it to a :class:`Stream` using the :class:`Device` ``create_stream()`` method.
+- An :class:`~_event.Event` may now be created without recording it to a :class:`Stream` using the :meth:`Device.create_event`` method.
 
 Limitations
 -----------

--- a/cuda_core/tests/test_device.py
+++ b/cuda_core/tests/test_device.py
@@ -58,6 +58,13 @@ def test_device_create_stream(init_cuda):
     assert stream.handle
 
 
+def test_device_create_event(init_cuda):
+    device = Device()
+    event = device.create_event()
+    assert event is not None
+    assert event.handle
+
+
 def test_pci_bus_id():
     device = Device()
     bus_id = handle_return(runtime.cudaDeviceGetPCIBusId(13, device.device_id))


### PR DESCRIPTION
Closes #485

Adds a method to the `Device` class which allows you to make an Event without immediately recording it to a Stream.