### PR TITLE
Add `@functools.lru_cache` decorator for `get_binding_version()`

### DIFF
--- a/cuda_core/cuda/core/experimental/_utils/cuda_utils.py
+++ b/cuda_core/cuda/core/experimental/_utils/cuda_utils.py
@@ -182,6 +182,7 @@ def is_nested_sequence(obj):
     return is_sequence(obj) and any(is_sequence(elem) for elem in obj)
 
 
+@functools.lru_cache
 def get_binding_version():
     try:
         major_minor = importlib.metadata.version("cuda-bindings").split(".")[:2]


### PR DESCRIPTION
This one-line change results in a 8k+ fold speedup.

```
>>> 35.381859/0.004149
8527.804049168473
```

```
$ git stash
$ python test_slowness.py 100000
driver.cuDriverGetVersion() 12060
cuda_utils.get_binding_version() (12, 8)
driver.cuDriverGetVersion()
    0.023946 seconds for 100000 iterations
    0.24 µs per call
cuda_utils.get_binding_version()
    35.381859 seconds for 100000 iterations
    353.82 µs per call
```

```
$ git stash pop
$ python test_slowness.py 100000
driver.cuDriverGetVersion() 12060
cuda_utils.get_binding_version() (12, 8)
driver.cuDriverGetVersion()
    0.022644 seconds for 100000 iterations
    0.23 µs per call
cuda_utils.get_binding_version()
    0.004149 seconds for 100000 iterations
    0.04 µs per call
```
________

In retrospect, I should have just looked at the `get_bindings()` implementation immediately.

The way I actually found this (perf version 6.8.12):

```
perf record -F 99 -g -- python test_slowness.py 100000
perf report
```

I gave the top of the perf report and the `get_bindings()` implementation  to ChatGPT:

* https://chatgpt.com/share/67d20482-8914-8008-b382-e450fd5a4d74

That made it immediately obvious that `importlib.metadata.version("cuda-bindings")` is the bottleneck, mainly because it involves regex calls, but also because it triggers filesystem calls.
________

```Python
import sys
import time

from cuda.bindings import driver
from cuda.core.experimental._utils import cuda_utils


class show_timings:
    def __init__(self, num_iters, label):
        self.label = label
        self.num_iters = num_iters

    def __enter__(self):
        self.start = time.perf_counter()
        return self

    def __exit__(self, exc_type, exc_val, exc_tb):
        elapsed = time.perf_counter() - self.start
        print(self.label)
        if self.num_iters:
            print(f"    {elapsed:.6f} seconds for {self.num_iters} iterations")
            print(f"    {(elapsed / self.num_iters) * 1e6:.2f} µs per call")
        else:
            print(f"    {elapsed:.6f} seconds")


err, dv = driver.cuDriverGetVersion()
assert err == driver.CUresult.CUDA_SUCCESS
print("driver.cuDriverGetVersion()", dv, flush=True)

bv = cuda_utils.get_binding_version()
print("cuda_utils.get_binding_version()", bv, flush=True)

num_iters = int(sys.argv[1])

if 1:
    with show_timings(num_iters, "driver.cuDriverGetVersion()"):
        for _ in range(num_iters):
            driver.cuDriverGetVersion()
if 1:
    with show_timings(num_iters, "cuda_utils.get_binding_version()"):
        for _ in range(num_iters):
            cuda_utils.get_binding_version()
```