### PR TITLE
WIP: Cythonize away some perf hot spots

### DIFF
--- a/cuda_core/cuda/core/experimental/_context.pyx
+++ b/cuda_core/cuda/core/experimental/_context.pyx
@@ -16,7 +16,7 @@ class ContextOptions:
 cdef class Context:
 
     cdef:
-        object _handle
+        readonly object _handle
         int _device_id
 
     def __init__(self, *args, **kwargs):

--- a/cuda_core/cuda/core/experimental/_context.pyx
+++ b/cuda_core/cuda/core/experimental/_context.pyx
@@ -13,16 +13,21 @@ class ContextOptions:
     pass  # TODO
 
 
-class Context:
-    __slots__ = ("_handle", "_id")
+cdef class Context:
 
-    def __new__(self, *args, **kwargs):
+    cdef:
+        object _handle
+        int _device_id
+
+    def __init__(self, *args, **kwargs):
         raise RuntimeError("Context objects cannot be instantiated directly. Please use Device or Stream APIs.")
 
     @classmethod
-    def _from_ctx(cls, obj, dev_id):
-        assert_type(obj, driver.CUcontext)
-        ctx = super().__new__(cls)
-        ctx._handle = obj
-        ctx._id = dev_id
+    def _from_ctx(cls, handle: driver.CUcontext, int device_id):
+        cdef Context ctx = Context.__new__(Context)
+        ctx._handle = handle
+        ctx._device_id = device_id
         return ctx
+
+    def __eq__(self, other):
+        return int(self._handle) == int(other._handle)

--- a/cuda_core/cuda/core/experimental/_device.py
+++ b/cuda_core/cuda/core/experimental/_device.py
@@ -1251,7 +1251,7 @@ class Device:
 
         """
         self._check_context_initialized()
-        return Stream._init(obj=obj, options=options)
+        return Stream._init(obj=obj, options=options, device_id=self._id)
 
     def create_event(self, options: Optional[EventOptions] = None) -> Event:
         """Create an Event object without recording it to a Stream.

--- a/cuda_core/cuda/core/experimental/_device.py
+++ b/cuda_core/cuda/core/experimental/_device.py
@@ -1026,7 +1026,7 @@ class Device:
         err, ctx = driver.cuCtxGetCurrent()
 
         # TODO: We want to just call this:
-        #_check_driver_error(err)
+        # _check_driver_error(err)
         # but even the simplest success check causes 50-100 ns. Wait until we cythonize this file...
         if ctx is None:
             _check_driver_error(err)

--- a/cuda_core/cuda/core/experimental/_device.py
+++ b/cuda_core/cuda/core/experimental/_device.py
@@ -1237,7 +1237,6 @@ class Device:
         """
         return Stream._init(obj=obj, options=options)
 
-    @precondition(_check_context_initialized)
     def create_event(self, options: Optional[EventOptions] = None) -> Event:
         """Create an Event object without recording it to a Stream.
 
@@ -1256,7 +1255,10 @@ class Device:
             Newly created event object.
 
         """
-        return Event._init(self._id, self.context._handle, options)
+        ctx = driver.cuCtxGetCurrent()[1]
+        if int(ctx) == 0:
+            raise CUDAError("No context is bound to the calling CPU thread.")
+        return Event._init(self._id, ctx, options)
 
     @precondition(_check_context_initialized)
     def allocate(self, size, stream: Optional[Stream] = None) -> Buffer:

--- a/cuda_core/cuda/core/experimental/_device.py
+++ b/cuda_core/cuda/core/experimental/_device.py
@@ -1222,7 +1222,7 @@ class Device:
         """
         raise NotImplementedError("WIP: https://github.com/NVIDIA/cuda-python/issues/189")
 
