### PR TITLE
[DONT MERGE] Make stream creation faster

### DIFF
--- a/cuda_core/cuda/core/experimental/_utils/_error_utils.pxd
+++ b/cuda_core/cuda/core/experimental/_utils/_error_utils.pxd
@@ -1,0 +1,5 @@
+from cuda.bindings cimport cydriver as driver
+from cuda.bindings cimport cyruntime as runtime
+
+cpdef _check_driver_error(driver.CUresult result)
+cpdef _check_runtime_error(runtime.cudaError_t error)

--- a/cuda_core/cuda/core/experimental/_utils/_error_utils.pyx
+++ b/cuda_core/cuda/core/experimental/_utils/_error_utils.pyx
@@ -1,0 +1,56 @@
+from cython cimport NULL
+from libc.string cimport strlen 
+
+import cuda.bindings
+from cuda.bindings import driver, runtime
+
+from cuda.bindings cimport cydriver as cdriver
+from cuda.bindings cimport cyruntime as cruntime
+
+from cuda.core.experimental._utils.driver_cu_result_explanations import DRIVER_CU_RESULT_EXPLANATIONS
+from cuda.core.experimental._utils.runtime_cuda_error_explanations import RUNTIME_CUDA_ERROR_EXPLANATIONS
+
+
+class CUDAError(Exception):
+    pass
+
+
+
+cpdef _check_driver_error(cdriver.CUresult error):
+    if error == cdriver.CUresult.CUDA_SUCCESS:
+        return
+    cdef const char *c_name = NULL
+    name_err = driver.cuGetErrorName(error, &c_name)
+    if name_err != driver.CUresult.CUDA_SUCCESS:
+        raise CUDAError(f"UNEXPECTED ERROR CODE: {error}")
+    name: str = (<char *>c_name)[:strlen(c_name)].decode()
+    #name = name.decode()
+    expl = DRIVER_CU_RESULT_EXPLANATIONS.get(int(error))
+    if expl is not None:
+        raise CUDAError(f"{name}: {expl}")
+    cdef const char *c_desc = NULL
+    desc_err = driver.cuGetErrorString(error, &c_desc)
+    if desc_err != driver.CUresult.CUDA_SUCCESS:
+        raise CUDAError(f"{name}")
+    desc: str = (<char *>c_desc)[:strlen(c_desc)].decode()
+    #desc = desc.decode()
+    raise CUDAError(f"{name}: {desc}")
+
+
+cpdef _check_runtime_error(cruntime.cudaError_t error):
+    if error == cruntime.cudaError_t.cudaSuccess:
+        return
+    name_err, name = runtime.cudaGetErrorName(error)
+    if name_err != runtime.cudaError_t.cudaSuccess:
+        raise CUDAError(f"UNEXPECTED ERROR CODE: {error}")
+    name = name.decode()
+    expl = RUNTIME_CUDA_ERROR_EXPLANATIONS.get(int(error))
+    if expl is not None:
+        raise CUDAError(f"{name}: {expl}")
+    desc_err, desc = runtime.cudaGetErrorString(error)
+    if desc_err != runtime.cudaError_t.cudaSuccess:
+        raise CUDAError(f"{name}")
+    desc = desc.decode()
+    raise CUDAError(f"{name}: {desc}")
+
+

--- a/cuda_core/cuda/core/experimental/_utils/cuda_utils.py
+++ b/cuda_core/cuda/core/experimental/_utils/cuda_utils.py
@@ -15,12 +15,9 @@ except ImportError:
     from cuda import cudart as runtime
     from cuda import nvrtc
 
+from cuda.core.experimental._utils._error_utils import CUDAError, _check_driver_error, _check_runtime_error
 from cuda.core.experimental._utils.driver_cu_result_explanations import DRIVER_CU_RESULT_EXPLANATIONS
 from cuda.core.experimental._utils.runtime_cuda_error_explanations import RUNTIME_CUDA_ERROR_EXPLANATIONS
-
-
-class CUDAError(Exception):
-    pass
 
 
 class NVRTCError(CUDAError):
@@ -46,40 +43,6 @@ def cast_to_3_tuple(label, cfg):
         plural_s = "" if len(cfg) == 1 else "s"
         raise ValueError(f"{label} value{plural_s} must be >= 1 (got {cfg_orig})")
     return cfg + (1,) * (3 - len(cfg))
