### PR TITLE
Minimal cufile cuda_bindings updates for CTK 13

### DIFF
--- a/cuda_bindings/cuda/bindings/_internal/cufile.pxd
+++ b/cuda_bindings/cuda/bindings/_internal/cufile.pxd
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated with version 12.9.0. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.0 to 13.0.0. Do not modify it directly.
 
 from ..cycufile cimport *
 
@@ -41,3 +41,16 @@ cdef CUfileError_t _cuFileGetParameterString(CUFileStringConfigParameter_t param
 cdef CUfileError_t _cuFileSetParameterSizeT(CUFileSizeTConfigParameter_t param, size_t value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t _cuFileSetParameterBool(CUFileBoolConfigParameter_t param, cpp_bool value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t _cuFileSetParameterString(CUFileStringConfigParameter_t param, const char* desc_str) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t _cuFileDriverClose() except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t _cuFileGetParameterMinMaxValue(CUFileSizeTConfigParameter_t param, size_t* min_value, size_t* max_value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t _cuFileSetStatsLevel(int level) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t _cuFileGetStatsLevel(int* level) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t _cuFileStatsStart() except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t _cuFileStatsStop() except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t _cuFileStatsReset() except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t _cuFileGetStatsL1(CUfileStatsLevel1_t* stats) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t _cuFileGetStatsL2(CUfileStatsLevel2_t* stats) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t _cuFileGetStatsL3(CUfileStatsLevel3_t* stats) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t _cuFileGetBARSizeInKB(int gpuIndex, size_t* barSize) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t _cuFileSetParameterPosixPoolSlabArray(const size_t* size_values, const size_t* count_values, int len) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t _cuFileGetParameterPosixPoolSlabArray(size_t* size_values, size_t* count_values, int len) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil

--- a/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated with version 12.9.0. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.0 to 13.0.0. Do not modify it directly.
 
 from libc.stdint cimport intptr_t, uintptr_t
 
@@ -68,6 +68,19 @@ cdef void* __cuFileGetParameterString = NULL
 cdef void* __cuFileSetParameterSizeT = NULL
 cdef void* __cuFileSetParameterBool = NULL
 cdef void* __cuFileSetParameterString = NULL
+cdef void* __cuFileDriverClose = NULL
+cdef void* __cuFileGetParameterMinMaxValue = NULL
+cdef void* __cuFileSetStatsLevel = NULL
+cdef void* __cuFileGetStatsLevel = NULL
+cdef void* __cuFileStatsStart = NULL
+cdef void* __cuFileStatsStop = NULL
+cdef void* __cuFileStatsReset = NULL
+cdef void* __cuFileGetStatsL1 = NULL
+cdef void* __cuFileGetStatsL2 = NULL
+cdef void* __cuFileGetStatsL3 = NULL
+cdef void* __cuFileGetBARSizeInKB = NULL
+cdef void* __cuFileSetParameterPosixPoolSlabArray = NULL
+cdef void* __cuFileGetParameterPosixPoolSlabArray = NULL
 
 
 cdef void* load_library(const int driver_ver) except* with gil:
@@ -312,6 +325,97 @@ cdef int _check_or_init_cufile() except -1 nogil:
             handle = load_library(driver_ver)
         __cuFileSetParameterString = dlsym(handle, 'cuFileSetParameterString')
 
+    global __cuFileDriverClose
+    __cuFileDriverClose = dlsym(RTLD_DEFAULT, 'cuFileDriverClose')
+    if __cuFileDriverClose == NULL:
+        if handle == NULL:
+            handle = load_library(driver_ver)
+        __cuFileDriverClose = dlsym(handle, 'cuFileDriverClose')
+
+    global __cuFileGetParameterMinMaxValue
+    __cuFileGetParameterMinMaxValue = dlsym(RTLD_DEFAULT, 'cuFileGetParameterMinMaxValue')
+    if __cuFileGetParameterMinMaxValue == NULL:
+        if handle == NULL:
+            handle = load_library(driver_ver)
+        __cuFileGetParameterMinMaxValue = dlsym(handle, 'cuFileGetParameterMinMaxValue')
+
+    global __cuFileSetStatsLevel
+    __cuFileSetStatsLevel = dlsym(RTLD_DEFAULT, 'cuFileSetStatsLevel')
+    if __cuFileSetStatsLevel == NULL:
+        if handle == NULL:
+            handle = load_library(driver_ver)
+        __cuFileSetStatsLevel = dlsym(handle, 'cuFileSetStatsLevel')
+
+    global __cuFileGetStatsLevel
+    __cuFileGetStatsLevel = dlsym(RTLD_DEFAULT, 'cuFileGetStatsLevel')
+    if __cuFileGetStatsLevel == NULL:
+        if handle == NULL:
+            handle = load_library(driver_ver)
+        __cuFileGetStatsLevel = dlsym(handle, 'cuFileGetStatsLevel')
+
+    global __cuFileStatsStart
+    __cuFileStatsStart = dlsym(RTLD_DEFAULT, 'cuFileStatsStart')
+    if __cuFileStatsStart == NULL:
+        if handle == NULL:
+            handle = load_library(driver_ver)
+        __cuFileStatsStart = dlsym(handle, 'cuFileStatsStart')
+
+    global __cuFileStatsStop
+    __cuFileStatsStop = dlsym(RTLD_DEFAULT, 'cuFileStatsStop')
+    if __cuFileStatsStop == NULL:
+        if handle == NULL:
+            handle = load_library(driver_ver)
+        __cuFileStatsStop = dlsym(handle, 'cuFileStatsStop')
+
+    global __cuFileStatsReset
+    __cuFileStatsReset = dlsym(RTLD_DEFAULT, 'cuFileStatsReset')
+    if __cuFileStatsReset == NULL:
+        if handle == NULL:
+            handle = load_library(driver_ver)
+        __cuFileStatsReset = dlsym(handle, 'cuFileStatsReset')
+
+    global __cuFileGetStatsL1
+    __cuFileGetStatsL1 = dlsym(RTLD_DEFAULT, 'cuFileGetStatsL1')
+    if __cuFileGetStatsL1 == NULL:
+        if handle == NULL:
+            handle = load_library(driver_ver)
+        __cuFileGetStatsL1 = dlsym(handle, 'cuFileGetStatsL1')
+
+    global __cuFileGetStatsL2
+    __cuFileGetStatsL2 = dlsym(RTLD_DEFAULT, 'cuFileGetStatsL2')
+    if __cuFileGetStatsL2 == NULL:
+        if handle == NULL:
+            handle = load_library(driver_ver)
+        __cuFileGetStatsL2 = dlsym(handle, 'cuFileGetStatsL2')
+
+    global __cuFileGetStatsL3
+    __cuFileGetStatsL3 = dlsym(RTLD_DEFAULT, 'cuFileGetStatsL3')
+    if __cuFileGetStatsL3 == NULL:
+        if handle == NULL:
+            handle = load_library(driver_ver)
+        __cuFileGetStatsL3 = dlsym(handle, 'cuFileGetStatsL3')
+
+    global __cuFileGetBARSizeInKB
+    __cuFileGetBARSizeInKB = dlsym(RTLD_DEFAULT, 'cuFileGetBARSizeInKB')
+    if __cuFileGetBARSizeInKB == NULL:
+        if handle == NULL:
+            handle = load_library(driver_ver)
+        __cuFileGetBARSizeInKB = dlsym(handle, 'cuFileGetBARSizeInKB')
+
+    global __cuFileSetParameterPosixPoolSlabArray
+    __cuFileSetParameterPosixPoolSlabArray = dlsym(RTLD_DEFAULT, 'cuFileSetParameterPosixPoolSlabArray')
+    if __cuFileSetParameterPosixPoolSlabArray == NULL:
+        if handle == NULL:
+            handle = load_library(driver_ver)
+        __cuFileSetParameterPosixPoolSlabArray = dlsym(handle, 'cuFileSetParameterPosixPoolSlabArray')
+
+    global __cuFileGetParameterPosixPoolSlabArray
+    __cuFileGetParameterPosixPoolSlabArray = dlsym(RTLD_DEFAULT, 'cuFileGetParameterPosixPoolSlabArray')
+    if __cuFileGetParameterPosixPoolSlabArray == NULL:
+        if handle == NULL:
+            handle = load_library(driver_ver)
+        __cuFileGetParameterPosixPoolSlabArray = dlsym(handle, 'cuFileGetParameterPosixPoolSlabArray')
+
     __py_cufile_init = True
     return 0
 
@@ -416,6 +520,45 @@ cpdef dict _inspect_function_pointers():
 
     global __cuFileSetParameterString
     data["__cuFileSetParameterString"] = <intptr_t>__cuFileSetParameterString
+
+    global __cuFileDriverClose
+    data["__cuFileDriverClose"] = <intptr_t>__cuFileDriverClose
+
+    global __cuFileGetParameterMinMaxValue
+    data["__cuFileGetParameterMinMaxValue"] = <intptr_t>__cuFileGetParameterMinMaxValue
+
+    global __cuFileSetStatsLevel
+    data["__cuFileSetStatsLevel"] = <intptr_t>__cuFileSetStatsLevel
+
+    global __cuFileGetStatsLevel
+    data["__cuFileGetStatsLevel"] = <intptr_t>__cuFileGetStatsLevel
+
+    global __cuFileStatsStart
+    data["__cuFileStatsStart"] = <intptr_t>__cuFileStatsStart
+
+    global __cuFileStatsStop
+    data["__cuFileStatsStop"] = <intptr_t>__cuFileStatsStop
+
+    global __cuFileStatsReset
+    data["__cuFileStatsReset"] = <intptr_t>__cuFileStatsReset
+
+    global __cuFileGetStatsL1
+    data["__cuFileGetStatsL1"] = <intptr_t>__cuFileGetStatsL1
+
+    global __cuFileGetStatsL2
+    data["__cuFileGetStatsL2"] = <intptr_t>__cuFileGetStatsL2
+
+    global __cuFileGetStatsL3
+    data["__cuFileGetStatsL3"] = <intptr_t>__cuFileGetStatsL3
+
+    global __cuFileGetBARSizeInKB
+    data["__cuFileGetBARSizeInKB"] = <intptr_t>__cuFileGetBARSizeInKB
+
+    global __cuFileSetParameterPosixPoolSlabArray
+    data["__cuFileSetParameterPosixPoolSlabArray"] = <intptr_t>__cuFileSetParameterPosixPoolSlabArray
+
+    global __cuFileGetParameterPosixPoolSlabArray
+    data["__cuFileGetParameterPosixPoolSlabArray"] = <intptr_t>__cuFileGetParameterPosixPoolSlabArray
 
     func_ptrs = data
     return data
@@ -732,3 +875,133 @@ cdef CUfileError_t _cuFileSetParameterString(CUFileStringConfigParameter_t param
             raise FunctionNotFoundError("function cuFileSetParameterString is not found")
     return (<CUfileError_t (*)(CUFileStringConfigParameter_t, const char*) noexcept nogil>__cuFileSetParameterString)(
         param, desc_str)
+
+
+cdef CUfileError_t _cuFileDriverClose() except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    global __cuFileDriverClose
+    _check_or_init_cufile()
+    if __cuFileDriverClose == NULL:
+        with gil:
+            raise FunctionNotFoundError("function cuFileDriverClose is not found")
+    return (<CUfileError_t (*)() noexcept nogil>__cuFileDriverClose)(
+        )
+
+
+cdef CUfileError_t _cuFileGetParameterMinMaxValue(CUFileSizeTConfigParameter_t param, size_t* min_value, size_t* max_value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    global __cuFileGetParameterMinMaxValue
+    _check_or_init_cufile()
+    if __cuFileGetParameterMinMaxValue == NULL:
+        with gil:
+            raise FunctionNotFoundError("function cuFileGetParameterMinMaxValue is not found")
+    return (<CUfileError_t (*)(CUFileSizeTConfigParameter_t, size_t*, size_t*) noexcept nogil>__cuFileGetParameterMinMaxValue)(
+        param, min_value, max_value)
+
+
+cdef CUfileError_t _cuFileSetStatsLevel(int level) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    global __cuFileSetStatsLevel
+    _check_or_init_cufile()
+    if __cuFileSetStatsLevel == NULL:
+        with gil:
+            raise FunctionNotFoundError("function cuFileSetStatsLevel is not found")
+    return (<CUfileError_t (*)(int) noexcept nogil>__cuFileSetStatsLevel)(
+        level)
+
+
+cdef CUfileError_t _cuFileGetStatsLevel(int* level) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    global __cuFileGetStatsLevel
+    _check_or_init_cufile()
+    if __cuFileGetStatsLevel == NULL:
+        with gil:
+            raise FunctionNotFoundError("function cuFileGetStatsLevel is not found")
+    return (<CUfileError_t (*)(int*) noexcept nogil>__cuFileGetStatsLevel)(
+        level)
+
+
+cdef CUfileError_t _cuFileStatsStart() except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    global __cuFileStatsStart
+    _check_or_init_cufile()
+    if __cuFileStatsStart == NULL:
+        with gil:
+            raise FunctionNotFoundError("function cuFileStatsStart is not found")
+    return (<CUfileError_t (*)() noexcept nogil>__cuFileStatsStart)(
+        )
+
+
+cdef CUfileError_t _cuFileStatsStop() except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    global __cuFileStatsStop
+    _check_or_init_cufile()
+    if __cuFileStatsStop == NULL:
+        with gil:
+            raise FunctionNotFoundError("function cuFileStatsStop is not found")
+    return (<CUfileError_t (*)() noexcept nogil>__cuFileStatsStop)(
+        )
+
+
+cdef CUfileError_t _cuFileStatsReset() except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    global __cuFileStatsReset
+    _check_or_init_cufile()
+    if __cuFileStatsReset == NULL:
+        with gil:
+            raise FunctionNotFoundError("function cuFileStatsReset is not found")
+    return (<CUfileError_t (*)() noexcept nogil>__cuFileStatsReset)(
+        )
+
+
+cdef CUfileError_t _cuFileGetStatsL1(CUfileStatsLevel1_t* stats) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    global __cuFileGetStatsL1
+    _check_or_init_cufile()
+    if __cuFileGetStatsL1 == NULL:
+        with gil:
+            raise FunctionNotFoundError("function cuFileGetStatsL1 is not found")
+    return (<CUfileError_t (*)(CUfileStatsLevel1_t*) noexcept nogil>__cuFileGetStatsL1)(
+        stats)
+
+
+cdef CUfileError_t _cuFileGetStatsL2(CUfileStatsLevel2_t* stats) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    global __cuFileGetStatsL2
+    _check_or_init_cufile()
+    if __cuFileGetStatsL2 == NULL:
+        with gil:
+            raise FunctionNotFoundError("function cuFileGetStatsL2 is not found")
+    return (<CUfileError_t (*)(CUfileStatsLevel2_t*) noexcept nogil>__cuFileGetStatsL2)(
+        stats)
+
+
+cdef CUfileError_t _cuFileGetStatsL3(CUfileStatsLevel3_t* stats) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    global __cuFileGetStatsL3
+    _check_or_init_cufile()
+    if __cuFileGetStatsL3 == NULL:
+        with gil:
+            raise FunctionNotFoundError("function cuFileGetStatsL3 is not found")
+    return (<CUfileError_t (*)(CUfileStatsLevel3_t*) noexcept nogil>__cuFileGetStatsL3)(
+        stats)
+
+
+cdef CUfileError_t _cuFileGetBARSizeInKB(int gpuIndex, size_t* barSize) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    global __cuFileGetBARSizeInKB
+    _check_or_init_cufile()
+    if __cuFileGetBARSizeInKB == NULL:
+        with gil:
+            raise FunctionNotFoundError("function cuFileGetBARSizeInKB is not found")
+    return (<CUfileError_t (*)(int, size_t*) noexcept nogil>__cuFileGetBARSizeInKB)(
+        gpuIndex, barSize)
+
+
+cdef CUfileError_t _cuFileSetParameterPosixPoolSlabArray(const size_t* size_values, const size_t* count_values, int len) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    global __cuFileSetParameterPosixPoolSlabArray
+    _check_or_init_cufile()
+    if __cuFileSetParameterPosixPoolSlabArray == NULL:
+        with gil:
+            raise FunctionNotFoundError("function cuFileSetParameterPosixPoolSlabArray is not found")
+    return (<CUfileError_t (*)(const size_t*, const size_t*, int) noexcept nogil>__cuFileSetParameterPosixPoolSlabArray)(
+        size_values, count_values, len)
+
+
+cdef CUfileError_t _cuFileGetParameterPosixPoolSlabArray(size_t* size_values, size_t* count_values, int len) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    global __cuFileGetParameterPosixPoolSlabArray
+    _check_or_init_cufile()
+    if __cuFileGetParameterPosixPoolSlabArray == NULL:
+        with gil:
+            raise FunctionNotFoundError("function cuFileGetParameterPosixPoolSlabArray is not found")
+    return (<CUfileError_t (*)(size_t*, size_t*, int) noexcept nogil>__cuFileGetParameterPosixPoolSlabArray)(
+        size_values, count_values, len)

--- a/cuda_bindings/cuda/bindings/cufile.pxd
+++ b/cuda_bindings/cuda/bindings/cufile.pxd
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated with version 12.9.0. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.0 to 13.0.0. Do not modify it directly.
 
 from libc.stdint cimport intptr_t
 
@@ -18,7 +18,12 @@ ctypedef CUfileBatchHandle_t BatchHandle
 ctypedef CUfileError_t Error
 ctypedef cufileRDMAInfo_t RDMAInfo
 ctypedef CUfileFSOps_t FSOps
+ctypedef CUfileOpCounter_t OpCounter
+ctypedef CUfilePerGpuStats_t PerGpuStats
 ctypedef CUfileDrvProps_t DrvProps
+ctypedef CUfileStatsLevel1_t StatsLevel1
+ctypedef CUfileStatsLevel2_t StatsLevel2
+ctypedef CUfileStatsLevel3_t StatsLevel3
 
 
 ###############################################################################
@@ -36,6 +41,7 @@ ctypedef CUfileBatchMode_t _BatchMode
 ctypedef CUFileSizeTConfigParameter_t _SizeTConfigParameter
 ctypedef CUFileBoolConfigParameter_t _BoolConfigParameter
 ctypedef CUFileStringConfigParameter_t _StringConfigParameter
+ctypedef CUFileArrayConfigParameter_t _ArrayConfigParameter
 
 
 ###############################################################################
@@ -68,6 +74,3 @@ cpdef int get_version() except? 0
 cpdef size_t get_parameter_size_t(int param) except? 0
 cpdef bint get_parameter_bool(int param) except? 0
 cpdef str get_parameter_string(int param, int len)
-cpdef set_parameter_size_t(int param, size_t value)
-cpdef set_parameter_bool(int param, bint value)
-cpdef set_parameter_string(int param, intptr_t desc_str)

--- a/cuda_bindings/cuda/bindings/cufile.pxd
+++ b/cuda_bindings/cuda/bindings/cufile.pxd
@@ -74,3 +74,6 @@ cpdef int get_version() except? 0
 cpdef size_t get_parameter_size_t(int param) except? 0
 cpdef bint get_parameter_bool(int param) except? 0
 cpdef str get_parameter_string(int param, int len)
+cpdef set_parameter_size_t(int param, size_t value)
+cpdef set_parameter_bool(int param, bint value)
+cpdef set_parameter_string(int param, intptr_t desc_str)

--- a/cuda_bindings/cuda/bindings/cufile.pyx
+++ b/cuda_bindings/cuda/bindings/cufile.pyx
@@ -1273,6 +1273,24 @@ cpdef str get_parameter_string(int param, int len):
     return _desc_str_.decode()
 
 
+cpdef set_parameter_size_t(int param, size_t value):
+    with nogil:
+        status = cuFileSetParameterSizeT(<_SizeTConfigParameter>param, value)
+    check_status(status)
+
+
+cpdef set_parameter_bool(int param, bint value):
+    with nogil:
+        status = cuFileSetParameterBool(<_BoolConfigParameter>param, <cpp_bool>value)
+    check_status(status)
+
+
+cpdef set_parameter_string(int param, intptr_t desc_str):
+    with nogil:
+        status = cuFileSetParameterString(<_StringConfigParameter>param, <const char*>desc_str)
+    check_status(status)
+
+
 cpdef str op_status_error(int status):
     """cufileop status string.
 

--- a/cuda_bindings/cuda/bindings/cufile.pyx
+++ b/cuda_bindings/cuda/bindings/cufile.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated with version 12.9.0. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.0 to 13.0.0. Do not modify it directly.
 
 cimport cython  # NOQA
 from libc cimport errno
@@ -859,6 +859,17 @@ class OpError(_IntEnum):
     GPU_MEMORY_PINNING_FAILED = CU_FILE_GPU_MEMORY_PINNING_FAILED
     BATCH_FULL = CU_FILE_BATCH_FULL
     ASYNC_NOT_SUPPORTED = CU_FILE_ASYNC_NOT_SUPPORTED
+    INTERNAL_BATCH_SETUP_ERROR = CU_FILE_INTERNAL_BATCH_SETUP_ERROR
+    INTERNAL_BATCH_SUBMIT_ERROR = CU_FILE_INTERNAL_BATCH_SUBMIT_ERROR
+    INTERNAL_BATCH_GETSTATUS_ERROR = CU_FILE_INTERNAL_BATCH_GETSTATUS_ERROR
+    INTERNAL_BATCH_CANCEL_ERROR = CU_FILE_INTERNAL_BATCH_CANCEL_ERROR
+    NOMEM_ERROR = CU_FILE_NOMEM_ERROR
+    IO_ERROR = CU_FILE_IO_ERROR
+    INTERNAL_BUF_REGISTER_ERROR = CU_FILE_INTERNAL_BUF_REGISTER_ERROR
+    HASH_OPR_ERROR = CU_FILE_HASH_OPR_ERROR
+    INVALID_CONTEXT_ERROR = CU_FILE_INVALID_CONTEXT_ERROR
+    NVFS_INTERNAL_DRIVER_ERROR = CU_FILE_NVFS_INTERNAL_DRIVER_ERROR
+    BATCH_NOCOMPAT_ERROR = CU_FILE_BATCH_NOCOMPAT_ERROR
     IO_MAX_ERROR = CU_FILE_IO_MAX_ERROR
 
 class DriverStatusFlags(_IntEnum):
@@ -948,6 +959,11 @@ class StringConfigParameter(_IntEnum):
     LOGGING_LEVEL = CUFILE_PARAM_LOGGING_LEVEL
     ENV_LOGFILE_PATH = CUFILE_PARAM_ENV_LOGFILE_PATH
     LOG_DIR = CUFILE_PARAM_LOG_DIR
+
+class ArrayConfigParameter(_IntEnum):
+    """See `CUFileArrayConfigParameter_t`."""
+    POSIX_POOL_SLAB_SIZE_KB = CUFILE_PARAM_POSIX_POOL_SLAB_SIZE_KB
+    POSIX_POOL_SLAB_COUNT = CUFILE_PARAM_POSIX_POOL_SLAB_COUNT
 
 
 ###############################################################################
@@ -1255,24 +1271,6 @@ cpdef str get_parameter_string(int param, int len):
         status = cuFileGetParameterString(<_StringConfigParameter>param, desc_str, len)
     check_status(status)
     return _desc_str_.decode()
-
-
-cpdef set_parameter_size_t(int param, size_t value):
-    with nogil:
-        status = cuFileSetParameterSizeT(<_SizeTConfigParameter>param, value)
-    check_status(status)
-
-
-cpdef set_parameter_bool(int param, bint value):
-    with nogil:
-        status = cuFileSetParameterBool(<_BoolConfigParameter>param, <cpp_bool>value)
-    check_status(status)
-
-
-cpdef set_parameter_string(int param, intptr_t desc_str):
-    with nogil:
-        status = cuFileSetParameterString(<_StringConfigParameter>param, <const char*>desc_str)
-    check_status(status)
 
 
 cpdef str op_status_error(int status):

--- a/cuda_bindings/cuda/bindings/cycufile.pxd
+++ b/cuda_bindings/cuda/bindings/cycufile.pxd
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated with version 12.9.0. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.0 to 13.0.0. Do not modify it directly.
 
+from libc.stdint cimport uint32_t, uint64_t
 from libc.time cimport time_t
 from libcpp cimport bool as cpp_bool
 from posix.types cimport off_t
@@ -69,6 +70,17 @@ cdef extern from '<cufile.h>':
         CU_FILE_GPU_MEMORY_PINNING_FAILED
         CU_FILE_BATCH_FULL
         CU_FILE_ASYNC_NOT_SUPPORTED
+        CU_FILE_INTERNAL_BATCH_SETUP_ERROR
+        CU_FILE_INTERNAL_BATCH_SUBMIT_ERROR
+        CU_FILE_INTERNAL_BATCH_GETSTATUS_ERROR
+        CU_FILE_INTERNAL_BATCH_CANCEL_ERROR
+        CU_FILE_NOMEM_ERROR
+        CU_FILE_IO_ERROR
+        CU_FILE_INTERNAL_BUF_REGISTER_ERROR
+        CU_FILE_HASH_OPR_ERROR
+        CU_FILE_INVALID_CONTEXT_ERROR
+        CU_FILE_NVFS_INTERNAL_DRIVER_ERROR
+        CU_FILE_BATCH_NOCOMPAT_ERROR
         CU_FILE_IO_MAX_ERROR
 
     ctypedef enum CUfileDriverStatusFlags_t:
@@ -149,6 +161,10 @@ cdef extern from '<cufile.h>':
         CUFILE_PARAM_ENV_LOGFILE_PATH
         CUFILE_PARAM_LOG_DIR
 
+    ctypedef enum CUFileArrayConfigParameter_t:
+        CUFILE_PARAM_POSIX_POOL_SLAB_SIZE_KB
+        CUFILE_PARAM_POSIX_POOL_SLAB_COUNT
+
     # types
     ctypedef void* CUfileHandle_t 'CUfileHandle_t'
     ctypedef void* CUfileBatchHandle_t 'CUfileBatchHandle_t'
@@ -184,6 +200,40 @@ cdef extern from '<cufile.h>':
         void* cookie
         CUfileStatus_t status
         size_t ret
+    ctypedef struct CUfileOpCounter_t 'CUfileOpCounter_t':
+        uint64_t ok
+        uint64_t err
+    ctypedef struct CUfilePerGpuStats_t 'CUfilePerGpuStats_t':
+        char uuid[16]
+        uint64_t read_bytes
+        uint64_t read_bw_bytes_per_sec
+        uint64_t read_utilization
+        uint64_t read_duration_us
+        uint64_t n_total_reads
+        uint64_t n_p2p_reads
+        uint64_t n_nvfs_reads
+        uint64_t n_posix_reads
+        uint64_t n_unaligned_reads
+        uint64_t n_dr_reads
+        uint64_t n_sparse_regions
+        uint64_t n_inline_regions
+        uint64_t n_reads_err
+        uint64_t writes_bytes
+        uint64_t write_bw_bytes_per_sec
+        uint64_t write_utilization
+        uint64_t write_duration_us
+        uint64_t n_total_writes
+        uint64_t n_p2p_writes
+        uint64_t n_nvfs_writes
+        uint64_t n_posix_writes
+        uint64_t n_unaligned_writes
+        uint64_t n_dr_writes
+        uint64_t n_writes_err
+        uint64_t n_mmap
+        uint64_t n_mmap_ok
+        uint64_t n_mmap_err
+        uint64_t n_mmap_free
+        uint64_t reg_bytes
     ctypedef struct CUfileDrvProps_t 'CUfileDrvProps_t':
         _anon_pod0 nvfs
         unsigned int fflags
@@ -198,12 +248,64 @@ cdef extern from '<cufile.h>':
         CUfileFSOps_t* fs_ops
     cdef union _anon_pod2 '_anon_pod2':
         _anon_pod3 batch
+    ctypedef struct CUfileStatsLevel1_t 'CUfileStatsLevel1_t':
+        CUfileOpCounter_t read_ops
+        CUfileOpCounter_t write_ops
+        CUfileOpCounter_t hdl_register_ops
+        CUfileOpCounter_t hdl_deregister_ops
+        CUfileOpCounter_t buf_register_ops
+        CUfileOpCounter_t buf_deregister_ops
+        uint64_t read_bytes
+        uint64_t write_bytes
+        uint64_t read_bw_bytes_per_sec
+        uint64_t write_bw_bytes_per_sec
+        uint64_t read_lat_avg_us
+        uint64_t write_lat_avg_us
+        uint64_t read_ops_per_sec
+        uint64_t write_ops_per_sec
+        uint64_t read_lat_sum_us
+        uint64_t write_lat_sum_us
+        CUfileOpCounter_t batch_submit_ops
+        CUfileOpCounter_t batch_complete_ops
+        CUfileOpCounter_t batch_setup_ops
+        CUfileOpCounter_t batch_cancel_ops
+        CUfileOpCounter_t batch_destroy_ops
+        CUfileOpCounter_t batch_enqueued_ops
+        CUfileOpCounter_t batch_posix_enqueued_ops
+        CUfileOpCounter_t batch_processed_ops
+        CUfileOpCounter_t batch_posix_processed_ops
+        CUfileOpCounter_t batch_nvfs_submit_ops
+        CUfileOpCounter_t batch_p2p_submit_ops
+        CUfileOpCounter_t batch_aio_submit_ops
+        CUfileOpCounter_t batch_iouring_submit_ops
+        CUfileOpCounter_t batch_mixed_io_submit_ops
+        CUfileOpCounter_t batch_total_submit_ops
+        uint64_t batch_read_bytes
+        uint64_t batch_write_bytes
+        uint64_t batch_read_bw_bytes
+        uint64_t batch_write_bw_bytes
+        uint64_t batch_submit_lat_avg_us
+        uint64_t batch_completion_lat_avg_us
+        uint64_t batch_submit_ops_per_sec
+        uint64_t batch_complete_ops_per_sec
+        uint64_t batch_submit_lat_sum_us
+        uint64_t batch_completion_lat_sum_us
+        uint64_t last_batch_read_bytes
+        uint64_t last_batch_write_bytes
     ctypedef struct CUfileIOParams_t 'CUfileIOParams_t':
         CUfileBatchMode_t mode
         _anon_pod2 u
         CUfileHandle_t fh
         CUfileOpcode_t opcode
         void* cookie
+    ctypedef struct CUfileStatsLevel2_t 'CUfileStatsLevel2_t':
+        CUfileStatsLevel1_t basic
+        uint64_t read_size_kb_hist[32]
+        uint64_t write_size_kb_hist[32]
+    ctypedef struct CUfileStatsLevel3_t 'CUfileStatsLevel3_t':
+        CUfileStatsLevel2_t detailed
+        uint32_t num_gpus
+        CUfilePerGpuStats_t per_gpu_stats[16]
 
 
 cdef extern from *:
@@ -254,3 +356,16 @@ cdef CUfileError_t cuFileGetParameterString(CUFileStringConfigParameter_t param,
 cdef CUfileError_t cuFileSetParameterSizeT(CUFileSizeTConfigParameter_t param, size_t value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t cuFileSetParameterBool(CUFileBoolConfigParameter_t param, cpp_bool value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t cuFileSetParameterString(CUFileStringConfigParameter_t param, const char* desc_str) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t cuFileDriverClose() except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t cuFileGetParameterMinMaxValue(CUFileSizeTConfigParameter_t param, size_t* min_value, size_t* max_value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t cuFileSetStatsLevel(int level) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t cuFileGetStatsLevel(int* level) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t cuFileStatsStart() except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t cuFileStatsStop() except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t cuFileStatsReset() except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t cuFileGetStatsL1(CUfileStatsLevel1_t* stats) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t cuFileGetStatsL2(CUfileStatsLevel2_t* stats) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t cuFileGetStatsL3(CUfileStatsLevel3_t* stats) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t cuFileGetBARSizeInKB(int gpuIndex, size_t* barSize) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t cuFileSetParameterPosixPoolSlabArray(const size_t* size_values, const size_t* count_values, int len) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t cuFileGetParameterPosixPoolSlabArray(size_t* size_values, size_t* count_values, int len) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil

--- a/cuda_bindings/cuda/bindings/cycufile.pyx
+++ b/cuda_bindings/cuda/bindings/cycufile.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated with version 12.9.0. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.0 to 13.0.0. Do not modify it directly.
 
 from ._internal cimport cufile as _cufile
 
@@ -132,3 +132,55 @@ cdef CUfileError_t cuFileSetParameterBool(CUFileBoolConfigParameter_t param, cpp
 
 cdef CUfileError_t cuFileSetParameterString(CUFileStringConfigParameter_t param, const char* desc_str) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
     return _cufile._cuFileSetParameterString(param, desc_str)
+
+
+cdef CUfileError_t cuFileDriverClose() except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    return _cufile._cuFileDriverClose()
+
+
+cdef CUfileError_t cuFileGetParameterMinMaxValue(CUFileSizeTConfigParameter_t param, size_t* min_value, size_t* max_value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    return _cufile._cuFileGetParameterMinMaxValue(param, min_value, max_value)
+
+
+cdef CUfileError_t cuFileSetStatsLevel(int level) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    return _cufile._cuFileSetStatsLevel(level)
+
+
+cdef CUfileError_t cuFileGetStatsLevel(int* level) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    return _cufile._cuFileGetStatsLevel(level)
+
+
+cdef CUfileError_t cuFileStatsStart() except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    return _cufile._cuFileStatsStart()
+
+
+cdef CUfileError_t cuFileStatsStop() except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    return _cufile._cuFileStatsStop()
+
+
+cdef CUfileError_t cuFileStatsReset() except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    return _cufile._cuFileStatsReset()
+
+
+cdef CUfileError_t cuFileGetStatsL1(CUfileStatsLevel1_t* stats) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    return _cufile._cuFileGetStatsL1(stats)
+
+
+cdef CUfileError_t cuFileGetStatsL2(CUfileStatsLevel2_t* stats) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    return _cufile._cuFileGetStatsL2(stats)
+
+
+cdef CUfileError_t cuFileGetStatsL3(CUfileStatsLevel3_t* stats) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    return _cufile._cuFileGetStatsL3(stats)
+
+
+cdef CUfileError_t cuFileGetBARSizeInKB(int gpuIndex, size_t* barSize) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    return _cufile._cuFileGetBARSizeInKB(gpuIndex, barSize)
+
+
+cdef CUfileError_t cuFileSetParameterPosixPoolSlabArray(const size_t* size_values, const size_t* count_values, int len) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    return _cufile._cuFileSetParameterPosixPoolSlabArray(size_values, count_values, len)
+
+
+cdef CUfileError_t cuFileGetParameterPosixPoolSlabArray(size_t* size_values, size_t* count_values, int len) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+    return _cufile._cuFileGetParameterPosixPoolSlabArray(size_values, count_values, len)


### PR DESCRIPTION
Some APIs added with CTK 13 are still missing:

* `cuFileSetParameterSizeT`
* `cuFileSetParameterBool`
* `cuFileSetParameterString`
* `cuFileDriverClose`
* `cuFileGetParameterMinMaxValue`
* `cuFileSetStatsLevel`
* `cuFileGetStatsLevel`
* `cuFileStatsStart`
* `cuFileStatsStop`
* `cuFileStatsReset`
* `cuFileGetStatsL1`
* `cuFileGetStatsL2`
* `cuFileGetStatsL3`
* `cuFileGetBARSizeInKB`
* `cuFileSetParameterPosixPoolSlabArray`
* `cuFileGetParameterPosixPoolSlabArray`

These will be worked on separately.