### PR TITLE
Update the notes on the CCCL and nvmath-python projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@ CUDA Python is the home for accessing NVIDIA’s CUDA platform from Python. It c
 
 * [cuda.core](https://nvidia.github.io/cuda-python/cuda-core/latest): Pythonic access to CUDA Runtime and other core functionalities
 * [cuda.bindings](https://nvidia.github.io/cuda-python/cuda-bindings/latest): Low-level Python bindings to CUDA C APIs
-* [cuda.cooperative](https://nvidia.github.io/cccl/cuda_cooperative/): A Python package providing CCCL's reusable block-wide and warp-wide *device* primitives for use within Numba CUDA kernels
-* [cuda.parallel](https://nvidia.github.io/cccl/cuda_parallel/): A Python package for easy access to CCCL's highly efficient and customizable parallel algorithms, like `sort`, `scan`, `reduce`, `transform`, etc, that are callable on the *host*
+* [cuda.cccl.cooperative](https://nvidia.github.io/cccl/cuda_cooperative/): A Python module providing CCCL's reusable block-wide and warp-wide *device* primitives for use within Numba CUDA kernels
+* [cuda.cccl.parallel](https://nvidia.github.io/cccl/cuda_parallel/): A Python module for easy access to CCCL's highly efficient and customizable parallel algorithms, like `sort`, `scan`, `reduce`, `transform`, etc, that are callable on the *host*
 * [numba.cuda](https://nvidia.github.io/numba-cuda/): Numba's target for CUDA GPU programming by directly compiling a restricted subset of Python code into CUDA kernels and device functions following the CUDA execution model.
-
-For access to NVIDIA CPU & GPU Math Libraries, please refer to [nvmath-python](https://docs.nvidia.com/cuda/nvmath-python/latest).
+* [nvmath-python](https://docs.nvidia.com/cuda/nvmath-python/latest): Pythonic access to NVIDIA CPU & GPU Math Libraries, with both [*host*](https://docs.nvidia.com/cuda/nvmath-python/latest/overview.html#host-apis) and [*device* (nvmath.device)](https://docs.nvidia.com/cuda/nvmath-python/latest/overview.html#device-apis) APIs. It also provides low-level Python bindings to host C APIs ([nvmath.bindings](https://docs.nvidia.com/cuda/nvmath-python/latest/bindings/index.html)).
 
 CUDA Python is currently undergoing an overhaul to improve existing and bring up new components. All of the previously available functionalities from the `cuda-python` package will continue to be available, please refer to the [cuda.bindings](https://nvidia.github.io/cuda-python/cuda-bindings/latest) documentation for installation guide and further detail.
 

--- a/cuda_python/docs/source/conf.py
+++ b/cuda_python/docs/source/conf.py
@@ -96,7 +96,7 @@ CUDA_PYTHON_DOMAIN = os.environ.get("CUDA_PYTHON_DOMAIN", "https://nvidia.github
 rst_epilog = f"""
 .. _cuda.core: {CUDA_PYTHON_DOMAIN}/cuda-core/latest
 .. _cuda.bindings: {CUDA_PYTHON_DOMAIN}/cuda-bindings/latest
-.. _cuda.cooperative: https://nvidia.github.io/cccl/cuda_cooperative/
-.. _cuda.parallel: https://nvidia.github.io/cccl/cuda_parallel/
+.. _cuda.cccl.cooperative: https://nvidia.github.io/cccl/cuda_cooperative/
+.. _cuda.cccl.parallel: https://nvidia.github.io/cccl/cuda_parallel/
 .. _numba.cuda: https://nvidia.github.io/numba-cuda/
 """

--- a/cuda_python/docs/source/index.rst
+++ b/cuda_python/docs/source/index.rst
@@ -8,13 +8,14 @@ multiple components:
 
 - `cuda.core`_: Pythonic access to CUDA runtime and other core functionalities
 - `cuda.bindings`_: Low-level Python bindings to CUDA C APIs
-- `cuda.cooperative`_: A Python package providing CCCL's reusable block-wide and warp-wide *device* primitives for use within Numba CUDA kernels
-- `cuda.parallel`_: A Python package for easy access to CCCL's highly efficient and customizable parallel algorithms, like ``sort``, ``scan``, ``reduce``, ``transform``, etc, that are callable on the *host*
+- `cuda.cccl.cooperative`_: A Python module providing CCCL's reusable block-wide and warp-wide *device* primitives for use within Numba CUDA kernels
+- `cuda.cccl.parallel`_: A Python module for easy access to CCCL's highly efficient and customizable parallel algorithms, like ``sort``, ``scan``, ``reduce``, ``transform``, etc, that are callable on the *host*
 - `numba.cuda`_: Numba's target for CUDA GPU programming by directly compiling a restricted subset of Python code into CUDA kernels and device functions following the CUDA execution model.
-
-For access to NVIDIA CPU & GPU Math Libraries, please refer to `nvmath-python`_.
+* `nvmath-python`_: Pythonic access to NVIDIA CPU & GPU Math Libraries, with both *host* and *device* (through `nvmath.device`_) APIs. It also provides low-level Python bindings to host C APIs (through `nvmath.bindings`_).
 
 .. _nvmath-python: https://docs.nvidia.com/cuda/nvmath-python/latest
+.. _nvmath.device: https://docs.nvidia.com/cuda/nvmath-python/latest/overview.html#device-apis
+.. _nvmath.bindings: https://docs.nvidia.com/cuda/nvmath-python/latest/bindings/index.html
 
 CUDA Python is currently undergoing an overhaul to improve existing and bring up new components.
 All of the previously available functionalities from the ``cuda-python`` package will continue to
@@ -31,6 +32,7 @@ be available, please refer to the `cuda.bindings`_ documentation for installatio
    release.md
    cuda.core <https://nvidia.github.io/cuda-python/cuda-core/latest>
    cuda.bindings <https://nvidia.github.io/cuda-python/cuda-bindings/latest>
-   cuda.cooperative <https://nvidia.github.io/cccl/cuda_cooperative>
-   cuda.parallel <https://nvidia.github.io/cccl/cuda_parallel>
+   cuda.cccl.cooperative <https://nvidia.github.io/cccl/cuda_cooperative>
+   cuda.cccl.parallel <https://nvidia.github.io/cccl/cuda_parallel>
    numba.cuda <https://nvidia.github.io/numba-cuda/>
+   nvmath-python <https://docs.nvidia.com/cuda/nvmath-python/>


### PR DESCRIPTION
## Description

- cuda.coop & cuda.par are merged into cuda.cccl
- emphasize the versatile roles of nvmath-python 

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