-
-
-def _check_driver_error(error):
-    if error == driver.CUresult.CUDA_SUCCESS:
-        return
-    name_err, name = driver.cuGetErrorName(error)
-    if name_err != driver.CUresult.CUDA_SUCCESS:
-        raise CUDAError(f"UNEXPECTED ERROR CODE: {error}")
-    name = name.decode()
-    expl = DRIVER_CU_RESULT_EXPLANATIONS.get(int(error))
-    if expl is not None:
-        raise CUDAError(f"{name}: {expl}")
-    desc_err, desc = driver.cuGetErrorString(error)
-    if desc_err != driver.CUresult.CUDA_SUCCESS:
-        raise CUDAError(f"{name}")
-    desc = desc.decode()
-    raise CUDAError(f"{name}: {desc}")
-
-
-def _check_runtime_error(error):
-    if error == runtime.cudaError_t.cudaSuccess:
-        return
-    name_err, name = runtime.cudaGetErrorName(error)
-    if name_err != runtime.cudaError_t.cudaSuccess:
-        raise CUDAError(f"UNEXPECTED ERROR CODE: {error}")
-    name = name.decode()
-    expl = RUNTIME_CUDA_ERROR_EXPLANATIONS.get(int(error))
-    if expl is not None:
-        raise CUDAError(f"{name}: {expl}")
-    desc_err, desc = runtime.cudaGetErrorString(error)
-    if desc_err != runtime.cudaError_t.cudaSuccess:
-        raise CUDAError(f"{name}")
-    desc = desc.decode()
-    raise CUDAError(f"{name}: {desc}")
 
 
 def _check_error(error, handle=None):


### PR DESCRIPTION
This is for discussion only.

Currently stream and other objects creation is very slow when compared to CuPy

```
>>> import timeit
>>> timeit.timeit('device.create_stream()', setup='import cuda.core.experimental as ccx; device = ccx.Device(); device.set_current()')
5.1670654399786144
>>> timeit.timeit('cp.cuda.Stream()', setup='import cupy as cp')
2.4941531461663544
```

The cause between the performance difference is that in CuPy, the Stream constructor is entirely Cythonized and all that calls that it does to the runtime/driver APIs are direct calls to the c functions by cimporting the corresponding modules.

The two major overheads that we see in cuda-python are:
- The `weakref.finalize` for destruction and `_MembersNeededForFinalize` taking around 20% of the `_init` time
- Options object manipulation, an additional 20~30% of the time

If we naively rename the `_stream.py` to `_stream.pyx` and Cythonize it, we don't get any benefit.
The cythonized code is dealing with several python objects and every call to the bindings needs to go to through the interpreter and convert the argument/returns to python objects. Moreover, the error check of a binding call is also done in Python and it becomes one of the most noticeable bottlenecks. Even in the plain python flamegraph you can see how `handle_return` appear several times having a noticeable impact.

After testing the changes done here we get the following time for cuda-python
```
>>> timeit.timeit('device.create_stream()', setup='import cuda.core.experimental as ccx; device = ccx.Device(); device.set_current()')
2.2055921980645508
```

I don't want to merge this PR as it is, the current approach is not good and needs a lot of discussion. The aim of this PR is to show where current bottlenecks are and some ideas to work around them. For example:

- I think we should delegate error checking to the `cuda.bindings` package similarly to what CuPy does. Going in/out the python interpreter for a binding call and then the error check is not cheap when dealing with times ~1us

- There should be an easy way to use directly the cdef functions of the bindings. However, we don't want to `cimport` bindings stuff in cuda.core because this requires compile with the cuda headers and we will need to maintain various packages. Maybe it is better to add some base `Stream` and `Event` classes in `cuda.bindings` and other objects that are performance sensitive and build over them in `cuda.core`

- The destruction of some objects with `weakref` is expensive. We may want to switch to `__del__` with interpreter shutdown detection like CuPy does, or Cythonize these objects and use `__dealloc__`

cuda-python flamegraph with main branch
![cuda_pyhon_main](https://github.com/user-attachments/assets/06289add-71f4-4764-86f8-07219d0d9957)

cuda-python flamegraph with this pr
![cuda_python_this_pr](https://github.com/user-attachments/assets/2f67969a-b239-442d-b135-f4f95513a1d7)

CuPy latest release flamegraph
![cupy](https://github.com/user-attachments/assets/b38b3db5-cade-43ec-a136-85817ad42575)
