### PR TITLE
Make compute-sanitizer not report API errors as errors

### DIFF
--- a/ci/tools/setup-sanitizer
+++ b/ci/tools/setup-sanitizer
@@ -16,8 +16,6 @@ if [[ "${SETUP_SANITIZER}" == 1 ]]; then
   if [[ "$COMPUTE_SANITIZER_VERSION" -ge 202111 ]]; then
     SANITIZER_CMD="${SANITIZER_CMD} --padding=32"
   fi
-  # TODO: remove me
-  echo "CUDA_PYTHON_TESTING_WITH_COMPUTE_SANITIZER=1" >> $GITHUB_ENV
 else
   SANITIZER_CMD=""
 fi

--- a/ci/tools/setup-sanitizer
+++ b/ci/tools/setup-sanitizer
@@ -12,10 +12,11 @@ set -euo pipefail
 if [[ "${SETUP_SANITIZER}" == 1 ]]; then
   COMPUTE_SANITIZER="${CUDA_HOME}/bin/compute-sanitizer"
   COMPUTE_SANITIZER_VERSION=$(${COMPUTE_SANITIZER} --version | grep -Eo "[0-9]{4}\.[0-9]\.[0-9]" | sed -e 's/\.//g')
-  SANITIZER_CMD="${COMPUTE_SANITIZER} --target-processes=all --launch-timeout=0 --tool=memcheck --error-exitcode=1"
+  SANITIZER_CMD="${COMPUTE_SANITIZER} --target-processes=all --launch-timeout=0 --tool=memcheck --error-exitcode=1 --report-api-errors=no"
   if [[ "$COMPUTE_SANITIZER_VERSION" -ge 202111 ]]; then
     SANITIZER_CMD="${SANITIZER_CMD} --padding=32"
   fi
+  # TODO: remove me
   echo "CUDA_PYTHON_TESTING_WITH_COMPUTE_SANITIZER=1" >> $GITHUB_ENV
 else
   SANITIZER_CMD=""

