### PR TITLE
Bugfix/multiple ptxas options values

### DIFF
--- a/cuda_core/cuda/core/experimental/_program.py
+++ b/cuda_core/cuda/core/experimental/_program.py
@@ -242,12 +242,12 @@ class ProgramOptions:
         if self.device_code_optimize is not None:
             self._formatted_options.append(f"--dopt={'on' if self.device_code_optimize else 'off'}")
         if self.ptxas_options is not None:
-            self._formatted_options.append("--ptxas-options")
+            opt_name = "--ptxas-options"
             if isinstance(self.ptxas_options, str):
-                self._formatted_options.append(self.ptxas_options)
+                self._formatted_options.append(f"{opt_name}={self.ptxas_options}")
             elif is_sequence(self.ptxas_options):
-                for option in self.ptxas_options:
-                    self._formatted_options.append(option)
+                for opt_value in self.ptxas_options:
+                    self._formatted_options.append(f"{opt_name}={opt_value}")
         if self.max_register_count is not None:
             self._formatted_options.append(f"--maxrregcount={self.max_register_count}")
         if self.ftz is not None:

--- a/cuda_core/tests/test_program.py
+++ b/cuda_core/tests/test_program.py
@@ -43,6 +43,8 @@ def ptx_code_object():
         ProgramOptions(diag_error=1234, diag_suppress=1234),
         ProgramOptions(diag_error=[1234, 1223], diag_suppress=(1234, 1223)),
         ProgramOptions(diag_warn=1000),
+        ProgramOptions(std="c++11", ptxas_options=["-v"]),
+        ProgramOptions(std="c++11", ptxas_options=["-v", "-O2"]),
     ],
 )
 def test_cpp_program_with_various_options(init_cuda, options):


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes gh-668

This PR fixes the issue by changing how sequence values for `ptxas_options`  are handled. Multiple values should be passed to NVRTC as a sequence of `--ptx-options=val` for each `val` in the sequence.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

