### PR TITLE
Backport #497 and #499

### DIFF
--- a/cuda_bindings/cuda/bindings/driver.pyx.in
+++ b/cuda_bindings/cuda/bindings/driver.pyx.in
@@ -13208,7 +13208,7 @@ def cuGetErrorString(error not None : CUresult):
     cdef cydriver.CUresult cyerror = error.value
     cdef const char* pStr = NULL
     err = cydriver.cuGetErrorString(cyerror, &pStr)
-    return (CUresult(err), <bytes>pStr)
+    return (CUresult(err), <bytes>pStr if pStr != NULL else None)
 {{endif}}
 
 {{if 'cuGetErrorName' in found_functions}}
@@ -13241,7 +13241,7 @@ def cuGetErrorName(error not None : CUresult):
     cdef cydriver.CUresult cyerror = error.value
     cdef const char* pStr = NULL
     err = cydriver.cuGetErrorName(cyerror, &pStr)
-    return (CUresult(err), <bytes>pStr)
+    return (CUresult(err), <bytes>pStr if pStr != NULL else None)
 {{endif}}
 
 {{if 'cuInit' in found_functions}}

--- a/cuda_bindings/cuda/bindings/nvrtc.pyx.in
+++ b/cuda_bindings/cuda/bindings/nvrtc.pyx.in
@@ -715,7 +715,7 @@ def nvrtcGetLoweredName(prog, char* name_expression):
         cyprog = <cynvrtc.nvrtcProgram><void_ptr>pprog
     cdef const char* lowered_name = NULL
     err = cynvrtc.nvrtcGetLoweredName(cyprog, name_expression, &lowered_name)
-    return (nvrtcResult(err), <bytes>lowered_name)
+    return (nvrtcResult(err), <bytes>lowered_name if lowered_name != NULL else None)
 {{endif}}
 
 @cython.embedsignature(True)

--- a/cuda_bindings/tests/test_nvrtc.py
+++ b/cuda_bindings/tests/test_nvrtc.py
@@ -27,6 +27,7 @@ def test_nvrtcGetSupportedArchs():
     assert len(supportedArchs) != 0
 
 
+@pytest.mark.skipif(nvrtcVersionLessThan(12, 1), reason="Preempt Segmentation Fault (see #499)")
 def test_nvrtcGetLoweredName_failure():
     err, name = nvrtc.nvrtcGetLoweredName(None, b"I'm an elevated name!")
     assert err == nvrtc.nvrtcResult.NVRTC_ERROR_INVALID_PROGRAM

--- a/cuda_bindings/tests/test_nvrtc.py
+++ b/cuda_bindings/tests/test_nvrtc.py
@@ -27,7 +27,6 @@ def test_nvrtcGetSupportedArchs():
     assert len(supportedArchs) != 0
 
 
-@pytest.mark.skipif(nvrtcVersionLessThan(12, 1), reason="Preempt Segmentation Fault (see #499)")
 def test_nvrtcGetLoweredName_failure():
     err, name = nvrtc.nvrtcGetLoweredName(None, b"I'm an elevated name!")
     assert err == nvrtc.nvrtcResult.NVRTC_ERROR_INVALID_PROGRAM

--- a/cuda_bindings/tests/test_nvrtc.py
+++ b/cuda_bindings/tests/test_nvrtc.py
@@ -25,3 +25,13 @@ def test_nvrtcGetSupportedArchs():
     err, supportedArchs = nvrtc.nvrtcGetSupportedArchs()
     ASSERT_DRV(err)
     assert len(supportedArchs) != 0
+
+
+@pytest.mark.skipif(nvrtcVersionLessThan(12, 1), reason="Preempt Segmentation Fault (see #499)")
+def test_nvrtcGetLoweredName_failure():
+    err, name = nvrtc.nvrtcGetLoweredName(None, b"I'm an elevated name!")
+    assert err == nvrtc.nvrtcResult.NVRTC_ERROR_INVALID_PROGRAM
+    assert name is None
+    err, name = nvrtc.nvrtcGetLoweredName(0, b"I'm another elevated name!")
+    assert err == nvrtc.nvrtcResult.NVRTC_ERROR_INVALID_PROGRAM
+    assert name is None


### PR DESCRIPTION
Manual backports of:
* #497
* #499

`cuKernelGetName` and `cuFuncGetName` do not exist on the 11.8.x branch.