### PR TITLE
[pathfinder] Fix #763 (load `libnvJitLink.so.12` from conda, not `/usr/local/cuda`)

### DIFF
--- a/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/load_dl_linux.py
+++ b/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/load_dl_linux.py
@@ -96,7 +96,7 @@ def load_with_system_search(libname: str) -> Optional[LoadedDL]:
         RuntimeError: If the library is loaded but no expected symbol is found
     """
     candidate_sonames = list(SUPPORTED_LINUX_SONAMES.get(libname, ()))
-    candidate_sonames.append(f"{libname}.so")
+    candidate_sonames.append(f"lib{libname}.so")
     for soname in candidate_sonames:
         try:
             handle = ctypes.CDLL(soname, CDLL_MODE)

--- a/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/load_dl_windows.py
+++ b/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/load_dl_windows.py
@@ -120,12 +120,11 @@ def check_if_already_loaded_from_elsewhere(libname: str) -> Optional[LoadedDL]:
     return None
 
 
-def load_with_system_search(libname: str, _soname: str) -> Optional[LoadedDL]:
+def load_with_system_search(libname: str) -> Optional[LoadedDL]:
     """Try to load a DLL using system search paths.
 
     Args:
         libname: The name of the library to load
-        soname: Unused parameter (kept for interface consistency)
 
     Returns:
         A LoadedDL object if successful, None if the library cannot be loaded

--- a/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/load_nvidia_dynamic_lib.py
+++ b/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/load_nvidia_dynamic_lib.py
@@ -37,7 +37,7 @@ def _load_lib_no_cache(libname: str) -> LoadedDL:
     # Find the library path
     found = _FindNvidiaDynamicLib(libname)
     if found.abs_path is None:
-        loaded = load_with_system_search(libname, found.lib_searched_for)
+        loaded = load_with_system_search(libname)
         if loaded is not None:
             return loaded
         found.retry_with_cuda_home_priority_last()


### PR DESCRIPTION
Closes #763

This fixes the issue, but corresponding new tests are missing.