### PR TITLE
NEW: Add Event to public API

### DIFF
--- a/cuda_core/cuda/core/experimental/__init__.py
+++ b/cuda_core/cuda/core/experimental/__init__.py
@@ -4,7 +4,7 @@
 
 from cuda.core.experimental import utils
 from cuda.core.experimental._device import Device
-from cuda.core.experimental._event import EventOptions
+from cuda.core.experimental._event import Event, EventOptions
 from cuda.core.experimental._launcher import LaunchConfig, launch
 from cuda.core.experimental._linker import Linker, LinkerOptions
 from cuda.core.experimental._module import ObjectCode


### PR DESCRIPTION
Downstream packages that want to use `Event` to type hint their APIs should be able to import `Event` without accessing private modules.

https://github.com/NVIDIA/cuda-python/issues/469#issuecomment-2707430036

I understand that `Event`s should not be constructed directly, but having `__new__()` raise a RuntimeError should be sufficient to prevent that.