-    def create_stream(self, obj: Optional[IsStreamT] = None, options: StreamOptions = None) -> Stream:
+    def create_stream(self, obj: Optional[IsStreamT] = None, options: Optional[StreamOptions] = None) -> Stream:
         """Create a Stream object.
 
         New stream objects can be created in two different ways:

--- a/cuda_core/cuda/core/experimental/_event.pyx
+++ b/cuda_core/cuda/core/experimental/_event.pyx
@@ -88,19 +88,19 @@ cdef class Event:
         raise RuntimeError("Event objects cannot be instantiated directly. Please use Stream APIs (record).")
 
     @classmethod
-    def _init(cls, device_id: int, ctx_handle: Context, opts=None):
+    def _init(cls, device_id: int, ctx_handle: Context, options: Optional[EventOptions] = None):
         cdef Event self = Event.__new__(Event)
-        cdef EventOptions options = check_or_create_options(EventOptions, opts, "Event options")
+        cdef EventOptions opts = check_or_create_options(EventOptions, options, "Event options")
         flags = 0x0
         self._timing_disabled = False
         self._busy_waited = False
-        if not options.enable_timing:
+        if not opts.enable_timing:
             flags |= driver.CUevent_flags.CU_EVENT_DISABLE_TIMING
             self._timing_disabled = True
-        if options.busy_waited_sync:
+        if opts.busy_waited_sync:
             flags |= driver.CUevent_flags.CU_EVENT_BLOCKING_SYNC
             self._busy_waited = True
-        if options.support_ipc:
+        if opts.support_ipc:
             raise NotImplementedError("WIP: https://github.com/NVIDIA/cuda-python/issues/103")
         err, self._handle = driver.cuEventCreate(flags)
         raise_if_driver_error(err)

--- a/cuda_core/cuda/core/experimental/_event.pyx
+++ b/cuda_core/cuda/core/experimental/_event.pyx
@@ -88,7 +88,7 @@ cdef class Event:
         raise RuntimeError("Event objects cannot be instantiated directly. Please use Stream APIs (record).")
 
     @classmethod
-    def _init(cls, device_id: int, ctx_handle: Context, options: Optional[EventOptions] = None):
+    def _init(cls, device_id: int, ctx_handle: Context, options=None):
         cdef Event self = Event.__new__(Event)
         cdef EventOptions opts = check_or_create_options(EventOptions, options, "Event options")
         flags = 0x0

--- a/cuda_core/cuda/core/experimental/_event.pyx
+++ b/cuda_core/cuda/core/experimental/_event.pyx
@@ -102,7 +102,8 @@ cdef class Event:
             self._busy_waited = True
         if options.support_ipc:
             raise NotImplementedError("WIP: https://github.com/NVIDIA/cuda-python/issues/103")
-        _, self._handle = driver.cuEventCreate(flags)
+        err, self._handle = driver.cuEventCreate(flags)
+        raise_if_driver_error(err)
         self._device_id = device_id
         self._ctx_handle = ctx_handle
         return self
@@ -110,7 +111,8 @@ cdef class Event:
     cpdef close(self):
         """Destroy the event."""
         if self._handle is not None:
-            _ = driver.cuEventDestroy(self._handle)
+            err, = driver.cuEventDestroy(self._handle)
+            raise_if_driver_error(err)
             self._handle = None
 
     def __del__(self):
@@ -180,7 +182,7 @@ cdef class Event:
     @property
     def is_done(self) -> bool:
         """Return True if all captured works have been completed, otherwise False."""
-        (result,) = driver.cuEventQuery(self._handle)
+        result, = driver.cuEventQuery(self._handle)
         if result == driver.CUresult.CUDA_SUCCESS:
             return True
         if result == driver.CUresult.CUDA_ERROR_NOT_READY:

--- a/cuda_core/cuda/core/experimental/_event.pyx
+++ b/cuda_core/cuda/core/experimental/_event.pyx
@@ -125,17 +125,14 @@ cdef class Event:
         self._ctx_handle = ctx_handle
         return self
 
-    cdef _close(self):
+    cpdef close(self):
+        """Destroy the event."""
         if self._handle is not None:
             _ = driver.cuEventDestroy(self._handle)
             self._handle = None
 
-    def close(self):
-        """Destroy the event."""
-        self._close()
-
-    def __dealloc__(self):
-        self._close()
+    def __del__(self):
+        self.close()
 
     def __isub__(self, other):
         return NotImplemented

--- a/cuda_core/cuda/core/experimental/_event.pyx
+++ b/cuda_core/cuda/core/experimental/_event.pyx
@@ -4,6 +4,11 @@
 
 from __future__ import annotations
 
+from cuda.core.experimental._utils.cuda_utils cimport (
+    _check_driver_error as raise_if_driver_error,
+    check_or_create_options,
+)
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
@@ -12,9 +17,6 @@ from cuda.core.experimental._utils.cuda_utils import (
     CUDAError,
     driver,
     handle_return,
-)
-from cuda.core.experimental._utils.cuda_utils import (
-    _check_driver_error as raise_if_driver_error,
 )
 
 if TYPE_CHECKING:
@@ -45,26 +47,6 @@ cdef class EventOptions:
     enable_timing: Optional[bool] = False
     busy_waited_sync: Optional[bool] = False
     support_ipc: Optional[bool] = False
-
-
-cdef inline EventOptions check_or_create_options(options, str options_description):
-    """
-    Create the specified options dataclass from a dictionary of options or None.
-    """
-    cdef EventOptions opts
-    if options is None:
-        opts = EventOptions()
-    elif isinstance(options, dict):
-        opts = EventOptions(**options)
-    elif not isinstance(options, EventOptions):
-        raise TypeError(
-            f"The {options_description} must be provided as an object "
-            f"of type {EventOptions.__name__} or as a dict with valid {options_description}. "
-            f"The provided object is '{options}'."
-        )
-
-    return opts
-
 
 
 cdef class Event:
@@ -108,7 +90,7 @@ cdef class Event:
     @classmethod
     def _init(cls, device_id: int, ctx_handle: Context, opts=None):
         cdef Event self = Event.__new__(Event)
-        cdef EventOptions options = check_or_create_options(opts, "Event options")
+        cdef EventOptions options = check_or_create_options(EventOptions, opts, "Event options")
         flags = 0x0
         self._timing_disabled = False
         self._busy_waited = False

--- a/cuda_core/cuda/core/experimental/_stream.pyx
+++ b/cuda_core/cuda/core/experimental/_stream.pyx
@@ -262,6 +262,7 @@ cdef class Stream:
         # on the stream. Event flags such as disabling timing, nonblocking,
         # and CU_EVENT_RECORD_EXTERNAL, can be set in EventOptions.
         if event is None:
+            self._get_device_and_context()
             event = Event._init(self._device_id, self._ctx_handle, options)
         err, = driver.cuEventRecord(event.handle, self._handle)
         raise_if_driver_error(err)

--- a/cuda_core/cuda/core/experimental/_stream.pyx
+++ b/cuda_core/cuda/core/experimental/_stream.pyx
@@ -145,7 +145,7 @@ cdef class Stream:
         return self
 
     @classmethod
-    def _init(cls, obj: Optional[IsStreamT] = None, *, options: Optional[StreamOptions] = None, device_id: int = None):
+    def _init(cls, obj: Optional[IsStreamT] = None, options=None, device_id: int = None):
         cdef Stream self = Stream.__new__(Stream)
         self._handle = None
         self._owner = None

--- a/cuda_core/cuda/core/experimental/_stream.pyx
+++ b/cuda_core/cuda/core/experimental/_stream.pyx
@@ -4,9 +4,13 @@
 
 from __future__ import annotations
 
+from cuda.core.experimental._utils.cuda_utils cimport (
+    _check_driver_error as raise_if_driver_error,
+    check_or_create_options,
+)
+
 import os
 import warnings
-import weakref
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Protocol, Tuple, Union
 
@@ -18,16 +22,14 @@ from cuda.core.experimental._event import Event, EventOptions
 from cuda.core.experimental._graph import GraphBuilder
 from cuda.core.experimental._utils.clear_error_support import assert_type
 from cuda.core.experimental._utils.cuda_utils import (
-    check_or_create_options,
     driver,
     get_device_from_ctx,
     handle_return,
-    runtime,
 )
 
 
 @dataclass
-class StreamOptions:
+cdef class StreamOptions:
     """Customizable :obj:`~_stream.Stream` options.
 
     Attributes
