### PR TITLE
CI: Run some tests with compute-sanitizer

### DIFF
--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -180,7 +180,7 @@ jobs:
           host-platform: ${{ inputs.host-platform }}
           cuda-version: ${{ inputs.cuda-version }}
 
-      - name: Set up compute-saniziter
+      - name: Set up compute-sanitizer
         run: |
           if [[ "${{ inputs.python-version }}" == "3.12" && "${{ inputs.local-ctk }}" == 1 ]]; then
             COMPUTE_SANITIZER="${CUDA_HOME}/bin/compute-sanitizer"

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -74,11 +74,16 @@ jobs:
             fi
           fi
 
-          COMPUTE_SANITIZER=${CUDA_HOME}/bin/compute-sanitizer
-          COMPUTE_SANITIZER_VERSION=$(${COMPUTE_SANITIZER} --version | grep -Eo "[0-9]{4}\.[0-9]\.[0-9]" | sed -e 's/\.//g')
-          SANITIZER_CMD="${COMPUTE_SANITIZER} --target-processes=all --launch-timeout=0 --tool=memcheck"
-          if [[ "$COMPUTE_SANITIZER_VERSION" -ge 202111 ]]; then
-              SANITIZER_CMD="${SANITIZER_CMD} --padding=32"
+          if [[ "${{ inputs.python-version }}" == "3.12" ]]; then
+            COMPUTE_SANITIZER=${CUDA_HOME}/bin/compute-sanitizer
+            COMPUTE_SANITIZER_VERSION=$(${COMPUTE_SANITIZER} --version | grep -Eo "[0-9]{4}\.[0-9]\.[0-9]" | sed -e 's/\.//g')
+            SANITIZER_CMD="${COMPUTE_SANITIZER} --target-processes=all --launch-timeout=0 --tool=memcheck"
+            if [[ "$COMPUTE_SANITIZER_VERSION" -ge 202111 ]]; then
+                SANITIZER_CMD="${SANITIZER_CMD} --padding=32"
+            fi
+          else
+            COMPUTE_SANITIZER_VERSION="None"
+            SANITIZER_CMD=""
           fi
 
           # make outputs from the previous job as env vars

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -194,10 +194,8 @@ jobs:
             fi
             echo "CUDA_PYTHON_SANITIZER_RUNNING=1" >> $GITHUB_ENV
           else
-            COMPUTE_SANITIZER_VERSION="None"
             SANITIZER_CMD=""
           fi
-          echo "COMPUTE_SANITIZER_VERSION=${COMPUTE_SANITIZER_VERSION}" >> $GITHUB_ENV
           echo "SANITIZER_CMD=${SANITIZER_CMD}" >> $GITHUB_ENV
 
       - name: Run cuda.bindings tests

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -203,7 +203,7 @@ jobs:
 
           pushd ./cuda_bindings
           pip install -r requirements.txt
-          pytest -rxXs -v tests/
+          ${SANITIZER_CMD} pytest -rxXs -v tests/
 
           # It is a bit convoluted to run the Cython tests against CTK wheels,
           # so let's just skip them.
@@ -214,7 +214,7 @@ jobs:
               # TODO: enable this once win-64 runners are up
               exit 1
             fi
-            pytest -rxXs -v tests/cython
+            ${SANITIZER_CMD} pytest -rxXs -v tests/cython
           fi
           popd
 
@@ -238,7 +238,7 @@ jobs:
 
           pushd ./cuda_core
           pip install -r "tests/requirements-cu${TEST_CUDA_MAJOR}.txt"
-          pytest -rxXs -v tests/
+          ${SANITIZER_CMD} pytest -rxXs -v tests/
 
           # It is a bit convoluted to run the Cython tests against CTK wheels,
           # so let's just skip them. Also, currently our CI always installs the
@@ -252,7 +252,7 @@ jobs:
               # TODO: enable this once win-64 runners are up
               exit 1
             fi
-            pytest -rxXs -v tests/cython
+            ${SANITIZER_CMD} pytest -rxXs -v tests/cython
           fi
           popd
 

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -74,7 +74,7 @@ jobs:
             fi
           fi
 
-          if [[ "${{ inputs.python-version }}" == "3.12" ]]; then
+          if [[ "${{ inputs.python-version }}" == "3.12" && "${{ inputs.local-ctk }}" == 1 ]]; then
             COMPUTE_SANITIZER=${CUDA_HOME}/bin/compute-sanitizer
             COMPUTE_SANITIZER_VERSION=$(${COMPUTE_SANITIZER} --version | grep -Eo "[0-9]{4}\.[0-9]\.[0-9]" | sed -e 's/\.//g')
             SANITIZER_CMD="${COMPUTE_SANITIZER} --target-processes=all --launch-timeout=0 --tool=memcheck --error-exitcode=1"

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -74,19 +74,6 @@ jobs:
             fi
           fi
 
-          if [[ "${{ inputs.python-version }}" == "3.12" && "${{ inputs.local-ctk }}" == 1 ]]; then
-            # Use single quotes to delay expansion of $CUDA_HOME until after mini-CTK step is complete
-            COMPUTE_SANITIZER='${CUDA_HOME}/bin/compute-sanitizer'
-            COMPUTE_SANITIZER_VERSION=$(${COMPUTE_SANITIZER} --version | grep -Eo "[0-9]{4}\.[0-9]\.[0-9]" | sed -e 's/\.//g')
-            SANITIZER_CMD="${COMPUTE_SANITIZER} --target-processes=all --launch-timeout=0 --tool=memcheck --error-exitcode=1"
-            if [[ "$COMPUTE_SANITIZER_VERSION" -ge 202111 ]]; then
-                SANITIZER_CMD="${SANITIZER_CMD} --padding=32"
-            fi
-          else
-            COMPUTE_SANITIZER_VERSION="None"
-            SANITIZER_CMD=""
-          fi
-
           # make outputs from the previous job as env vars
           CUDA_CORE_ARTIFACT_BASENAME="cuda-core-python${PYTHON_VERSION_FORMATTED}-${{ inputs.host-platform }}"
           echo "PYTHON_VERSION_FORMATTED=${PYTHON_VERSION_FORMATTED}" >> $GITHUB_ENV
