### PR TITLE
Add tests to cover scalar handling in `launch()` + Fix fp16 bug

### DIFF
--- a/cuda_core/docs/source/release/0.3.0-notes.rst
+++ b/cuda_core/docs/source/release/0.3.0-notes.rst
@@ -30,3 +30,4 @@ Fixes and enhancements
 ----------------------
 
 - An :class:`Event` can now be used to look up its corresponding device and context using the ``.device`` and ``.context`` attributes respectively.
+- The :func:`launch` function's handling of fp16 scalars was incorrect and is fixed

--- a/cuda_core/tests/test_launcher.py
+++ b/cuda_core/tests/test_launcher.py
@@ -104,6 +104,7 @@ if os.environ.get("CUDA_PATH"):
 
 
 @pytest.mark.parametrize("python_type, cpp_type, init_value", PARAMS)
+@pytest.mark.skipif(tuple(int(i) for i in np.__version__.split(".")[:2]) < (2, 1), reason="need numpy 2.1.0+")
 def test_launch_scalar_argument(python_type, cpp_type, init_value):
     dev = Device()
     dev.set_current()

--- a/cuda_core/tests/test_launcher.py
+++ b/cuda_core/tests/test_launcher.py
@@ -69,38 +69,39 @@ def test_launch_invalid_values(init_cuda):
 
 # Parametrize: (python_type, cpp_type, init_value)
 PARAMS = (
-    (bool,         'bool',          True),
-    (float, 'double',   2.718),
-    (np.bool,         'bool',          True),
-    (np.int8,         'signed char',   -42),
-    (np.int16,        'signed short',  -1234),
-    (np.int32,        'signed int',  -123456),
-    (np.int64,        'signed long long',  -123456789),
-    (np.uint8,        'unsigned char',  42),
-    (np.uint16,       'unsigned short', 1234),
-    (np.uint32,       'unsigned int', 123456),
-    (np.uint64,       'unsigned long long', 123456789),
-    (np.float32,      'float',    3.14),
-    (np.float64,      'double',   2.718),
-    (ctypes.c_bool,   'bool',          True),
-    (ctypes.c_int8,   'signed char',   -42),
-    (ctypes.c_int16,  'signed short',  -1234),
-    (ctypes.c_int32,  'signed int',  -123456),
-    (ctypes.c_int64,  'signed long long',  -123456789),
-    (ctypes.c_uint8,  'unsigned char',  42),
-    (ctypes.c_uint16, 'unsigned short', 1234),
-    (ctypes.c_uint32, 'unsigned int', 123456),
-    (ctypes.c_uint64, 'unsigned long long', 123456789),
-    (ctypes.c_float,  'float',    3.14),
-    (ctypes.c_double, 'double',   2.718),
+    (bool, "bool", True),
+    (float, "double", 2.718),
+    (np.bool, "bool", True),
+    (np.int8, "signed char", -42),
+    (np.int16, "signed short", -1234),
+    (np.int32, "signed int", -123456),
+    (np.int64, "signed long long", -123456789),
+    (np.uint8, "unsigned char", 42),
+    (np.uint16, "unsigned short", 1234),
+    (np.uint32, "unsigned int", 123456),
+    (np.uint64, "unsigned long long", 123456789),
+    (np.float32, "float", 3.14),
+    (np.float64, "double", 2.718),
+    (ctypes.c_bool, "bool", True),
+    (ctypes.c_int8, "signed char", -42),
+    (ctypes.c_int16, "signed short", -1234),
+    (ctypes.c_int32, "signed int", -123456),
+    (ctypes.c_int64, "signed long long", -123456789),
+    (ctypes.c_uint8, "unsigned char", 42),
+    (ctypes.c_uint16, "unsigned short", 1234),
+    (ctypes.c_uint32, "unsigned int", 123456),
+    (ctypes.c_uint64, "unsigned long long", 123456789),
+    (ctypes.c_float, "float", 3.14),
+    (ctypes.c_double, "double", 2.718),
 )
 if os.environ.get("CUDA_PATH"):
     PARAMS += (
-        (np.float16,      'half',    0.78),
-        (np.complex64, 'cuda::std::complex<float>', 1+2j),
-        (np.complex128, 'cuda::std::complex<double>', -3-4j),
-        (complex, 'cuda::std::complex<double>',   5-7j),
+        (np.float16, "half", 0.78),
+        (np.complex64, "cuda::std::complex<float>", 1 + 2j),
+        (np.complex128, "cuda::std::complex<double>", -3 - 4j),
+        (complex, "cuda::std::complex<double>", 5 - 7j),
     )
+
 
 @pytest.mark.parametrize("python_type, cpp_type, init_value", PARAMS)
 def test_launch_scalar_argument(python_type, cpp_type, init_value):
@@ -127,13 +128,16 @@ def test_launch_scalar_argument(python_type, cpp_type, init_value):
     # Compile and force instantiation for this type
     arch = "".join(f"{i}" for i in dev.compute_capability)
     if os.environ.get("CUDA_PATH"):
