### PR TITLE
Ensure correct handling of buffers allocated with `LegacyPinnedMemoryResource.allocate` as kernel parameters

### DIFF
--- a/cuda_core/cuda/core/experimental/_kernel_arg_handler.pyx
+++ b/cuda_core/cuda/core/experimental/_kernel_arg_handler.pyx
@@ -212,7 +212,13 @@ cdef class ParamHolder:
         for i, arg in enumerate(kernel_args):
             if isinstance(arg, Buffer):
                 # we need the address of where the actual buffer address is stored
-                self.data_addresses[i] = <void*><intptr_t>(arg.handle.getPtr())
+                if isinstance(arg.handle, int):
+                    # see note below on handling int arguments
+                    prepare_arg[intptr_t](self.data, self.data_addresses, arg.handle, i)
+                    continue              
+                else:
+                    # it's a CUdeviceptr:
+                    self.data_addresses[i] = <void*><intptr_t>(arg.handle.getPtr())
                 continue
             elif isinstance(arg, int):
                 # Here's the dilemma: We want to have a fast path to pass in Python

--- a/cuda_core/examples/memory_ops.py
+++ b/cuda_core/examples/memory_ops.py
@@ -1,0 +1,163 @@
+import cupy as cp
+import numpy as np
+from cuda.core.experimental import (
+    Device, LaunchConfig, Program, ProgramOptions, launch,
+    DeviceMemoryResource, LegacyPinnedMemoryResource, Buffer
+)
+from cuda.core.experimental._memory import MemoryResource
+from cuda.core.experimental._utils.cuda_utils import handle_return
+from cuda.bindings import driver
+
+# Kernel for memory operations
+code = """
+extern "C"
+__global__ void memory_ops(float* device_data, 
+                          float* pinned_data,
+                          size_t N) {
+    const unsigned int tid = threadIdx.x + blockIdx.x * blockDim.x;
+    if (tid < N) {
+        // Access device memory
+        device_data[tid] = device_data[tid] + 1.0f;
+        
+        // Access pinned memory (zero-copy from GPU)
+        pinned_data[tid] = pinned_data[tid] * 3.0f;
+    }
+}
+"""
+
+dev = Device()
+dev.set_current()
+stream = dev.create_stream()
+
+# Compile kernel
+arch = "".join(f"{i}" for i in dev.compute_capability)
+program_options = ProgramOptions(std="c++17", arch=f"sm_{arch}")
+prog = Program(code, code_type="c++", options=program_options)
+mod = prog.compile("cubin")
+kernel = mod.get_kernel("memory_ops")
+
+# Create different memory resources
+device_mr = DeviceMemoryResource(dev.device_id)
+pinned_mr = LegacyPinnedMemoryResource()
+
+# Allocate different types of memory
+size = 1024
+dtype = cp.float32
+element_size = dtype().itemsize
+total_size = size * element_size
+
+# 1. Device Memory (GPU-only)
+device_buffer = device_mr.allocate(total_size, stream=stream)
+device_array = cp.ndarray(
+    size, dtype=dtype,
+    memptr=cp.cuda.MemoryPointer(
+        cp.cuda.UnownedMemory(int(device_buffer.handle), device_buffer.size, device_buffer), 0
+    )
+)
+
+# 2. Pinned Memory (CPU memory, GPU accessible)
+pinned_buffer = pinned_mr.allocate(total_size, stream=stream)
+pinned_array = cp.ndarray(
+    size, dtype=dtype,
+    memptr=cp.cuda.MemoryPointer(
+        cp.cuda.UnownedMemory(int(pinned_buffer.handle), pinned_buffer.size, pinned_buffer), 0
+    )
+)
+
+# Initialize data
+rng = cp.random.default_rng()
+device_array[:] = rng.random(size, dtype=dtype)
+pinned_array[:] = rng.random(size, dtype=dtype)
+
+# Store original values for verification
+device_original = device_array.copy()
+pinned_original = pinned_array.copy()
+
+# Sync before kernel launch
+dev.sync()
+
+# Launch kernel
+block = 256
+grid = (size + block - 1) // block
+config = LaunchConfig(grid=grid, block=block)
+
+launch(stream, config, kernel, 
+       device_buffer, pinned_buffer, cp.uint64(size))
+stream.sync()
+
+# Verify kernel operations
+assert cp.allclose(device_array, device_original + 1.0), "Device memory operation failed"
+assert cp.allclose(pinned_array, pinned_original * 3.0), "Pinned memory operation failed"
+
+# Demonstrate buffer copying operations
+print("Memory buffer properties:")
+print(f"Device buffer - Device accessible: {device_buffer.is_device_accessible}")
+print(f"Pinned buffer - Device accessible: {pinned_buffer.is_device_accessible}")
+
+# Assert memory properties
+assert device_buffer.is_device_accessible, "Device buffer should be device accessible"
+assert not device_buffer.is_host_accessible, "Device buffer should not be host accessible"
+assert pinned_buffer.is_device_accessible, "Pinned buffer should be device accessible"
+assert pinned_buffer.is_host_accessible, "Pinned buffer should be host accessible"
+
+# Copy data between different memory types
+print("\nCopying data between memory types...")
+
+# Copy from device to pinned memory
+device_buffer.copy_to(pinned_buffer, stream=stream)
+stream.sync()
+
+# Verify the copy operation
+assert cp.allclose(pinned_array, device_array), "Device to pinned copy failed"
+
+# Create a new device buffer and copy from pinned
+new_device_buffer = device_mr.allocate(total_size, stream=stream)
+new_device_array = cp.ndarray(
+    size, dtype=dtype,
+    memptr=cp.cuda.MemoryPointer(
+        cp.cuda.UnownedMemory(int(new_device_buffer.handle), new_device_buffer.size, new_device_buffer), 0
+    )
+)
+
+pinned_buffer.copy_to(new_device_buffer, stream=stream)
+stream.sync()
+
+# Verify the copy operation
+assert cp.allclose(new_device_array, pinned_array), "Pinned to device copy failed"
+
+# Demonstrate DLPack integration
+print("\nDLPack device information:")
+print(f"Device buffer DLPack device: {device_buffer.__dlpack_device__()}")
+print(f"Pinned buffer DLPack device: {pinned_buffer.__dlpack_device__()}")
+
+# Assert DLPack device types
+from cuda.core.experimental._memory import DLDeviceType
+
+device_dlpack = device_buffer.__dlpack_device__()
+pinned_dlpack = pinned_buffer.__dlpack_device__()
+
+assert device_dlpack[0] == DLDeviceType.kDLCUDA, "Device buffer should have CUDA device type"
+assert pinned_dlpack[0] == DLDeviceType.kDLCUDAHost, "Pinned buffer should have CUDA host device type"
+
+# Test buffer size properties
+assert device_buffer.size == total_size, f"Device buffer size mismatch: expected {total_size}, got {device_buffer.size}"
+assert pinned_buffer.size == total_size, f"Pinned buffer size mismatch: expected {total_size}, got {pinned_buffer.size}"
+assert new_device_buffer.size == total_size, f"New device buffer size mismatch: expected {total_size}, got {new_device_buffer.size}"
+
+# Test memory resource properties
+assert device_buffer.memory_resource == device_mr, "Device buffer should use device memory resource"
+assert pinned_buffer.memory_resource == pinned_mr, "Pinned buffer should use pinned memory resource"
+assert new_device_buffer.memory_resource == device_mr, "New device buffer should use device memory resource"
+
+# Clean up
+device_buffer.close(stream)
+pinned_buffer.close(stream)
+new_device_buffer.close(stream)
+stream.close()
+
+# Verify buffers are properly closed
+assert device_buffer.handle == 0, "Device buffer should be closed"
+assert pinned_buffer.handle == 0, "Pinned buffer should be closed"
+assert new_device_buffer.handle == 0, "New device buffer should be closed"
+
+print("Memory management example completed!")