@@ -99,8 +86,6 @@ jobs:
           echo "CUDA_BINDINGS_ARTIFACTS_DIR=$(realpath "$REPO_DIR/cuda_bindings/dist")" >> $GITHUB_ENV
           echo "SKIP_CUDA_BINDINGS_TEST=${SKIP_CUDA_BINDINGS_TEST}" >> $GITHUB_ENV
           echo "SKIP_CUDA_CORE_CYTHON_TEST=${SKIP_CUDA_CORE_CYTHON_TEST}" >> $GITHUB_ENV
-          echo "COMPUTE_SANITIZER_VERSION=${COMPUTE_SANITIZER_VERSION}" >> $GITHUB_ENV
-          echo "SANITIZER_CMD=${SANITIZER_CMD}" >> $GITHUB_ENV
 
       - name: Install dependencies
         uses: ./.github/actions/install_unix_deps
@@ -194,6 +179,22 @@ jobs:
         with:
           host-platform: ${{ inputs.host-platform }}
           cuda-version: ${{ inputs.cuda-version }}
+
+      - name: Set up compute-saniziter
+        run: |
+          if [[ "${{ inputs.python-version }}" == "3.12" && "${{ inputs.local-ctk }}" == 1 ]]; then
+            COMPUTE_SANITIZER="${CUDA_HOME}/bin/compute-sanitizer"
+            COMPUTE_SANITIZER_VERSION=$(${COMPUTE_SANITIZER} --version | grep -Eo "[0-9]{4}\.[0-9]\.[0-9]" | sed -e 's/\.//g')
+            SANITIZER_CMD="${COMPUTE_SANITIZER} --target-processes=all --launch-timeout=0 --tool=memcheck --error-exitcode=1"
+            if [[ "$COMPUTE_SANITIZER_VERSION" -ge 202111 ]]; then
+                SANITIZER_CMD="${SANITIZER_CMD} --padding=32"
+            fi
+          else
+            COMPUTE_SANITIZER_VERSION="None"
+            SANITIZER_CMD=""
+          fi
+          echo "COMPUTE_SANITIZER_VERSION=${COMPUTE_SANITIZER_VERSION}" >> $GITHUB_ENV
+          echo "SANITIZER_CMD=${SANITIZER_CMD}" >> $GITHUB_ENV
 
       - name: Run cuda.bindings tests
         if: ${{ env.SKIP_CUDA_BINDINGS_TEST == '0' }}

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -192,7 +192,7 @@ jobs:
             if [[ "$COMPUTE_SANITIZER_VERSION" -ge 202111 ]]; then
                 SANITIZER_CMD="${SANITIZER_CMD} --padding=32"
             fi
-            echo "CUDA_PYTHON_SANITIZER_RUNNING=1" >> $GITHUB_ENV
+            echo "CUDA_PYTHON_TESTING_WITH_COMPUTE_SANITIZER=1" >> $GITHUB_ENV
           else
             SANITIZER_CMD=""
           fi

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -182,7 +182,10 @@ jobs:
 
       - name: Set up compute-sanitizer
         run: |
-          if [[ "${{ inputs.python-version }}" == "3.12" && "${{ inputs.local-ctk }}" == 1 ]]; then
+          # We don't test compute-sanitizer on CTK<12 because backporting fixes is too much effort
+          # We only test compute-sanitizer on python 3.12 arbitrarily; we don't need to use sanitizer on the entire matrix
+          # Only local ctk installs have compute-sanitizer; there is not wheel for it
+          if [[ "${{ inputs.python-version }}" == "3.12" && "${{ inputs.cuda-verion }}" != "11.8.0" && "${{ inputs.local-ctk }}" == 1 ]]; then
             COMPUTE_SANITIZER="${CUDA_HOME}/bin/compute-sanitizer"
             COMPUTE_SANITIZER_VERSION=$(${COMPUTE_SANITIZER} --version | grep -Eo "[0-9]{4}\.[0-9]\.[0-9]" | sed -e 's/\.//g')
             SANITIZER_CMD="${COMPUTE_SANITIZER} --target-processes=all --launch-timeout=0 --tool=memcheck --error-exitcode=1"

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -74,6 +74,13 @@ jobs:
             fi
           fi
 
+          COMPUTE_SANITIZER=${CUDA_HOME}/bin/compute-sanitizer
+          COMPUTE_SANITIZER_VERSION=$(${COMPUTE_SANITIZER} --version | grep -Eo "[0-9]{4}\.[0-9]\.[0-9]" | sed -e 's/\.//g')
+          SANITIZER_CMD="${COMPUTE_SANITIZER} --target-processes=all --launch-timeout=0 --tool=memcheck"
+          if [[ "$COMPUTE_SANITIZER_VERSION" -ge 202111 ]]; then
+              SANITIZER_CMD="${SANITIZER_CMD} --padding=32"
+          fi
+
           # make outputs from the previous job as env vars
           CUDA_CORE_ARTIFACT_BASENAME="cuda-core-python${PYTHON_VERSION_FORMATTED}-${{ inputs.host-platform }}"
           echo "PYTHON_VERSION_FORMATTED=${PYTHON_VERSION_FORMATTED}" >> $GITHUB_ENV