@@ -85,7 +87,7 @@ def _try_to_get_stream_ptr(obj: IsStreamT):
     return driver.CUstream(info[1])
 
 
-class Stream:
+cdef class Stream:
     """Represent a queue of GPU operations that are executed in a specific order.
 
     Applications use streams to control the order of execution for
@@ -103,35 +105,27 @@ class Stream:
 
     """
 
-    class _MembersNeededForFinalize:
-        __slots__ = ("handle", "owner", "builtin")
+    cdef:
+        object _handle
+        object _owner
+        object _builtin
+        object _nonblocking
+        object _priority
+        object _device_id
+        object _ctx_handle
 
-        def __init__(self, stream_obj, handle, owner, builtin):
-            self.handle = handle
-            self.owner = owner
-            self.builtin = builtin
-            weakref.finalize(stream_obj, self.close)
-
-        def close(self):
-            if self.owner is None:
-                if self.handle and not self.builtin:
-                    handle_return(driver.cuStreamDestroy(self.handle))
-            else:
-                self.owner = None
-            self.handle = None
-
-    def __new__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         raise RuntimeError(
             "Stream objects cannot be instantiated directly. "
             "Please use Device APIs (create_stream) or other Stream APIs (from_handle)."
         )
 
-    __slots__ = ("__weakref__", "_mnff", "_nonblocking", "_priority", "_device_id", "_ctx_handle")
-
     @classmethod
     def _legacy_default(cls):
