### PR TITLE
DOC: Add admonition to docstrings for cuda.core handle properties

### DIFF
--- a/cuda_core/cuda/core/experimental/_event.py
+++ b/cuda_core/cuda/core/experimental/_event.py
@@ -168,7 +168,7 @@ class Event:
 
         .. caution::
 
-            This handle is a python object. To get the memory address of the C struct, call
-            ``int(Event.handle)`` not ``Event.handle.getPtr()``.
+            This handle is a Python object. To get the memory address of the underlying C
+            handle, call ``int(Event.handle)``.
         """
         return self._mnff.handle

--- a/cuda_core/cuda/core/experimental/_event.py
+++ b/cuda_core/cuda/core/experimental/_event.py
@@ -164,5 +164,11 @@ class Event:
 
     @property
     def handle(self) -> cuda.bindings.driver.CUevent:
-        """Return the underlying CUevent object."""
+        """Return the underlying CUevent object.
+
+        .. caution::
+
+            This handle is a python object. To get the memory address of the C struct, call
+            ``int(Event.handle)`` not ``Event.handle.getPtr()``.
+        """
         return self._mnff.handle

--- a/cuda_core/cuda/core/experimental/_linker.py
+++ b/cuda_core/cuda/core/experimental/_linker.py
@@ -506,8 +506,8 @@ class Linker:
 
         .. caution::
 
-            This handle is a python object. To get the memory address of the C struct, call
-            ``int(Linker.handle)`` not ``Linker.handle.getPtr()``.
+            This handle is a Python object. To get the memory address of the underlying C
+            handle, call ``int(Linker.handle)``.
         """
         return self._mnff.handle
 

--- a/cuda_core/cuda/core/experimental/_linker.py
+++ b/cuda_core/cuda/core/experimental/_linker.py
@@ -503,6 +503,11 @@ class Linker:
         .. note::
 
            The type of the returned object depends on the backend.
+
+        .. caution::
+
+            This handle is a python object. To get the memory address of the C struct, call
+            ``int(Linker.handle)`` not ``Linker.handle.getPtr()``.
         """
         return self._mnff.handle
 

--- a/cuda_core/cuda/core/experimental/_memory.py
+++ b/cuda_core/cuda/core/experimental/_memory.py
@@ -81,8 +81,14 @@ class Buffer:
         self._mnff.close(stream)
 
     @property
-    def handle(self):
-        """Return the buffer handle object."""
+    def handle(self) -> driver.CUdeviceptr:
+        """Return the buffer handle object.
+
+        .. caution::
+
+            This handle is a python object. To get the memory address of the C struct, call
+            ``int(Buffer.handle)`` not ``Buffer.handle.getPtr()``.
+        """
         return self._mnff.ptr
 
     @property

--- a/cuda_core/cuda/core/experimental/_memory.py
+++ b/cuda_core/cuda/core/experimental/_memory.py
@@ -86,8 +86,8 @@ class Buffer:
 
         .. caution::
 
-            This handle is a python object. To get the memory address of the C struct, call
-            ``int(Buffer.handle)`` not ``Buffer.handle.getPtr()``.
+            This handle is a Python object. To get the memory address of the underlying C
+            handle, call ``int(Buffer.handle)``.
         """
         return self._mnff.ptr
 

--- a/cuda_core/cuda/core/experimental/_memory.py
+++ b/cuda_core/cuda/core/experimental/_memory.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import abc
 import weakref
-from typing import Optional, Tuple, TypeVar
+from typing import Optional, Tuple, TypeVar, Union
 
 from cuda.core.experimental._dlpack import DLDeviceType, make_py_capsule
 from cuda.core.experimental._stream import default_stream
@@ -17,6 +17,9 @@ PyCapsule = TypeVar("PyCapsule")
 
 # TODO: define a memory property mixin class and make Buffer and
 # MemoryResource both inherit from it
