### PR TITLE
Make `test_nvjitlink.py` less noisy.

### DIFF
--- a/cuda_bindings/tests/test_nvjitlink.py
+++ b/cuda_bindings/tests/test_nvjitlink.py
@@ -36,19 +36,8 @@ ptx_kernel = """
 }
 """
 
-minimal_ptx_kernel = """
-.func _MinimalKernel()
-{
-    ret;
-}
-"""
-
 ptx_kernel_bytes = [
     (ptx_header(version, arch) + ptx_kernel).encode("utf-8") for version, arch in zip(PTX_VERSIONS, ARCHITECTURES)
-]
-minimal_ptx_kernel_bytes = [
-    (ptx_header(version, arch) + minimal_ptx_kernel).encode("utf-8")
-    for version, arch in zip(PTX_VERSIONS, ARCHITECTURES)
 ]
 
 

--- a/cuda_bindings/tests/test_nvjitlink.py
+++ b/cuda_bindings/tests/test_nvjitlink.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
-#
+# Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 import pytest
@@ -11,15 +10,13 @@ ARCHITECTURES = ["sm_60", "sm_75", "sm_80", "sm_90"]
 PTX_VERSIONS = ["5.0", "6.4", "7.0", "8.5"]
 
 
-def ptx_header(version, arch):
-    return f"""
-.version {version}
-.target {arch}
+PTX_HEADER = """\
+.version {VERSION}
+.target {ARCH}
 .address_size 64
 """
 
-
-ptx_kernel = """
+PTX_KERNEL = """
 .visible .entry _Z6kernelPi(
     .param .u64 _Z6kernelPi_param_0
 )
@@ -36,9 +33,21 @@ ptx_kernel = """
 }
 """
 
-ptx_kernel_bytes = [
-    (ptx_header(version, arch) + ptx_kernel).encode("utf-8") for version, arch in zip(PTX_VERSIONS, ARCHITECTURES)
-]
+
+def _build_arch_ptx_parametrized_callable():
+    av = tuple(zip(ARCHITECTURES, PTX_VERSIONS))
+    return pytest.mark.parametrize(
+        ("arch", "ptx_bytes"),
+        [(a, (PTX_HEADER.format(VERSION=v, ARCH=a) + PTX_KERNEL).encode("utf-8")) for a, v in av],
+        ids=[f"{a}_{v}" for a, v in av],
+    )
+
+
+ARCH_PTX_PARAMETRIZED_CALLABLE = _build_arch_ptx_parametrized_callable()
+
+
+def arch_ptx_parametrized(func):
+    return ARCH_PTX_PARAMETRIZED_CALLABLE(func)
 
 
 def check_nvjitlink_usable():
@@ -97,17 +106,17 @@ def test_complete_empty(option):
     nvjitlink.destroy(handle)
 
 
-@pytest.mark.parametrize("option, ptx_bytes", zip(ARCHITECTURES, ptx_kernel_bytes))
-def test_add_data(option, ptx_bytes):
-    handle = nvjitlink.create(1, [f"-arch={option}"])
+@arch_ptx_parametrized
+def test_add_data(arch, ptx_bytes):
+    handle = nvjitlink.create(1, [f"-arch={arch}"])
     nvjitlink.add_data(handle, nvjitlink.InputType.ANY, ptx_bytes, len(ptx_bytes), "test_data")
     nvjitlink.complete(handle)
     nvjitlink.destroy(handle)
 
 
-@pytest.mark.parametrize("option, ptx_bytes", zip(ARCHITECTURES, ptx_kernel_bytes))
-def test_add_file(option, ptx_bytes, tmp_path):
-    handle = nvjitlink.create(1, [f"-arch={option}"])
+@arch_ptx_parametrized
+def test_add_file(arch, ptx_bytes, tmp_path):
+    handle = nvjitlink.create(1, [f"-arch={arch}"])
     file_path = tmp_path / "test_file.cubin"
     file_path.write_bytes(ptx_bytes)
     nvjitlink.add_file(handle, nvjitlink.InputType.ANY, str(file_path))
@@ -115,9 +124,9 @@ def test_add_file(option, ptx_bytes, tmp_path):
     nvjitlink.destroy(handle)
 
 
-@pytest.mark.parametrize("option", ARCHITECTURES)
-def test_get_error_log(option):
-    handle = nvjitlink.create(1, [f"-arch={option}"])
+@pytest.mark.parametrize("arch", ARCHITECTURES)
+def test_get_error_log(arch):
+    handle = nvjitlink.create(1, [f"-arch={arch}"])
     nvjitlink.complete(handle)
     log_size = nvjitlink.get_error_log_size(handle)
     log = bytearray(log_size)
@@ -126,9 +135,9 @@ def test_get_error_log(option):
     nvjitlink.destroy(handle)
 
 
-@pytest.mark.parametrize("option, ptx_bytes", zip(ARCHITECTURES, ptx_kernel_bytes))
-def test_get_info_log(option, ptx_bytes):
-    handle = nvjitlink.create(1, [f"-arch={option}"])
+@arch_ptx_parametrized
+def test_get_info_log(arch, ptx_bytes):
+    handle = nvjitlink.create(1, [f"-arch={arch}"])
     nvjitlink.add_data(handle, nvjitlink.InputType.ANY, ptx_bytes, len(ptx_bytes), "test_data")
     nvjitlink.complete(handle)
     log_size = nvjitlink.get_info_log_size(handle)
@@ -138,9 +147,9 @@ def test_get_info_log(option, ptx_bytes):
     nvjitlink.destroy(handle)
 
 
-@pytest.mark.parametrize("option, ptx_bytes", zip(ARCHITECTURES, ptx_kernel_bytes))
-def test_get_linked_cubin(option, ptx_bytes):
-    handle = nvjitlink.create(1, [f"-arch={option}"])
+@arch_ptx_parametrized
+def test_get_linked_cubin(arch, ptx_bytes):
+    handle = nvjitlink.create(1, [f"-arch={arch}"])
     nvjitlink.add_data(handle, nvjitlink.InputType.ANY, ptx_bytes, len(ptx_bytes), "test_data")
     nvjitlink.complete(handle)
     cubin_size = nvjitlink.get_linked_cubin_size(handle)
@@ -150,9 +159,9 @@ def test_get_linked_cubin(option, ptx_bytes):
     nvjitlink.destroy(handle)
 
 
-@pytest.mark.parametrize("option", ARCHITECTURES)
-def test_get_linked_ptx(option, get_dummy_ltoir):
-    handle = nvjitlink.create(3, [f"-arch={option}", "-lto", "-ptx"])
+@pytest.mark.parametrize("arch", ARCHITECTURES)
+def test_get_linked_ptx(arch, get_dummy_ltoir):
+    handle = nvjitlink.create(3, [f"-arch={arch}", "-lto", "-ptx"])
     nvjitlink.add_data(handle, nvjitlink.InputType.LTOIR, get_dummy_ltoir, len(get_dummy_ltoir), "test_data")
     nvjitlink.complete(handle)
     ptx_size = nvjitlink.get_linked_ptx_size(handle)


### PR DESCRIPTION
## Description
To minimize distractions while debugging, e.g. when upgrading to newer CTK versions.

Before this PR:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.6.0 -- /home/rgrossekunst/forked/cuda-python/venvs/scratch/bin/python
cachedir: .pytest_cache
benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /home/rgrossekunst/forked/cuda-python/cuda_bindings/tests
configfile: pytest.ini
plugins: benchmark-5.1.0
collecting ... collected 35 items

tests/test_nvjitlink.py::test_unrecognized_option_error PASSED           [  2%]
tests/test_nvjitlink.py::test_invalid_arch_error PASSED                  [  5%]
tests/test_nvjitlink.py::test_create_and_destroy[sm_60] PASSED           [  8%]
tests/test_nvjitlink.py::test_create_and_destroy[sm_75] PASSED           [ 11%]
tests/test_nvjitlink.py::test_create_and_destroy[sm_80] PASSED           [ 14%]
tests/test_nvjitlink.py::test_create_and_destroy[sm_90] PASSED           [ 17%]
tests/test_nvjitlink.py::test_complete_empty[sm_60] PASSED               [ 20%]
tests/test_nvjitlink.py::test_complete_empty[sm_75] PASSED               [ 22%]
tests/test_nvjitlink.py::test_complete_empty[sm_80] PASSED               [ 25%]
tests/test_nvjitlink.py::test_complete_empty[sm_90] PASSED               [ 28%]
tests/test_nvjitlink.py::test_add_data[sm_60-\n.version 5.0\n.target sm_60\n.address_size 64\n\n.visible .entry _Z6kernelPi(\n    .param .u64 _Z6kernelPi_param_0\n)\n{\n    .reg .pred  %p<2>;\n    .reg .b32   %r<3>;\n    .reg .b64   %rd<3>;\n\n    ld.param.u64    %rd1, [_Z6kernelPi_param_0];\n    cvta.to.global.u64  %rd2, %rd1;\n    mov.u32     %r1, %tid.x;\n    st.global.u32   [%rd2+0], %r1;\n    ret;\n}\n] PASSED [ 31%]
tests/test_nvjitlink.py::test_add_data[sm_75-\n.version 6.4\n.target sm_75\n.address_size 64\n\n.visible .entry _Z6kernelPi(\n    .param .u64 _Z6kernelPi_param_0\n)\n{\n    .reg .pred  %p<2>;\n    .reg .b32   %r<3>;\n    .reg .b64   %rd<3>;\n\n    ld.param.u64    %rd1, [_Z6kernelPi_param_0];\n    cvta.to.global.u64  %rd2, %rd1;\n    mov.u32     %r1, %tid.x;\n    st.global.u32   [%rd2+0], %r1;\n    ret;\n}\n] PASSED [ 34%]
tests/test_nvjitlink.py::test_add_data[sm_80-\n.version 7.0\n.target sm_80\n.address_size 64\n\n.visible .entry _Z6kernelPi(\n    .param .u64 _Z6kernelPi_param_0\n)\n{\n    .reg .pred  %p<2>;\n    .reg .b32   %r<3>;\n    .reg .b64   %rd<3>;\n\n    ld.param.u64    %rd1, [_Z6kernelPi_param_0];\n    cvta.to.global.u64  %rd2, %rd1;\n    mov.u32     %r1, %tid.x;\n    st.global.u32   [%rd2+0], %r1;\n    ret;\n}\n] PASSED [ 37%]
tests/test_nvjitlink.py::test_add_data[sm_90-\n.version 8.5\n.target sm_90\n.address_size 64\n\n.visible .entry _Z6kernelPi(\n    .param .u64 _Z6kernelPi_param_0\n)\n{\n    .reg .pred  %p<2>;\n    .reg .b32   %r<3>;\n    .reg .b64   %rd<3>;\n\n    ld.param.u64    %rd1, [_Z6kernelPi_param_0];\n    cvta.to.global.u64  %rd2, %rd1;\n    mov.u32     %r1, %tid.x;\n    st.global.u32   [%rd2+0], %r1;\n    ret;\n}\n] PASSED [ 40%]
tests/test_nvjitlink.py::test_add_file[sm_60-\n.version 5.0\n.target sm_60\n.address_size 64\n\n.visible .entry _Z6kernelPi(\n    .param .u64 _Z6kernelPi_param_0\n)\n{\n    .reg .pred  %p<2>;\n    .reg .b32   %r<3>;\n    .reg .b64   %rd<3>;\n\n    ld.param.u64    %rd1, [_Z6kernelPi_param_0];\n    cvta.to.global.u64  %rd2, %rd1;\n    mov.u32     %r1, %tid.x;\n    st.global.u32   [%rd2+0], %r1;\n    ret;\n}\n] PASSED [ 42%]
tests/test_nvjitlink.py::test_add_file[sm_75-\n.version 6.4\n.target sm_75\n.address_size 64\n\n.visible .entry _Z6kernelPi(\n    .param .u64 _Z6kernelPi_param_0\n)\n{\n    .reg .pred  %p<2>;\n    .reg .b32   %r<3>;\n    .reg .b64   %rd<3>;\n\n    ld.param.u64    %rd1, [_Z6kernelPi_param_0];\n    cvta.to.global.u64  %rd2, %rd1;\n    mov.u32     %r1, %tid.x;\n    st.global.u32   [%rd2+0], %r1;\n    ret;\n}\n] PASSED [ 45%]
tests/test_nvjitlink.py::test_add_file[sm_80-\n.version 7.0\n.target sm_80\n.address_size 64\n\n.visible .entry _Z6kernelPi(\n    .param .u64 _Z6kernelPi_param_0\n)\n{\n    .reg .pred  %p<2>;\n    .reg .b32   %r<3>;\n    .reg .b64   %rd<3>;\n\n    ld.param.u64    %rd1, [_Z6kernelPi_param_0];\n    cvta.to.global.u64  %rd2, %rd1;\n    mov.u32     %r1, %tid.x;\n    st.global.u32   [%rd2+0], %r1;\n    ret;\n}\n] PASSED [ 48%]
tests/test_nvjitlink.py::test_add_file[sm_90-\n.version 8.5\n.target sm_90\n.address_size 64\n\n.visible .entry _Z6kernelPi(\n    .param .u64 _Z6kernelPi_param_0\n)\n{\n    .reg .pred  %p<2>;\n    .reg .b32   %r<3>;\n    .reg .b64   %rd<3>;\n\n    ld.param.u64    %rd1, [_Z6kernelPi_param_0];\n    cvta.to.global.u64  %rd2, %rd1;\n    mov.u32     %r1, %tid.x;\n    st.global.u32   [%rd2+0], %r1;\n    ret;\n}\n] PASSED [ 51%]
tests/test_nvjitlink.py::test_get_error_log[sm_60] PASSED                [ 54%]
tests/test_nvjitlink.py::test_get_error_log[sm_75] PASSED                [ 57%]
tests/test_nvjitlink.py::test_get_error_log[sm_80] PASSED                [ 60%]
tests/test_nvjitlink.py::test_get_error_log[sm_90] PASSED                [ 62%]
tests/test_nvjitlink.py::test_get_info_log[sm_60-\n.version 5.0\n.target sm_60\n.address_size 64\n\n.visible .entry _Z6kernelPi(\n    .param .u64 _Z6kernelPi_param_0\n)\n{\n    .reg .pred  %p<2>;\n    .reg .b32   %r<3>;\n    .reg .b64   %rd<3>;\n\n    ld.param.u64    %rd1, [_Z6kernelPi_param_0];\n    cvta.to.global.u64  %rd2, %rd1;\n    mov.u32     %r1, %tid.x;\n    st.global.u32   [%rd2+0], %r1;\n    ret;\n}\n] PASSED [ 65%]
tests/test_nvjitlink.py::test_get_info_log[sm_75-\n.version 6.4\n.target sm_75\n.address_size 64\n\n.visible .entry _Z6kernelPi(\n    .param .u64 _Z6kernelPi_param_0\n)\n{\n    .reg .pred  %p<2>;\n    .reg .b32   %r<3>;\n    .reg .b64   %rd<3>;\n\n    ld.param.u64    %rd1, [_Z6kernelPi_param_0];\n    cvta.to.global.u64  %rd2, %rd1;\n    mov.u32     %r1, %tid.x;\n    st.global.u32   [%rd2+0], %r1;\n    ret;\n}\n] PASSED [ 68%]
tests/test_nvjitlink.py::test_get_info_log[sm_80-\n.version 7.0\n.target sm_80\n.address_size 64\n\n.visible .entry _Z6kernelPi(\n    .param .u64 _Z6kernelPi_param_0\n)\n{\n    .reg .pred  %p<2>;\n    .reg .b32   %r<3>;\n    .reg .b64   %rd<3>;\n\n    ld.param.u64    %rd1, [_Z6kernelPi_param_0];\n    cvta.to.global.u64  %rd2, %rd1;\n    mov.u32     %r1, %tid.x;\n    st.global.u32   [%rd2+0], %r1;\n    ret;\n}\n] PASSED [ 71%]
tests/test_nvjitlink.py::test_get_info_log[sm_90-\n.version 8.5\n.target sm_90\n.address_size 64\n\n.visible .entry _Z6kernelPi(\n    .param .u64 _Z6kernelPi_param_0\n)\n{\n    .reg .pred  %p<2>;\n    .reg .b32   %r<3>;\n    .reg .b64   %rd<3>;\n\n    ld.param.u64    %rd1, [_Z6kernelPi_param_0];\n    cvta.to.global.u64  %rd2, %rd1;\n    mov.u32     %r1, %tid.x;\n    st.global.u32   [%rd2+0], %r1;\n    ret;\n}\n] PASSED [ 74%]
tests/test_nvjitlink.py::test_get_linked_cubin[sm_60-\n.version 5.0\n.target sm_60\n.address_size 64\n\n.visible .entry _Z6kernelPi(\n    .param .u64 _Z6kernelPi_param_0\n)\n{\n    .reg .pred  %p<2>;\n    .reg .b32   %r<3>;\n    .reg .b64   %rd<3>;\n\n    ld.param.u64    %rd1, [_Z6kernelPi_param_0];\n    cvta.to.global.u64  %rd2, %rd1;\n    mov.u32     %r1, %tid.x;\n    st.global.u32   [%rd2+0], %r1;\n    ret;\n}\n] PASSED [ 77%]
tests/test_nvjitlink.py::test_get_linked_cubin[sm_75-\n.version 6.4\n.target sm_75\n.address_size 64\n\n.visible .entry _Z6kernelPi(\n    .param .u64 _Z6kernelPi_param_0\n)\n{\n    .reg .pred  %p<2>;\n    .reg .b32   %r<3>;\n    .reg .b64   %rd<3>;\n\n    ld.param.u64    %rd1, [_Z6kernelPi_param_0];\n    cvta.to.global.u64  %rd2, %rd1;\n    mov.u32     %r1, %tid.x;\n    st.global.u32   [%rd2+0], %r1;\n    ret;\n}\n] PASSED [ 80%]
tests/test_nvjitlink.py::test_get_linked_cubin[sm_80-\n.version 7.0\n.target sm_80\n.address_size 64\n\n.visible .entry _Z6kernelPi(\n    .param .u64 _Z6kernelPi_param_0\n)\n{\n    .reg .pred  %p<2>;\n    .reg .b32   %r<3>;\n    .reg .b64   %rd<3>;\n\n    ld.param.u64    %rd1, [_Z6kernelPi_param_0];\n    cvta.to.global.u64  %rd2, %rd1;\n    mov.u32     %r1, %tid.x;\n    st.global.u32   [%rd2+0], %r1;\n    ret;\n}\n] PASSED [ 82%]
tests/test_nvjitlink.py::test_get_linked_cubin[sm_90-\n.version 8.5\n.target sm_90\n.address_size 64\n\n.visible .entry _Z6kernelPi(\n    .param .u64 _Z6kernelPi_param_0\n)\n{\n    .reg .pred  %p<2>;\n    .reg .b32   %r<3>;\n    .reg .b64   %rd<3>;\n\n    ld.param.u64    %rd1, [_Z6kernelPi_param_0];\n    cvta.to.global.u64  %rd2, %rd1;\n    mov.u32     %r1, %tid.x;\n    st.global.u32   [%rd2+0], %r1;\n    ret;\n}\n] PASSED [ 85%]
tests/test_nvjitlink.py::test_get_linked_ptx[sm_60] PASSED               [ 88%]
tests/test_nvjitlink.py::test_get_linked_ptx[sm_75] PASSED               [ 91%]
tests/test_nvjitlink.py::test_get_linked_ptx[sm_80] PASSED               [ 94%]
tests/test_nvjitlink.py::test_get_linked_ptx[sm_90] PASSED               [ 97%]
tests/test_nvjitlink.py::test_package_version PASSED                     [100%]

============================== 35 passed in 0.23s ==============================
```

With this PR:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.6.0 -- /home/rgrossekunst/forked/cuda-python/venvs/scratch/bin/python
cachedir: .pytest_cache
benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /home/rgrossekunst/forked/cuda-python/cuda_bindings/tests
configfile: pytest.ini
plugins: benchmark-5.1.0
collecting ... collected 35 items

tests/test_nvjitlink.py::test_unrecognized_option_error PASSED           [  2%]
tests/test_nvjitlink.py::test_invalid_arch_error PASSED                  [  5%]
tests/test_nvjitlink.py::test_create_and_destroy[sm_60] PASSED           [  8%]
tests/test_nvjitlink.py::test_create_and_destroy[sm_75] PASSED           [ 11%]
tests/test_nvjitlink.py::test_create_and_destroy[sm_80] PASSED           [ 14%]
tests/test_nvjitlink.py::test_create_and_destroy[sm_90] PASSED           [ 17%]
tests/test_nvjitlink.py::test_complete_empty[sm_60] PASSED               [ 20%]
tests/test_nvjitlink.py::test_complete_empty[sm_75] PASSED               [ 22%]
tests/test_nvjitlink.py::test_complete_empty[sm_80] PASSED               [ 25%]
tests/test_nvjitlink.py::test_complete_empty[sm_90] PASSED               [ 28%]
tests/test_nvjitlink.py::test_add_data[sm_60_5.0] PASSED                 [ 31%]
tests/test_nvjitlink.py::test_add_data[sm_75_6.4] PASSED                 [ 34%]
tests/test_nvjitlink.py::test_add_data[sm_80_7.0] PASSED                 [ 37%]
tests/test_nvjitlink.py::test_add_data[sm_90_8.5] PASSED                 [ 40%]
tests/test_nvjitlink.py::test_add_file[sm_60_5.0] PASSED                 [ 42%]
tests/test_nvjitlink.py::test_add_file[sm_75_6.4] PASSED                 [ 45%]
tests/test_nvjitlink.py::test_add_file[sm_80_7.0] PASSED                 [ 48%]
tests/test_nvjitlink.py::test_add_file[sm_90_8.5] PASSED                 [ 51%]
tests/test_nvjitlink.py::test_get_error_log[sm_60] PASSED                [ 54%]
tests/test_nvjitlink.py::test_get_error_log[sm_75] PASSED                [ 57%]
tests/test_nvjitlink.py::test_get_error_log[sm_80] PASSED                [ 60%]
tests/test_nvjitlink.py::test_get_error_log[sm_90] PASSED                [ 62%]
tests/test_nvjitlink.py::test_get_info_log[sm_60_5.0] PASSED             [ 65%]
tests/test_nvjitlink.py::test_get_info_log[sm_75_6.4] PASSED             [ 68%]
tests/test_nvjitlink.py::test_get_info_log[sm_80_7.0] PASSED             [ 71%]
tests/test_nvjitlink.py::test_get_info_log[sm_90_8.5] PASSED             [ 74%]
tests/test_nvjitlink.py::test_get_linked_cubin[sm_60_5.0] PASSED         [ 77%]
tests/test_nvjitlink.py::test_get_linked_cubin[sm_75_6.4] PASSED         [ 80%]
tests/test_nvjitlink.py::test_get_linked_cubin[sm_80_7.0] PASSED         [ 82%]
tests/test_nvjitlink.py::test_get_linked_cubin[sm_90_8.5] PASSED         [ 85%]
tests/test_nvjitlink.py::test_get_linked_ptx[sm_60] PASSED               [ 88%]
tests/test_nvjitlink.py::test_get_linked_ptx[sm_75] PASSED               [ 91%]
tests/test_nvjitlink.py::test_get_linked_ptx[sm_80] PASSED               [ 94%]
tests/test_nvjitlink.py::test_get_linked_ptx[sm_90] PASSED               [ 97%]
tests/test_nvjitlink.py::test_package_version PASSED                     [100%]

============================== 35 passed in 0.24s ==============================
```