-        self = super().__new__(cls)
-        self._mnff = Stream._MembersNeededForFinalize(self, driver.CUstream(driver.CU_STREAM_LEGACY), None, True)
+        cdef Stream self = Stream.__new__(Stream)
+        self._handle = driver.CUstream(driver.CU_STREAM_LEGACY)
+        self._owner = None
+        self._builtin = True
         self._nonblocking = None  # delayed
         self._priority = None  # delayed
         self._device_id = None  # delayed
@@ -140,8 +134,10 @@ class Stream:
 
     @classmethod
     def _per_thread_default(cls):
-        self = super().__new__(cls)
-        self._mnff = Stream._MembersNeededForFinalize(self, driver.CUstream(driver.CU_STREAM_PER_THREAD), None, True)
+        cdef Stream self = Stream.__new__(Stream)
+        self._handle = driver.CUstream(driver.CU_STREAM_PER_THREAD)
+        self._owner = None
+        self._builtin = True
         self._nonblocking = None  # delayed
         self._priority = None  # delayed
         self._device_id = None  # delayed
@@ -149,57 +145,65 @@ class Stream:
         return self
 
     @classmethod
-    def _init(cls, obj: Optional[IsStreamT] = None, *, options: Optional[StreamOptions] = None):
-        self = super().__new__(cls)
-        self._mnff = Stream._MembersNeededForFinalize(self, None, None, False)
+    def _init(cls, obj: Optional[IsStreamT] = None, *, options: Optional[StreamOptions] = None, device_id: int = None):
+        cdef Stream self = Stream.__new__(Stream)
+        self._handle = None
+        self._owner = None
+        self._builtin = False
 
         if obj is not None and options is not None:
             raise ValueError("obj and options cannot be both specified")
         if obj is not None:
-            self._mnff.handle = _try_to_get_stream_ptr(obj)
+            self._handle = _try_to_get_stream_ptr(obj)
             # TODO: check if obj is created under the current context/device
-            self._mnff.owner = obj
+            self._owner = obj
             self._nonblocking = None  # delayed
             self._priority = None  # delayed
             self._device_id = None  # delayed
             self._ctx_handle = None  # delayed
             return self
 
-        options = check_or_create_options(StreamOptions, options, "Stream options")
-        nonblocking = options.nonblocking
-        priority = options.priority
+        cdef StreamOptions opts = check_or_create_options(StreamOptions, options, "Stream options")
+        nonblocking = opts.nonblocking
+        priority = opts.priority
 
         flags = driver.CUstream_flags.CU_STREAM_NON_BLOCKING if nonblocking else driver.CUstream_flags.CU_STREAM_DEFAULT
-
-        high, low = handle_return(runtime.cudaDeviceGetStreamPriorityRange())
+        err, high, low = driver.cuCtxGetStreamPriorityRange()
+        raise_if_driver_error(err)
         if priority is not None:
             if not (low <= priority <= high):
                 raise ValueError(f"{priority=} is out of range {[low, high]}")
         else:
             priority = high
 
-        self._mnff.handle = handle_return(driver.cuStreamCreateWithPriority(flags, priority))
-        self._mnff.owner = None
+        self._handle = handle_return(driver.cuStreamCreateWithPriority(flags, priority))
+        self._owner = None
         self._nonblocking = nonblocking
         self._priority = priority
-        # don't defer this because we will have to pay a cost for context
-        # switch later
-        self._device_id = int(handle_return(driver.cuCtxGetDevice()))
+        self._device_id = device_id
         self._ctx_handle = None  # delayed
         return self
 
-    def close(self):
+    def __del__(self):
+        self.close()
+
+    cpdef close(self):
         """Destroy the stream.
 
         Destroy the stream if we own it. Borrowed foreign stream
         object will instead have their references released.
 
         """