--- a/cuda_bindings/docs/source/environment_variables.md
+++ b/cuda_bindings/docs/source/environment_variables.md
@@ -11,8 +11,3 @@
 ## Runtime Environment Variables
 
 - `CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM` : When set to 1, the default stream is the per-thread default stream. When set to 0, the default stream is the legacy default stream. This defaults to 0, for the legacy default stream. See [Stream Synchronization Behavior](https://docs.nvidia.com/cuda/cuda-runtime-api/stream-sync-behavior.html) for an explanation of the legacy and per-thread default streams.
-
-
-## Test-Time Environment Variables
-
-- `CUDA_PYTHON_TESTING_WITH_COMPUTE_SANITIZER` : When set to 1, tests are skipped that would cause [compute-sanitizer](https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html) to raise an error.

--- a/cuda_bindings/tests/conftest.py
+++ b/cuda_bindings/tests/conftest.py
@@ -5,11 +5,6 @@ import os
 
 import pytest
 
-skipif_testing_with_compute_sanitizer = pytest.mark.skipif(
-    os.environ.get("CUDA_PYTHON_TESTING_WITH_COMPUTE_SANITIZER", "0") == "1",
-    reason="The compute-sanitizer is running, and this test causes an API error.",
-)
-
 
 def pytest_configure(config):
     config.custom_info = []

--- a/cuda_bindings/tests/conftest.py
+++ b/cuda_bindings/tests/conftest.py
@@ -1,7 +1,6 @@
 # Copyright 2025 NVIDIA Corporation.  All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-import os
 
 import pytest
 

--- a/cuda_bindings/tests/test_cuda.py
+++ b/cuda_bindings/tests/test_cuda.py
@@ -7,7 +7,6 @@ import textwrap
 
 import numpy as np
 import pytest
-from conftest import skipif_testing_with_compute_sanitizer
 
 import cuda.cuda as cuda
 import cuda.cudart as cudart
@@ -80,7 +79,6 @@ def test_cuda_memcpy():
     assert err == cuda.CUresult.CUDA_SUCCESS
 
 
-@skipif_testing_with_compute_sanitizer
 def test_cuda_array():
     (err,) = cuda.cuInit(0)
     assert err == cuda.CUresult.CUDA_SUCCESS
@@ -234,7 +232,6 @@ def test_cuda_uuid_list_access():
     assert err == cuda.CUresult.CUDA_SUCCESS
 
 
-@skipif_testing_with_compute_sanitizer
 def test_cuda_cuModuleLoadDataEx():
     (err,) = cuda.cuInit(0)
     assert err == cuda.CUresult.CUDA_SUCCESS
@@ -622,7 +619,6 @@ def test_cuda_coredump_attr():
     assert err == cuda.CUresult.CUDA_SUCCESS
 
 
-@skipif_testing_with_compute_sanitizer
 def test_get_error_name_and_string():
     (err,) = cuda.cuInit(0)
     assert err == cuda.CUresult.CUDA_SUCCESS
@@ -952,7 +948,6 @@ def test_CUmemDecompressParams_st():
     assert int(desc.dstActBytes) == 0
 
 
-@skipif_testing_with_compute_sanitizer
 def test_all_CUresult_codes():
     max_code = int(max(cuda.CUresult))
     # Smoke test. CUDA_ERROR_UNKNOWN = 999, but intentionally using literal value.
@@ -985,21 +980,18 @@ def test_all_CUresult_codes():
     assert num_good >= 76  # CTK 11.0.3_450.51.06
 
 
-@skipif_testing_with_compute_sanitizer
 def test_cuKernelGetName_failure():
     err, name = cuda.cuKernelGetName(0)
     assert err == cuda.CUresult.CUDA_ERROR_INVALID_VALUE
     assert name is None
 
 
-@skipif_testing_with_compute_sanitizer
 def test_cuFuncGetName_failure():
     err, name = cuda.cuFuncGetName(0)
     assert err == cuda.CUresult.CUDA_ERROR_INVALID_VALUE
     assert name is None
 
 
-@skipif_testing_with_compute_sanitizer
 @pytest.mark.skipif(
     driverVersionLessThan(12080) or not supportsCudaAPI("cuCheckpointProcessGetState"),
     reason="When API was introduced",

--- a/cuda_bindings/tests/test_cudart.py
+++ b/cuda_bindings/tests/test_cudart.py
@@ -6,7 +6,6 @@ import math
 
 import numpy as np
 import pytest
-from conftest import skipif_testing_with_compute_sanitizer
 
 import cuda.cuda as cuda
 import cuda.cudart as cudart
@@ -67,7 +66,6 @@ def test_cudart_memcpy():
     assertSuccess(err)
 
 
-@skipif_testing_with_compute_sanitizer
 def test_cudart_hostRegister():
     # Use hostRegister API to check for correct enum return values
     page_size = 80

--- a/cuda_core/tests/conftest.py
+++ b/cuda_core/tests/conftest.py
@@ -65,11 +65,5 @@ def deinit_all_contexts_function():
     return pop_all_contexts
 
 
-skipif_testing_with_compute_sanitizer = pytest.mark.skipif(
-    os.environ.get("CUDA_PYTHON_TESTING_WITH_COMPUTE_SANITIZER", "0") == "1",
-    reason="The compute-sanitizer is running, and this test causes an API error.",
-)
-
-
 # TODO: make the fixture more sophisticated using path finder
 skipif_need_cuda_headers = pytest.mark.skipif(os.environ.get("CUDA_PATH") is None, reason="need CUDA header")

--- a/cuda_core/tests/test_cuda_utils.py
+++ b/cuda_core/tests/test_cuda_utils.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 import pytest
-from conftest import skipif_testing_with_compute_sanitizer
 
 from cuda.bindings import driver, runtime
 from cuda.core.experimental._utils import cuda_utils
@@ -41,8 +40,6 @@ def test_runtime_cuda_error_explanations_health():
         assert not extra_expl
 
 
-# this test causes an API error when the driver is too old to know about all of the error codes
-@skipif_testing_with_compute_sanitizer
 def test_check_driver_error():
     num_unexpected = 0
     for error in driver.CUresult:

--- a/cuda_core/tests/test_event.py
+++ b/cuda_core/tests/test_event.py
@@ -7,7 +7,7 @@ import time
 
 import numpy as np
 import pytest
-from conftest import skipif_need_cuda_headers, skipif_testing_with_compute_sanitizer
+from conftest import skipif_need_cuda_headers
 
 import cuda.core.experimental
 from cuda.core.experimental import Device, EventOptions, LaunchConfig, Program, ProgramOptions, launch
@@ -71,7 +71,6 @@ def test_is_done(init_cuda):
     assert event.is_done in (True, False)
 
 
-@skipif_testing_with_compute_sanitizer
 def test_error_timing_disabled():
     device = Device()
     device.set_current()
@@ -94,7 +93,6 @@ def test_error_timing_disabled():
         event2 - event1
 
 
-@skipif_testing_with_compute_sanitizer
 def test_error_timing_recorded():
     device = Device()
     device.set_current()
@@ -114,7 +112,6 @@ def test_error_timing_recorded():
         event3 - event2
 
 
-@skipif_testing_with_compute_sanitizer
 @skipif_need_cuda_headers  # libcu++
 @pytest.mark.skipif(tuple(int(i) for i in np.__version__.split(".")[:2]) < (2, 1), reason="need numpy 2.1.0+")
 def test_error_timing_incomplete():

--- a/cuda_core/tests/test_linker.py
+++ b/cuda_core/tests/test_linker.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 import pytest
-from conftest import skipif_testing_with_compute_sanitizer
 
 from cuda.core.experimental import Device, Linker, LinkerOptions, Program, ProgramOptions, _linker
 from cuda.core.experimental._module import ObjectCode
@@ -145,8 +144,6 @@ def test_linker_link_invalid_target_type(compile_ptx_functions):
         linker.link("invalid_target")
 
 
-# this test causes an API error when using the culink API
-@skipif_testing_with_compute_sanitizer
 def test_linker_get_error_log(compile_ptx_functions):
     options = LinkerOptions(name="ABC", arch=ARCH)
 

--- a/cuda_core/tests/test_module.py
+++ b/cuda_core/tests/test_module.py
@@ -6,7 +6,6 @@ import pickle  # nosec B403, B301
 import warnings
 
 import pytest
-from conftest import skipif_testing_with_compute_sanitizer
 
 import cuda.core.experimental
 from cuda.core.experimental import Device, ObjectCode, Program, ProgramOptions, system
@@ -181,7 +180,6 @@ def test_object_code_handle(get_saxpy_object_code):
     assert mod.handle is not None
 
 
-@skipif_testing_with_compute_sanitizer
 def test_saxpy_arguments(get_saxpy_kernel, cuda12_prerequisite_check):
     if not cuda12_prerequisite_check:
         pytest.skip("Test requires CUDA 12")
@@ -212,7 +210,6 @@ def test_saxpy_arguments(get_saxpy_kernel, cuda12_prerequisite_check):
     assert all(actual == expected for actual, expected in zip(sizes, expected_sizes))
 
 
-@skipif_testing_with_compute_sanitizer
 @pytest.mark.parametrize("nargs", [0, 1, 2, 3, 16])
 @pytest.mark.parametrize("c_type_name,c_type", [("int", ctypes.c_int), ("short", ctypes.c_short)], ids=["int", "short"])
 def test_num_arguments(init_cuda, nargs, c_type_name, c_type, cuda12_prerequisite_check):
@@ -238,7 +235,6 @@ def test_num_arguments(init_cuda, nargs, c_type_name, c_type, cuda12_prerequisit
     assert all([actual.size == expected.size for actual, expected in zip(arg_info, members)])
 
 
-@skipif_testing_with_compute_sanitizer
 def test_num_args_error_handling(deinit_all_contexts_function, cuda12_prerequisite_check):
     if not cuda12_prerequisite_check:
         pytest.skip("Test requires CUDA 12")


### PR DESCRIPTION
## Description

We rely on driver/runtime to report API errors to us for decision making and input checking (https://github.com/NVIDIA/cuda-python/issues/685). If the compute-sanitizer keeps treating API errors as real errors, we end up skipping the majority of the test suite. Before the sanitizer can suppress errors on a per-API basis, we turn `--report-api-errors` off globally.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

