### PR TITLE
Implement Kernel.num_arguments, and Kernel.arguments_info

### DIFF
--- a/cuda_core/cuda/core/experimental/_module.py
+++ b/cuda_core/cuda/core/experimental/_module.py
@@ -232,6 +232,8 @@ class Kernel:
                 p_info = Kernel.ParamInfo(offset=result[1], size=result[2])
                 param_info_data.append(p_info)
             arg_pos = arg_pos + 1
+        if result[0] != driver.CUresult.CUDA_ERROR_INVALID_VALUE:
+            handle_return(result)
         return arg_pos, param_info_data
 
     @property

--- a/cuda_core/cuda/core/experimental/_module.py
+++ b/cuda_core/cuda/core/experimental/_module.py
@@ -196,6 +196,7 @@ class Kernel:
     """
 
     __slots__ = ("_handle", "_module", "_attributes")
+    ParamInfo = namedtuple("ParamInfo", ["offset", "size"])
 
     def __new__(self, *args, **kwargs):
         raise RuntimeError("Kernel objects cannot be instantiated directly. Please use ObjectCode APIs.")
@@ -222,15 +223,14 @@ class Kernel:
         if attr_impl._backend_version != "new":
             raise NotImplementedError("New backend is required")
         arg_pos = 0
-        if param_info:
-            ParamInfo = namedtuple("ParamInfo", ["offset", "size"])
         param_info_data = []
         while True:
             result = attr_impl._loader["paraminfo"](self._handle, arg_pos)
             if result[0] != driver.CUresult.CUDA_SUCCESS:
                 break
             if param_info:
-                param_info_data.append(ParamInfo._make(result[1:3]))
+                p_info = Kernel.ParamInfo(offset=result[1], size=result[2])
+                param_info_data.append(p_info)
             arg_pos = arg_pos + 1
         return arg_pos, param_info_data
 

--- a/cuda_core/docs/source/release/0.3.0-notes.rst
+++ b/cuda_core/docs/source/release/0.3.0-notes.rst
@@ -20,6 +20,7 @@ Breaking Changes
 New features
 ------------
 
+- :class:`Kernel` adds :property:`Kernel.num_arguments` and :property:`Kernel.arguments_info` for introspection of kernel arguments. (#612)
 
 New examples
 ------------

--- a/cuda_core/tests/conftest.py
+++ b/cuda_core/tests/conftest.py
@@ -31,29 +31,45 @@ def init_cuda():
     device = Device()
     device.set_current()
     yield
-    _device_unset_current()
+    _ = _device_unset_current()
 
 
-def _device_unset_current():
+def _device_unset_current() -> bool:
+    """Pop current CUDA context.
+
+    Returns True if context was popped, False it the stack was empty.
+    """
     ctx = handle_return(driver.cuCtxGetCurrent())
     if int(ctx) == 0:
         # no active context, do nothing
-        return
+        return False
     handle_return(driver.cuCtxPopCurrent())
     if hasattr(_device._tls, "devices"):
         del _device._tls.devices
+    return True
 
 
 @pytest.fixture(scope="function")
 def deinit_cuda():
     # TODO: rename this to e.g. deinit_context
     yield
-    _device_unset_current()
+    _ = _device_unset_current()
 
 
 @pytest.fixture(scope="function")
-def deinit_context_function():
-    return _device_unset_current
+def deinit_all_contexts_function():
+    def pop_all_contexts():
+        max_iters = 256
+        for _ in range(max_iters):
+            if _device_unset_current():
+                # context was popped, continue until stack is empty
+                continue
+            # no active context, we are ready
+            break
+        else:
+            raise RuntimeError(f"Number of iterations popping current CUDA contexts, exceded {max_iters}")
+
+    return pop_all_contexts
 
 
 # samples relying on cffi could fail as the modules cannot be imported

--- a/cuda_core/tests/conftest.py
+++ b/cuda_core/tests/conftest.py
@@ -51,6 +51,11 @@ def deinit_cuda():
     _device_unset_current()
 
 
+@pytest.fixture(scope="function")
+def deinit_context_function():
+    return _device_unset_current
+
+
 # samples relying on cffi could fail as the modules cannot be imported
 sys.path.append(os.getcwd())
 

--- a/cuda_core/tests/test_module.py
+++ b/cuda_core/tests/test_module.py
@@ -245,7 +245,12 @@ def test_num_args_error_handling(deinit_context_function, cuda12_prerequisite_ch
     )
     krn = mod.get_kernel("foo")
     # Unset current context using function from conftest
-    deinit_context_function()
+    while True:
+        deinit_context_function()
+        ctx = handle_return(driver.cuCtxGetCurrent())
+        if int(ctx) == 0:
+            # no active context, we are ready
+            break
     # with no context, cuKernelGetParamInfo would report
     # exception which we expect to handle by raising
     with pytest.raises(CUDAError):


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #568 

<!-- Provide a standalone description of changes in this PR. -->

This PR implements `Kernel.num_arguments` and `Kernel.argument_info` properties:
  - `Kernel.num_arguments` returns the number of arguments in the kernel instance
  - `Kernel.argument_info` returns a list of tuples `(offset, size)` which describes layout of the struct containing all kernel arguments,

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