-        self._mnff.close()
+        if self._owner is None:
+            if self._handle and not self._builtin:
+                handle_return(driver.cuStreamDestroy(self._handle))
+        else:
+            self._owner = None
+        self._handle = None
 
     def __cuda_stream__(self) -> Tuple[int, int]:
         """Return an instance of a __cuda_stream__ protocol."""
-        return (0, self.handle)
+        return (0, int(self.handle))
 
     @property
     def handle(self) -> cuda.bindings.driver.CUstream:
@@ -210,13 +214,13 @@ class Stream:
             This handle is a Python object. To get the memory address of the underlying C
             handle, call ``int(Stream.handle)``.
         """
-        return self._mnff.handle
+        return self._handle
 
     @property
     def is_nonblocking(self) -> bool:
         """Return True if this is a nonblocking stream, otherwise False."""
         if self._nonblocking is None:
-            flag = handle_return(driver.cuStreamGetFlags(self._mnff.handle))
+            flag = handle_return(driver.cuStreamGetFlags(self._handle))
             if flag == driver.CUstream_flags.CU_STREAM_NON_BLOCKING:
                 self._nonblocking = True
             else:
@@ -227,13 +231,13 @@ class Stream:
     def priority(self) -> int:
         """Return the stream priority."""
         if self._priority is None:
-            prio = handle_return(driver.cuStreamGetPriority(self._mnff.handle))
+            prio = handle_return(driver.cuStreamGetPriority(self._handle))
             self._priority = prio
         return self._priority
 
     def sync(self):
         """Synchronize the stream."""
-        handle_return(driver.cuStreamSynchronize(self._mnff.handle))
+        handle_return(driver.cuStreamSynchronize(self._handle))
 
     def record(self, event: Event = None, options: EventOptions = None) -> Event:
         """Record an event onto the stream.
@@ -259,8 +263,8 @@ class Stream:
         # and CU_EVENT_RECORD_EXTERNAL, can be set in EventOptions.
         if event is None:
             event = Event._init(self._device_id, self._ctx_handle, options)
-        assert_type(event, Event)
-        handle_return(driver.cuEventRecord(event.handle, self._mnff.handle))
+        err, = driver.cuEventRecord(event.handle, self._handle)
+        raise_if_driver_error(err)
         return event
 
     def wait(self, event_or_stream: Union[Event, Stream]):
@@ -281,7 +285,7 @@ class Stream:
                 stream = event_or_stream
             else:
                 try:
