### PR TITLE
Fix URLs for cccl docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ CUDA Python is the home for accessing NVIDIA’s CUDA platform from Python. It c
 
 * [cuda.core](https://nvidia.github.io/cuda-python/cuda-core/latest): Pythonic access to CUDA Runtime and other core functionalities
 * [cuda.bindings](https://nvidia.github.io/cuda-python/cuda-bindings/latest): Low-level Python bindings to CUDA C APIs
-* [cuda.cccl.cooperative](https://nvidia.github.io/cccl/cuda_cooperative/): A Python module providing CCCL's reusable block-wide and warp-wide *device* primitives for use within Numba CUDA kernels
-* [cuda.cccl.parallel](https://nvidia.github.io/cccl/cuda_parallel/): A Python module for easy access to CCCL's highly efficient and customizable parallel algorithms, like `sort`, `scan`, `reduce`, `transform`, etc. that are callable on the *host*
+* [cuda.cccl.cooperative](https://nvidia.github.io/cccl/python/cooperative): A Python module providing CCCL's reusable block-wide and warp-wide *device* primitives for use within Numba CUDA kernels
+* [cuda.cccl.parallel](https://nvidia.github.io/cccl/python/parallel): A Python module for easy access to CCCL's highly efficient and customizable parallel algorithms, like `sort`, `scan`, `reduce`, `transform`, etc. that are callable on the *host*
 * [numba.cuda](https://nvidia.github.io/numba-cuda/): Numba's target for CUDA GPU programming by directly compiling a restricted subset of Python code into CUDA kernels and device functions following the CUDA execution model.
 * [nvmath-python](https://docs.nvidia.com/cuda/nvmath-python/latest): Pythonic access to NVIDIA CPU & GPU Math Libraries, with both [*host*](https://docs.nvidia.com/cuda/nvmath-python/latest/overview.html#host-apis) and [*device* (nvmath.device)](https://docs.nvidia.com/cuda/nvmath-python/latest/overview.html#device-apis) APIs. It also provides low-level Python bindings to host C APIs ([nvmath.bindings](https://docs.nvidia.com/cuda/nvmath-python/latest/bindings/index.html)).
 

--- a/cuda_python/DESCRIPTION.rst
+++ b/cuda_python/DESCRIPTION.rst
@@ -9,8 +9,8 @@ CUDA Python is the home for accessing NVIDIA's CUDA platform from Python. It con
 
 * `cuda.core <https://nvidia.github.io/cuda-python/cuda-core/latest>`_: Pythonic access to CUDA Runtime and other core functionalities
 * `cuda.bindings <https://nvidia.github.io/cuda-python/cuda-bindings/latest>`_: Low-level Python bindings to CUDA C APIs
-* `cuda.cooperative <https://nvidia.github.io/cccl/cuda_cooperative/>`_: A Python package providing CCCL's reusable block-wide and warp-wide *device* primitives for use within Numba CUDA kernels
-* `cuda.parallel <https://nvidia.github.io/cccl/cuda_parallel/>`_: A Python package for easy access to CCCL's highly efficient and customizable parallel algorithms, like `sort`, `scan`, `reduce`, `transform`, etc, that are callable on the *host*
+* `cuda.cooperative <https://nvidia.github.io/cccl/python/cooperative>`_: A Python package providing CCCL's reusable block-wide and warp-wide *device* primitives for use within Numba CUDA kernels
+* `cuda.parallel <https://nvidia.github.io/cccl/python/parallel>`_: A Python package for easy access to CCCL's highly efficient and customizable parallel algorithms, like `sort`, `scan`, `reduce`, `transform`, etc, that are callable on the *host*
 * `numba.cuda <https://nvidia.github.io/numba-cuda/>`_: Numba's target for CUDA GPU programming by directly compiling a restricted subset of Python code into CUDA kernels and device functions following the CUDA execution model.
 
 For access to NVIDIA CPU & GPU Math Libraries, please refer to `nvmath-python <https://docs.nvidia.com/cuda/nvmath-python/latest>`_.

--- a/cuda_python/docs/source/conf.py
+++ b/cuda_python/docs/source/conf.py
@@ -96,7 +96,7 @@ CUDA_PYTHON_DOMAIN = os.environ.get("CUDA_PYTHON_DOMAIN", "https://nvidia.github
 rst_epilog = f"""
 .. _cuda.core: {CUDA_PYTHON_DOMAIN}/cuda-core/latest
 .. _cuda.bindings: {CUDA_PYTHON_DOMAIN}/cuda-bindings/latest
-.. _cuda.cccl.cooperative: https://nvidia.github.io/cccl/cuda_cooperative/
-.. _cuda.cccl.parallel: https://nvidia.github.io/cccl/cuda_parallel/
+.. _cuda.cccl.cooperative: https://nvidia.github.io/cccl/python/cooperative
+.. _cuda.cccl.parallel: https://nvidia.github.io/cccl/python/parallel
 .. _numba.cuda: https://nvidia.github.io/numba-cuda/
 """

--- a/cuda_python/docs/source/index.rst
+++ b/cuda_python/docs/source/index.rst
@@ -33,7 +33,7 @@ be available, please refer to the `cuda.bindings`_ documentation for installatio
    release.md
    cuda.core <https://nvidia.github.io/cuda-python/cuda-core/latest>
    cuda.bindings <https://nvidia.github.io/cuda-python/cuda-bindings/latest>
-   cuda.cccl.cooperative <https://nvidia.github.io/cccl/cuda_cooperative>
-   cuda.cccl.parallel <https://nvidia.github.io/cccl/cuda_parallel>
+   cuda.cccl.cooperative <https://nvidia.github.io/cccl/python/cooperative>
+   cuda.cccl.parallel <https://nvidia.github.io/cccl/python/parallel>
    numba.cuda <https://nvidia.github.io/numba-cuda/>
    nvmath-python <https://docs.nvidia.com/cuda/nvmath-python/>


### PR DESCRIPTION
## Description

https://nvidia.github.io/cccl/cuda_cooperative/ and https://nvidia.github.io/cccl/cuda_parallel/ are 404s

Update to pages under https://nvidia.github.io/cccl/python/

> Let me know if opening a github issue is necessary just for this

## Checklist

> My main dev machine with my gpg key for signing is down with power outage in our office, I'll resign and push tomorrow if that's required.
