### PR TITLE
cuda-python: make it possible to build wheel from sdist

### DIFF
--- a/cuda_python/MANIFEST.in
+++ b/cuda_python/MANIFEST.in
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
+
+include _version.py

--- a/cuda_python/_version.py
+++ b/cuda_python/_version.py
@@ -1,0 +1,1 @@
+../cuda_bindings/cuda/bindings/_version.py

--- a/cuda_python/setup.py
+++ b/cuda_python/setup.py
@@ -5,10 +5,10 @@
 import ast
 from setuptools import setup
 
-# We want to keep the version in sync with cuda.bindings, but setuptools would not let
-# us to refer to any files outside of the project root, so we have to employ our own
-# run-time lookup using setup()...
-with open("../cuda_bindings/cuda/bindings/_version.py") as f:
+# We want to keep the version in sync with cuda.bindings, but setuptools does not
+# provide a nice way to construct the dependencies in pyproject.toml, so we need
+# to manually grab the version and do it ourselves.
+with open("_version.py") as f:
     for line in f:
         if line.startswith("__version__"):
             version = ast.parse(line).body[0].value.value


### PR DESCRIPTION
## Description

Refactor cuda-bindings version lookup to make it possible to build cuda-python from a source distribution.  Rather than using the version file straight from `cuda_bindings` tree, use a `_version.py` symlink. This is equivalent inside the git repository, and is replaced by the actual file in the source distribution, resulting in a standalone archive.

Related to issue #754.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

(the changes don't affect package code, so no changes required)