### PR TITLE
_cuda_bindings_redirector.py fix (made necessary by PR #773)

### DIFF
--- a/cuda_bindings/site-packages/_cuda_bindings_redirector.py
+++ b/cuda_bindings/site-packages/_cuda_bindings_redirector.py
@@ -1,9 +1,30 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-import os
-import site
+import sys
+from types import ModuleType
 
-_bindings_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-if _bindings_root not in site.getsitepackages():
-    site.addsitedir(_bindings_root)
+
+# Make sure 'cuda' is importable as a namespace package
+import cuda
+
+
+class LazyCudaModule(ModuleType):
+
+    def __getattr__(self, name):
+        if name == '__version__':
+            import warnings
+            warnings.warn(
+                "accessing cuda.__version__ is deprecated, " "please switch to use cuda.bindings.__version__ instead",
+                FutureWarning,
+                stacklevel=2,
+            )
+            from cuda.bindings import __version__
+
+            return __version__
+
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+# Patch in LazyCudaModule for `cuda`
+sys.modules['cuda'].__class__ = LazyCudaModule

--- a/cuda_bindings/site-packages/_cuda_bindings_redirector.py
+++ b/cuda_bindings/site-packages/_cuda_bindings_redirector.py
@@ -1,29 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-import sys
-from types import ModuleType
+import os
+import site
 
-
-class LazyCudaModule(ModuleType):
-
-    def __getattr__(self, name):
-        if name == '__version__':
-            import warnings
-            warnings.warn(
-                "accessing cuda.__version__ is deprecated, " "please switch to use cuda.bindings.__version__ instead",
-                FutureWarning,
-                stacklevel=2,
-            )
-            from cuda.bindings import __version__
-
-            return __version__
-
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-# Important: We need to populate the cuda namespace module first, otherwise
-# we'd lose access to any of its submodules. This is a cheap op because there
-# is nothing under cuda.bindings.
-import cuda.bindings
-sys.modules['cuda'].__class__ = LazyCudaModule
+_bindings_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _bindings_root not in site.getsitepackages():
+    site.addsitedir(_bindings_root)


### PR DESCRIPTION
Avoid premature import of `cuda.bindings` in redirector to fix startup noise (see [here](https://github.com/NVIDIA/cuda-python/pull/773#issuecomment-3111270268)).

Previously, the `_cuda_bindings_redirector.py` file imported `cuda.bindings` at interpreter startup to ensure the `cuda` namespace was initialized. However, this triggered early loading of Cython modules that depend on `win32api`, which may not be available yet due to `.pth` file processing order.

This commit replaces `import cuda.bindings` with `import cuda`, which is sufficient to ensure the `cuda` namespace is in `sys.modules`. The version redirect via `cuda.__version__` is preserved by assigning a custom `LazyCudaModule` type to `sys.modules["cuda"]`.

As a result, `cuda.__version__` continues to work (with a deprecation warning), while avoiding startup errors when `win32api` is not yet importable.