### PR TITLE
Remove profile directive from cuda_bindings default Cython build settings

### DIFF
--- a/cuda_bindings/setup.py
+++ b/cuda_bindings/setup.py
@@ -323,7 +323,7 @@ def do_cythonize(extensions):
     return cythonize(
         extensions,
         nthreads=nthreads,
-        compiler_directives=dict(profile=True, language_level=3, embedsignature=True, binding=True),
+        compiler_directives=dict(language_level=3, embedsignature=True, binding=True),
         **extra_cythonize_kwargs,
     )
 


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cuda-python/issues/786

<!-- Provide a standalone description of changes in this PR. -->
This PR removes the default setting of having profiling support embedded in Cython builds.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [x] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

