### PR TITLE
Add missing `nvvmGetErrorString()` bindings.

### DIFF
--- a/cuda_bindings/cuda/bindings/_internal/nvvm.pxd
+++ b/cuda_bindings/cuda/bindings/_internal/nvvm.pxd
@@ -11,6 +11,7 @@ from ..cynvvm cimport *
 # Wrapper functions
 ###############################################################################
 
+cdef const char* _nvvmGetErrorString(nvvmResult result) except?NULL nogil
 cdef nvvmResult _nvvmVersion(int* major, int* minor) except?_NVVMRESULT_INTERNAL_LOADING_ERROR nogil
 cdef nvvmResult _nvvmIRVersion(int* majorIR, int* minorIR, int* majorDbg, int* minorDbg) except?_NVVMRESULT_INTERNAL_LOADING_ERROR nogil
 cdef nvvmResult _nvvmCreateProgram(nvvmProgram* prog) except?_NVVMRESULT_INTERNAL_LOADING_ERROR nogil

--- a/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx
@@ -36,6 +36,7 @@ cdef extern from "<dlfcn.h>" nogil:
 cdef bint __py_nvvm_init = False
 cdef void* __cuDriverGetVersion = NULL
 
+cdef void* __nvvmGetErrorString = NULL
 cdef void* __nvvmVersion = NULL
 cdef void* __nvvmIRVersion = NULL
 cdef void* __nvvmCreateProgram = NULL
@@ -82,6 +83,13 @@ cdef int _check_or_init_nvvm() except -1 nogil:
     handle = NULL
 
     # Load function
+    global __nvvmGetErrorString
+    __nvvmGetErrorString = dlsym(RTLD_DEFAULT, 'nvvmGetErrorString')
+    if __nvvmGetErrorString == NULL:
+        if handle == NULL:
+            handle = load_library(driver_ver)
+        __nvvmGetErrorString = dlsym(handle, 'nvvmGetErrorString')
+
     global __nvvmVersion
     __nvvmVersion = dlsym(RTLD_DEFAULT, 'nvvmVersion')
     if __nvvmVersion == NULL:
@@ -181,6 +189,9 @@ cpdef dict _inspect_function_pointers():
     _check_or_init_nvvm()
     cdef dict data = {}
 
+    global __nvvmGetErrorString
+    data["__nvvmGetErrorString"] = <intptr_t>__nvvmGetErrorString
+
     global __nvvmVersion
     data["__nvvmVersion"] = <intptr_t>__nvvmVersion
 
@@ -231,6 +242,16 @@ cpdef _inspect_function_pointer(str name):
 ###############################################################################
 # Wrapper functions
 ###############################################################################
+
+cdef const char* _nvvmGetErrorString(nvvmResult result) except?NULL nogil:
+    global __nvvmGetErrorString
+    _check_or_init_nvvm()
+    if __nvvmGetErrorString == NULL:
+        with gil:
+            raise FunctionNotFoundError("function nvvmGetErrorString is not found")
+    return (<const char* (*)(nvvmResult) noexcept nogil>__nvvmGetErrorString)(
+        result)
+
 
 cdef nvvmResult _nvvmVersion(int* major, int* minor) except?_NVVMRESULT_INTERNAL_LOADING_ERROR nogil:
     global __nvvmVersion

--- a/cuda_bindings/cuda/bindings/cynvvm.pxd
+++ b/cuda_bindings/cuda/bindings/cynvvm.pxd
@@ -33,6 +33,7 @@ ctypedef void* nvvmProgram 'nvvmProgram'
 # Functions
 ###############################################################################
 
+cdef const char* nvvmGetErrorString(nvvmResult result) except?NULL nogil
 cdef nvvmResult nvvmVersion(int* major, int* minor) except?_NVVMRESULT_INTERNAL_LOADING_ERROR nogil
 cdef nvvmResult nvvmIRVersion(int* majorIR, int* minorIR, int* majorDbg, int* minorDbg) except?_NVVMRESULT_INTERNAL_LOADING_ERROR nogil
 cdef nvvmResult nvvmCreateProgram(nvvmProgram* prog) except?_NVVMRESULT_INTERNAL_LOADING_ERROR nogil

--- a/cuda_bindings/cuda/bindings/cynvvm.pyx
+++ b/cuda_bindings/cuda/bindings/cynvvm.pyx
@@ -11,6 +11,10 @@ from ._internal cimport nvvm as _nvvm
 # Wrapper functions
 ###############################################################################
 
+cdef const char* nvvmGetErrorString(nvvmResult result) except?NULL nogil:
+    return _nvvm._nvvmGetErrorString(result)
+
+
 cdef nvvmResult nvvmVersion(int* major, int* minor) except?_NVVMRESULT_INTERNAL_LOADING_ERROR nogil:
     return _nvvm._nvvmVersion(major, minor)
 

--- a/cuda_bindings/cuda/bindings/nvvm.pxd
+++ b/cuda_bindings/cuda/bindings/nvvm.pxd
@@ -27,6 +27,7 @@ ctypedef nvvmResult _Result
 # Functions
 ###############################################################################
 
+cpdef str get_error_string(int result)
 cpdef tuple version()
 cpdef tuple ir_version()
 cpdef intptr_t create_program() except? 0

--- a/cuda_bindings/cuda/bindings/nvvm.pyx
+++ b/cuda_bindings/cuda/bindings/nvvm.pyx
@@ -73,6 +73,19 @@ cpdef destroy_program(intptr_t prog):
     check_status(status)
 
 
+cpdef str get_error_string(int result):
+    """Get the message string for the given ``nvvmResult`` code.
+
+    Args:
+        result (Result): NVVM API result code.
+
+    .. seealso:: `nvvmGetErrorString`
+    """
+    cdef bytes _output_
+    _output_ = nvvmGetErrorString(<_Result>result)
+    return _output_.decode()
+
+
 cpdef tuple version():
     """Get the NVVM version.
 

--- a/cuda_bindings/tests/test_nvvm.py
+++ b/cuda_bindings/tests/test_nvvm.py
@@ -194,6 +194,20 @@ def get_program_log(prog):
     return buffer.decode(errors="backslashreplace")
 
 
+def test_get_error_string():
+    num_success = 0
+    num_errors = 0
+    for enum_obj in nvvm.Result:
+        es = nvvm.get_error_string(enum_obj)
+        if enum_obj is nvvm.Result.SUCCESS:
+            num_success += 1
+        else:
+            assert es.startswith("NVVM_ERROR")
+            num_errors += 1
+    assert num_success == 1
+    assert num_errors > 1  # smoke check is sufficient
+
+
 def test_nvvm_version():
     ver = nvvm.version()
     assert len(ver) == 2


### PR DESCRIPTION
## Description
Closes #683

Fix a minor accidental omission.