-        include_path=str(pathlib.Path(os.environ["CUDA_PATH"]) / pathlib.Path("include"))
-        code = r"""
+        include_path = str(pathlib.Path(os.environ["CUDA_PATH"]) / pathlib.Path("include"))
+        code = (
+            r"""
         #include <cuda_fp16.h>
         #include <cuda/std/complex>
-        """ + code
+        """
+            + code
+        )
     else:
-        include_path=None
+        include_path = None
     pro_opts = ProgramOptions(std="c++11", arch=f"sm_{arch}", include_path=include_path)
     prog = Program(code, code_type="c++", options=pro_opts)
     ker_name = f"write_scalar<{cpp_type}>"

--- a/cuda_core/tests/test_launcher.py
+++ b/cuda_core/tests/test_launcher.py
@@ -1,9 +1,15 @@
-# Copyright 2024 NVIDIA Corporation.  All rights reserved.
+# Copyright 2024-2025 NVIDIA Corporation.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import ctypes
+import os
+import pathlib
+
+import numpy as np
 import pytest
 
-from cuda.core.experimental import Device, LaunchConfig, Program, launch
+from cuda.core.experimental import Device, LaunchConfig, Program, ProgramOptions, launch
+from cuda.core.experimental._memory import _DefaultPinnedMemorySource
 
 
 def test_launch_config_init(init_cuda):
@@ -59,3 +65,85 @@ def test_launch_invalid_values(init_cuda):
         launch(stream, ker, None)
 
     launch(stream, config, ker)
+
+
+# Parametrize: (python_type, cpp_type, init_value)
+PARAMS = (
+    (bool,         'bool',          True),
+    (float, 'double',   2.718),
+    (np.bool,         'bool',          True),
+    (np.int8,         'signed char',   -42),
+    (np.int16,        'signed short',  -1234),
+    (np.int32,        'signed int',  -123456),
+    (np.int64,        'signed long long',  -123456789),
+    (np.uint8,        'unsigned char',  42),
+    (np.uint16,       'unsigned short', 1234),
+    (np.uint32,       'unsigned int', 123456),
+    (np.uint64,       'unsigned long long', 123456789),
+    (np.float32,      'float',    3.14),
+    (np.float64,      'double',   2.718),
+    (ctypes.c_bool,   'bool',          True),
+    (ctypes.c_int8,   'signed char',   -42),
+    (ctypes.c_int16,  'signed short',  -1234),
+    (ctypes.c_int32,  'signed int',  -123456),
+    (ctypes.c_int64,  'signed long long',  -123456789),
+    (ctypes.c_uint8,  'unsigned char',  42),
+    (ctypes.c_uint16, 'unsigned short', 1234),
+    (ctypes.c_uint32, 'unsigned int', 123456),
+    (ctypes.c_uint64, 'unsigned long long', 123456789),
+    (ctypes.c_float,  'float',    3.14),
+    (ctypes.c_double, 'double',   2.718),
+)
+if os.environ.get("CUDA_PATH"):
+    PARAMS += (
+        (np.float16,      'half',    0.78),
+        (np.complex64, 'cuda::std::complex<float>', 1+2j),
+        (np.complex128, 'cuda::std::complex<double>', -3-4j),
+        (complex, 'cuda::std::complex<double>',   5-7j),
+    )
+
+@pytest.mark.parametrize("python_type, cpp_type, init_value", PARAMS)
+def test_launch_scalar_argument(python_type, cpp_type, init_value):
+    dev = Device()
+    dev.set_current()
+
+    # Prepare pinned host array
+    mr = _DefaultPinnedMemorySource()
+    b = mr.allocate(np.dtype(python_type).itemsize)
+    arr = np.from_dlpack(b).view(python_type)
+    arr[:] = 0
+
+    # Prepare scalar argument in Python
+    scalar = python_type(init_value)
+
+    # CUDA kernel templated on type T
+    code = r"""
+    template <typename T>
+    __global__ void write_scalar(T* arr, T val) {
+        arr[0] = val;
+    }
+    """
+
+    # Compile and force instantiation for this type
+    arch = "".join(f"{i}" for i in dev.compute_capability)
+    if os.environ.get("CUDA_PATH"):
+        include_path=str(pathlib.Path(os.environ["CUDA_PATH"]) / pathlib.Path("include"))
+        code = r"""
+        #include <cuda_fp16.h>
+        #include <cuda/std/complex>
+        """ + code
+    else:
+        include_path=None
+    pro_opts = ProgramOptions(std="c++11", arch=f"sm_{arch}", include_path=include_path)
+    prog = Program(code, code_type="c++", options=pro_opts)
+    ker_name = f"write_scalar<{cpp_type}>"
+    mod = prog.compile("cubin", name_expressions=(ker_name,))
+    ker = mod.get_kernel(ker_name)
+
+    # Launch with 1 thread
+    config = LaunchConfig(grid=1, block=1)
+    launch(dev.default_stream, config, ker, arr.ctypes.data, scalar)
+    dev.default_stream.sync()
+
+    # Check result
+    assert arr[0] == init_value, f"Expected {init_value}, got {arr[0]}"


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #260.

The test coverage revealed a bug in the fp16 scalar handling. The existing handling is obviously wrong and it's me to blame, but I honestly can't recall why I believed the code was correct 😞 

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

