### PR TITLE
Remove nvvm-related `LD_LIBRARY_PATH`, `PATH` manipulations in fetch_ctk action.

### DIFF
--- a/.github/actions/fetch_ctk/action.yml
+++ b/.github/actions/fetch_ctk/action.yml
@@ -151,14 +151,13 @@ runs:
         # mimics actual CTK installation
         if [[ "${{ inputs.host-platform }}" == linux* ]]; then
           CUDA_PATH=$(realpath "./cuda_toolkit")
-          echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:${CUDA_PATH}/lib:${CUDA_PATH}/nvvm/lib64" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:${CUDA_PATH}/lib" >> $GITHUB_ENV
         elif [[ "${{ inputs.host-platform }}" == win* ]]; then
           function normpath() {
             echo "$(echo $(cygpath -w $1) | sed 's/\\/\\\\/g')"
           }
           CUDA_PATH=$(normpath $(realpath "./cuda_toolkit"))
           echo "$(normpath ${CUDA_PATH}/bin)" >> $GITHUB_PATH
-          echo "$(normpath $CUDA_PATH/nvvm/bin)" >> $GITHUB_PATH
         fi
         echo "CUDA_PATH=${CUDA_PATH}" >> $GITHUB_ENV
         echo "CUDA_HOME=${CUDA_PATH}" >> $GITHUB_ENV


### PR DESCRIPTION
## Description
Currently we do not need any `LD_LIBRARY_PATH` or `PATH` manipulations for `nvvm` in any of our testing environments.

Possible explanation (I have NOT verified this): Either `nvvm` is installed via a Python wheel, or `CUDA_HOME` is set.