+
+DevicePointerT = Union[driver.CUdeviceptr, int, None]
+"""A type union of `Cudeviceptr`, `int` and `None` for hinting Buffer.handle."""
 
 
 class Buffer:
@@ -81,7 +84,7 @@ class Buffer:
         self._mnff.close(stream)
 
     @property
-    def handle(self) -> driver.CUdeviceptr:
+    def handle(self) -> DevicePointerT:
         """Return the buffer handle object.
 
         .. caution::

--- a/cuda_core/cuda/core/experimental/_module.py
+++ b/cuda_core/cuda/core/experimental/_module.py
@@ -358,7 +358,7 @@ class ObjectCode:
 
         .. caution::
 
-            This handle is a python object. To get the memory address of the C struct, call
-            ``int(ObjectCode.handle)`` not ``ObjectCode.handle.getPtr()``.
+            This handle is a Python object. To get the memory address of the underlying C
+            handle, call ``int(ObjectCode.handle)``.
         """
         return self._handle

--- a/cuda_core/cuda/core/experimental/_module.py
+++ b/cuda_core/cuda/core/experimental/_module.py
@@ -354,5 +354,11 @@ class ObjectCode:
     @property
     @precondition(_lazy_load_module)
     def handle(self):
-        """Return the underlying handle object."""
+        """Return the underlying handle object.
+
+        .. caution::
+
+            This handle is a python object. To get the memory address of the C struct, call
+            ``int(ObjectCode.handle)`` not ``ObjectCode.handle.getPtr()``.
+        """
         return self._handle

--- a/cuda_core/cuda/core/experimental/_program.py
+++ b/cuda_core/cuda/core/experimental/_program.py
@@ -527,7 +527,7 @@ class Program:
 
         .. caution::
 
-            This handle is a python object. To get the memory address of the C struct, call
-            ``int(Program.handle)`` not ``Program.handle.getPtr()``.
+            This handle is a Python object. To get the memory address of the underlying C
+            handle, call ``int(Program.handle)``.
         """
         return self._mnff.handle

--- a/cuda_core/cuda/core/experimental/_program.py
+++ b/cuda_core/cuda/core/experimental/_program.py
@@ -524,5 +524,10 @@ class Program:
         .. note::
 
            The type of the returned object depends on the backend.
+
+        .. caution::
+
+            This handle is a python object. To get the memory address of the C struct, call
+            ``int(Program.handle)`` not ``Program.handle.getPtr()``.
         """
         return self._mnff.handle

--- a/cuda_core/cuda/core/experimental/_stream.py
+++ b/cuda_core/cuda/core/experimental/_stream.py
@@ -189,7 +189,13 @@ class Stream:
 
     @property
     def handle(self) -> cuda.bindings.driver.CUstream:
-        """Return the underlying ``CUstream`` object."""
+        """Return the underlying ``CUstream`` object.
+
+        .. caution::
+
+            This handle is a python object. To get the memory address of the C struct, call
+            ``int(Stream.handle)`` not ``Stream.handle.getPtr()``.
+        """
         return self._mnff.handle
 
     @property

--- a/cuda_core/cuda/core/experimental/_stream.py
+++ b/cuda_core/cuda/core/experimental/_stream.py
@@ -193,8 +193,8 @@ class Stream:
 
         .. caution::
 
-            This handle is a python object. To get the memory address of the C struct, call
-            ``int(Stream.handle)`` not ``Stream.handle.getPtr()``.
+            This handle is a Python object. To get the memory address of the underlying C
+            handle, call ``int(Stream.handle)``.
         """
         return self._mnff.handle
 


### PR DESCRIPTION
## Description

Adds caution admonition to documentation for users who are accessing the handle property of cuda.core objects. The alternative was to add a docstring for __int__() for the cuda.bindings python objects. However, these python objects are autogenerated, and I couldn't see where the bindings were generated from. There's just text at the top of all the pyx files that state the bindings are autogenerated and that they should not be manually edited.

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cuda-python/issues/557

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