--- a/cuda_core/examples/memory_ops.py
+++ b/cuda_core/examples/memory_ops.py
@@ -72,7 +72,7 @@ device_original = device_array.copy()
 pinned_original = pinned_array.copy()
 
 # Sync before kernel launch
-dev.sync()
+stream.sync()
 
 # Launch kernel
 block = 256

--- a/cuda_core/examples/memory_ops.py
+++ b/cuda_core/examples/memory_ops.py
@@ -2,6 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# ################################################################################
+#
+# This demo illustrates:
+#
+#   1. How to use different memory resources to allocate and manage memory
+#   2. How to copy data between different memory types
+#   3. How to use DLPack to interoperate with other libraries
+#
+# ################################################################################
+
+import sys
+
 import cupy as cp
 import numpy as np
 
@@ -14,6 +26,10 @@ from cuda.core.experimental import (
     ProgramOptions,
     launch,
 )
+
+if np.__version__ < "2.1.0":
+    print("This example requires NumPy 2.1.0 or later", file=sys.stderr)
+    sys.exit(0)
 
 # Kernel for memory operations
 code = """

--- a/cuda_core/examples/memory_ops.py
+++ b/cuda_core/examples/memory_ops.py
@@ -19,7 +19,6 @@ import numpy as np
 
 from cuda.core.experimental import (
     Device,
-    DeviceMemoryResource,
     LaunchConfig,
     LegacyPinnedMemoryResource,
     Program,
@@ -62,7 +61,7 @@ mod = prog.compile("cubin")
 kernel = mod.get_kernel("memory_ops")
 
 # Create different memory resources
-device_mr = DeviceMemoryResource(dev.device_id)
+device_mr = dev.memory_resource
 pinned_mr = LegacyPinnedMemoryResource()
 
 # Allocate different types of memory

--- a/cuda_core/examples/memory_ops.py
+++ b/cuda_core/examples/memory_ops.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cupy as cp
+import numpy as np
 
 from cuda.core.experimental import (
     Device,
@@ -55,28 +56,16 @@ total_size = size * element_size
 
 # 1. Device Memory (GPU-only)
 device_buffer = device_mr.allocate(total_size, stream=stream)
-device_array = cp.ndarray(
-    size,
-    dtype=dtype,
-    memptr=cp.cuda.MemoryPointer(
-        cp.cuda.UnownedMemory(int(device_buffer.handle), device_buffer.size, device_buffer), 0
-    ),
-)
+device_array = cp.from_dlpack(device_buffer).view(dtype=dtype)
 
 # 2. Pinned Memory (CPU memory, GPU accessible)
 pinned_buffer = pinned_mr.allocate(total_size, stream=stream)
-pinned_array = cp.ndarray(
-    size,
-    dtype=dtype,
-    memptr=cp.cuda.MemoryPointer(
-        cp.cuda.UnownedMemory(int(pinned_buffer.handle), pinned_buffer.size, pinned_buffer), 0
-    ),
-)
+pinned_array = np.from_dlpack(pinned_buffer).view(dtype=dtype)
 
 # Initialize data
 rng = cp.random.default_rng()
 device_array[:] = rng.random(size, dtype=dtype)
-pinned_array[:] = rng.random(size, dtype=dtype)
+pinned_array[:] = rng.random(size, dtype=dtype).get()
 
 # Store original values for verification
 device_original = device_array.copy()
@@ -97,17 +86,6 @@ stream.sync()
 assert cp.allclose(device_array, device_original + 1.0), "Device memory operation failed"
 assert cp.allclose(pinned_array, pinned_original * 3.0), "Pinned memory operation failed"
 
-# Demonstrate buffer copying operations
-print("Memory buffer properties:")
-print(f"Device buffer - Device accessible: {device_buffer.is_device_accessible}")
-print(f"Pinned buffer - Device accessible: {pinned_buffer.is_device_accessible}")
-
-# Assert memory properties
-assert device_buffer.is_device_accessible, "Device buffer should be device accessible"
-assert not device_buffer.is_host_accessible, "Device buffer should not be host accessible"
-assert pinned_buffer.is_device_accessible, "Pinned buffer should be device accessible"
-assert pinned_buffer.is_host_accessible, "Pinned buffer should be host accessible"
-
 # Copy data between different memory types
 print("\nCopying data between memory types...")
 
@@ -120,13 +98,7 @@ assert cp.allclose(pinned_array, device_array), "Device to pinned copy failed"
 
 # Create a new device buffer and copy from pinned
 new_device_buffer = device_mr.allocate(total_size, stream=stream)
-new_device_array = cp.ndarray(
-    size,
-    dtype=dtype,
-    memptr=cp.cuda.MemoryPointer(
-        cp.cuda.UnownedMemory(int(new_device_buffer.handle), new_device_buffer.size, new_device_buffer), 0
-    ),
-)
+new_device_array = cp.from_dlpack(new_device_buffer).view(dtype=dtype)
 
 pinned_buffer.copy_to(new_device_buffer, stream=stream)
 stream.sync()
@@ -145,18 +117,6 @@ pinned_dlpack = pinned_buffer.__dlpack_device__()
 
 assert device_dlpack[0] == DLDeviceType.kDLCUDA, "Device buffer should have CUDA device type"
 assert pinned_dlpack[0] == DLDeviceType.kDLCUDAHost, "Pinned buffer should have CUDA host device type"
-
-# Test buffer size properties
-assert device_buffer.size == total_size, f"Device buffer size mismatch: expected {total_size}, got {device_buffer.size}"
-assert pinned_buffer.size == total_size, f"Pinned buffer size mismatch: expected {total_size}, got {pinned_buffer.size}"
-assert new_device_buffer.size == total_size, (
-    f"New device buffer size mismatch: expected {total_size}, got {new_device_buffer.size}"
-)
-
-# Test memory resource properties
-assert device_buffer.memory_resource == device_mr, "Device buffer should use device memory resource"
-assert pinned_buffer.memory_resource == pinned_mr, "Pinned buffer should use pinned memory resource"
-assert new_device_buffer.memory_resource == device_mr, "New device buffer should use device memory resource"
 
 # Clean up
 device_buffer.close(stream)

--- a/cuda_core/tests/test_launcher.py
+++ b/cuda_core/tests/test_launcher.py
@@ -212,7 +212,13 @@ def test_cooperative_launch():
     "memory_resource_class",
     [
         DeviceMemoryResource,
-        LegacyPinnedMemoryResource,
+        pytest.param(
+            LegacyPinnedMemoryResource,
+            marks=pytest.mark.skipif(
+                tuple(int(i) for i in np.__version__.split(".")[:3]) < (2, 2, 5),
+                reason="need numpy 2.2.5+, numpy GH #28632",
+            ),
+        ),
     ],
 )
 def test_launch_with_buffers_allocated_by_memory_resource(init_cuda, memory_resource_class):

--- a/cuda_core/tests/test_launcher.py
+++ b/cuda_core/tests/test_launcher.py
@@ -10,7 +10,6 @@ import numpy as np
 import pytest
 from conftest import skipif_need_cuda_headers
 
-from cuda.bindings import driver
 from cuda.core.experimental import (
     Device,
     DeviceMemoryResource,
@@ -21,7 +20,6 @@ from cuda.core.experimental import (
     launch,
 )
 from cuda.core.experimental._memory import _SynchronousMemoryResource
-from cuda.core.experimental._utils.cuda_utils import handle_return
 
 
 def test_launch_config_init(init_cuda):

--- a/cuda_core/tests/test_launcher.py
+++ b/cuda_core/tests/test_launcher.py
@@ -253,13 +253,7 @@ def test_launch_with_buffers_allocated_by_memory_resource(init_cuda, memory_reso
 
     # Create memory resource
     if memory_resource_class == "device_memory_resource":
-        if (
-            handle_return(
-                driver.cuDeviceGetAttribute(
-                    driver.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED, dev.device_id
-                )
-            )
-        ) == 1:
+        if dev.properties.memory_pools_supported:
             mr = DeviceMemoryResource(dev.device_id)
         else:
             mr = _SynchronousMemoryResource(dev.device_id)

--- a/cuda_core/tests/test_launcher.py
+++ b/cuda_core/tests/test_launcher.py
@@ -9,7 +9,15 @@ import numpy as np
 import pytest
 from conftest import skipif_need_cuda_headers
 
-from cuda.core.experimental import Device, LaunchConfig, LegacyPinnedMemoryResource, Program, ProgramOptions, launch
+from cuda.core.experimental import (
+    Device,
+    DeviceMemoryResource,
+    LaunchConfig,
+    LegacyPinnedMemoryResource,
+    Program,
+    ProgramOptions,
+    launch,
+)
 
 
 def test_launch_config_init(init_cuda):
@@ -197,3 +205,99 @@ def test_cooperative_launch():
     config = LaunchConfig(grid=1, block=1, cooperative_launch=True)
     launch(s, config, ker)
     s.sync()
+
+
+@pytest.mark.parametrize(
+    "memory_resource_class",
+    [
+        DeviceMemoryResource,
+        LegacyPinnedMemoryResource,
+    ],
+)
+def test_launch_with_buffers_allocated_by_memory_resource(init_cuda, memory_resource_class):
+    """Test that kernels can access memory allocated by memory resources."""
+    dev = Device()
+    dev.set_current()
+    stream = dev.create_stream()
+
+    # Kernel that operates on memory
+    code = """
+    extern "C"
+    __global__ void memory_ops(float* data, size_t N) {
+        const unsigned int tid = threadIdx.x + blockIdx.x * blockDim.x;
+        if (tid < N) {
+            // Access memory (device or pinned)
+            data[tid] = data[tid] * 3.0f;
+        }
+    }
+    """
+
+    # Compile kernel
+    arch = "".join(f"{i}" for i in dev.compute_capability)
+    program_options = ProgramOptions(std="c++17", arch=f"sm_{arch}")
+    prog = Program(code, code_type="c++", options=program_options)
+    mod = prog.compile("cubin")
+    kernel = mod.get_kernel("memory_ops")
+
+    # Create memory resource
+    if memory_resource_class == DeviceMemoryResource:
+        mr = memory_resource_class(dev.device_id)
+    else:  # LegacyPinnedMemoryResource
+        mr = memory_resource_class()
+
+    # Allocate memory
+    size = 1024
+    dtype = np.float32
+    element_size = dtype().itemsize
+    total_size = size * element_size
+
+    buffer = mr.allocate(total_size, stream=stream)
+
+    # Create array view based on memory type
+    if mr.is_host_accessible:
+        # For pinned memory, use numpy
+        array = np.from_dlpack(buffer).view(dtype=dtype)
+    else:
+        # For device memory, use cupy
+        import cupy as cp
+
+        array = cp.from_dlpack(buffer).view(dtype=dtype)
+
+    # Initialize data with random values
+    if mr.is_host_accessible:
+        rng = np.random.default_rng()
+        array[:] = rng.random(size, dtype=dtype)
+    else:
+        import cupy as cp
+
+        rng = cp.random.default_rng()
+        array[:] = rng.random(size, dtype=dtype)
+
+    # Store original values for verification
+    original = array.copy()
+
+    # Sync before kernel launch
+    stream.sync()
+
+    # Launch kernel
+    block = 256
+    grid = (size + block - 1) // block
+    config = LaunchConfig(grid=grid, block=block)
+
+    launch(stream, config, kernel, buffer, np.uint64(size))
+    stream.sync()
+
+    # Verify kernel operations
+    if mr.is_host_accessible:
+        assert np.allclose(array, original * 3.0), f"{memory_resource_class.__name__} operation failed"
+    else:
+        import cupy as cp
+
+        assert cp.allclose(array, original * 3.0), f"{memory_resource_class.__name__} operation failed"
+
+    # Clean up
+    buffer.close(stream)
+    stream.close()
+
+    # Verify buffer is properly closed
+    assert buffer.handle == 0, f"{memory_resource_class.__name__} buffer should be closed"


### PR DESCRIPTION
## Description

Buffers allocated using the `LegacyPinnedMemoryResource` have , but the kernel param handler doesn't know how to handle these buffers. This PR fixes that.

Closes #715 

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

