### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,10 @@ jobs:
           mkdir dist
           for p in ${{ inputs.component }}*
           do
+            # exclude cython test artifacts
+            if [[ "${p}" == *-tests ]]; then
+              continue
+            fi
             mv ${p}/*.whl dist/
           done
           rmdir ${{ inputs.component }}*


### PR DESCRIPTION
## Description

Fix this error https://github.com/NVIDIA/cuda-python/actions/runs/15613446366/job/43979976338 caused by #640. 
```
+ gh run download 15593389965 -p 'cuda-core*' -R NVIDIA/cuda-python
+ mkdir dist
+ for p in cuda-core*
+ mv cuda-core-python310-linux-64-a13a9173622b1096f30905eb07a9f476bc3bdd18/cuda_core-0.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl dist/
+ for p in cuda-core*
+ mv 'cuda-core-python310-linux-64-a13a9173622b1096f30905eb07a9f476bc3bdd18-tests/*.whl' dist/
mv: cannot stat 'cuda-core-python310-linux-64-a13a9173622b1096f30905eb07a9f476bc3bdd18-tests/*.whl': No such file or directory
Error: Process completed with exit code 1.
```
When we copy the artifacts for PyPI releases, we should not copy the artifacts.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

