### PR TITLE
Restore option to run testing without cupy installed.

### DIFF
--- a/cuda_core/tests/test_launcher.py
+++ b/cuda_core/tests/test_launcher.py
@@ -5,7 +5,10 @@ import ctypes
 import os
 import pathlib
 
-import cupy as cp
+try:
+    import cupy as cp
+except ImportError:
+    cp = None
 import numpy as np
 import pytest
 from conftest import skipif_need_cuda_headers
@@ -209,6 +212,7 @@ def test_cooperative_launch():
     s.sync()
 
 
+@pytest.mark.skipif(cp is None, reason="cupy not installed")
 @pytest.mark.parametrize(
     "memory_resource_class",
     [


### PR DESCRIPTION
## Description
cuda_core is generally set up to run most tests without `cupy` installed.

PR #717 added one unconditional `cupy` import. This PR adopts the approach in `tests/test_utils.py` for the import in `tests/test_launcher.py`, and copies the `SKIPPED` message from `tests/example_tests/utils.py`.