### PR TITLE
Disable doc build on the backport branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,21 +91,21 @@ jobs:
       host-platform: ${{ matrix.host-platform }}
       build-ctk-ver: ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
 
-  doc:
-    name: Docs
-    if: ${{ github.repository_owner == 'nvidia' }}
-    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-    permissions:
-      id-token: write
-      contents: write
-      pull-requests: write
-    needs:
-      - ci-vars
-      - build
-    secrets: inherit
-    uses: ./.github/workflows/build-docs.yml
-    with:
-      build-ctk-ver: ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
+#  doc:
+#    name: Docs
+#    if: ${{ github.repository_owner == 'nvidia' }}
+#    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+#    permissions:
+#      id-token: write
+#      contents: write
+#      pull-requests: write
+#    needs:
+#      - ci-vars
+#      - build
+#    secrets: inherit
+#    uses: ./.github/workflows/build-docs.yml
+#    with:
+#      build-ctk-ver: ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
 
   checks:
     name: Check job status
@@ -115,6 +115,6 @@ jobs:
       - build
       - test-linux
       - test-windows
-      - doc
+#      - doc
     secrets: inherit
     uses: ./.github/workflows/status-check.yml


### PR DESCRIPTION
## Description

Doc build on the backport branch is currently failing: 
https://github.com/NVIDIA/cuda-python/actions/runs/16740254311/job/47399563108
I don't think this is ever enabled before. Let's disable it for now.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