-                    stream = Stream._init(event_or_stream)
+                    stream = Stream._init(obj=event_or_stream)
                 except Exception as e:
                     raise ValueError(
                         "only an Event, Stream, or object supporting __cuda_stream__ can be waited,"
@@ -292,7 +296,7 @@ class Stream:
             discard_event = True
 
         # TODO: support flags other than 0?
-        handle_return(driver.cuStreamWaitEvent(self._mnff.handle, event, 0))
+        handle_return(driver.cuStreamWaitEvent(self._handle, event, 0))
         if discard_event:
             handle_return(driver.cuEventDestroy(event))
 
@@ -308,21 +312,22 @@ class Stream:
 
         """
         from cuda.core.experimental._device import Device  # avoid circular import
-
-        if self._device_id is None:
-            # Get the stream context first
-            if self._ctx_handle is None:
-                self._ctx_handle = handle_return(driver.cuStreamGetCtx(self._mnff.handle))
-            self._device_id = get_device_from_ctx(self._ctx_handle)
+        self._get_device_and_context()
         return Device(self._device_id)
+
+    cdef _get_device_and_context(self):
+        # Get the stream context first
+        if self._ctx_handle is None:
+            err, self._ctx_handle = driver.cuStreamGetCtx(self._handle)
+            raise_if_driver_error(err)
+        if self._device_id is None:
+            self._device_id = get_device_from_ctx(self._ctx_handle)
+            raise_if_driver_error(err)
 
     @property
     def context(self) -> Context:
         """Return the :obj:`~_context.Context` associated with this stream."""
-        if self._ctx_handle is None:
-            self._ctx_handle = handle_return(driver.cuStreamGetCtx(self._mnff.handle))
-        if self._device_id is None:
-            self._device_id = get_device_from_ctx(self._ctx_handle)
+        self._get_device_and_context()
         return Context._from_ctx(self._ctx_handle, self._device_id)
 
     @staticmethod

--- a/cuda_core/cuda/core/experimental/_utils/cuda_utils.pxd
+++ b/cuda_core/cuda/core/experimental/_utils/cuda_utils.pxd
@@ -1,0 +1,8 @@
+# Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+cpdef int _check_driver_error(error) except?-1
+cpdef int _check_runtime_error(error) except?-1
+cpdef int _check_nvrtc_error(error) except?-1
+cpdef check_or_create_options(type cls, options, str options_description=*, bint keep_none=*)

--- a/cuda_core/cuda/core/experimental/_utils/cuda_utils.pyx
+++ b/cuda_core/cuda/core/experimental/_utils/cuda_utils.pyx
@@ -1,12 +1,12 @@
 # Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
 #
-# SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
+# SPDX-License-Identifier: Apache-2.0
 
 import functools
 import importlib.metadata
 from collections import namedtuple
 from collections.abc import Sequence
-from typing import Callable, Dict
+from typing import Callable
 
 try:
     from cuda.bindings import driver, nvrtc, runtime
@@ -123,26 +123,24 @@ def handle_return(tuple result, handle=None):
         return result[1:]
 
 
-def check_or_create_options(cls, options, options_description, *, keep_none=False):
+cpdef check_or_create_options(type cls, options, str options_description="", bint keep_none=False):
     """
     Create the specified options dataclass from a dictionary of options or None.
     """
-
     if options is None:
         if keep_none:
             return options
-        options = cls()
-    elif isinstance(options, Dict):
-        options = cls(**options)
-
-    if not isinstance(options, cls):
+        return cls()
+    elif isinstance(options, cls):
+        return options
+    elif isinstance(options, dict):
+        return cls(**options)
+    else:
         raise TypeError(
             f"The {options_description} must be provided as an object "
             f"of type {cls.__name__} or as a dict with valid {options_description}. "
             f"The provided object is '{options}'."
         )
-
-    return options
 
 
 def _handle_boolean_option(option: bool) -> str:

--- a/cuda_core/cuda/core/experimental/_utils/cuda_utils.pyx
+++ b/cuda_core/cuda/core/experimental/_utils/cuda_utils.pyx
@@ -52,7 +52,7 @@ def _reduce_3_tuple(t: tuple):
     return t[0] * t[1] * t[2]
 
 
-def _check_driver_error(error):
+cpdef inline void _check_driver_error(error) except*:
     if error == driver.CUresult.CUDA_SUCCESS:
         return
     name_err, name = driver.cuGetErrorName(error)
@@ -69,7 +69,7 @@ def _check_driver_error(error):
     raise CUDAError(f"{name}: {desc}")
 
 
-def _check_runtime_error(error):
+cpdef inline void _check_runtime_error(error) except*:
     if error == runtime.cudaError_t.cudaSuccess:
         return
     name_err, name = runtime.cudaGetErrorName(error)
@@ -86,7 +86,7 @@ def _check_runtime_error(error):
     raise CUDAError(f"{name}: {desc}")
 
 
-def _check_error(error, handle=None):
+cdef inline void _check_error(error, handle=None) except*:
     if isinstance(error, driver.CUresult):
         _check_driver_error(error)
     elif isinstance(error, runtime.cudaError_t):
@@ -105,7 +105,7 @@ def _check_error(error, handle=None):
         raise RuntimeError(f"Unknown error type: {error}")
 
 
-def handle_return(result, handle=None):
+def handle_return(tuple result, handle=None):
     _check_error(result[0], handle=handle)
     if len(result) == 1:
         return

--- a/cuda_core/setup.py
+++ b/cuda_core/setup.py
@@ -2,33 +2,28 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import glob
 import os
 
 from Cython.Build import cythonize
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext as _build_ext
 
-ext_modules = (
+
+# It seems setuptools' wildcard support has problems for namespace packages,
+# so we explicitly spell out all Extension instances.
+root_module = "cuda.core.experimental"
+root_path = f"{os.path.sep}".join(root_module.split(".")) + os.path.sep
+ext_files = glob.glob(f"{root_path}/**/*.pyx", recursive=True)
+def strip_prefix_suffix(filename):
+    return filename[len(root_path):-4]
+module_names = (strip_prefix_suffix(f) for f in ext_files)
+ext_modules = tuple(
     Extension(
-        "cuda.core.experimental._event",
-        sources=["cuda/core/experimental/_event.pyx"],
+        f"cuda.core.experimental.{mod.replace(os.path.sep, '.')}",
+        sources=[f"cuda/core/experimental/{mod}.pyx"],
         language="c++",
-    ),
-    Extension(
-        "cuda.core.experimental._dlpack",
-        sources=["cuda/core/experimental/_dlpack.pyx"],
-        language="c++",
-    ),
-    Extension(
-        "cuda.core.experimental._memoryview",
-        sources=["cuda/core/experimental/_memoryview.pyx"],
-        language="c++",
-    ),
-    Extension(
-        "cuda.core.experimental._kernel_arg_handler",
-        sources=["cuda/core/experimental/_kernel_arg_handler.pyx"],
-        language="c++",
-    ),
+    ) for mod in module_names
 )
 
 

--- a/cuda_core/setup.py
+++ b/cuda_core/setup.py
@@ -9,21 +9,25 @@ from Cython.Build import cythonize
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext as _build_ext
 
-
 # It seems setuptools' wildcard support has problems for namespace packages,
 # so we explicitly spell out all Extension instances.
 root_module = "cuda.core.experimental"
 root_path = f"{os.path.sep}".join(root_module.split(".")) + os.path.sep
 ext_files = glob.glob(f"{root_path}/**/*.pyx", recursive=True)
+
+
 def strip_prefix_suffix(filename):
-    return filename[len(root_path):-4]
+    return filename[len(root_path) : -4]
+
+
 module_names = (strip_prefix_suffix(f) for f in ext_files)
 ext_modules = tuple(
     Extension(
         f"cuda.core.experimental.{mod.replace(os.path.sep, '.')}",
         sources=[f"cuda/core/experimental/{mod}.pyx"],
         language="c++",
-    ) for mod in module_names
+    )
+    for mod in module_names
 )
 
 

--- a/cuda_core/setup.py
+++ b/cuda_core/setup.py
@@ -10,6 +10,11 @@ from setuptools.command.build_ext import build_ext as _build_ext
 
 ext_modules = (
     Extension(
+        "cuda.core.experimental._event",
+        sources=["cuda/core/experimental/_event.pyx"],
+        language="c++",
+    ),
+    Extension(
         "cuda.core.experimental._dlpack",
         sources=["cuda/core/experimental/_dlpack.pyx"],
         language="c++",

--- a/cuda_core/tests/test_cuda_utils.py
+++ b/cuda_core/tests/test_cuda_utils.py
@@ -44,7 +44,7 @@ def test_check_driver_error():
     num_unexpected = 0
     for error in driver.CUresult:
         if error == driver.CUresult.CUDA_SUCCESS:
-            assert cuda_utils._check_driver_error(error) is None
+            assert cuda_utils._check_driver_error(error) == 0
         else:
             with pytest.raises(cuda_utils.CUDAError) as e:
                 cuda_utils._check_driver_error(error)
@@ -63,7 +63,7 @@ def test_check_runtime_error():
     num_unexpected = 0
     for error in runtime.cudaError_t:
         if error == runtime.cudaError_t.cudaSuccess:
-            assert cuda_utils._check_runtime_error(error) is None
+            assert cuda_utils._check_runtime_error(error) == 0
         else:
             with pytest.raises(cuda_utils.CUDAError) as e:
                 cuda_utils._check_runtime_error(error)

--- a/cuda_core/tests/test_stream.py
+++ b/cuda_core/tests/test_stream.py
@@ -52,7 +52,7 @@ def test_stream_record(init_cuda):
 
 def test_stream_record_invalid_event(init_cuda):
     stream = Device().create_stream(options=StreamOptions())
-    with pytest.raises(TypeError):
+    with pytest.raises(AttributeError):
         stream.record(event="invalid_event")
 
 


### PR DESCRIPTION
## Description

Less aggressive version of #677. PR description to follow later. Still WIP.

Preliminary data:
- cuda.core main branch
```python
In [5]: %timeit e = dev.create_event()
4.65 μs ± 18.4 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```
```python
In [5]: %timeit s = dev.create_stream()
7.7 μs ± 9.98 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```
- this PR
```python
In [6]: %timeit e = dev.create_event()
1.11 μs ± 6.91 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```
```python
In [4]: %timeit s = dev.create_stream()
4.12 μs ± 14 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```
- cupy
```python
In [8]: %timeit e = cp.cuda.Event(disable_timing=True)
749 ns ± 5.45 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```
```python
In [14]: %timeit s = cp.cuda.Stream(non_blocking=True)
3.8 μs ± 8.54 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

