### PR TITLE
Always build and run Cython tests + other CI improvements 

### DIFF
--- a/.github/actions/doc_preview/action.yml
+++ b/.github/actions/doc_preview/action.yml
@@ -21,7 +21,7 @@ runs:
     # Note: the PR previews will be removed once merged to main (see below) 
     - name: Deploy doc preview
       if: ${{ github.ref_name != 'main' }}
-      uses: JamesIves/github-pages-deploy-action@v4
+      uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8  # v4.7.3
       with:
         git-config-name: cuda-python-bot
         git-config-email: cuda-python-bot@users.noreply.github.com
@@ -31,7 +31,7 @@ runs:
     
     - name: Leave a comment after deployment
       if: ${{ github.ref_name != 'main' }}
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db  # v2.9.2
       with:
         header: pr-preview
         number: ${{ inputs.pr-number }}
@@ -47,7 +47,7 @@ runs:
     # The steps below are executed only when building on main.    
     - name: Remove doc preview
       if: ${{ github.ref_name == 'main' }}
-      uses: JamesIves/github-pages-deploy-action@v4
+      uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8  # v4.7.3
       with:
         git-config-name: cuda-python-bot
         git-config-email: cuda-python-bot@users.noreply.github.com
@@ -57,7 +57,7 @@ runs:
     
     - name: Leave a comment after removal
       if: ${{ github.ref_name == 'main' }}
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db  # v2.9.2
       with:
         header: pr-preview
         number: ${{ inputs.pr-number }}

--- a/.github/actions/fetch_ctk/action.yml
+++ b/.github/actions/fetch_ctk/action.yml
@@ -39,7 +39,7 @@ runs:
 
     - name: Download CTK cache
       id: ctk-get-cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
       continue-on-error: true
       with:
         key: ${{ env.CTK_CACHE_KEY }}
@@ -123,7 +123,7 @@ runs:
     - name: Upload CTK cache
       if: ${{ always() &&
               steps.ctk-get-cache.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
       with:
         key: ${{ env.CTK_CACHE_KEY }}
         path: ./${{ env.CTK_CACHE_FILENAME }}

--- a/.github/actions/get_pr_number/action.yml
+++ b/.github/actions/get_pr_number/action.yml
@@ -29,7 +29,7 @@ runs:
 
     - name: Get PR data (main branch)
       if: ${{ github.ref_name == 'main' }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
       id: get-pr-data
       with:
         script: |

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 version: 2
 updates:
   - package-ecosystem: github-actions

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,7 +23,7 @@ jobs:
          }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Load branch name
         id: get-branch
@@ -32,7 +32,7 @@ jobs:
           echo "OLD_BRANCH=${OLD_BRANCH}" >> $GITHUB_ENV
 
       - name: Create backport pull requests
-        uses: korthout/backport-action@v3
+        uses: korthout/backport-action@436145e922f9561fc5ea157ff406f21af2d6b363  # v3.2.0
         with:
           copy_assignees: true
           copy_labels_pattern: true

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -47,7 +47,7 @@ jobs:
         shell: bash -el {0}
     steps:
       - name: Checkout ${{ github.event.repository.name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
           ref: ${{ inputs.git-tag }}
@@ -56,7 +56,7 @@ jobs:
       # is resolved
 
       - name: Set up miniforge
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830  # v3.1.1
         with:
           activate-environment: cuda-python-docs
           environment-file: ./cuda_python/docs/environment-docs.yml
@@ -103,7 +103,7 @@ jobs:
           echo "CUDA_BINDINGS_ARTIFACTS_DIR=$(realpath "$REPO_DIR/cuda_bindings/dist")" >> $GITHUB_ENV
 
       - name: Download cuda-python build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: cuda-python-wheel
           path: .
@@ -117,14 +117,14 @@ jobs:
 
       - name: Download cuda.bindings build artifacts
         if: ${{ !inputs.is-release }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}
           path: ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}
 
       - name: Download cuda.bindings build artifacts
         if: ${{ inputs.is-release }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           pattern: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}
           merge-multiple: true
@@ -139,14 +139,14 @@ jobs:
 
       - name: Download cuda.core build artifacts
         if: ${{ !inputs.is-release }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: ${{ env.CUDA_CORE_ARTIFACT_NAME }}
           path: ${{ env.CUDA_CORE_ARTIFACTS_DIR }}
 
       - name: Download cuda.core build artifacts
         if: ${{ inputs.is-release }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           pattern: ${{ env.CUDA_CORE_ARTIFACT_NAME }}
           merge-multiple: true
@@ -221,7 +221,7 @@ jobs:
 
       # TODO: Consider removing this step?
       - name: Upload doc artifacts
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
         with:
           path: artifacts/
           retention-days: 3
@@ -236,7 +236,7 @@ jobs:
 
       - name: Deploy doc update
         if: ${{ github.ref_name == 'main' || inputs.is-release }}
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8  # v4.7.3
         with:
           git-config-name: cuda-python-bot
           git-config-email: cuda-python-bot@users.noreply.github.com

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -219,5 +219,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}-tests
-          path: ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}/test_*.${{ env.PY_EXT_SUFFIX }}
+          path: ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}/test_*${{ env.PY_EXT_SUFFIX }}
           if-no-files-found: error

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -48,12 +48,12 @@ jobs:
 
       - name: Set up Python
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
         env:
           # we use self-hosted runners on which setup-python behaves weirdly...
-          AGENT_TOOLSDIRECTORY: "../RUNNER_TEMP"
+          AGENT_TOOLSDIRECTORY: "${{ env.RUNNER_TEMP }}"
 
       - name: Set up MSVC
         if: ${{ startsWith(inputs.host-platform, 'win') }}

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -51,6 +51,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+        env:
+          # we use self-hosted runners on which setup-python behaves weirdly...
+          AGENT_TOOLSDIRECTORY: "/opt/hostedtoolcache"
 
       - name: Set up MSVC
         if: ${{ startsWith(inputs.host-platform, 'win') }}

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -204,9 +204,9 @@ jobs:
         run: |
           pip install $(ls ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl)[test]
           if [[ "${{ inputs.host-platform }}" == linux* ]]; then
-            export CPLUS_INCLUDE_PATH=${CUDA_HOME}/include:${CPLUS_INCLUDE_PATH}
+            export CPLUS_INCLUDE_PATH=${CUDA_HOME}/include
           elif [[ "${{ inputs.host-platform }}" == win* ]]; then
-            export CL="${CL} /I\"${CUDA_HOME}\include\""
+            export CL="/I\"${CUDA_HOME}\include\""
           fi
           cythonize -3 -i ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}/test_*.pyx
 

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Build cuda.bindings Cython tests
         run: |
-          pip install ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl
+          pip install $(ls -l ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl)[test]
           bash ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}/build_tests.sh
 
       - name: Upload cuda.bindings Cython tests

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -76,11 +76,14 @@ jobs:
           echo "CUDA_CORE_ARTIFACT_BASENAME=${CUDA_CORE_ARTIFACT_BASENAME}" >> $GITHUB_ENV
           echo "CUDA_CORE_ARTIFACT_NAME=${CUDA_CORE_ARTIFACT_BASENAME}-${{ github.sha }}" >> $GITHUB_ENV
           echo "CUDA_CORE_ARTIFACTS_DIR=$(realpath "$REPO_DIR/cuda_core/dist")" >> $GITHUB_ENV
+          echo "CUDA_CORE_CYTHON_TESTS_DIR=$(realpath "$REPO_DIR/cuda_core/tests/cython")" >> $GITHUB_ENV
           CUDA_BINDINGS_ARTIFACT_BASENAME="cuda-bindings-python${PYTHON_VERSION_FORMATTED}-cuda${{ inputs.cuda-version }}-${{ inputs.host-platform }}"
           echo "CUDA_BINDINGS_ARTIFACT_BASENAME=${CUDA_BINDINGS_ARTIFACT_BASENAME}" >> $GITHUB_ENV
           echo "CUDA_BINDINGS_ARTIFACT_NAME=${CUDA_BINDINGS_ARTIFACT_BASENAME}-${{ github.sha }}" >> $GITHUB_ENV
           echo "CUDA_BINDINGS_ARTIFACTS_DIR=$(realpath "$REPO_DIR/cuda_bindings/dist")" >> $GITHUB_ENV