@@ -86,6 +93,8 @@ jobs:
           echo "CUDA_BINDINGS_ARTIFACTS_DIR=$(realpath "$REPO_DIR/cuda_bindings/dist")" >> $GITHUB_ENV
           echo "SKIP_CUDA_BINDINGS_TEST=${SKIP_CUDA_BINDINGS_TEST}" >> $GITHUB_ENV
           echo "SKIP_CUDA_CORE_CYTHON_TEST=${SKIP_CUDA_CORE_CYTHON_TEST}" >> $GITHUB_ENV
+          echo "COMPUTE_SANITIZER_VERSION=${COMPUTE_SANITIZER_VERSION}" >> $GITHUB_ENV
+          echo "SANITIZER_CMD=${SANITIZER_CMD}" >> $GITHUB_ENV
 
       - name: Install dependencies
         uses: ./.github/actions/install_unix_deps
@@ -202,9 +211,9 @@ jobs:
             if [[ "${{ inputs.host-platform }}" == linux* ]]; then
               bash tests/cython/build_tests.sh
             elif [[ "${{ inputs.host-platform }}" == win* ]]; then
-              # TODO: enable this once win-64 runners are up 
+              # TODO: enable this once win-64 runners are up
               exit 1
-            fi  
+            fi
             pytest -rxXs -v tests/cython
           fi
           popd

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -77,7 +77,7 @@ jobs:
           if [[ "${{ inputs.python-version }}" == "3.12" ]]; then
             COMPUTE_SANITIZER=${CUDA_HOME}/bin/compute-sanitizer
             COMPUTE_SANITIZER_VERSION=$(${COMPUTE_SANITIZER} --version | grep -Eo "[0-9]{4}\.[0-9]\.[0-9]" | sed -e 's/\.//g')
-            SANITIZER_CMD="${COMPUTE_SANITIZER} --target-processes=all --launch-timeout=0 --tool=memcheck"
+            SANITIZER_CMD="${COMPUTE_SANITIZER} --target-processes=all --launch-timeout=0 --tool=memcheck --error-exitcode=1"
             if [[ "$COMPUTE_SANITIZER_VERSION" -ge 202111 ]]; then
                 SANITIZER_CMD="${SANITIZER_CMD} --padding=32"
             fi

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -189,6 +189,7 @@ jobs:
             if [[ "$COMPUTE_SANITIZER_VERSION" -ge 202111 ]]; then
                 SANITIZER_CMD="${SANITIZER_CMD} --padding=32"
             fi
+            echo "CUDA_PYTHON_SANITIZER_RUNNING=1" >> $GITHUB_ENV
           else
             COMPUTE_SANITIZER_VERSION="None"
             SANITIZER_CMD=""

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -75,7 +75,8 @@ jobs:
           fi
 
           if [[ "${{ inputs.python-version }}" == "3.12" && "${{ inputs.local-ctk }}" == 1 ]]; then
-            COMPUTE_SANITIZER=${CUDA_HOME}/bin/compute-sanitizer
+            # Use single quotes to delay expansion of $CUDA_HOME until after mini-CTK step is complete
+            COMPUTE_SANITIZER='${CUDA_HOME}/bin/compute-sanitizer'
             COMPUTE_SANITIZER_VERSION=$(${COMPUTE_SANITIZER} --version | grep -Eo "[0-9]{4}\.[0-9]\.[0-9]" | sed -e 's/\.//g')
             SANITIZER_CMD="${COMPUTE_SANITIZER} --target-processes=all --launch-timeout=0 --tool=memcheck --error-exitcode=1"
             if [[ "$COMPUTE_SANITIZER_VERSION" -ge 202111 ]]; then

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -185,7 +185,7 @@ jobs:
           # We don't test compute-sanitizer on CTK<12 because backporting fixes is too much effort
           # We only test compute-sanitizer on python 3.12 arbitrarily; we don't need to use sanitizer on the entire matrix
           # Only local ctk installs have compute-sanitizer; there is not wheel for it
-          if [[ "${{ inputs.python-version }}" == "3.12" && "${{ inputs.cuda-verion }}" != "11.8.0" && "${{ inputs.local-ctk }}" == 1 ]]; then
+          if [[ "${{ inputs.python-version }}" == "3.12" && "${{ inputs.cuda-version }}" != "11.8.0" && "${{ inputs.local-ctk }}" == 1 ]]; then
             COMPUTE_SANITIZER="${CUDA_HOME}/bin/compute-sanitizer"
             COMPUTE_SANITIZER_VERSION=$(${COMPUTE_SANITIZER} --version | grep -Eo "[0-9]{4}\.[0-9]\.[0-9]" | sed -e 's/\.//g')
             SANITIZER_CMD="${COMPUTE_SANITIZER} --target-processes=all --launch-timeout=0 --tool=memcheck --error-exitcode=1"

--- a/cuda_bindings/docs/source/environment_variables.md
+++ b/cuda_bindings/docs/source/environment_variables.md
@@ -15,4 +15,4 @@
 
 ## Test-Time Environment Variables
 
-- `CUDA_PYTHON_SANITIZER_RUNNING` : When set to 1, tests are skipped that would cause [compute-sanitizer](https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html) to raise an error.
+- `CUDA_PYTHON_TESTING_WITH_COMPUTE_SANITIZER` : When set to 1, tests are skipped that would cause [compute-sanitizer](https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html) to raise an error.

