### PR TITLE
Increase tolerance in `test_timing()` to avoid flaky tests.

### DIFF
--- a/cuda_core/tests/test_event.py
+++ b/cuda_core/tests/test_event.py
@@ -33,7 +33,12 @@ def test_timing(init_cuda, enable_timing):
     if enable_timing:
         elapsed_time_ms = e2 - e1
         assert isinstance(elapsed_time_ms, float)
-        assert delay_seconds * 1000 <= elapsed_time_ms < delay_seconds * 1000 + 2  # tolerance 2 ms
+        # Using a generous tolerance, to avoid flaky tests:
+        # We only want to exercise the __sub__ method, this test is not meant
+        # to stress-test the CUDA driver or time.sleep().
+        delay_ms = delay_seconds * 1000
+        generous_tolerance = 20
+        assert delay_ms <= elapsed_time_ms < delay_ms + generous_tolerance
     else:
         with pytest.raises(RuntimeError) as e:
             elapsed_time_ms = e2 - e1


### PR DESCRIPTION
Observed failures:

```
>           assert delay_seconds * 1000 <= elapsed_time_ms < delay_seconds * 1000 + 2  # tolerance 2 ms
E           assert 503.1598205566406 < ((0.5 * 1000) + 2)
```

```
>           assert delay_seconds * 1000 <= elapsed_time_ms < delay_seconds * 1000 + 2  # tolerance 2 ms
E           assert 505.0583190917969 < ((0.5 * 1000) + 2)
```