### PR TITLE
Make a few memory management objects public 

### DIFF
--- a/cuda_core/cuda/core/experimental/__init__.py
+++ b/cuda_core/cuda/core/experimental/__init__.py
@@ -8,6 +8,7 @@ from cuda.core.experimental._event import Event, EventOptions
 from cuda.core.experimental._launch_config import LaunchConfig
 from cuda.core.experimental._launcher import launch
 from cuda.core.experimental._linker import Linker, LinkerOptions
+from cuda.core.experimental._memory import Buffer, DeviceMemoryResource, LegacyPinnedMemoryResource, MemoryResource
 from cuda.core.experimental._module import ObjectCode
 from cuda.core.experimental._program import Program, ProgramOptions
 from cuda.core.experimental._stream import Stream, StreamOptions

--- a/cuda_core/cuda/core/experimental/_memory.py
+++ b/cuda_core/cuda/core/experimental/_memory.py
@@ -338,3 +338,7 @@ class _SynchronousMemoryResource(MemoryResource):
     @property
     def device_id(self) -> int:
         return self._dev_id
+
+
+DeviceMemoryResource = _DefaultAsyncMempool
+LegacyPinnedMemoryResource = _DefaultPinnedMemorySource

--- a/cuda_core/docs/source/api.rst
+++ b/cuda_core/docs/source/api.rst
@@ -25,6 +25,11 @@ CUDA runtime
    StreamOptions
    LaunchConfig
 
+   Buffer
+   MemoryResource
+   DeviceMemoryResource
+   LegacyPinnedMemoryResource
+
 
 CUDA compilation toolchain
 --------------------------

--- a/cuda_core/docs/source/api_private.rst
+++ b/cuda_core/docs/source/api_private.rst
@@ -15,7 +15,6 @@ CUDA runtime
 .. autosummary::
    :toctree: generated/
 
-   _memory.Buffer
    _stream.Stream
    _event.Event
    _device.DeviceProperties

--- a/cuda_core/tests/test_event.py
+++ b/cuda_core/tests/test_event.py
@@ -10,8 +10,15 @@ import pytest
 from conftest import skipif_need_cuda_headers
 
 import cuda.core.experimental
-from cuda.core.experimental import Device, EventOptions, LaunchConfig, Program, ProgramOptions, launch
-from cuda.core.experimental._memory import _DefaultPinnedMemorySource
+from cuda.core.experimental import (
+    Device,
+    EventOptions,
+    LaunchConfig,
+    LegacyPinnedMemoryResource,
+    Program,
+    ProgramOptions,
+    launch,
+)
 
 
 def test_event_init_disabled():
@@ -143,7 +150,7 @@ __global__ void wait(int* val) {
     mod = prog.compile(target_type="cubin")
     ker = mod.get_kernel("wait")
 
-    mr = _DefaultPinnedMemorySource()
+    mr = LegacyPinnedMemoryResource()
     b = mr.allocate(4)
     arr = np.from_dlpack(b).view(np.int32)
     arr[0] = 0

--- a/cuda_core/tests/test_launcher.py
+++ b/cuda_core/tests/test_launcher.py
@@ -9,8 +9,7 @@ import numpy as np
 import pytest
 from conftest import skipif_need_cuda_headers
 
-from cuda.core.experimental import Device, LaunchConfig, Program, ProgramOptions, launch
-from cuda.core.experimental._memory import _DefaultPinnedMemorySource
+from cuda.core.experimental import Device, LaunchConfig, LegacyPinnedMemoryResource, Program, ProgramOptions, launch
 
 
 def test_launch_config_init(init_cuda):
@@ -111,7 +110,7 @@ def test_launch_scalar_argument(python_type, cpp_type, init_value):
     dev.set_current()
 
     # Prepare pinned host array
-    mr = _DefaultPinnedMemorySource()
+    mr = LegacyPinnedMemoryResource()
     b = mr.allocate(np.dtype(python_type).itemsize)
     arr = np.from_dlpack(b).view(python_type)
     arr[:] = 0

--- a/cuda_core/tests/test_memory.py
+++ b/cuda_core/tests/test_memory.py
@@ -10,8 +10,8 @@ import ctypes
 
 import pytest
 
-from cuda.core.experimental import Device
-from cuda.core.experimental._memory import Buffer, DLDeviceType, MemoryResource
+from cuda.core.experimental import Buffer, Device, MemoryResource
+from cuda.core.experimental._memory import DLDeviceType
 from cuda.core.experimental._utils.cuda_utils import handle_return
 
 


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #596.

<!-- Provide a standalone description of changes in this PR. -->
- `Buffer` and `MemoryResource` are already public (ex: returned by `Device.memory_resource.allocate()`). We just expose them under the `cuda.core` namespace for documentation purposes (#601)
- The names `DeviceMemoryResource` and `LegacyPinnedMemoryResource` follow the cccl-rt/cudax counterparts. 

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

