### PR TITLE
CI: Always fetch the compute-sanitizer from the CTK 12.8.1

### DIFF
--- a/.github/actions/fetch_ctk/action.yml
+++ b/.github/actions/fetch_ctk/action.yml
@@ -55,7 +55,6 @@ runs:
 
         # The binary archives (redist) are guaranteed to be updated as part of the release posting.
         CTK_BASE_URL="https://developer.download.nvidia.com/compute/cuda/redist/"
-        CTK_JSON_URL="$CTK_BASE_URL/redistrib_${{ inputs.cuda-version }}.json"
         if [[ "${{ inputs.host-platform }}" == linux* ]]; then
           if [[ "${{ inputs.host-platform }}" == "linux-64" ]]; then
             CTK_SUBDIR="linux-x86_64"
@@ -74,13 +73,15 @@ runs:
             rm -rf $_TEMP_DIR_
           }
         fi
+
         function populate_cuda_path() {
           # take the component name as a argument
           function download() {
             curl -kLSs $1 -o $2
           }
-          CTK_COMPONENT=$1
-          CTK_COMPONENT_REL_PATH="$(curl -s $CTK_JSON_URL |
+          local CTK_COMPONENT=$1
+          local CTK_VERSION=$2
+          CTK_COMPONENT_REL_PATH="$(curl -s ${CTK_BASE_URL}/redistrib_${CTK_VERSION}.json |
               python -c "import sys, json; print(json.load(sys.stdin)['${CTK_COMPONENT}']['${CTK_SUBDIR}']['relative_path'])")"
           CTK_COMPONENT_URL="${CTK_BASE_URL}/${CTK_COMPONENT_REL_PATH}"
           CTK_COMPONENT_COMPONENT_FILENAME="$(basename $CTK_COMPONENT_REL_PATH)"
@@ -97,7 +98,13 @@ runs:
         CTK_CACHE_COMPONENTS="${CTK_CACHE_COMPONENTS//,,/,}"
         # Get headers and shared libraries in place
         for item in $(echo $CTK_CACHE_COMPONENTS | tr ',' ' '); do
-            populate_cuda_path "$item"
+            ctk_version="${{ inputs.cuda-version }}"
+            if [[ "$item" == "cuda_sanitizer_api" ]]; then
+              # Always use latest CTK for cuda_sanitizer_api
+              # FIXME: Automatically track latest CTK version
+              ctk_version="12.8.1"
+            fi
+            populate_cuda_path "$item" "$ctk_version"
         done
         ls -l $CUDA_PATH
 

--- a/.github/actions/fetch_ctk/action.yml
+++ b/.github/actions/fetch_ctk/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: "A list of the CTK components to install as a comma-separated list. e.g. 'cuda_nvcc,cuda_nvrtc,cuda_cudart'"
     required: false
     type: string
-    default: "cuda_nvcc,cuda_cudart,cuda_nvrtc,cuda_profiler_api,cuda_cccl,cuda_sanitizer_api,libnvjitlink,libcublas"
+    default: "cuda_nvcc,cuda_cudart,cuda_nvrtc,cuda_profiler_api,cuda_cccl,cuda_sanitizer_api,libnvjitlink"
 
 runs:
   using: composite
@@ -102,7 +102,11 @@ runs:
             if [[ "$item" == "cuda_sanitizer_api" ]]; then
               # Always use latest CTK for cuda_sanitizer_api
               # FIXME: Automatically track latest CTK version
-              ctk_version="12.8.1"
+              CUDA_MAJOR="$(cut -d '.' -f 1 <<< ${{ inputs.cuda-version }})"
+              if [[ "$CUDA_MAJOR" == "12" ]]; then
+                # TODO: Automatically track latest CTK minor version
+                ctk_version="12.8.0"
+              fi
             fi
             populate_cuda_path "$item" "$ctk_version"
         done

--- a/.github/actions/fetch_ctk/action.yml
+++ b/.github/actions/fetch_ctk/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: "A list of the CTK components to install as a comma-separated list. e.g. 'cuda_nvcc,cuda_nvrtc,cuda_cudart'"
     required: false
     type: string
-    default: "cuda_nvcc,cuda_cudart,cuda_nvrtc,cuda_profiler_api,cuda_cccl,cuda_sanitizer_api,libnvjitlink"
+    default: "cuda_nvcc,cuda_cudart,cuda_nvrtc,cuda_profiler_api,cuda_cccl,cuda_sanitizer_api,libnvjitlink,libcublas"
 
 runs:
   using: composite


### PR DESCRIPTION
## Description

We want to always use the latest compute-sanitizer because there could be bug fixes for the compute-sanitizer, and it is OK to use the newest compute-sanitizer on programs running with old CTK versions.

closes #594

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