+          echo "CUDA_BINDINGS_CYTHON_TESTS_DIR=$(realpath "$REPO_DIR/cuda_bindings/tests/cython")" >> $GITHUB_ENV
           echo "CIBW_BUILD=${CIBW_BUILD}" >> $GITHUB_ENV
+          echo "PY_EXT_SUFFIX=$(python -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")" >> $GITHUB_ENV
       
       - name: Dump environment
         run: |
@@ -163,6 +166,18 @@ jobs:
         with:
           name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}
           path: ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl
+          if-no-files-found: error
+
+      - name: Build cuda.bindings Cython tests
+        run: |
+          pip install ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl
+          bash ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}/build_tests.sh
+
+      - name: Upload cuda.bindings Cython tests
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}-tests
+          path: ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}/test_*.${{ env.PY_EXT_SUFFIX }}
           if-no-files-found: error
 
       # We only need/want a single pure python wheel, pick linux-64 index 0.

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -202,12 +202,12 @@ jobs:
 
       - name: Build cuda.bindings Cython tests
         run: |
-          pip install cython setuptools $(ls ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl)
+          pip install $(ls ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl)[test]
           pushd ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}
           if [[ "${{ inputs.host-platform }}" == linux* ]]; then
             export CPLUS_INCLUDE_PATH=${CUDA_HOME}/include:${Python3_ROOT_DIR}/include/python${{ matrix.python-version }}
           elif [[ "${{ inputs.host-platform }}" == win* ]]; then
-            export CL="/I\"${CUDA_HOME}\include\" /I\"${Python3_ROOT_DIR}\include\python${{ matrix.python-version }}""
+            export CL="/I\"${CUDA_HOME}\include\" /I\"${Python3_ROOT_DIR}\include\python${{ matrix.python-version }}\""
           fi
           cythonize -3 -i test_*.pyx
           popd

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -53,7 +53,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
         env:
           # we use self-hosted runners on which setup-python behaves weirdly...
-          AGENT_TOOLSDIRECTORY: "$(mktemp -d)"
+          # see actions/setup-python#1087
+          AGENT_TOOLSDIRECTORY: "${{ runner.temp }}/SETUP_PYTHON"
 
       - name: Set up MSVC
         if: ${{ startsWith(inputs.host-platform, 'win') }}

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -203,9 +203,9 @@ jobs:
       - name: Set up include paths
         run: |
           if [[ "${{ inputs.host-platform }}" == linux* ]]; then
-            echo "CPLUS_INCLUDE_PATH=${CUDA_HOME}/include:${Python3_ROOT_DIR}/include/python${{ matrix.python-version }}" >> $GITHUB_ENV
+            echo "CPLUS_INCLUDE_PATH=${CUDA_HOME}/include:${Python3_ROOT_DIR}/include/python${{ matrix.python-version }}:$(realpath "cuda_core/cuda/core/experimental/include")" >> $GITHUB_ENV
           elif [[ "${{ inputs.host-platform }}" == win* ]]; then
-            echo "CL=/I\"${CUDA_HOME}\include\" /I\"${Python3_ROOT_DIR}\include\python${{ matrix.python-version }}\"" >> $GITHUB_ENV
+            echo "CL=/I\"${CUDA_HOME}\include\" /I\"${Python3_ROOT_DIR}\include\python${{ matrix.python-version }}\" /I\"$(realpath \"cuda_core/cuda/core/experimental/include\")\"" >> $GITHUB_ENV
           fi
           # For caching
           echo "PY_EXT_SUFFIX=$(python -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")" >> $GITHUB_ENV

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -53,7 +53,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
         env:
           # we use self-hosted runners on which setup-python behaves weirdly...
-          AGENT_TOOLSDIRECTORY: "${{ env.RUNNER_TEMP }}"
+          AGENT_TOOLSDIRECTORY: "$(mktemp -d)"
 
       - name: Set up MSVC
         if: ${{ startsWith(inputs.host-platform, 'win') }}

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -205,7 +205,7 @@ jobs:
           if [[ "${{ inputs.host-platform }}" == linux* ]]; then
             echo "CPLUS_INCLUDE_PATH=${CUDA_HOME}/include:${Python3_ROOT_DIR}/include/python${{ matrix.python-version }}:$(realpath "cuda_core/cuda/core/experimental/include")" >> $GITHUB_ENV
           elif [[ "${{ inputs.host-platform }}" == win* ]]; then
-            echo "CL=/I\"${CUDA_HOME}\include\" /I\"${Python3_ROOT_DIR}\include\python${{ matrix.python-version }}\" /I\"$(realpath \"cuda_core/cuda/core/experimental/include\")\"" >> $GITHUB_ENV
+            echo "CL=/I\"${CUDA_HOME}\include\" /I\"${Python3_ROOT_DIR}\include\python${{ matrix.python-version }}\" /I\"$(realpath cuda_core/cuda/core/experimental/include)\"" >> $GITHUB_ENV
           fi
           # For caching
           echo "PY_EXT_SUFFIX=$(python -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")" >> $GITHUB_ENV

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -46,15 +46,18 @@ jobs:
         # Skip the cache on Windows nodes outside of our org.
         if: ${{ inputs.host-platform != 'win-64' }}
 
+      - name: Set up one env var
+        run: |
+          # we use self-hosted runners on which setup-python behaves weirdly...
+          # see actions/setup-python#1087
+          # this can influence both setup-python and cibuildtools
+          echo "AGENT_TOOLSDIRECTORY=${{ runner.temp }}/SETUP_PYTHON" >> $GITHUB_ENV
+
       - name: Set up Python
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
-        env:
-          # we use self-hosted runners on which setup-python behaves weirdly...
-          # see actions/setup-python#1087
-          AGENT_TOOLSDIRECTORY: "${{ runner.temp }}/SETUP_PYTHON"
 
       - name: Set up MSVC
         if: ${{ startsWith(inputs.host-platform, 'win') }}

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -202,12 +202,12 @@ jobs:
 
       - name: Build cuda.bindings Cython tests
         run: |
-          pip install $(ls ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl)[test]
+          pip install cython setuptools $(ls ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl)
           pushd ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}
           if [[ "${{ inputs.host-platform }}" == linux* ]]; then
-            export CPLUS_INCLUDE_PATH=${CUDA_HOME}/include:${Python3_ROOT_DIR}/include
+            export CPLUS_INCLUDE_PATH=${CUDA_HOME}/include:${Python3_ROOT_DIR}/include/python${{ matrix.python-version }}
           elif [[ "${{ inputs.host-platform }}" == win* ]]; then
-            export CL="/I\"${CUDA_HOME}\include\" /I\"${Python3_ROOT_DIR}\include\""
+            export CL="/I\"${CUDA_HOME}\include\" /I\"${Python3_ROOT_DIR}\include\python${{ matrix.python-version }}""
           fi
           cythonize -3 -i test_*.pyx
           popd

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -46,18 +46,13 @@ jobs:
         # Skip the cache on Windows nodes outside of our org.
         if: ${{ inputs.host-platform != 'win-64' }}
 
-      - name: Set up one env var
-        run: |
-          # we use self-hosted runners on which setup-python behaves weirdly...
-          # see actions/setup-python#1087
-          # this can influence both setup-python and cibuildtools
-          echo "AGENT_TOOLSDIRECTORY=${{ runner.temp }}/SETUP_PYTHON" >> $GITHUB_ENV
-
       - name: Set up Python
-        id: setup-python
+        id: setup-python1
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
-          python-version: ${{ matrix.python-version }}
+          # WAR: setup-python is not relocatable, and cibuildwheel hard-wires to 3.12...
+          # see https://github.com/actions/setup-python/issues/871
+          python-version: "3.12"
 
       - name: Set up MSVC
         if: ${{ startsWith(inputs.host-platform, 'win') }}
@@ -173,18 +168,6 @@ jobs:
           path: ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl
           if-no-files-found: error
 
-      - name: Build cuda.bindings Cython tests
-        run: |
-          pip install $(ls -l ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl)[test]
-          bash ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}/build_tests.sh
-
-      - name: Upload cuda.bindings Cython tests
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}-tests
-          path: ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}/test_*.${{ env.PY_EXT_SUFFIX }}
-          if-no-files-found: error
-
       # We only need/want a single pure python wheel, pick linux-64 index 0.
       - name: Build and check cuda-python wheel
         if: ${{ strategy.job-index == 0 && inputs.host-platform == 'linux-64' }}