--- a/cuda_bindings/docs/source/environment_variables.md
+++ b/cuda_bindings/docs/source/environment_variables.md
@@ -11,3 +11,8 @@
 ## Runtime Environment Variables
 
 - `CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM` : When set to 1, the default stream is the per-thread default stream. When set to 0, the default stream is the legacy default stream. This defaults to 0, for the legacy default stream. See [Stream Synchronization Behavior](https://docs.nvidia.com/cuda/cuda-runtime-api/stream-sync-behavior.html) for an explanation of the legacy and per-thread default streams.
+
+
+## Test-Time Environment Variables
+
+- `CUDA_PYTHON_SANTIZER_RUNNING` : When set to 1, tests are skipped that would cause [compute-sanitizer](https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html) to raise an error.

--- a/cuda_bindings/docs/source/environment_variables.md
+++ b/cuda_bindings/docs/source/environment_variables.md
@@ -15,4 +15,4 @@
 
 ## Test-Time Environment Variables
 
-- `CUDA_PYTHON_SANTIZER_RUNNING` : When set to 1, tests are skipped that would cause [compute-sanitizer](https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html) to raise an error.
+- `CUDA_PYTHON_SANITIZER_RUNNING` : When set to 1, tests are skipped that would cause [compute-sanitizer](https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html) to raise an error.

--- a/cuda_bindings/tests/conftest.py
+++ b/cuda_bindings/tests/conftest.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-skipif_compute_sanitizer_is_running = pytest.mark.skipif(
-    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
+skipif_testing_with_compute_sanitizer = pytest.mark.skipif(
+    os.environ.get("CUDA_PYTHON_TESTING_WITH_COMPUTE_SANITIZER", "0") == "1",
     reason="The compute-sanitizer is running, and this test causes an API error.",
 )

--- a/cuda_bindings/tests/conftest.py
+++ b/cuda_bindings/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+
+import pytest
+
+skipif_compute_sanitizer_is_running = pytest.mark.skipif(
+    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
+    reason="The compute-sanitizer is running, and this test causes an API error.",
+)

--- a/cuda_bindings/tests/test_cuda.py
+++ b/cuda_bindings/tests/test_cuda.py
@@ -1021,6 +1021,10 @@ def test_cuFuncGetName_failure():
 
 
 @pytest.mark.skipif(
+    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
+    reason="The compute-sanitzer is running, and this test intentionally causes an API error.",
+)
+@pytest.mark.skipif(
     driverVersionLessThan(12080) or not supportsCudaAPI("cuCheckpointProcessGetState"),
     reason="When API was introduced",
 )

--- a/cuda_bindings/tests/test_cuda.py
+++ b/cuda_bindings/tests/test_cuda.py
@@ -86,7 +86,7 @@ def test_cuda_memcpy():
 
 @pytest.mark.skipif(
     os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
-    reason="The compute-sanitzer is running, and this test intentionally causes an API error.",
+    reason="The compute-sanitizer is running, and this test intentionally causes an API error.",
 )
 def test_cuda_array():
     (err,) = cuda.cuInit(0)
@@ -634,7 +634,7 @@ def test_cuda_coredump_attr():
 
 @pytest.mark.skipif(
     os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
-    reason="The compute-sanitzer is running, and this test intentionally causes an API error.",
+    reason="The compute-sanitizer is running, and this test intentionally causes an API error.",
 )
 def test_get_error_name_and_string():
     (err,) = cuda.cuInit(0)
@@ -966,7 +966,7 @@ def test_CUmemDecompressParams_st():
 
 @pytest.mark.skipif(
     os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
-    reason="The compute-sanitzer is running, and this test intentionally causes an API error.",
+    reason="The compute-sanitizer is running, and this test intentionally causes an API error.",
 )
 def test_all_CUresult_codes():
     max_code = int(max(cuda.CUresult))
@@ -1002,7 +1002,7 @@ def test_all_CUresult_codes():
 
 @pytest.mark.skipif(
     os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
-    reason="The compute-sanitzer is running, and this test intentionally causes an API error.",
+    reason="The compute-sanitizer is running, and this test intentionally causes an API error.",
 )
 def test_cuKernelGetName_failure():
     err, name = cuda.cuKernelGetName(0)
@@ -1012,7 +1012,7 @@ def test_cuKernelGetName_failure():
 
 @pytest.mark.skipif(
     os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
-    reason="The compute-sanitzer is running, and this test intentionally causes an API error.",
+    reason="The compute-sanitizer is running, and this test intentionally causes an API error.",
 )
 def test_cuFuncGetName_failure():
     err, name = cuda.cuFuncGetName(0)
@@ -1022,7 +1022,7 @@ def test_cuFuncGetName_failure():
 
 @pytest.mark.skipif(
     os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
-    reason="The compute-sanitzer is running, and this test intentionally causes an API error.",
+    reason="The compute-sanitizer is running, and this test intentionally causes an API error.",
 )
 @pytest.mark.skipif(
     driverVersionLessThan(12080) or not supportsCudaAPI("cuCheckpointProcessGetState"),

--- a/cuda_bindings/tests/test_cuda.py
+++ b/cuda_bindings/tests/test_cuda.py
@@ -5,13 +5,13 @@
 # this software. Any use, reproduction, disclosure, or distribution of
 # this software and related documentation outside the terms of the EULA
 # is strictly prohibited.
-import os
 import platform
 import shutil
 import textwrap
 
 import numpy as np
 import pytest
+from conftest import skipif_compute_sanitizer_is_running
 
 import cuda.cuda as cuda
 import cuda.cudart as cudart
@@ -84,10 +84,7 @@ def test_cuda_memcpy():
     assert err == cuda.CUresult.CUDA_SUCCESS
 
 
-@pytest.mark.skipif(
-    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
-    reason="The compute-sanitizer is running, and this test intentionally causes an API error.",
-)
+@skipif_compute_sanitizer_is_running
 def test_cuda_array():
     (err,) = cuda.cuInit(0)
     assert err == cuda.CUresult.CUDA_SUCCESS
@@ -241,10 +238,7 @@ def test_cuda_uuid_list_access():
     assert err == cuda.CUresult.CUDA_SUCCESS
 
 
-@pytest.mark.skipif(
-    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
-    reason="FIXME: This test causes an API error.",
-)
+@skipif_compute_sanitizer_is_running
 def test_cuda_cuModuleLoadDataEx():
     (err,) = cuda.cuInit(0)
     assert err == cuda.CUresult.CUDA_SUCCESS
@@ -632,10 +626,7 @@ def test_cuda_coredump_attr():
     assert err == cuda.CUresult.CUDA_SUCCESS
 
 
-@pytest.mark.skipif(
-    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
-    reason="The compute-sanitizer is running, and this test intentionally causes an API error.",
-)
+@skipif_compute_sanitizer_is_running
 def test_get_error_name_and_string():
     (err,) = cuda.cuInit(0)
     assert err == cuda.CUresult.CUDA_SUCCESS
@@ -964,10 +955,7 @@ def test_CUmemDecompressParams_st():
     assert int(desc.dstActBytes) == 0
 
 
-@pytest.mark.skipif(
-    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
-    reason="The compute-sanitizer is running, and this test intentionally causes an API error.",
-)
+@skipif_compute_sanitizer_is_running
 def test_all_CUresult_codes():
     max_code = int(max(cuda.CUresult))
     # Smoke test. CUDA_ERROR_UNKNOWN = 999, but intentionally using literal value.
@@ -1000,30 +988,21 @@ def test_all_CUresult_codes():
     assert num_good >= 76  # CTK 11.0.3_450.51.06
 
 
-@pytest.mark.skipif(
-    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
-    reason="The compute-sanitizer is running, and this test intentionally causes an API error.",
-)
+@skipif_compute_sanitizer_is_running
 def test_cuKernelGetName_failure():
     err, name = cuda.cuKernelGetName(0)
     assert err == cuda.CUresult.CUDA_ERROR_INVALID_VALUE
     assert name is None
 
 
-@pytest.mark.skipif(
-    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
-    reason="The compute-sanitizer is running, and this test intentionally causes an API error.",
-)
+@skipif_compute_sanitizer_is_running
 def test_cuFuncGetName_failure():
     err, name = cuda.cuFuncGetName(0)
     assert err == cuda.CUresult.CUDA_ERROR_INVALID_VALUE
     assert name is None
 
 
-@pytest.mark.skipif(
-    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
-    reason="The compute-sanitizer is running, and this test intentionally causes an API error.",
-)
+@skipif_compute_sanitizer_is_running
 @pytest.mark.skipif(
     driverVersionLessThan(12080) or not supportsCudaAPI("cuCheckpointProcessGetState"),
     reason="When API was introduced",

--- a/cuda_bindings/tests/test_cuda.py
+++ b/cuda_bindings/tests/test_cuda.py
@@ -5,6 +5,7 @@
 # this software. Any use, reproduction, disclosure, or distribution of
 # this software and related documentation outside the terms of the EULA
 # is strictly prohibited.
+import os
 import platform
 import shutil
 import textwrap
@@ -83,6 +84,10 @@ def test_cuda_memcpy():
     assert err == cuda.CUresult.CUDA_SUCCESS
 
 
+@pytest.mark.skipif(
+    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
+    reason="The compute-sanitzer is running, and this test intentionally causes an API error.",
+)
 def test_cuda_array():
     (err,) = cuda.cuInit(0)
     assert err == cuda.CUresult.CUDA_SUCCESS
@@ -236,6 +241,10 @@ def test_cuda_uuid_list_access():
     assert err == cuda.CUresult.CUDA_SUCCESS
 
 
+@pytest.mark.skipif(
+    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
+    reason="FIXME: This test causes an API error.",
+)
 def test_cuda_cuModuleLoadDataEx():
     (err,) = cuda.cuInit(0)
     assert err == cuda.CUresult.CUDA_SUCCESS
@@ -251,6 +260,7 @@ def test_cuda_cuModuleLoadDataEx():
         cuda.CUjit_option.CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES,
         cuda.CUjit_option.CU_JIT_LOG_VERBOSE,
     ]
+    # FIXME: This function call raises CUDA_ERROR_INVALID_VALUE
     err, mod = cuda.cuModuleLoadDataEx(0, 0, option_keys, [])
 
     (err,) = cuda.cuCtxDestroy(ctx)
@@ -622,6 +632,10 @@ def test_cuda_coredump_attr():
     assert err == cuda.CUresult.CUDA_SUCCESS
 
 
+@pytest.mark.skipif(
+    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
+    reason="The compute-sanitzer is running, and this test intentionally causes an API error.",
+)
 def test_get_error_name_and_string():
     (err,) = cuda.cuInit(0)
     assert err == cuda.CUresult.CUDA_SUCCESS
@@ -950,6 +964,10 @@ def test_CUmemDecompressParams_st():
     assert int(desc.dstActBytes) == 0
 
 
+@pytest.mark.skipif(
+    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
+    reason="The compute-sanitzer is running, and this test intentionally causes an API error.",
+)
 def test_all_CUresult_codes():
     max_code = int(max(cuda.CUresult))
     # Smoke test. CUDA_ERROR_UNKNOWN = 999, but intentionally using literal value.
@@ -982,12 +1000,20 @@ def test_all_CUresult_codes():
     assert num_good >= 76  # CTK 11.0.3_450.51.06
 
 
+@pytest.mark.skipif(
+    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
+    reason="The compute-sanitzer is running, and this test intentionally causes an API error.",
+)
 def test_cuKernelGetName_failure():
     err, name = cuda.cuKernelGetName(0)
     assert err == cuda.CUresult.CUDA_ERROR_INVALID_VALUE
     assert name is None
 
 
+@pytest.mark.skipif(
+    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
+    reason="The compute-sanitzer is running, and this test intentionally causes an API error.",
+)
 def test_cuFuncGetName_failure():
     err, name = cuda.cuFuncGetName(0)
     assert err == cuda.CUresult.CUDA_ERROR_INVALID_VALUE

--- a/cuda_bindings/tests/test_cuda.py
+++ b/cuda_bindings/tests/test_cuda.py
@@ -11,7 +11,7 @@ import textwrap
 
 import numpy as np
 import pytest
-from conftest import skipif_compute_sanitizer_is_running
+from conftest import skipif_testing_with_compute_sanitizer
 
 import cuda.cuda as cuda
 import cuda.cudart as cudart
@@ -84,7 +84,7 @@ def test_cuda_memcpy():
     assert err == cuda.CUresult.CUDA_SUCCESS
 
 
-@skipif_compute_sanitizer_is_running
+@skipif_testing_with_compute_sanitizer
 def test_cuda_array():
     (err,) = cuda.cuInit(0)
     assert err == cuda.CUresult.CUDA_SUCCESS
@@ -238,7 +238,7 @@ def test_cuda_uuid_list_access():
     assert err == cuda.CUresult.CUDA_SUCCESS
 
 
-@skipif_compute_sanitizer_is_running
+@skipif_testing_with_compute_sanitizer
 def test_cuda_cuModuleLoadDataEx():
     (err,) = cuda.cuInit(0)
     assert err == cuda.CUresult.CUDA_SUCCESS
@@ -626,7 +626,7 @@ def test_cuda_coredump_attr():
     assert err == cuda.CUresult.CUDA_SUCCESS
 
 
-@skipif_compute_sanitizer_is_running
+@skipif_testing_with_compute_sanitizer
 def test_get_error_name_and_string():
     (err,) = cuda.cuInit(0)
     assert err == cuda.CUresult.CUDA_SUCCESS
@@ -956,7 +956,7 @@ def test_CUmemDecompressParams_st():
     assert int(desc.dstActBytes) == 0
 
 
-@skipif_compute_sanitizer_is_running
+@skipif_testing_with_compute_sanitizer
 def test_all_CUresult_codes():
     max_code = int(max(cuda.CUresult))
     # Smoke test. CUDA_ERROR_UNKNOWN = 999, but intentionally using literal value.
@@ -989,21 +989,21 @@ def test_all_CUresult_codes():
     assert num_good >= 76  # CTK 11.0.3_450.51.06
 
 
-@skipif_compute_sanitizer_is_running
+@skipif_testing_with_compute_sanitizer
 def test_cuKernelGetName_failure():
     err, name = cuda.cuKernelGetName(0)
     assert err == cuda.CUresult.CUDA_ERROR_INVALID_VALUE
     assert name is None
 
 
-@skipif_compute_sanitizer_is_running
+@skipif_testing_with_compute_sanitizer
 def test_cuFuncGetName_failure():
     err, name = cuda.cuFuncGetName(0)
     assert err == cuda.CUresult.CUDA_ERROR_INVALID_VALUE
     assert name is None
 
 
-@skipif_compute_sanitizer_is_running
+@skipif_testing_with_compute_sanitizer
 @pytest.mark.skipif(
     driverVersionLessThan(12080) or not supportsCudaAPI("cuCheckpointProcessGetState"),
     reason="When API was introduced",

--- a/cuda_bindings/tests/test_cudart.py
+++ b/cuda_bindings/tests/test_cudart.py
@@ -7,10 +7,10 @@
 # is strictly prohibited.
 import ctypes
 import math
-import os
 
 import numpy as np
 import pytest
+from conftest import skipif_compute_sanitizer_is_running
 
 import cuda.cuda as cuda
 import cuda.cudart as cudart
@@ -71,10 +71,7 @@ def test_cudart_memcpy():
     assertSuccess(err)
 
 
-@pytest.mark.skipif(
-    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
-    reason="The compute-sanitizer is running, and this test intentionally causes an API error.",
-)
+@skipif_compute_sanitizer_is_running
 def test_cudart_hostRegister():
     # Use hostRegister API to check for correct enum return values
     page_size = 80

--- a/cuda_bindings/tests/test_cudart.py
+++ b/cuda_bindings/tests/test_cudart.py
@@ -7,6 +7,7 @@
 # is strictly prohibited.
 import ctypes
 import math
+import os
 
 import numpy as np
 import pytest
@@ -70,6 +71,10 @@ def test_cudart_memcpy():
     assertSuccess(err)
 
 
+@pytest.mark.skipif(
+    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
+    reason="The compute-sanitzer is running, and this test intentionally causes an API error.",
+)
 def test_cudart_hostRegister():
     # Use hostRegister API to check for correct enum return values
     page_size = 80

--- a/cuda_bindings/tests/test_cudart.py
+++ b/cuda_bindings/tests/test_cudart.py
@@ -73,7 +73,7 @@ def test_cudart_memcpy():
 
 @pytest.mark.skipif(
     os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
-    reason="The compute-sanitzer is running, and this test intentionally causes an API error.",
+    reason="The compute-sanitizer is running, and this test intentionally causes an API error.",
 )
 def test_cudart_hostRegister():
     # Use hostRegister API to check for correct enum return values

--- a/cuda_bindings/tests/test_cudart.py
+++ b/cuda_bindings/tests/test_cudart.py
@@ -10,7 +10,7 @@ import math
 
 import numpy as np
 import pytest
-from conftest import skipif_compute_sanitizer_is_running
+from conftest import skipif_testing_with_compute_sanitizer
 
 import cuda.cuda as cuda
 import cuda.cudart as cudart
@@ -71,7 +71,7 @@ def test_cudart_memcpy():
     assertSuccess(err)
 
 
-@skipif_compute_sanitizer_is_running
+@skipif_testing_with_compute_sanitizer
 def test_cudart_hostRegister():
     # Use hostRegister API to check for correct enum return values
     page_size = 80

--- a/cuda_core/tests/conftest.py
+++ b/cuda_core/tests/conftest.py
@@ -64,3 +64,9 @@ def clean_up_cffi_files():
             os.remove(f)
         except FileNotFoundError:
             pass  # noqa: SIM105
+
+
+skipif_compute_sanitizer_is_running = pytest.mark.skipif(
+    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
+    reason="The compute-sanitizer is running, and this test causes an API error.",
+)

--- a/cuda_core/tests/conftest.py
+++ b/cuda_core/tests/conftest.py
@@ -66,7 +66,7 @@ def clean_up_cffi_files():
             pass  # noqa: SIM105
 
 
-skipif_compute_sanitizer_is_running = pytest.mark.skipif(
-    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
+skipif_testing_with_compute_sanitizer = pytest.mark.skipif(
+    os.environ.get("CUDA_PYTHON_TESTING_WITH_COMPUTE_SANITIZER", "0") == "1",
     reason="The compute-sanitizer is running, and this test causes an API error.",
 )

--- a/cuda_core/tests/test_cuda_utils.py
+++ b/cuda_core/tests/test_cuda_utils.py
@@ -44,7 +44,7 @@ def test_runtime_cuda_error_explanations_health():
 @pytest.mark.skipif(
     os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
     reason=(
-        "The compute-sanitzer is running, and this test causes an API error "
+        "The compute-sanitizer is running, and this test causes an API error "
         "when the driver is too old to know about all of the error codes."
     ),
 )

--- a/cuda_core/tests/test_cuda_utils.py
+++ b/cuda_core/tests/test_cuda_utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
+import os
 
 import pytest
 
@@ -40,6 +41,13 @@ def test_runtime_cuda_error_explanations_health():
         assert not extra_expl
 
 
+@pytest.mark.skipif(
+    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
+    reason=(
+        "The compute-sanitzer is running, and this test causes an API error "
+        "when the driver is too old to know about all of the error codes."
+    ),
+)
 def test_check_driver_error():
     num_unexpected = 0
     for error in driver.CUresult:

--- a/cuda_core/tests/test_cuda_utils.py
+++ b/cuda_core/tests/test_cuda_utils.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 import pytest
-from conftest import skipif_compute_sanitizer_is_running
+from conftest import skipif_testing_with_compute_sanitizer
 
 from cuda.bindings import driver, runtime
 from cuda.core.experimental._utils import cuda_utils
@@ -42,7 +42,7 @@ def test_runtime_cuda_error_explanations_health():
 
 
 # this test causes an API error when the driver is too old to know about all of the error codes
-@skipif_compute_sanitizer_is_running
+@skipif_testing_with_compute_sanitizer
 def test_check_driver_error():
     num_unexpected = 0
     for error in driver.CUresult:

--- a/cuda_core/tests/test_cuda_utils.py
+++ b/cuda_core/tests/test_cuda_utils.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
-import os
 
 import pytest
+from conftest import skipif_compute_sanitizer_is_running
 
 from cuda.bindings import driver, runtime
 from cuda.core.experimental._utils import cuda_utils
@@ -41,13 +41,8 @@ def test_runtime_cuda_error_explanations_health():
         assert not extra_expl
 
 
-@pytest.mark.skipif(
-    os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
-    reason=(
-        "The compute-sanitizer is running, and this test causes an API error "
-        "when the driver is too old to know about all of the error codes."
-    ),
-)
+# this test causes an API error when the driver is too old to know about all of the error codes
+@skipif_compute_sanitizer_is_running
 def test_check_driver_error():
     num_unexpected = 0
     for error in driver.CUresult:

--- a/cuda_core/tests/test_event.py
+++ b/cuda_core/tests/test_event.py
@@ -12,6 +12,7 @@ import time
 
 import numpy as np
 import pytest
+from conftest import skipif_compute_sanitizer_is_running
 
 import cuda.core.experimental
 from cuda.core.experimental import Device, EventOptions, LaunchConfig, Program, ProgramOptions, launch
@@ -75,6 +76,7 @@ def test_is_done(init_cuda):
     assert event.is_done in (True, False)
 
 
+@skipif_compute_sanitizer_is_running
 def test_error_timing_disabled():
     device = Device()
     device.set_current()
@@ -97,6 +99,7 @@ def test_error_timing_disabled():
         event2 - event1
 
 
+@skipif_compute_sanitizer_is_running
 def test_error_timing_recorded():
     device = Device()
     device.set_current()

--- a/cuda_core/tests/test_event.py
+++ b/cuda_core/tests/test_event.py
@@ -120,6 +120,7 @@ def test_error_timing_recorded():
 
 
 # TODO: improve this once path finder can find headers
+@skipif_compute_sanitizer_is_running
 @pytest.mark.skipif(os.environ.get("CUDA_PATH") is None, reason="need libcu++ header")
 @pytest.mark.skipif(tuple(int(i) for i in np.__version__.split(".")[:2]) < (2, 1), reason="need numpy 2.1.0+")
 def test_error_timing_incomplete():

--- a/cuda_core/tests/test_event.py
+++ b/cuda_core/tests/test_event.py
@@ -12,7 +12,7 @@ import time
 
 import numpy as np
 import pytest
-from conftest import skipif_compute_sanitizer_is_running
+from conftest import skipif_testing_with_compute_sanitizer
 
 import cuda.core.experimental
 from cuda.core.experimental import Device, EventOptions, LaunchConfig, Program, ProgramOptions, launch
@@ -76,7 +76,7 @@ def test_is_done(init_cuda):
     assert event.is_done in (True, False)
 
 
-@skipif_compute_sanitizer_is_running
+@skipif_testing_with_compute_sanitizer
 def test_error_timing_disabled():
     device = Device()
     device.set_current()
@@ -99,7 +99,7 @@ def test_error_timing_disabled():
         event2 - event1
 
 
-@skipif_compute_sanitizer_is_running
+@skipif_testing_with_compute_sanitizer
 def test_error_timing_recorded():
     device = Device()
     device.set_current()
@@ -120,7 +120,7 @@ def test_error_timing_recorded():
 
 
 # TODO: improve this once path finder can find headers
-@skipif_compute_sanitizer_is_running
+@skipif_testing_with_compute_sanitizer
 @pytest.mark.skipif(os.environ.get("CUDA_PATH") is None, reason="need libcu++ header")
 @pytest.mark.skipif(tuple(int(i) for i in np.__version__.split(".")[:2]) < (2, 1), reason="need numpy 2.1.0+")
 def test_error_timing_incomplete():

--- a/cuda_core/tests/test_event.py
+++ b/cuda_core/tests/test_event.py
@@ -25,7 +25,7 @@ def test_event_init_disabled():
     [
         True,
     ]
-    # The compute-sanitzer is running, and this test intentionally causes an API error.
+    # The compute-sanitizer is running, and this test intentionally causes an API error.
     + ([False, None] if os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") != "1" else []),
 )
 def test_timing(init_cuda, enable_timing):

--- a/cuda_core/tests/test_event.py
+++ b/cuda_core/tests/test_event.py
@@ -20,7 +20,13 @@ def test_event_init_disabled():
         cuda.core.experimental._event.Event()  # Ensure back door is locked.
 
 
-@pytest.mark.parametrize("enable_timing", [True, False, None])
+@pytest.mark.parametrize(
+    "enable_timing",
+    [
+        True,
+    ]
+    + ([False, None] if os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") != "1" else []),
+)
 def test_timing(init_cuda, enable_timing):
     options = EventOptions(enable_timing=enable_timing)
     stream = Device().create_stream()

--- a/cuda_core/tests/test_event.py
+++ b/cuda_core/tests/test_event.py
@@ -25,6 +25,7 @@ def test_event_init_disabled():
     [
         True,
     ]
+    # The compute-sanitzer is running, and this test intentionally causes an API error.
     + ([False, None] if os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") != "1" else []),
 )
 def test_timing(init_cuda, enable_timing):

--- a/cuda_core/tests/test_linker.py
+++ b/cuda_core/tests/test_linker.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 import pytest
-from conftest import skipif_compute_sanitizer_is_running
+from conftest import skipif_testing_with_compute_sanitizer
 
 from cuda.core.experimental import Device, Linker, LinkerOptions, Program, ProgramOptions, _linker
 from cuda.core.experimental._module import ObjectCode
@@ -142,7 +142,7 @@ def test_linker_link_invalid_target_type(compile_ptx_functions):
 
 
 # this test causes an API error when using the culink API
-@skipif_compute_sanitizer_is_running
+@skipif_testing_with_compute_sanitizer
 def test_linker_get_error_log(compile_ptx_functions):
     options = LinkerOptions(arch=ARCH)
 

--- a/cuda_core/tests/test_linker.py
+++ b/cuda_core/tests/test_linker.py
@@ -143,7 +143,7 @@ def test_linker_link_invalid_target_type(compile_ptx_functions):
 
 @pytest.mark.skipif(
     is_culink_backend and os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
-    reason="The compute-sanitzer is running, and this test causes an API error using the culink API.",
+    reason="The compute-sanitizer is running, and this test causes an API error using the culink API.",
 )
 def test_linker_get_error_log(compile_ptx_functions):
     options = LinkerOptions(arch=ARCH)

--- a/cuda_core/tests/test_linker.py
+++ b/cuda_core/tests/test_linker.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
-import os
 
 import pytest
+from conftest import skipif_compute_sanitizer_is_running
 
 from cuda.core.experimental import Device, Linker, LinkerOptions, Program, ProgramOptions, _linker
 from cuda.core.experimental._module import ObjectCode
@@ -141,10 +141,8 @@ def test_linker_link_invalid_target_type(compile_ptx_functions):
         linker.link("invalid_target")
 
 
-@pytest.mark.skipif(
-    is_culink_backend and os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
-    reason="The compute-sanitizer is running, and this test causes an API error using the culink API.",
-)
+# this test causes an API error when using the culink API
+@skipif_compute_sanitizer_is_running
 def test_linker_get_error_log(compile_ptx_functions):
     options = LinkerOptions(arch=ARCH)
 

--- a/cuda_core/tests/test_linker.py
+++ b/cuda_core/tests/test_linker.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
+import os
 
 import pytest
 
@@ -140,6 +141,10 @@ def test_linker_link_invalid_target_type(compile_ptx_functions):
         linker.link("invalid_target")
 
 
+@pytest.mark.skipif(
+    is_culink_backend and os.environ.get("CUDA_PYTHON_SANITIZER_RUNNING", "0") == "1",
+    reason="The compute-sanitzer is running, and this test causes an API error using the culink API.",
+)
 def test_linker_get_error_log(compile_ptx_functions):
     options = LinkerOptions(arch=ARCH)
 


### PR DESCRIPTION
## Description

Runs python 3.12 pytests in the context of [compute-sanitizer](https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html#about-compute-sanitizer) to check for memory issues and errors from the CUDA API. 

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cuda-python/issues/565
closes https://github.com/NVIDIA/cuda-python/issues/562

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

