### PR TITLE
Improve documentation of CUstream.getPtr

### DIFF
--- a/cuda_bindings/docs/source/tips_and_tricks.rst
+++ b/cuda_bindings/docs/source/tips_and_tricks.rst
@@ -9,7 +9,7 @@ Getting the address of underlying C objects from the low-level bindings
 
 All CUDA C types are exposed to Python as Python classes. For example, the :class:`~cuda.bindings.driver.CUstream` type is exposed as a class with methods :meth:`~cuda.bindings.driver.CUstream.getPtr()` and :meth:`~cuda.bindings.driver.CUstream.__int__()` implemented.
 
-There is an important distinction between the ``getPtr()`` method and the behaviour of ``__int__()``. If you need to get the pointer address *of* the underlying ``CUstream`` C object wrapped in the Python class, you can do so by calling ``int(instance_of_CUstream)``, which returns the address as a Python `int`, while calling ``instance_of_CUstream.getPtr()`` returns the pointer *to* the ``CUstream`` C object (that is, ``&CUstream``) as a Python `int`.
+There is an important distinction between the ``getPtr()`` method and the behaviour of ``__int__()``. Since a `CUstream` is itself just a pointer, calling ``instance_of_CUstream.getPtr()`` returns the pointer *to* the pointer instead of the value of the ``CUstream`` C object that is the pointer to the underlying stream handle. ``int(instance_of_CUstream)`` returns the value of the `CUstream` converted to a Python int and is the actual address of the underlying handle.
 
 
 Lifetime management of the CUDA objects


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

The documentation of the difference between `CUstream.getPtr` and `CUstream.__int__` is not clear. This change emphasizes the key fact that `CUstream` is itself a pointer to help clarify that the former returns a pointer to a pointer while the latter returns the usually desired pointer.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [x] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

