### PR TITLE
Fix Windows build CI

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -185,7 +185,8 @@ jobs:
         id: setup-python2
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
-          python-version: ${{ matrix.python-version }}
+          # workaround for actions/runner-images#12377 (the cached 3.13.4 is buggy on Windows)
+          python-version: ${{ matrix.python-version == '3.13' && '3.13.5' || matrix.python-version }}
 
       - name: Set up Python include paths
         run: |


### PR DESCRIPTION
## Description

xef: https://github.com/NVIDIA/cuda-python/actions/runs/15710272181/job/44266220329

@kkraus14 found that the failure was due to the Windows CI image update rolled out recently 
- Working: https://github.com/actions/runner-images/blob/win22/20250602.1/images/windows/Windows2022-Readme.md
- Broken: https://github.com/actions/runner-images/blob/win22/20250609.2/images/windows/Windows2022-Readme.md
- https://github.com/actions/runner-images/issues/12377

The cached Python 3.13.4 in the image is known buggy on Windows and 3.13.5 fixed it. We need to be explicit about which patch version to use before the base image updates.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