@@ -211,4 +194,22 @@ jobs:
         with:
           name: cuda-python-wheel
           path: cuda_python/*.whl
+          if-no-files-found: error
+
+      - name: Set up Python
+        id: setup-python2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Build cuda.bindings Cython tests
+        run: |
+          pip install $(ls -l ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl)[test]
+          bash ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}/build_tests.sh
+
+      - name: Upload cuda.bindings Cython tests
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}-tests
+          path: ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}/test_*.${{ env.PY_EXT_SUFFIX }}
           if-no-files-found: error

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -83,8 +83,6 @@ jobs:
           echo "CUDA_BINDINGS_CYTHON_TESTS_DIR=$(realpath "$REPO_DIR/cuda_bindings/tests/cython")" >> $GITHUB_ENV
           echo "CIBW_BUILD=${CIBW_BUILD}" >> $GITHUB_ENV
 
-          echo "PY_EXT_SUFFIX=$(python -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")" >> $GITHUB_ENV
-
       - name: Dump environment
         run: |
           env
@@ -204,8 +202,11 @@ jobs:
 
       - name: Build cuda.bindings Cython tests
         run: |
-          pip install $(ls -l ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl)[test]
+          pip install $(ls ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl)[test]
           bash ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}/build_tests.sh
+
+          # For caching
+          echo "PY_EXT_SUFFIX=$(python -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")" >> $GITHUB_ENV
 
       - name: Upload cuda.bindings Cython tests
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -36,7 +36,7 @@ jobs:
                  (inputs.host-platform == 'win-64' && 'windows-2019') }}
     steps:
       - name: Checkout ${{ github.event.repository.name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 
@@ -56,7 +56,7 @@ jobs:
 
       - name: Set up MSVC
         if: ${{ startsWith(inputs.host-platform, 'win') }}
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756  # v1.13.0
       
       - name: Set environment variables
         run: |
@@ -113,7 +113,7 @@ jobs:
           twine check ${{ env.CUDA_CORE_ARTIFACTS_DIR }}/*.whl
 
       - name: Upload cuda.core build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: ${{ env.CUDA_CORE_ARTIFACT_NAME }}
           path: ${{ env.CUDA_CORE_ARTIFACTS_DIR }}/*.whl
@@ -160,7 +160,7 @@ jobs:
           twine check ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl
 
       - name: Upload cuda.bindings build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}
           path: ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl
@@ -188,7 +188,7 @@ jobs:
 
       - name: Upload cuda-python build artifacts
         if: ${{ strategy.job-index == 0 && inputs.host-platform == 'linux-64' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: cuda-python-wheel
           path: cuda_python/*.whl
@@ -200,24 +200,40 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Set up include paths
+        run: |
+          if [[ "${{ inputs.host-platform }}" == linux* ]]; then
+            echo "CPLUS_INCLUDE_PATH=${CUDA_HOME}/include:${Python3_ROOT_DIR}/include/python${{ matrix.python-version }}" >> $GITHUB_ENV
+          elif [[ "${{ inputs.host-platform }}" == win* ]]; then
+            echo "CL=/I\"${CUDA_HOME}\include\" /I\"${Python3_ROOT_DIR}\include\python${{ matrix.python-version }}\"" >> $GITHUB_ENV
+          fi
+          # For caching
+          echo "PY_EXT_SUFFIX=$(python -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")" >> $GITHUB_ENV
+
       - name: Build cuda.bindings Cython tests
         run: |
           pip install $(ls ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl)[test]
           pushd ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}
-          if [[ "${{ inputs.host-platform }}" == linux* ]]; then
-            export CPLUS_INCLUDE_PATH=${CUDA_HOME}/include:${Python3_ROOT_DIR}/include/python${{ matrix.python-version }}
-          elif [[ "${{ inputs.host-platform }}" == win* ]]; then
-            export CL="/I\"${CUDA_HOME}\include\" /I\"${Python3_ROOT_DIR}\include\python${{ matrix.python-version }}\""
-          fi
           cythonize -3 -i test_*.pyx
           popd
 
-          # For caching
-          echo "PY_EXT_SUFFIX=$(python -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")" >> $GITHUB_ENV
-
       - name: Upload cuda.bindings Cython tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}-tests
           path: ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}/test_*${{ env.PY_EXT_SUFFIX }}
+          if-no-files-found: error
+
+      - name: Build cuda.core Cython tests
+        run: |
+          pip install $(ls ${{ env.CUDA_CORE_ARTIFACTS_DIR }}/*.whl)[test]
+          pushd ${{ env.CUDA_CORE_CYTHON_TESTS_DIR }}
+          cythonize -3 -i test_*.pyx
+          popd
+
+      - name: Upload cuda.core Cython tests
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: ${{ env.CUDA_CORE_ARTIFACT_NAME }}-tests
+          path: ${{ env.CUDA_CORE_CYTHON_TESTS_DIR }}/test_*${{ env.PY_EXT_SUFFIX }}
           if-no-files-found: error

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -203,7 +203,12 @@ jobs:
       - name: Build cuda.bindings Cython tests
         run: |
           pip install $(ls ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl)[test]
-          bash ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}/build_tests.sh
+          if [[ "${{ inputs.host-platform }}" == linux* ]]; then
+            export CPLUS_INCLUDE_PATH=${CUDA_HOME}/include:${CPLUS_INCLUDE_PATH}
+          elif [[ "${{ inputs.host-platform }}" == win* ]]; then
+            export CL="${CL} /I\"${CUDA_HOME}\include\""
+          fi
+          cythonize -3 -i ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}/test_*.pyx
 
           # For caching
           echo "PY_EXT_SUFFIX=$(python -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")" >> $GITHUB_ENV

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -203,12 +203,14 @@ jobs:
       - name: Build cuda.bindings Cython tests
         run: |
           pip install $(ls ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl)[test]
+          pushd ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}
           if [[ "${{ inputs.host-platform }}" == linux* ]]; then
             export CPLUS_INCLUDE_PATH=${CUDA_HOME}/include
           elif [[ "${{ inputs.host-platform }}" == win* ]]; then
             export CL="/I\"${CUDA_HOME}\include\""
           fi
-          cythonize -3 -i ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}/test_*.pyx
+          cythonize -3 -i test_*.pyx
+          popd
 
           # For caching
           echo "PY_EXT_SUFFIX=$(python -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")" >> $GITHUB_ENV

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -53,7 +53,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
         env:
           # we use self-hosted runners on which setup-python behaves weirdly...
-          AGENT_TOOLSDIRECTORY: "/opt/hostedtoolcache"
+          AGENT_TOOLSDIRECTORY: "../RUNNER_TEMP"
 
       - name: Set up MSVC
         if: ${{ startsWith(inputs.host-platform, 'win') }}
@@ -83,8 +83,9 @@ jobs:
           echo "CUDA_BINDINGS_ARTIFACTS_DIR=$(realpath "$REPO_DIR/cuda_bindings/dist")" >> $GITHUB_ENV
           echo "CUDA_BINDINGS_CYTHON_TESTS_DIR=$(realpath "$REPO_DIR/cuda_bindings/tests/cython")" >> $GITHUB_ENV
           echo "CIBW_BUILD=${CIBW_BUILD}" >> $GITHUB_ENV
+
           echo "PY_EXT_SUFFIX=$(python -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")" >> $GITHUB_ENV
-      
+
       - name: Dump environment
         run: |
           env

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -205,9 +205,9 @@ jobs:
           pip install $(ls ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl)[test]
           pushd ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}
           if [[ "${{ inputs.host-platform }}" == linux* ]]; then
-            export CPLUS_INCLUDE_PATH=${CUDA_HOME}/include
+            export CPLUS_INCLUDE_PATH=${CUDA_HOME}/include:${Python3_ROOT_DIR}/include
           elif [[ "${{ inputs.host-platform }}" == win* ]]; then
-            export CL="/I\"${CUDA_HOME}\include\""
+            export CL="/I\"${CUDA_HOME}\include\" /I\"${Python3_ROOT_DIR}\include\""
           fi
           cythonize -3 -i test_*.pyx
           popd

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -200,12 +200,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Set up include paths
+      - name: Set up Python include paths
         run: |
           if [[ "${{ inputs.host-platform }}" == linux* ]]; then
-            echo "CPLUS_INCLUDE_PATH=${CUDA_HOME}/include:${Python3_ROOT_DIR}/include/python${{ matrix.python-version }}:$(realpath "cuda_core/cuda/core/experimental/include")" >> $GITHUB_ENV
+            echo "CPLUS_INCLUDE_PATH=${Python3_ROOT_DIR}/include/python${{ matrix.python-version }}" >> $GITHUB_ENV
           elif [[ "${{ inputs.host-platform }}" == win* ]]; then
-            echo "CL=/I\"${CUDA_HOME}\include\" /I\"${Python3_ROOT_DIR}\include\python${{ matrix.python-version }}\" /I\"$(cygpath -w $(realpath cuda_core/cuda/core/experimental/include))\"" >> $GITHUB_ENV
+            echo "CL=/I\"${Python3_ROOT_DIR}\include\python${{ matrix.python-version }}\"" >> $GITHUB_ENV
           fi
           # For caching
           echo "PY_EXT_SUFFIX=$(python -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")" >> $GITHUB_ENV
@@ -214,7 +214,7 @@ jobs:
         run: |
           pip install $(ls ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl)[test]
           pushd ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}
-          cythonize -3 -i test_*.pyx
+          bash build_tests.sh
           popd
 
       - name: Upload cuda.bindings Cython tests
@@ -228,7 +228,7 @@ jobs:
         run: |
           pip install $(ls ${{ env.CUDA_CORE_ARTIFACTS_DIR }}/*.whl)[test]
           pushd ${{ env.CUDA_CORE_CYTHON_TESTS_DIR }}
-          cythonize -3 -i test_*.pyx
+          bash build_tests.sh
           popd
 
       - name: Upload cuda.core Cython tests

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -205,7 +205,7 @@ jobs:
           if [[ "${{ inputs.host-platform }}" == linux* ]]; then
             echo "CPLUS_INCLUDE_PATH=${CUDA_HOME}/include:${Python3_ROOT_DIR}/include/python${{ matrix.python-version }}:$(realpath "cuda_core/cuda/core/experimental/include")" >> $GITHUB_ENV
           elif [[ "${{ inputs.host-platform }}" == win* ]]; then
-            echo "CL=/I\"${CUDA_HOME}\include\" /I\"${Python3_ROOT_DIR}\include\python${{ matrix.python-version }}\" /I\"$(realpath cuda_core/cuda/core/experimental/include)\"" >> $GITHUB_ENV
+            echo "CL=/I\"${CUDA_HOME}\include\" /I\"${Python3_ROOT_DIR}\include\python${{ matrix.python-version }}\" /I\"$(cygpath -w $(realpath cuda_core/cuda/core/experimental/include))\"" >> $GITHUB_ENV
           fi
           # For caching
           echo "PY_EXT_SUFFIX=$(python -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")" >> $GITHUB_ENV

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Set up MSVC
         if: ${{ startsWith(inputs.host-platform, 'win') }}
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756  # v1.13.0
+        uses: ilammy/msvc-dev-cmd@v1  # TODO: ask admin to allow pinning commits
       
       - name: Set environment variables
         run: |

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -47,13 +47,10 @@ jobs:
         if: ${{ inputs.host-platform != 'win-64' }}
 
       - name: Set up Python
-        if: ${{ startsWith(inputs.host-platform, 'linux') }}
         id: setup-python
         uses: actions/setup-python@v5
         with:
-          # WAR: setup-python is not relocatable...
-          # see https://github.com/actions/setup-python/issues/871
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Set up MSVC
         if: ${{ startsWith(inputs.host-platform, 'win') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       CUDA_BUILD_VER: ${{ steps.get-vars.outputs.cuda_build_ver }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
       - name: Get CUDA build version
@@ -45,8 +45,7 @@ jobs:
     name: Build ${{ matrix.host-platform }}, CUDA ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
     if: ${{ github.repository_owner == 'nvidia' }}
     secrets: inherit
-    uses:
-      ./.github/workflows/build-wheel.yml
+    uses: ./.github/workflows/build-wheel.yml
     with:
       host-platform: ${{ matrix.host-platform }}
       cuda-version: ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
@@ -66,8 +65,7 @@ jobs:
       - ci-vars
       - build
     secrets: inherit
-    uses:
-      ./.github/workflows/test-wheel-linux.yml
+    uses: ./.github/workflows/test-wheel-linux.yml
     with:
       build-type: pull-request
       host-platform: ${{ matrix.host-platform }}
@@ -87,8 +85,7 @@ jobs:
       - ci-vars
       - build
     secrets: inherit
-    uses:
-      ./.github/workflows/test-wheel-windows.yml
+    uses: ./.github/workflows/test-wheel-windows.yml
     with:
       build-type: pull-request
       host-platform: ${{ matrix.host-platform }}
@@ -106,8 +103,7 @@ jobs:
       - ci-vars
       - build
     secrets: inherit
-    uses:
-      ./.github/workflows/build-docs.yml
+    uses: ./.github/workflows/build-docs.yml
     with:
       build-ctk-ver: ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
 
@@ -121,5 +117,4 @@ jobs:
       - test-windows
       - doc
     secrets: inherit
-    uses:
-      ./.github/workflows/status-check.yml
+    uses: ./.github/workflows/status-check.yml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,16 +28,16 @@ jobs:
           build-mode: none
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@ff0a06e83cb2de871e5a09832bc6a81e7276941f  # v3.28.18
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         queries: security-extended
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@ff0a06e83cb2de871e5a09832bc6a81e7276941f  # v3.28.18
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/release-upload.yml
+++ b/.github/workflows/release-upload.yml
@@ -33,7 +33,7 @@ jobs:
       ARCHIVE_NAME: ${{ github.event.repository.name }}-${{ inputs.git-tag }}
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
           ref: ${{ inputs.git-tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,8 +86,7 @@ jobs:
     needs:
       - check-tag
     secrets: inherit
-    uses:
-      ./.github/workflows/build-docs.yml
+    uses: ./.github/workflows/build-docs.yml
     with:
       build-ctk-ver: ${{ inputs.build-ctk-ver }}
       component: ${{ inputs.component }}
@@ -102,8 +101,7 @@ jobs:
     needs:
       - check-tag
     secrets: inherit
-    uses:
-      ./.github/workflows/release-upload.yml
+    uses: ./.github/workflows/release-upload.yml
     with:
       git-tag: ${{ inputs.git-tag }}
 
@@ -132,11 +130,11 @@ jobs:
 
       - name: Publish package distributions to PyPI
         if: ${{ inputs.wheel-dst == 'pypi' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
 
       - name: Publish package distributions to TestPyPI
         if: ${{ inputs.wheel-dst == 'testpypi' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
         with:
           repository-url: https://test.pypi.org/legacy/
 

--- a/.github/workflows/status-check.yml
+++ b/.github/workflows/status-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: GitHub Checks
-        uses: poseidon/wait-for-status-checks@v0.6.0
+        uses: poseidon/wait-for-status-checks@899c768d191b56eef585c18f8558da19e1f3e707  # v0.6.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           match_pattern: "CI*"

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -264,12 +264,14 @@ jobs:
           ls -lahR $CUDA_BINDINGS_ARTIFACTS_DIR
 
       - name: Download cuda.bindings Cython tests
+        if: ${{ env.SKIP_CUDA_BINDINGS_TEST == '0' }}
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}-tests
           path: ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}
 
       - name: Display structure of downloaded cuda.bindings Cython tests
+        if: ${{ env.SKIP_CUDA_BINDINGS_TEST == '0' }}
         run: |
           pwd
           ls -lahR $CUDA_BINDINGS_CYTHON_TESTS_DIR

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -149,9 +149,9 @@ jobs:
         uses: ./.github/actions/install_unix_deps
         continue-on-error: false
         with:
-          # gcc for Cython tests, jq/wget for artifact fetching
-          dependencies: "build-essential jq wget"
-          dependent_exes: "gcc jq wget"
+          # for artifact fetching
+          dependencies: "jq wget"
+          dependent_exes: "jq wget"
 
       - name: Set environment variables
         run: |
@@ -167,15 +167,15 @@ jobs:
           TEST_CUDA_MAJOR="$(cut -d '.' -f 1 <<< ${{ matrix.CUDA_VER }})"
           if [[ $BUILD_CUDA_MAJOR != $TEST_CUDA_MAJOR ]]; then
             SKIP_CUDA_BINDINGS_TEST=1
-            SKIP_CUDA_CORE_CYTHON_TEST=0
+            SKIP_CYTHON_TEST=1
           else
             SKIP_CUDA_BINDINGS_TEST=0
             BUILD_CUDA_MINOR="$(cut -d '.' -f 2 <<< ${{ inputs.build-ctk-ver }})"
             TEST_CUDA_MINOR="$(cut -d '.' -f 2 <<< ${{ matrix.CUDA_VER }})"
             if [[ $BUILD_CUDA_MINOR != $TEST_CUDA_MINOR ]]; then
-              SKIP_CUDA_CORE_CYTHON_TEST=1
+              SKIP_CYTHON_TEST=1
             else
-              SKIP_CUDA_CORE_CYTHON_TEST=0
+              SKIP_CYTHON_TEST=0
             fi
           fi
 
@@ -204,7 +204,7 @@ jobs:
           echo "CUDA_BINDINGS_CYTHON_TESTS_DIR=$(realpath "$REPO_DIR/cuda_bindings/tests/cython")" >> $GITHUB_ENV
 
           echo "SKIP_CUDA_BINDINGS_TEST=${SKIP_CUDA_BINDINGS_TEST}" >> $GITHUB_ENV
-          echo "SKIP_CUDA_CORE_CYTHON_TEST=${SKIP_CUDA_CORE_CYTHON_TEST}" >> $GITHUB_ENV
+          echo "SKIP_CYTHON_TEST=${SKIP_CYTHON_TEST}" >> $GITHUB_ENV
 
       - name: Download cuda-python build artifacts
         if: ${{ env.SKIP_CUDA_BINDINGS_TEST == '0'}}
@@ -265,14 +265,14 @@ jobs:
           ls -lahR $CUDA_BINDINGS_ARTIFACTS_DIR
 
       - name: Download cuda.bindings Cython tests
-        if: ${{ env.SKIP_CUDA_BINDINGS_TEST == '0' }}
+        if: ${{ env.SKIP_CYTHON_TEST == '0' }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}-tests
           path: ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}
 
       - name: Display structure of downloaded cuda.bindings Cython tests
-        if: ${{ env.SKIP_CUDA_BINDINGS_TEST == '0' }}
+        if: ${{ env.SKIP_CYTHON_TEST == '0' }}
         run: |
           pwd
           ls -lahR $CUDA_BINDINGS_CYTHON_TESTS_DIR
@@ -289,14 +289,14 @@ jobs:
           ls -lahR $CUDA_CORE_ARTIFACTS_DIR
 
       - name: Download cuda.core Cython tests
-        if: ${{ env.SKIP_CUDA_CORE_CYTHON_TEST == '0' }}
+        if: ${{ env.SKIP_CYTHON_TEST == '0' }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: ${{ env.CUDA_CORE_ARTIFACT_NAME }}-tests
           path: ${{ env.CUDA_CORE_CYTHON_TESTS_DIR }}
 
       - name: Display structure of downloaded cuda.core Cython tests
-        if: ${{ env.SKIP_CUDA_CORE_CYTHON_TEST == '0' }}
+        if: ${{ env.SKIP_CYTHON_TEST == '0' }}
         run: |
           pwd
           ls -lahR $CUDA_CORE_CYTHON_TESTS_DIR
@@ -355,7 +355,9 @@ jobs:
 
           pushd ./cuda_bindings
           ${SANITIZER_CMD} pytest -rxXs -v tests/
-          ${SANITIZER_CMD} pytest -rxXs -v tests/cython
+          if [[ "${SKIP_CYTHON_TEST}" == 0 ]]; then
+            ${SANITIZER_CMD} pytest -rxXs -v tests/cython
+          fi
           popd
 
       - name: Run cuda.core tests
@@ -381,7 +383,7 @@ jobs:
 
           # Currently our CI always installs the latest bindings (from either major version).
           # This is not compatible with the test requirements.
-          if [[ "${SKIP_CUDA_CORE_CYTHON_TEST}" == 0 ]]; then
+          if [[ "${SKIP_CYTHON_TEST}" == 0 ]]; then
             ${SANITIZER_CMD} pytest -rxXs -v tests/cython
           fi
           popd

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -200,6 +200,8 @@ jobs:
           echo "CUDA_BINDINGS_ARTIFACT_BASENAME=${CUDA_BINDINGS_ARTIFACT_BASENAME}" >> $GITHUB_ENV
           echo "CUDA_BINDINGS_ARTIFACT_NAME=${CUDA_BINDINGS_ARTIFACT_BASENAME}-${{ github.sha }}" >> $GITHUB_ENV
           echo "CUDA_BINDINGS_ARTIFACTS_DIR=$(realpath "$REPO_DIR/cuda_bindings/dist")" >> $GITHUB_ENV
+          echo "CUDA_BINDINGS_CYTHON_TESTS_DIR=$(realpath "$REPO_DIR/cuda_bindings/tests/cython")" >> $GITHUB_ENV
+
           echo "SKIP_CUDA_BINDINGS_TEST=${SKIP_CUDA_BINDINGS_TEST}" >> $GITHUB_ENV
           echo "SKIP_CUDA_CORE_CYTHON_TEST=${SKIP_CUDA_CORE_CYTHON_TEST}" >> $GITHUB_ENV
 
@@ -260,6 +262,17 @@ jobs:
         run: |
           pwd
           ls -lahR $CUDA_BINDINGS_ARTIFACTS_DIR
+
+      - name: Download cuda.bindings Cython tests
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}-tests
+          path: ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}
+
+      - name: Display structure of downloaded cuda.bindings Cython tests
+        run: |
+          pwd
+          ls -lahR $CUDA_BINDINGS_CYTHON_TESTS_DIR
 
       - name: Download cuda.core build artifacts
         uses: actions/download-artifact@v4
@@ -326,18 +339,7 @@ jobs:
 
           pushd ./cuda_bindings
           ${SANITIZER_CMD} pytest -rxXs -v tests/
-
-          # It is a bit convoluted to run the Cython tests against CTK wheels,
-          # so let's just skip them.
-          if [[ "${{ matrix.LOCAL_CTK }}" == 1 ]]; then
-            if [[ "${{ inputs.host-platform }}" == linux* ]]; then
-              bash tests/cython/build_tests.sh
-            elif [[ "${{ inputs.host-platform }}" == win* ]]; then
-              # TODO: enable this once win-64 runners are up
-              exit 1
-            fi
-            ${SANITIZER_CMD} pytest -rxXs -v tests/cython
-          fi
+          ${SANITIZER_CMD} pytest -rxXs -v tests/cython
           popd
 
       - name: Run cuda.core tests

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -141,7 +141,7 @@ jobs:
         run: nvidia-smi
 
       - name: Checkout ${{ github.event.repository.name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 
@@ -196,6 +196,7 @@ jobs:
           echo "CUDA_CORE_ARTIFACT_BASENAME=${CUDA_CORE_ARTIFACT_BASENAME}" >> $GITHUB_ENV
           echo "CUDA_CORE_ARTIFACT_NAME=${CUDA_CORE_ARTIFACT_BASENAME}-${{ github.sha }}" >> $GITHUB_ENV
           echo "CUDA_CORE_ARTIFACTS_DIR=$(realpath "$REPO_DIR/cuda_core/dist")" >> $GITHUB_ENV
+          echo "CUDA_CORE_CYTHON_TESTS_DIR=$(realpath "$REPO_DIR/cuda_core/tests/cython")" >> $GITHUB_ENV
           CUDA_BINDINGS_ARTIFACT_BASENAME="cuda-bindings-python${PYTHON_VERSION_FORMATTED}-cuda${{ inputs.build-ctk-ver }}-${{ inputs.host-platform }}"
           echo "CUDA_BINDINGS_ARTIFACT_BASENAME=${CUDA_BINDINGS_ARTIFACT_BASENAME}" >> $GITHUB_ENV
           echo "CUDA_BINDINGS_ARTIFACT_NAME=${CUDA_BINDINGS_ARTIFACT_BASENAME}-${{ github.sha }}" >> $GITHUB_ENV
@@ -207,14 +208,14 @@ jobs:
 
       - name: Download cuda-python build artifacts
         if: ${{ env.SKIP_CUDA_BINDINGS_TEST == '0'}}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: cuda-python-wheel
           path: .
 
       - name: Download cuda.bindings build artifacts
         if: ${{ env.SKIP_CUDA_BINDINGS_TEST == '0'}}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}
           path: ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}
@@ -265,7 +266,7 @@ jobs:
 
       - name: Download cuda.bindings Cython tests
         if: ${{ env.SKIP_CUDA_BINDINGS_TEST == '0' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}-tests
           path: ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}
@@ -277,7 +278,7 @@ jobs:
           ls -lahR $CUDA_BINDINGS_CYTHON_TESTS_DIR
 
       - name: Download cuda.core build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: ${{ env.CUDA_CORE_ARTIFACT_NAME }}
           path: ${{ env.CUDA_CORE_ARTIFACTS_DIR }}
@@ -287,8 +288,21 @@ jobs:
           pwd
           ls -lahR $CUDA_CORE_ARTIFACTS_DIR
 
+      - name: Download cuda.core Cython tests
+        if: ${{ env.SKIP_CUDA_CORE_CYTHON_TEST == '0' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: ${{ env.CUDA_CORE_ARTIFACT_NAME }}-tests
+          path: ${{ env.CUDA_CORE_CYTHON_TESTS_DIR }}
+
+      - name: Display structure of downloaded cuda.core Cython tests
+        if: ${{ env.SKIP_CUDA_CORE_CYTHON_TEST == '0' }}
+        run: |
+          pwd
+          ls -lahR $CUDA_CORE_CYTHON_TESTS_DIR
+
       - name: Set up Python ${{ matrix.PY_VER }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.PY_VER }}
         env:
@@ -365,18 +379,9 @@ jobs:
           pushd ./cuda_core
           ${SANITIZER_CMD} pytest -rxXs -v tests/
 
-          # It is a bit convoluted to run the Cython tests against CTK wheels,
-          # so let's just skip them. Also, currently our CI always installs the
-          # latest bindings (from either major version). This is not compatible
-          # with the test requirements.
-          if [[ "${{ matrix.LOCAL_CTK }}" == 1 && "${SKIP_CUDA_CORE_CYTHON_TEST}" == 0 ]]; then
-            pip install cython setuptools  # setuptools needed starting PY312
-            if [[ "${{ inputs.host-platform }}" == linux* ]]; then
-              bash tests/cython/build_tests.sh
-            elif [[ "${{ inputs.host-platform }}" == win* ]]; then
-              # TODO: enable this once win-64 runners are up
-              exit 1
-            fi
+          # Currently our CI always installs the latest bindings (from either major version).
+          # This is not compatible with the test requirements.
+          if [[ "${SKIP_CUDA_CORE_CYTHON_TEST}" == 0 ]]; then
             ${SANITIZER_CMD} pytest -rxXs -v tests/cython
           fi
           popd

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -105,15 +105,15 @@ jobs:
           $TEST_CUDA_MAJOR = '${{ matrix.CUDA_VER }}' -split '\.' | Select-Object -First 1
           if ($BUILD_CUDA_MAJOR -ne $TEST_CUDA_MAJOR) {
             $SKIP_CUDA_BINDINGS_TEST = 1
-            $SKIP_CUDA_CORE_CYTHON_TEST = 0
+            $SKIP_CYTHON_TEST = 1
           } else {
             $SKIP_CUDA_BINDINGS_TEST = 0
             $BUILD_CUDA_MINOR = '${{ inputs.build-ctk-ver }}' -split '\.' | Select-Object -Skip 1 -First 1
             $TEST_CUDA_MINOR = '${{ matrix.CUDA_VER }}' -split '\.' | Select-Object -Skip 1 -First 1
             if ($BUILD_CUDA_MINOR -ne $TEST_CUDA_MINOR) {
-              $SKIP_CUDA_CORE_CYTHON_TEST = 1
+              $SKIP_CYTHON_TEST = 1
             } else {
-              $SKIP_CUDA_CORE_CYTHON_TEST = 0
+              $SKIP_CYTHON_TEST = 0
             }
           }
 
@@ -130,7 +130,7 @@ jobs:
           "CUDA_BINDINGS_ARTIFACTS_DIR=$($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$REPO_DIR\cuda_bindings\dist"))" >> $env:GITHUB_ENV
           "CUDA_BINDINGS_CYTHON_TESTS_DIR=$($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$REPO_DIR\cuda_bindings\tests\cython"))" >> $env:GITHUB_ENV
           "SKIP_CUDA_BINDINGS_TEST=${SKIP_CUDA_BINDINGS_TEST}" >> $env:GITHUB_ENV
-          "SKIP_CUDA_CORE_CYTHON_TEST=${SKIP_CUDA_CORE_CYTHON_TEST}" >> $env:GITHUB_ENV
+          "SKIP_CYTHON_TEST=${SKIP_CYTHON_TEST}" >> $env:GITHUB_ENV
 
       - name: Download cuda-python build artifacts
         if: ${{ env.SKIP_CUDA_BINDINGS_TEST == '0'}}
@@ -145,13 +145,6 @@ jobs:
         with:
           name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}
           path: ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}
-
-      - name: Download cuda.bindings Cython tests
-        if: ${{ env.SKIP_CUDA_BINDINGS_TEST == '0' }}
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
-        with:
-          name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}-tests
-          path: ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}
 
       - name: Install gh cli
         # the GPU runner image does not have gh pre-installed...
@@ -233,8 +226,15 @@ jobs:
           Get-Location
           Get-ChildItem -Recurse -Force $env:CUDA_BINDINGS_ARTIFACTS_DIR | Select-Object Mode, LastWriteTime, Length, FullName
 
+      - name: Download cuda.bindings Cython tests
+        if: ${{ env.SKIP_CYTHON_TEST == '0' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}-tests
+          path: ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}
+
       - name: Display structure of downloaded cuda.bindings Cython tests
-        if: ${{ env.SKIP_CUDA_BINDINGS_TEST == '0' }}
+        if: ${{ env.SKIP_CYTHON_TEST == '0' }}
         run: |
           Get-Location
           Get-ChildItem -Recurse -Force $env:CUDA_BINDINGS_CYTHON_TESTS_DIR | Select-Object Mode, LastWriteTime, Length, FullName
@@ -251,14 +251,14 @@ jobs:
           Get-ChildItem -Recurse -Force $env:CUDA_CORE_ARTIFACTS_DIR | Select-Object Mode, LastWriteTime, Length, FullName
 
       - name: Download cuda.core Cython tests
-        if: ${{ env.SKIP_CUDA_CORE_CYTHON_TEST == '0' }}
+        if: ${{ env.SKIP_CYTHON_TEST == '0' }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: ${{ env.CUDA_CORE_ARTIFACT_NAME }}-tests
           path: ${{ env.CUDA_CORE_CYTHON_TESTS_DIR }}
 
       - name: Display structure of downloaded cuda.core Cython tests
-        if: ${{ env.SKIP_CUDA_CORE_CYTHON_TEST == '0' }}
+        if: ${{ env.SKIP_CYTHON_TEST == '0' }}
         run: |
           Get-Location
           Get-ChildItem -Recurse -Force $env:CUDA_CORE_CYTHON_TESTS_DIR | Select-Object Mode, LastWriteTime, Length, FullName
@@ -291,7 +291,9 @@ jobs:
 
           Push-Location ./cuda_bindings
           pytest -rxXs -v tests/
-          pytest -rxXs -v tests/cython
+          if ($env:SKIP_CYTHON_TEST -eq '0') {
+            pytest -rxXs -v tests/cython
+          }
           Pop-Location
 
       - name: Run cuda.core tests
@@ -314,7 +316,7 @@ jobs:
 
           Push-Location ./cuda_core
           pytest -rxXs -v tests/
-          if ($env:SKIP_CUDA_CORE_CYTHON_TEST -eq '0') {
+          if ($env:SKIP_CYTHON_TEST -eq '0') {
             pytest -rxXs -v tests/cython
           }
           Pop-Location

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -115,12 +115,12 @@ jobs:
           "CUDA_CORE_ARTIFACT_BASENAME=${CUDA_CORE_ARTIFACT_BASENAME}" >> $env:GITHUB_ENV
           "CUDA_CORE_ARTIFACT_NAME=${CUDA_CORE_ARTIFACT_BASENAME}-${{ github.sha }}" >> $env:GITHUB_ENV
           "CUDA_CORE_ARTIFACTS_DIR=$($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$REPO_DIR\cuda_core\dist"))" >> $env:GITHUB_ENV
-          "CUDA_CORE_CYTHON_TESTS_DIR=$($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$REPO_DIR\cuda_core\test\cython"))" >> $env:GITHUB_ENV
+          "CUDA_CORE_CYTHON_TESTS_DIR=$($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$REPO_DIR\cuda_core\tests\cython"))" >> $env:GITHUB_ENV
           $CUDA_BINDINGS_ARTIFACT_BASENAME = "cuda-bindings-python${PYTHON_VERSION_FORMATTED}-cuda${{ inputs.build-ctk-ver }}-${{ inputs.host-platform }}"
           "CUDA_BINDINGS_ARTIFACT_BASENAME=${CUDA_BINDINGS_ARTIFACT_BASENAME}" >> $env:GITHUB_ENV
           "CUDA_BINDINGS_ARTIFACT_NAME=${CUDA_BINDINGS_ARTIFACT_BASENAME}-${{ github.sha }}" >> $env:GITHUB_ENV
           "CUDA_BINDINGS_ARTIFACTS_DIR=$($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$REPO_DIR\cuda_bindings\dist"))" >> $env:GITHUB_ENV
-          "CUDA_BINDINGS_CYTHON_TESTS_DIR=$($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$REPO_DIR\cuda_bindings\test\cython"))" >> $env:GITHUB_ENV
+          "CUDA_BINDINGS_CYTHON_TESTS_DIR=$($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$REPO_DIR\cuda_bindings\tests\cython"))" >> $env:GITHUB_ENV
           "SKIP_CUDA_BINDINGS_TEST=${SKIP_CUDA_BINDINGS_TEST}" >> $env:GITHUB_ENV
 
       - name: Download cuda-python build artifacts
@@ -138,6 +138,7 @@ jobs:
           path: ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}
 
       - name: Download cuda.bindings Cython tests
+        if: ${{ env.SKIP_CUDA_BINDINGS_TEST == '0' }}
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}-tests
@@ -224,6 +225,7 @@ jobs:
           Get-ChildItem -Recurse -Force $env:CUDA_BINDINGS_ARTIFACTS_DIR | Select-Object Mode, LastWriteTime, Length, FullName
 
       - name: Display structure of downloaded cuda.bindings Cython tests
+        if: ${{ env.SKIP_CUDA_BINDINGS_TEST == '0' }}
         run: |
           Get-Location
           Get-ChildItem -Recurse -Force $env:CUDA_BINDINGS_CYTHON_TESTS_DIR | Select-Object Mode, LastWriteTime, Length, FullName

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -115,10 +115,12 @@ jobs:
           "CUDA_CORE_ARTIFACT_BASENAME=${CUDA_CORE_ARTIFACT_BASENAME}" >> $env:GITHUB_ENV
           "CUDA_CORE_ARTIFACT_NAME=${CUDA_CORE_ARTIFACT_BASENAME}-${{ github.sha }}" >> $env:GITHUB_ENV
           "CUDA_CORE_ARTIFACTS_DIR=$($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$REPO_DIR\cuda_core\dist"))" >> $env:GITHUB_ENV
+          "CUDA_CORE_CYTHON_TESTS_DIR=$($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$REPO_DIR\cuda_core\test\cython"))" >> $env:GITHUB_ENV
           $CUDA_BINDINGS_ARTIFACT_BASENAME = "cuda-bindings-python${PYTHON_VERSION_FORMATTED}-cuda${{ inputs.build-ctk-ver }}-${{ inputs.host-platform }}"
           "CUDA_BINDINGS_ARTIFACT_BASENAME=${CUDA_BINDINGS_ARTIFACT_BASENAME}" >> $env:GITHUB_ENV
           "CUDA_BINDINGS_ARTIFACT_NAME=${CUDA_BINDINGS_ARTIFACT_BASENAME}-${{ github.sha }}" >> $env:GITHUB_ENV
           "CUDA_BINDINGS_ARTIFACTS_DIR=$($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$REPO_DIR\cuda_bindings\dist"))" >> $env:GITHUB_ENV
+          "CUDA_BINDINGS_CYTHON_TESTS_DIR=$($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$REPO_DIR\cuda_bindings\test\cython"))" >> $env:GITHUB_ENV
           "SKIP_CUDA_BINDINGS_TEST=${SKIP_CUDA_BINDINGS_TEST}" >> $env:GITHUB_ENV
 
       - name: Download cuda-python build artifacts
@@ -134,6 +136,12 @@ jobs:
         with:
           name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}
           path: ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}
+
+      - name: Download cuda.bindings Cython tests
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}-tests
+          path: ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}
 
       - name: Install gh cli
         # the GPU runner image does not have gh pre-installed...
@@ -215,6 +223,11 @@ jobs:
           Get-Location
           Get-ChildItem -Recurse -Force $env:CUDA_BINDINGS_ARTIFACTS_DIR | Select-Object Mode, LastWriteTime, Length, FullName
 
+      - name: Display structure of downloaded cuda.bindings Cython tests
+        run: |
+          Get-Location
+          Get-ChildItem -Recurse -Force $env:CUDA_BINDINGS_CYTHON_TESTS_DIR | Select-Object Mode, LastWriteTime, Length, FullName
+
       - name: Download cuda.core build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -254,7 +267,7 @@ jobs:
 
           Push-Location ./cuda_bindings
           pytest -rxXs -v tests/
-          # skip Cython tests for now (NVIDIA/cuda-python#466)
+          pytest -rxXs -v tests/cython
           Pop-Location
 
       - name: Run cuda.core tests

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -85,7 +85,7 @@ jobs:
     runs-on: 'cuda-python-windows-gpu-github'
     steps:
       - name: Checkout ${{ github.event.repository.name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 
@@ -105,8 +105,16 @@ jobs:
           $TEST_CUDA_MAJOR = '${{ matrix.CUDA_VER }}' -split '\.' | Select-Object -First 1
           if ($BUILD_CUDA_MAJOR -ne $TEST_CUDA_MAJOR) {
             $SKIP_CUDA_BINDINGS_TEST = 1
+            $SKIP_CUDA_CORE_CYTHON_TEST = 0
           } else {
             $SKIP_CUDA_BINDINGS_TEST = 0
+            $BUILD_CUDA_MINOR = '${{ inputs.build-ctk-ver }}' -split '\.' | Select-Object -Skip 1 -First 1
+            $TEST_CUDA_MINOR = '${{ matrix.CUDA_VER }}' -split '\.' | Select-Object -Skip 1 -First 1
+            if ($BUILD_CUDA_MINOR -ne $TEST_CUDA_MINOR) {
+              $SKIP_CUDA_CORE_CYTHON_TEST = 1
+            } else {
+              $SKIP_CUDA_CORE_CYTHON_TEST = 0
+            }
           }
 
           # Make outputs from the previous job as env vars
@@ -122,24 +130,25 @@ jobs:
           "CUDA_BINDINGS_ARTIFACTS_DIR=$($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$REPO_DIR\cuda_bindings\dist"))" >> $env:GITHUB_ENV
           "CUDA_BINDINGS_CYTHON_TESTS_DIR=$($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$REPO_DIR\cuda_bindings\tests\cython"))" >> $env:GITHUB_ENV
           "SKIP_CUDA_BINDINGS_TEST=${SKIP_CUDA_BINDINGS_TEST}" >> $env:GITHUB_ENV
+          "SKIP_CUDA_CORE_CYTHON_TEST=${SKIP_CUDA_CORE_CYTHON_TEST}" >> $env:GITHUB_ENV
 
       - name: Download cuda-python build artifacts
         if: ${{ env.SKIP_CUDA_BINDINGS_TEST == '0'}}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: cuda-python-wheel
           path: .
 
       - name: Download cuda.bindings build artifacts
         if: ${{ env.SKIP_CUDA_BINDINGS_TEST == '0'}}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}
           path: ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}
 
       - name: Download cuda.bindings Cython tests
         if: ${{ env.SKIP_CUDA_BINDINGS_TEST == '0' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: ${{ env.CUDA_BINDINGS_ARTIFACT_NAME }}-tests
           path: ${{ env.CUDA_BINDINGS_CYTHON_TESTS_DIR }}
@@ -231,7 +240,7 @@ jobs:
           Get-ChildItem -Recurse -Force $env:CUDA_BINDINGS_CYTHON_TESTS_DIR | Select-Object Mode, LastWriteTime, Length, FullName
 
       - name: Download cuda.core build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: ${{ env.CUDA_CORE_ARTIFACT_NAME }}
           path: ${{ env.CUDA_CORE_ARTIFACTS_DIR }}
@@ -241,8 +250,21 @@ jobs:
           Get-Location
           Get-ChildItem -Recurse -Force $env:CUDA_CORE_ARTIFACTS_DIR | Select-Object Mode, LastWriteTime, Length, FullName
 
+      - name: Download cuda.core Cython tests
+        if: ${{ env.SKIP_CUDA_CORE_CYTHON_TEST == '0' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: ${{ env.CUDA_CORE_ARTIFACT_NAME }}-tests
+          path: ${{ env.CUDA_CORE_CYTHON_TESTS_DIR }}
+
+      - name: Display structure of downloaded cuda.core Cython tests
+        if: ${{ env.SKIP_CUDA_CORE_CYTHON_TEST == '0' }}
+        run: |
+          Get-Location
+          Get-ChildItem -Recurse -Force $env:CUDA_CORE_CYTHON_TESTS_DIR | Select-Object Mode, LastWriteTime, Length, FullName
+
       - name: Set up Python ${{ matrix.PY_VER }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.PY_VER }}
 
@@ -292,6 +314,9 @@ jobs:
 
           Push-Location ./cuda_core
           pytest -rxXs -v tests/
+          if ($env:SKIP_CUDA_CORE_CYTHON_TEST -eq '0') {
+            pytest -rxXs -v tests/cython
+          }
           Pop-Location
 
       - name: Ensure cuda-python installable

--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -39,7 +39,7 @@ all = [
 
 test = [
     "cython>=3.0",
-    "setuptools",
+    "setuptools>=77.0.0",
     "numpy>=1.21.1",
     "pytest>=6.2.4",
     "pytest-benchmark>=3.4.1",

--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 [build-system]
-requires = ["setuptools>=77.0.0", "cython>=3.0", "pyclibrary>=0.1.7"]
+requires = ["setuptools>=77.0.0", "cython>=3.0,<3.1.0", "pyclibrary>=0.1.7"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -38,7 +38,7 @@ all = [
 ]
 
 test = [
-    "cython>=3.0",
+    "cython>=3.0,<3.1.0",
     "setuptools>=77.0.0",
     "numpy>=1.21.1",
     "pytest>=6.2.4",

--- a/cuda_bindings/tests/cython/build_tests.sh
+++ b/cuda_bindings/tests/cython/build_tests.sh
@@ -3,4 +3,15 @@
 # Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-CPLUS_INCLUDE_PATH=$CUDA_HOME/include:$CPLUS_INCLUDE_PATH cythonize -3 -i $(dirname "$0")/test_*.pyx
+UNAME=$(uname)
+if [ "$UNAME" == "Linux" ] ; then
+  SCRIPTPATH=$(dirname $(realpath "$0"))
+  export CPLUS_INCLUDE_PATH=$CUDA_HOME/include:$CPLUS_INCLUDE_PATH
+elif [[ "$UNAME" == CYGWIN* || "$UNAME" == MINGW* || "$UNAME" == MSYS* ]] ; then
+  SCRIPTPATH="$(dirname $(cygpath -w $(realpath "$0")))"
+  export CL="/I\"${CUDA_HOME}\\include\" ${CL}"
+else
+  exit 1
+fi
+
+cythonize -3 -i ${SCRIPTPATH}/test_*.pyx

--- a/cuda_core/tests/cython/build_tests.sh
+++ b/cuda_core/tests/cython/build_tests.sh
@@ -3,5 +3,15 @@
 # Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
 # SPDX-License-Identifier: Apache-2.0
 
-SCRIPTPATH=$(dirname $(realpath "$0"))
-CPLUS_INCLUDE_PATH=$SCRIPTPATH/../../cuda/core/experimental/include:$CUDA_HOME/include:$CPLUS_INCLUDE_PATH cythonize -3 -i $(dirname "$0")/test_*.pyx
+UNAME=$(uname)
+if [ "$UNAME" == "Linux" ] ; then
+  SCRIPTPATH=$(dirname $(realpath "$0"))
+  export CPLUS_INCLUDE_PATH=${SCRIPTPATH}/../../cuda/core/experimental/include:$CUDA_HOME/include:$CPLUS_INCLUDE_PATH
+elif [[ "$UNAME" == CYGWIN* || "$UNAME" == MINGW* || "$UNAME" == MSYS* ]] ; then
+  SCRIPTPATH="$(dirname $(cygpath -w $(realpath "$0")))"
+  export CL="/I\"${SCRIPTPATH}/../../cuda_core/cuda/core/experimental/include\" /I\"${CUDA_HOME}\\include\" ${CL}"
+else
+  exit 1
+fi
+
+cythonize -3 -i ${SCRIPTPATH}/test_*.pyx

--- a/cuda_core/tests/cython/build_tests.sh
+++ b/cuda_core/tests/cython/build_tests.sh
@@ -9,7 +9,7 @@ if [ "$UNAME" == "Linux" ] ; then
   export CPLUS_INCLUDE_PATH=${SCRIPTPATH}/../../cuda/core/experimental/include:$CUDA_HOME/include:$CPLUS_INCLUDE_PATH
 elif [[ "$UNAME" == CYGWIN* || "$UNAME" == MINGW* || "$UNAME" == MSYS* ]] ; then
   SCRIPTPATH="$(dirname $(cygpath -w $(realpath "$0")))"
-  export CL="/I\"${SCRIPTPATH}/../../cuda_core/cuda/core/experimental/include\" /I\"${CUDA_HOME}\\include\" ${CL}"
+  export CL="/I\"${SCRIPTPATH}\\..\\..\\cuda_core\\cuda\\core\\experimental\\include\" /I\"${CUDA_HOME}\\include\" ${CL}"
 else
   exit 1
 fi

--- a/cuda_core/tests/cython/build_tests.sh
+++ b/cuda_core/tests/cython/build_tests.sh
@@ -9,7 +9,8 @@ if [ "$UNAME" == "Linux" ] ; then
   export CPLUS_INCLUDE_PATH=${SCRIPTPATH}/../../cuda/core/experimental/include:$CUDA_HOME/include:$CPLUS_INCLUDE_PATH
 elif [[ "$UNAME" == CYGWIN* || "$UNAME" == MINGW* || "$UNAME" == MSYS* ]] ; then
   SCRIPTPATH="$(dirname $(cygpath -w $(realpath "$0")))"
-  export CL="/I\"${SCRIPTPATH}\\..\\..\\cuda_core\\cuda\\core\\experimental\\include\" /I\"${CUDA_HOME}\\include\" ${CL}"
+  CUDA_CORE_INCLUDE_PATH=$(echo "${SCRIPTPATH}\..\..\cuda\core\experimental\include" | sed 's/\\/\\\\/g')
+  export CL="/I\"${CUDA_CORE_INCLUDE_PATH}\" /I\"${CUDA_HOME}\\include\" ${CL}"
 else
   exit 1
 fi


### PR DESCRIPTION
## Description
- close #525
- close #466 
- close #639
- close #644
- tentatively pin at cython<3.1.0 (#642)

Previously, the Cython tests are run on
- Latest CUDA 11.x (11.8.0) and 12.x (12.9.0)
- Linux only 

With this PR, the Cython tests are run on
- Latest CUDA 12.x (12.9.0)
- Linux and Windows

We can no longer run against the previous major version because of the way of building the Cython tests is changed. It is now built against the build-time CTK, which is always the latest major.minor. But I think this is OK, because the same Cython tests are already run in each major version's branch ([example from 11.x](https://github.com/NVIDIA/cuda-python/blob/e290d52b779daff9961c3c18e30633a0052a31ea/.github/workflows/build-and-test.yml#L317)).

There is still one open task relevant to Cython tests (https://github.com/NVIDIA/cuda-python/issues/274#issuecomment-2824637343), but the requirement there is likely incompatible with either the old or new approach here and always needs a separate job/workflow, so I consider it out of scope.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

