### PR TITLE
[Backport] Make populating the internal symbol table thread-safe

### DIFF
--- a/cuda_bindings/cuda/bindings/_bindings/cydriver.pyx.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cydriver.pyx.in
@@ -490,16 +490,19 @@ cdef bint __cuPythonInit = False
 {{if True}}cdef void *__cuGraphicsVDPAURegisterVideoSurface = NULL{{endif}}
 {{if True}}cdef void *__cuGraphicsVDPAURegisterOutputSurface = NULL{{endif}}
 
+# To make cuPythonInit reentrant
+ctypedef CUresult (*__cuGetProcAddress_v2_T)(const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*) except?CUDA_ERROR_NOT_FOUND nogil
+cdef __cuGetProcAddress_v2_T _F_cuGetProcAddress_v2 = NULL
+
 cdef int cuPythonInit() except -1 nogil:
     global __cuPythonInit
+    if __cuPythonInit:
+        return 0
+
     cdef bint usePTDS
     cdef char libPath[260]
 
     with gil, __symbol_lock:
-        if __cuPythonInit:
-            return 0
-        __cuPythonInit = True
-
         usePTDS = os.getenv('CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM', default=0)
     
         # Load library
@@ -527,2258 +530,2260 @@ cdef int cuPythonInit() except -1 nogil:
         {{endif}}
     
         # Get latest __cuGetProcAddress_v2
+        global __cuGetProcAddress_v2
         {{if 'Windows' == platform.system()}}
         try:
-            global __cuGetProcAddress_v2
             __cuGetProcAddress_v2 = <void*><unsigned long long>win32api.GetProcAddress(handle, 'cuGetProcAddress_v2')
         except:
             pass
         {{else}}
-        global __cuGetProcAddress_v2
         __cuGetProcAddress_v2 = dlfcn.dlsym(handle, 'cuGetProcAddress_v2')
         {{endif}}
     
         # Load using cuGetProcAddress if available
         if __cuGetProcAddress_v2 != NULL:
+            _F_cuGetProcAddress_v2 = <__cuGetProcAddress_v2_T>__cuGetProcAddress_v2
             if usePTDS:
                 # Get all PTDS version of functions
                 pass
                 {{if 'cuMemcpy' in found_functions}}
                 global __cuMemcpy
-                cuGetProcAddress('cuMemcpy', &__cuMemcpy, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpy', &__cuMemcpy, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpyPeer' in found_functions}}
                 global __cuMemcpyPeer
-                cuGetProcAddress('cuMemcpyPeer', &__cuMemcpyPeer, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyPeer', &__cuMemcpyPeer, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpyHtoD_v2' in found_functions}}
                 global __cuMemcpyHtoD_v2
-                cuGetProcAddress('cuMemcpyHtoD', &__cuMemcpyHtoD_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyHtoD', &__cuMemcpyHtoD_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpyDtoH_v2' in found_functions}}
                 global __cuMemcpyDtoH_v2
-                cuGetProcAddress('cuMemcpyDtoH', &__cuMemcpyDtoH_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyDtoH', &__cuMemcpyDtoH_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpyDtoD_v2' in found_functions}}
                 global __cuMemcpyDtoD_v2
-                cuGetProcAddress('cuMemcpyDtoD', &__cuMemcpyDtoD_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyDtoD', &__cuMemcpyDtoD_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpyDtoA_v2' in found_functions}}
                 global __cuMemcpyDtoA_v2
-                cuGetProcAddress('cuMemcpyDtoA', &__cuMemcpyDtoA_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyDtoA', &__cuMemcpyDtoA_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpyAtoD_v2' in found_functions}}
                 global __cuMemcpyAtoD_v2
-                cuGetProcAddress('cuMemcpyAtoD', &__cuMemcpyAtoD_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyAtoD', &__cuMemcpyAtoD_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpyHtoA_v2' in found_functions}}
                 global __cuMemcpyHtoA_v2
-                cuGetProcAddress('cuMemcpyHtoA', &__cuMemcpyHtoA_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyHtoA', &__cuMemcpyHtoA_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpyAtoH_v2' in found_functions}}
                 global __cuMemcpyAtoH_v2
-                cuGetProcAddress('cuMemcpyAtoH', &__cuMemcpyAtoH_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyAtoH', &__cuMemcpyAtoH_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpyAtoA_v2' in found_functions}}
                 global __cuMemcpyAtoA_v2
-                cuGetProcAddress('cuMemcpyAtoA', &__cuMemcpyAtoA_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyAtoA', &__cuMemcpyAtoA_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpy2D_v2' in found_functions}}
                 global __cuMemcpy2D_v2
-                cuGetProcAddress('cuMemcpy2D', &__cuMemcpy2D_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpy2D', &__cuMemcpy2D_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpy2DUnaligned_v2' in found_functions}}
                 global __cuMemcpy2DUnaligned_v2
-                cuGetProcAddress('cuMemcpy2DUnaligned', &__cuMemcpy2DUnaligned_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpy2DUnaligned', &__cuMemcpy2DUnaligned_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpy3D_v2' in found_functions}}
                 global __cuMemcpy3D_v2
-                cuGetProcAddress('cuMemcpy3D', &__cuMemcpy3D_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpy3D', &__cuMemcpy3D_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpy3DPeer' in found_functions}}
                 global __cuMemcpy3DPeer
-                cuGetProcAddress('cuMemcpy3DPeer', &__cuMemcpy3DPeer, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpy3DPeer', &__cuMemcpy3DPeer, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpyAsync' in found_functions}}
                 global __cuMemcpyAsync
-                cuGetProcAddress('cuMemcpyAsync', &__cuMemcpyAsync, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyAsync', &__cuMemcpyAsync, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpyPeerAsync' in found_functions}}
                 global __cuMemcpyPeerAsync
-                cuGetProcAddress('cuMemcpyPeerAsync', &__cuMemcpyPeerAsync, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyPeerAsync', &__cuMemcpyPeerAsync, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpyHtoDAsync_v2' in found_functions}}
                 global __cuMemcpyHtoDAsync_v2
-                cuGetProcAddress('cuMemcpyHtoDAsync', &__cuMemcpyHtoDAsync_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyHtoDAsync', &__cuMemcpyHtoDAsync_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpyDtoHAsync_v2' in found_functions}}
                 global __cuMemcpyDtoHAsync_v2
-                cuGetProcAddress('cuMemcpyDtoHAsync', &__cuMemcpyDtoHAsync_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyDtoHAsync', &__cuMemcpyDtoHAsync_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpyDtoDAsync_v2' in found_functions}}
                 global __cuMemcpyDtoDAsync_v2
-                cuGetProcAddress('cuMemcpyDtoDAsync', &__cuMemcpyDtoDAsync_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyDtoDAsync', &__cuMemcpyDtoDAsync_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpyHtoAAsync_v2' in found_functions}}
                 global __cuMemcpyHtoAAsync_v2
-                cuGetProcAddress('cuMemcpyHtoAAsync', &__cuMemcpyHtoAAsync_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyHtoAAsync', &__cuMemcpyHtoAAsync_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpyAtoHAsync_v2' in found_functions}}
                 global __cuMemcpyAtoHAsync_v2
-                cuGetProcAddress('cuMemcpyAtoHAsync', &__cuMemcpyAtoHAsync_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyAtoHAsync', &__cuMemcpyAtoHAsync_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpy2DAsync_v2' in found_functions}}
                 global __cuMemcpy2DAsync_v2
-                cuGetProcAddress('cuMemcpy2DAsync', &__cuMemcpy2DAsync_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpy2DAsync', &__cuMemcpy2DAsync_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpy3DAsync_v2' in found_functions}}
                 global __cuMemcpy3DAsync_v2
-                cuGetProcAddress('cuMemcpy3DAsync', &__cuMemcpy3DAsync_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpy3DAsync', &__cuMemcpy3DAsync_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpy3DPeerAsync' in found_functions}}
                 global __cuMemcpy3DPeerAsync
-                cuGetProcAddress('cuMemcpy3DPeerAsync', &__cuMemcpy3DPeerAsync, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpy3DPeerAsync', &__cuMemcpy3DPeerAsync, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpyBatchAsync' in found_functions}}
                 global __cuMemcpyBatchAsync
-                cuGetProcAddress('cuMemcpyBatchAsync', &__cuMemcpyBatchAsync, 12080, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyBatchAsync', &__cuMemcpyBatchAsync, 12080, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemcpy3DBatchAsync' in found_functions}}
                 global __cuMemcpy3DBatchAsync
-                cuGetProcAddress('cuMemcpy3DBatchAsync', &__cuMemcpy3DBatchAsync, 12080, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpy3DBatchAsync', &__cuMemcpy3DBatchAsync, 12080, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemsetD8_v2' in found_functions}}
                 global __cuMemsetD8_v2
-                cuGetProcAddress('cuMemsetD8', &__cuMemsetD8_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD8', &__cuMemsetD8_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemsetD16_v2' in found_functions}}
                 global __cuMemsetD16_v2
-                cuGetProcAddress('cuMemsetD16', &__cuMemsetD16_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD16', &__cuMemsetD16_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemsetD32_v2' in found_functions}}
                 global __cuMemsetD32_v2
-                cuGetProcAddress('cuMemsetD32', &__cuMemsetD32_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD32', &__cuMemsetD32_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemsetD2D8_v2' in found_functions}}
                 global __cuMemsetD2D8_v2
-                cuGetProcAddress('cuMemsetD2D8', &__cuMemsetD2D8_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD2D8', &__cuMemsetD2D8_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemsetD2D16_v2' in found_functions}}
                 global __cuMemsetD2D16_v2
-                cuGetProcAddress('cuMemsetD2D16', &__cuMemsetD2D16_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD2D16', &__cuMemsetD2D16_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemsetD2D32_v2' in found_functions}}
                 global __cuMemsetD2D32_v2
-                cuGetProcAddress('cuMemsetD2D32', &__cuMemsetD2D32_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD2D32', &__cuMemsetD2D32_v2, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemsetD8Async' in found_functions}}
                 global __cuMemsetD8Async
-                cuGetProcAddress('cuMemsetD8Async', &__cuMemsetD8Async, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD8Async', &__cuMemsetD8Async, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemsetD16Async' in found_functions}}
                 global __cuMemsetD16Async
-                cuGetProcAddress('cuMemsetD16Async', &__cuMemsetD16Async, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD16Async', &__cuMemsetD16Async, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemsetD32Async' in found_functions}}
                 global __cuMemsetD32Async
-                cuGetProcAddress('cuMemsetD32Async', &__cuMemsetD32Async, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD32Async', &__cuMemsetD32Async, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemsetD2D8Async' in found_functions}}
                 global __cuMemsetD2D8Async
-                cuGetProcAddress('cuMemsetD2D8Async', &__cuMemsetD2D8Async, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD2D8Async', &__cuMemsetD2D8Async, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemsetD2D16Async' in found_functions}}
                 global __cuMemsetD2D16Async
-                cuGetProcAddress('cuMemsetD2D16Async', &__cuMemsetD2D16Async, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD2D16Async', &__cuMemsetD2D16Async, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemsetD2D32Async' in found_functions}}
                 global __cuMemsetD2D32Async
-                cuGetProcAddress('cuMemsetD2D32Async', &__cuMemsetD2D32Async, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD2D32Async', &__cuMemsetD2D32Async, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemBatchDecompressAsync' in found_functions}}
                 global __cuMemBatchDecompressAsync
-                cuGetProcAddress('cuMemBatchDecompressAsync', &__cuMemBatchDecompressAsync, 12060, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemBatchDecompressAsync', &__cuMemBatchDecompressAsync, 12060, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemMapArrayAsync' in found_functions}}
                 global __cuMemMapArrayAsync
-                cuGetProcAddress('cuMemMapArrayAsync', &__cuMemMapArrayAsync, 11010, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemMapArrayAsync', &__cuMemMapArrayAsync, 11010, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemFreeAsync' in found_functions}}
                 global __cuMemFreeAsync
-                cuGetProcAddress('cuMemFreeAsync', &__cuMemFreeAsync, 11020, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemFreeAsync', &__cuMemFreeAsync, 11020, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemAllocAsync' in found_functions}}
                 global __cuMemAllocAsync
-                cuGetProcAddress('cuMemAllocAsync', &__cuMemAllocAsync, 11020, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemAllocAsync', &__cuMemAllocAsync, 11020, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemAllocFromPoolAsync' in found_functions}}
                 global __cuMemAllocFromPoolAsync
-                cuGetProcAddress('cuMemAllocFromPoolAsync', &__cuMemAllocFromPoolAsync, 11020, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemAllocFromPoolAsync', &__cuMemAllocFromPoolAsync, 11020, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemPrefetchAsync' in found_functions}}
                 global __cuMemPrefetchAsync
-                cuGetProcAddress('cuMemPrefetchAsync', &__cuMemPrefetchAsync, 8000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemPrefetchAsync', &__cuMemPrefetchAsync, 8000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuMemPrefetchAsync_v2' in found_functions}}
                 global __cuMemPrefetchAsync_v2
-                cuGetProcAddress('cuMemPrefetchAsync', &__cuMemPrefetchAsync_v2, 12020, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuMemPrefetchAsync', &__cuMemPrefetchAsync_v2, 12020, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamGetPriority' in found_functions}}
                 global __cuStreamGetPriority
-                cuGetProcAddress('cuStreamGetPriority', &__cuStreamGetPriority, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamGetPriority', &__cuStreamGetPriority, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamGetDevice' in found_functions}}
                 global __cuStreamGetDevice
-                cuGetProcAddress('cuStreamGetDevice', &__cuStreamGetDevice, 12080, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamGetDevice', &__cuStreamGetDevice, 12080, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamGetFlags' in found_functions}}
                 global __cuStreamGetFlags
-                cuGetProcAddress('cuStreamGetFlags', &__cuStreamGetFlags, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamGetFlags', &__cuStreamGetFlags, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamGetId' in found_functions}}
                 global __cuStreamGetId
-                cuGetProcAddress('cuStreamGetId', &__cuStreamGetId, 12000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamGetId', &__cuStreamGetId, 12000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamGetCtx' in found_functions}}
                 global __cuStreamGetCtx
-                cuGetProcAddress('cuStreamGetCtx', &__cuStreamGetCtx, 9020, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamGetCtx', &__cuStreamGetCtx, 9020, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamGetCtx_v2' in found_functions}}
                 global __cuStreamGetCtx_v2
-                cuGetProcAddress('cuStreamGetCtx', &__cuStreamGetCtx_v2, 12050, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamGetCtx', &__cuStreamGetCtx_v2, 12050, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamWaitEvent' in found_functions}}
                 global __cuStreamWaitEvent
-                cuGetProcAddress('cuStreamWaitEvent', &__cuStreamWaitEvent, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamWaitEvent', &__cuStreamWaitEvent, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamAddCallback' in found_functions}}
                 global __cuStreamAddCallback
-                cuGetProcAddress('cuStreamAddCallback', &__cuStreamAddCallback, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamAddCallback', &__cuStreamAddCallback, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamBeginCapture_v2' in found_functions}}
                 global __cuStreamBeginCapture_v2
-                cuGetProcAddress('cuStreamBeginCapture', &__cuStreamBeginCapture_v2, 10010, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamBeginCapture', &__cuStreamBeginCapture_v2, 10010, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamBeginCaptureToGraph' in found_functions}}
                 global __cuStreamBeginCaptureToGraph
-                cuGetProcAddress('cuStreamBeginCaptureToGraph', &__cuStreamBeginCaptureToGraph, 12030, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamBeginCaptureToGraph', &__cuStreamBeginCaptureToGraph, 12030, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamEndCapture' in found_functions}}
                 global __cuStreamEndCapture
-                cuGetProcAddress('cuStreamEndCapture', &__cuStreamEndCapture, 10000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamEndCapture', &__cuStreamEndCapture, 10000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamIsCapturing' in found_functions}}
                 global __cuStreamIsCapturing
-                cuGetProcAddress('cuStreamIsCapturing', &__cuStreamIsCapturing, 10000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamIsCapturing', &__cuStreamIsCapturing, 10000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamGetCaptureInfo_v2' in found_functions}}
                 global __cuStreamGetCaptureInfo_v2
-                cuGetProcAddress('cuStreamGetCaptureInfo', &__cuStreamGetCaptureInfo_v2, 11030, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamGetCaptureInfo', &__cuStreamGetCaptureInfo_v2, 11030, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamGetCaptureInfo_v3' in found_functions}}
                 global __cuStreamGetCaptureInfo_v3
-                cuGetProcAddress('cuStreamGetCaptureInfo', &__cuStreamGetCaptureInfo_v3, 12030, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamGetCaptureInfo', &__cuStreamGetCaptureInfo_v3, 12030, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamUpdateCaptureDependencies' in found_functions}}
                 global __cuStreamUpdateCaptureDependencies
-                cuGetProcAddress('cuStreamUpdateCaptureDependencies', &__cuStreamUpdateCaptureDependencies, 11030, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamUpdateCaptureDependencies', &__cuStreamUpdateCaptureDependencies, 11030, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamUpdateCaptureDependencies_v2' in found_functions}}
                 global __cuStreamUpdateCaptureDependencies_v2
-                cuGetProcAddress('cuStreamUpdateCaptureDependencies', &__cuStreamUpdateCaptureDependencies_v2, 12030, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamUpdateCaptureDependencies', &__cuStreamUpdateCaptureDependencies_v2, 12030, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamAttachMemAsync' in found_functions}}
                 global __cuStreamAttachMemAsync
-                cuGetProcAddress('cuStreamAttachMemAsync', &__cuStreamAttachMemAsync, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamAttachMemAsync', &__cuStreamAttachMemAsync, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamQuery' in found_functions}}
                 global __cuStreamQuery
-                cuGetProcAddress('cuStreamQuery', &__cuStreamQuery, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamQuery', &__cuStreamQuery, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamSynchronize' in found_functions}}
                 global __cuStreamSynchronize
-                cuGetProcAddress('cuStreamSynchronize', &__cuStreamSynchronize, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamSynchronize', &__cuStreamSynchronize, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamCopyAttributes' in found_functions}}
                 global __cuStreamCopyAttributes
-                cuGetProcAddress('cuStreamCopyAttributes', &__cuStreamCopyAttributes, 11000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamCopyAttributes', &__cuStreamCopyAttributes, 11000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamGetAttribute' in found_functions}}
                 global __cuStreamGetAttribute
-                cuGetProcAddress('cuStreamGetAttribute', &__cuStreamGetAttribute, 11000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamGetAttribute', &__cuStreamGetAttribute, 11000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamSetAttribute' in found_functions}}
                 global __cuStreamSetAttribute
-                cuGetProcAddress('cuStreamSetAttribute', &__cuStreamSetAttribute, 11000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamSetAttribute', &__cuStreamSetAttribute, 11000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuEventRecord' in found_functions}}
                 global __cuEventRecord
-                cuGetProcAddress('cuEventRecord', &__cuEventRecord, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuEventRecord', &__cuEventRecord, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuEventRecordWithFlags' in found_functions}}
                 global __cuEventRecordWithFlags
-                cuGetProcAddress('cuEventRecordWithFlags', &__cuEventRecordWithFlags, 11010, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuEventRecordWithFlags', &__cuEventRecordWithFlags, 11010, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuSignalExternalSemaphoresAsync' in found_functions}}
                 global __cuSignalExternalSemaphoresAsync
-                cuGetProcAddress('cuSignalExternalSemaphoresAsync', &__cuSignalExternalSemaphoresAsync, 10000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuSignalExternalSemaphoresAsync', &__cuSignalExternalSemaphoresAsync, 10000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuWaitExternalSemaphoresAsync' in found_functions}}
                 global __cuWaitExternalSemaphoresAsync
-                cuGetProcAddress('cuWaitExternalSemaphoresAsync', &__cuWaitExternalSemaphoresAsync, 10000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuWaitExternalSemaphoresAsync', &__cuWaitExternalSemaphoresAsync, 10000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamWaitValue32_v2' in found_functions}}
                 global __cuStreamWaitValue32_v2
-                cuGetProcAddress('cuStreamWaitValue32', &__cuStreamWaitValue32_v2, 11070, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamWaitValue32', &__cuStreamWaitValue32_v2, 11070, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamWaitValue64_v2' in found_functions}}
                 global __cuStreamWaitValue64_v2
-                cuGetProcAddress('cuStreamWaitValue64', &__cuStreamWaitValue64_v2, 11070, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamWaitValue64', &__cuStreamWaitValue64_v2, 11070, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamWriteValue32_v2' in found_functions}}
                 global __cuStreamWriteValue32_v2
-                cuGetProcAddress('cuStreamWriteValue32', &__cuStreamWriteValue32_v2, 11070, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamWriteValue32', &__cuStreamWriteValue32_v2, 11070, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamWriteValue64_v2' in found_functions}}
                 global __cuStreamWriteValue64_v2
-                cuGetProcAddress('cuStreamWriteValue64', &__cuStreamWriteValue64_v2, 11070, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamWriteValue64', &__cuStreamWriteValue64_v2, 11070, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuStreamBatchMemOp_v2' in found_functions}}
                 global __cuStreamBatchMemOp_v2
-                cuGetProcAddress('cuStreamBatchMemOp', &__cuStreamBatchMemOp_v2, 11070, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuStreamBatchMemOp', &__cuStreamBatchMemOp_v2, 11070, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuLaunchKernel' in found_functions}}
                 global __cuLaunchKernel
-                cuGetProcAddress('cuLaunchKernel', &__cuLaunchKernel, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuLaunchKernel', &__cuLaunchKernel, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuLaunchKernelEx' in found_functions}}
                 global __cuLaunchKernelEx
-                cuGetProcAddress('cuLaunchKernelEx', &__cuLaunchKernelEx, 11060, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuLaunchKernelEx', &__cuLaunchKernelEx, 11060, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuLaunchCooperativeKernel' in found_functions}}
                 global __cuLaunchCooperativeKernel
-                cuGetProcAddress('cuLaunchCooperativeKernel', &__cuLaunchCooperativeKernel, 9000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuLaunchCooperativeKernel', &__cuLaunchCooperativeKernel, 9000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuLaunchHostFunc' in found_functions}}
                 global __cuLaunchHostFunc
-                cuGetProcAddress('cuLaunchHostFunc', &__cuLaunchHostFunc, 10000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuLaunchHostFunc', &__cuLaunchHostFunc, 10000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuGraphInstantiateWithParams' in found_functions}}
                 global __cuGraphInstantiateWithParams
-                cuGetProcAddress('cuGraphInstantiateWithParams', &__cuGraphInstantiateWithParams, 12000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuGraphInstantiateWithParams', &__cuGraphInstantiateWithParams, 12000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuGraphUpload' in found_functions}}
                 global __cuGraphUpload
-                cuGetProcAddress('cuGraphUpload', &__cuGraphUpload, 11010, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuGraphUpload', &__cuGraphUpload, 11010, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuGraphLaunch' in found_functions}}
                 global __cuGraphLaunch
-                cuGetProcAddress('cuGraphLaunch', &__cuGraphLaunch, 10000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuGraphLaunch', &__cuGraphLaunch, 10000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuGraphicsMapResources' in found_functions}}
                 global __cuGraphicsMapResources
-                cuGetProcAddress('cuGraphicsMapResources', &__cuGraphicsMapResources, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuGraphicsMapResources', &__cuGraphicsMapResources, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
                 {{if 'cuGraphicsUnmapResources' in found_functions}}
                 global __cuGraphicsUnmapResources
-                cuGetProcAddress('cuGraphicsUnmapResources', &__cuGraphicsUnmapResources, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
+                _F_cuGetProcAddress_v2('cuGraphicsUnmapResources', &__cuGraphicsUnmapResources, 7000, CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM, NULL)
                 {{endif}}
             else:
                 # Else get the regular version
                 pass
                 {{if 'cuMemcpy' in found_functions}}
                 global __cuMemcpy
-                cuGetProcAddress('cuMemcpy', &__cuMemcpy, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpy', &__cuMemcpy, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpyPeer' in found_functions}}
                 global __cuMemcpyPeer
-                cuGetProcAddress('cuMemcpyPeer', &__cuMemcpyPeer, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyPeer', &__cuMemcpyPeer, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpyHtoD_v2' in found_functions}}
                 global __cuMemcpyHtoD_v2
-                cuGetProcAddress('cuMemcpyHtoD', &__cuMemcpyHtoD_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyHtoD', &__cuMemcpyHtoD_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpyDtoH_v2' in found_functions}}
                 global __cuMemcpyDtoH_v2
-                cuGetProcAddress('cuMemcpyDtoH', &__cuMemcpyDtoH_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyDtoH', &__cuMemcpyDtoH_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpyDtoD_v2' in found_functions}}
                 global __cuMemcpyDtoD_v2
-                cuGetProcAddress('cuMemcpyDtoD', &__cuMemcpyDtoD_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyDtoD', &__cuMemcpyDtoD_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpyDtoA_v2' in found_functions}}
                 global __cuMemcpyDtoA_v2
-                cuGetProcAddress('cuMemcpyDtoA', &__cuMemcpyDtoA_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyDtoA', &__cuMemcpyDtoA_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpyAtoD_v2' in found_functions}}
                 global __cuMemcpyAtoD_v2
-                cuGetProcAddress('cuMemcpyAtoD', &__cuMemcpyAtoD_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyAtoD', &__cuMemcpyAtoD_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpyHtoA_v2' in found_functions}}
                 global __cuMemcpyHtoA_v2
-                cuGetProcAddress('cuMemcpyHtoA', &__cuMemcpyHtoA_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyHtoA', &__cuMemcpyHtoA_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpyAtoH_v2' in found_functions}}
                 global __cuMemcpyAtoH_v2
-                cuGetProcAddress('cuMemcpyAtoH', &__cuMemcpyAtoH_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyAtoH', &__cuMemcpyAtoH_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpyAtoA_v2' in found_functions}}
                 global __cuMemcpyAtoA_v2
-                cuGetProcAddress('cuMemcpyAtoA', &__cuMemcpyAtoA_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyAtoA', &__cuMemcpyAtoA_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpy2D_v2' in found_functions}}
                 global __cuMemcpy2D_v2
-                cuGetProcAddress('cuMemcpy2D', &__cuMemcpy2D_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpy2D', &__cuMemcpy2D_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpy2DUnaligned_v2' in found_functions}}
                 global __cuMemcpy2DUnaligned_v2
-                cuGetProcAddress('cuMemcpy2DUnaligned', &__cuMemcpy2DUnaligned_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpy2DUnaligned', &__cuMemcpy2DUnaligned_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpy3D_v2' in found_functions}}
                 global __cuMemcpy3D_v2
-                cuGetProcAddress('cuMemcpy3D', &__cuMemcpy3D_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpy3D', &__cuMemcpy3D_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpy3DPeer' in found_functions}}
                 global __cuMemcpy3DPeer
-                cuGetProcAddress('cuMemcpy3DPeer', &__cuMemcpy3DPeer, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpy3DPeer', &__cuMemcpy3DPeer, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpyAsync' in found_functions}}
                 global __cuMemcpyAsync
-                cuGetProcAddress('cuMemcpyAsync', &__cuMemcpyAsync, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyAsync', &__cuMemcpyAsync, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpyPeerAsync' in found_functions}}
                 global __cuMemcpyPeerAsync
-                cuGetProcAddress('cuMemcpyPeerAsync', &__cuMemcpyPeerAsync, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyPeerAsync', &__cuMemcpyPeerAsync, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpyHtoDAsync_v2' in found_functions}}
                 global __cuMemcpyHtoDAsync_v2
-                cuGetProcAddress('cuMemcpyHtoDAsync', &__cuMemcpyHtoDAsync_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyHtoDAsync', &__cuMemcpyHtoDAsync_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpyDtoHAsync_v2' in found_functions}}
                 global __cuMemcpyDtoHAsync_v2
-                cuGetProcAddress('cuMemcpyDtoHAsync', &__cuMemcpyDtoHAsync_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyDtoHAsync', &__cuMemcpyDtoHAsync_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpyDtoDAsync_v2' in found_functions}}
                 global __cuMemcpyDtoDAsync_v2
-                cuGetProcAddress('cuMemcpyDtoDAsync', &__cuMemcpyDtoDAsync_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyDtoDAsync', &__cuMemcpyDtoDAsync_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpyHtoAAsync_v2' in found_functions}}
                 global __cuMemcpyHtoAAsync_v2
-                cuGetProcAddress('cuMemcpyHtoAAsync', &__cuMemcpyHtoAAsync_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyHtoAAsync', &__cuMemcpyHtoAAsync_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpyAtoHAsync_v2' in found_functions}}
                 global __cuMemcpyAtoHAsync_v2
-                cuGetProcAddress('cuMemcpyAtoHAsync', &__cuMemcpyAtoHAsync_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyAtoHAsync', &__cuMemcpyAtoHAsync_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpy2DAsync_v2' in found_functions}}
                 global __cuMemcpy2DAsync_v2
-                cuGetProcAddress('cuMemcpy2DAsync', &__cuMemcpy2DAsync_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpy2DAsync', &__cuMemcpy2DAsync_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpy3DAsync_v2' in found_functions}}
                 global __cuMemcpy3DAsync_v2
-                cuGetProcAddress('cuMemcpy3DAsync', &__cuMemcpy3DAsync_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpy3DAsync', &__cuMemcpy3DAsync_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpy3DPeerAsync' in found_functions}}
                 global __cuMemcpy3DPeerAsync
-                cuGetProcAddress('cuMemcpy3DPeerAsync', &__cuMemcpy3DPeerAsync, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpy3DPeerAsync', &__cuMemcpy3DPeerAsync, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpyBatchAsync' in found_functions}}
                 global __cuMemcpyBatchAsync
-                cuGetProcAddress('cuMemcpyBatchAsync', &__cuMemcpyBatchAsync, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpyBatchAsync', &__cuMemcpyBatchAsync, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemcpy3DBatchAsync' in found_functions}}
                 global __cuMemcpy3DBatchAsync
-                cuGetProcAddress('cuMemcpy3DBatchAsync', &__cuMemcpy3DBatchAsync, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemcpy3DBatchAsync', &__cuMemcpy3DBatchAsync, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemsetD8_v2' in found_functions}}
                 global __cuMemsetD8_v2
-                cuGetProcAddress('cuMemsetD8', &__cuMemsetD8_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD8', &__cuMemsetD8_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemsetD16_v2' in found_functions}}
                 global __cuMemsetD16_v2
-                cuGetProcAddress('cuMemsetD16', &__cuMemsetD16_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD16', &__cuMemsetD16_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemsetD32_v2' in found_functions}}
                 global __cuMemsetD32_v2
-                cuGetProcAddress('cuMemsetD32', &__cuMemsetD32_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD32', &__cuMemsetD32_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemsetD2D8_v2' in found_functions}}
                 global __cuMemsetD2D8_v2
-                cuGetProcAddress('cuMemsetD2D8', &__cuMemsetD2D8_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD2D8', &__cuMemsetD2D8_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemsetD2D16_v2' in found_functions}}
                 global __cuMemsetD2D16_v2
-                cuGetProcAddress('cuMemsetD2D16', &__cuMemsetD2D16_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD2D16', &__cuMemsetD2D16_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemsetD2D32_v2' in found_functions}}
                 global __cuMemsetD2D32_v2
-                cuGetProcAddress('cuMemsetD2D32', &__cuMemsetD2D32_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD2D32', &__cuMemsetD2D32_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemsetD8Async' in found_functions}}
                 global __cuMemsetD8Async
-                cuGetProcAddress('cuMemsetD8Async', &__cuMemsetD8Async, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD8Async', &__cuMemsetD8Async, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemsetD16Async' in found_functions}}
                 global __cuMemsetD16Async
-                cuGetProcAddress('cuMemsetD16Async', &__cuMemsetD16Async, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD16Async', &__cuMemsetD16Async, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemsetD32Async' in found_functions}}
                 global __cuMemsetD32Async
-                cuGetProcAddress('cuMemsetD32Async', &__cuMemsetD32Async, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD32Async', &__cuMemsetD32Async, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemsetD2D8Async' in found_functions}}
                 global __cuMemsetD2D8Async
-                cuGetProcAddress('cuMemsetD2D8Async', &__cuMemsetD2D8Async, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD2D8Async', &__cuMemsetD2D8Async, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemsetD2D16Async' in found_functions}}
                 global __cuMemsetD2D16Async
-                cuGetProcAddress('cuMemsetD2D16Async', &__cuMemsetD2D16Async, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD2D16Async', &__cuMemsetD2D16Async, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemsetD2D32Async' in found_functions}}
                 global __cuMemsetD2D32Async
-                cuGetProcAddress('cuMemsetD2D32Async', &__cuMemsetD2D32Async, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemsetD2D32Async', &__cuMemsetD2D32Async, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemBatchDecompressAsync' in found_functions}}
                 global __cuMemBatchDecompressAsync
-                cuGetProcAddress('cuMemBatchDecompressAsync', &__cuMemBatchDecompressAsync, 12060, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemBatchDecompressAsync', &__cuMemBatchDecompressAsync, 12060, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemMapArrayAsync' in found_functions}}
                 global __cuMemMapArrayAsync
-                cuGetProcAddress('cuMemMapArrayAsync', &__cuMemMapArrayAsync, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemMapArrayAsync', &__cuMemMapArrayAsync, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemFreeAsync' in found_functions}}
                 global __cuMemFreeAsync
-                cuGetProcAddress('cuMemFreeAsync', &__cuMemFreeAsync, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemFreeAsync', &__cuMemFreeAsync, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemAllocAsync' in found_functions}}
                 global __cuMemAllocAsync
-                cuGetProcAddress('cuMemAllocAsync', &__cuMemAllocAsync, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemAllocAsync', &__cuMemAllocAsync, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemAllocFromPoolAsync' in found_functions}}
                 global __cuMemAllocFromPoolAsync
-                cuGetProcAddress('cuMemAllocFromPoolAsync', &__cuMemAllocFromPoolAsync, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemAllocFromPoolAsync', &__cuMemAllocFromPoolAsync, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemPrefetchAsync' in found_functions}}
                 global __cuMemPrefetchAsync
-                cuGetProcAddress('cuMemPrefetchAsync', &__cuMemPrefetchAsync, 8000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemPrefetchAsync', &__cuMemPrefetchAsync, 8000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuMemPrefetchAsync_v2' in found_functions}}
                 global __cuMemPrefetchAsync_v2
-                cuGetProcAddress('cuMemPrefetchAsync', &__cuMemPrefetchAsync_v2, 12020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuMemPrefetchAsync', &__cuMemPrefetchAsync_v2, 12020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamGetPriority' in found_functions}}
                 global __cuStreamGetPriority
-                cuGetProcAddress('cuStreamGetPriority', &__cuStreamGetPriority, 5050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamGetPriority', &__cuStreamGetPriority, 5050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamGetDevice' in found_functions}}
                 global __cuStreamGetDevice
-                cuGetProcAddress('cuStreamGetDevice', &__cuStreamGetDevice, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamGetDevice', &__cuStreamGetDevice, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamGetFlags' in found_functions}}
                 global __cuStreamGetFlags
-                cuGetProcAddress('cuStreamGetFlags', &__cuStreamGetFlags, 5050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamGetFlags', &__cuStreamGetFlags, 5050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamGetId' in found_functions}}
                 global __cuStreamGetId
-                cuGetProcAddress('cuStreamGetId', &__cuStreamGetId, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamGetId', &__cuStreamGetId, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamGetCtx' in found_functions}}
                 global __cuStreamGetCtx
-                cuGetProcAddress('cuStreamGetCtx', &__cuStreamGetCtx, 9020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamGetCtx', &__cuStreamGetCtx, 9020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamGetCtx_v2' in found_functions}}
                 global __cuStreamGetCtx_v2
-                cuGetProcAddress('cuStreamGetCtx', &__cuStreamGetCtx_v2, 12050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamGetCtx', &__cuStreamGetCtx_v2, 12050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamWaitEvent' in found_functions}}
                 global __cuStreamWaitEvent
-                cuGetProcAddress('cuStreamWaitEvent', &__cuStreamWaitEvent, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamWaitEvent', &__cuStreamWaitEvent, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamAddCallback' in found_functions}}
                 global __cuStreamAddCallback
-                cuGetProcAddress('cuStreamAddCallback', &__cuStreamAddCallback, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamAddCallback', &__cuStreamAddCallback, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamBeginCapture_v2' in found_functions}}
                 global __cuStreamBeginCapture_v2
-                cuGetProcAddress('cuStreamBeginCapture', &__cuStreamBeginCapture_v2, 10010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamBeginCapture', &__cuStreamBeginCapture_v2, 10010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamBeginCaptureToGraph' in found_functions}}
                 global __cuStreamBeginCaptureToGraph
-                cuGetProcAddress('cuStreamBeginCaptureToGraph', &__cuStreamBeginCaptureToGraph, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamBeginCaptureToGraph', &__cuStreamBeginCaptureToGraph, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamEndCapture' in found_functions}}
                 global __cuStreamEndCapture
-                cuGetProcAddress('cuStreamEndCapture', &__cuStreamEndCapture, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamEndCapture', &__cuStreamEndCapture, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamIsCapturing' in found_functions}}
                 global __cuStreamIsCapturing
-                cuGetProcAddress('cuStreamIsCapturing', &__cuStreamIsCapturing, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamIsCapturing', &__cuStreamIsCapturing, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamGetCaptureInfo_v2' in found_functions}}
                 global __cuStreamGetCaptureInfo_v2
-                cuGetProcAddress('cuStreamGetCaptureInfo', &__cuStreamGetCaptureInfo_v2, 11030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamGetCaptureInfo', &__cuStreamGetCaptureInfo_v2, 11030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamGetCaptureInfo_v3' in found_functions}}
                 global __cuStreamGetCaptureInfo_v3
-                cuGetProcAddress('cuStreamGetCaptureInfo', &__cuStreamGetCaptureInfo_v3, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamGetCaptureInfo', &__cuStreamGetCaptureInfo_v3, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamUpdateCaptureDependencies' in found_functions}}
                 global __cuStreamUpdateCaptureDependencies
-                cuGetProcAddress('cuStreamUpdateCaptureDependencies', &__cuStreamUpdateCaptureDependencies, 11030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamUpdateCaptureDependencies', &__cuStreamUpdateCaptureDependencies, 11030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamUpdateCaptureDependencies_v2' in found_functions}}
                 global __cuStreamUpdateCaptureDependencies_v2
-                cuGetProcAddress('cuStreamUpdateCaptureDependencies', &__cuStreamUpdateCaptureDependencies_v2, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamUpdateCaptureDependencies', &__cuStreamUpdateCaptureDependencies_v2, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamAttachMemAsync' in found_functions}}
                 global __cuStreamAttachMemAsync
-                cuGetProcAddress('cuStreamAttachMemAsync', &__cuStreamAttachMemAsync, 6000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamAttachMemAsync', &__cuStreamAttachMemAsync, 6000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamQuery' in found_functions}}
                 global __cuStreamQuery
-                cuGetProcAddress('cuStreamQuery', &__cuStreamQuery, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamQuery', &__cuStreamQuery, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamSynchronize' in found_functions}}
                 global __cuStreamSynchronize
-                cuGetProcAddress('cuStreamSynchronize', &__cuStreamSynchronize, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamSynchronize', &__cuStreamSynchronize, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamCopyAttributes' in found_functions}}
                 global __cuStreamCopyAttributes
-                cuGetProcAddress('cuStreamCopyAttributes', &__cuStreamCopyAttributes, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamCopyAttributes', &__cuStreamCopyAttributes, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamGetAttribute' in found_functions}}
                 global __cuStreamGetAttribute
-                cuGetProcAddress('cuStreamGetAttribute', &__cuStreamGetAttribute, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamGetAttribute', &__cuStreamGetAttribute, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamSetAttribute' in found_functions}}
                 global __cuStreamSetAttribute
-                cuGetProcAddress('cuStreamSetAttribute', &__cuStreamSetAttribute, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamSetAttribute', &__cuStreamSetAttribute, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuEventRecord' in found_functions}}
                 global __cuEventRecord
-                cuGetProcAddress('cuEventRecord', &__cuEventRecord, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuEventRecord', &__cuEventRecord, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuEventRecordWithFlags' in found_functions}}
                 global __cuEventRecordWithFlags
-                cuGetProcAddress('cuEventRecordWithFlags', &__cuEventRecordWithFlags, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuEventRecordWithFlags', &__cuEventRecordWithFlags, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuSignalExternalSemaphoresAsync' in found_functions}}
                 global __cuSignalExternalSemaphoresAsync
-                cuGetProcAddress('cuSignalExternalSemaphoresAsync', &__cuSignalExternalSemaphoresAsync, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuSignalExternalSemaphoresAsync', &__cuSignalExternalSemaphoresAsync, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuWaitExternalSemaphoresAsync' in found_functions}}
                 global __cuWaitExternalSemaphoresAsync
-                cuGetProcAddress('cuWaitExternalSemaphoresAsync', &__cuWaitExternalSemaphoresAsync, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuWaitExternalSemaphoresAsync', &__cuWaitExternalSemaphoresAsync, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamWaitValue32_v2' in found_functions}}
                 global __cuStreamWaitValue32_v2
-                cuGetProcAddress('cuStreamWaitValue32', &__cuStreamWaitValue32_v2, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamWaitValue32', &__cuStreamWaitValue32_v2, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamWaitValue64_v2' in found_functions}}
                 global __cuStreamWaitValue64_v2
-                cuGetProcAddress('cuStreamWaitValue64', &__cuStreamWaitValue64_v2, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamWaitValue64', &__cuStreamWaitValue64_v2, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamWriteValue32_v2' in found_functions}}
                 global __cuStreamWriteValue32_v2
-                cuGetProcAddress('cuStreamWriteValue32', &__cuStreamWriteValue32_v2, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamWriteValue32', &__cuStreamWriteValue32_v2, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamWriteValue64_v2' in found_functions}}
                 global __cuStreamWriteValue64_v2
-                cuGetProcAddress('cuStreamWriteValue64', &__cuStreamWriteValue64_v2, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamWriteValue64', &__cuStreamWriteValue64_v2, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuStreamBatchMemOp_v2' in found_functions}}
                 global __cuStreamBatchMemOp_v2
-                cuGetProcAddress('cuStreamBatchMemOp', &__cuStreamBatchMemOp_v2, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuStreamBatchMemOp', &__cuStreamBatchMemOp_v2, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuLaunchKernel' in found_functions}}
                 global __cuLaunchKernel
-                cuGetProcAddress('cuLaunchKernel', &__cuLaunchKernel, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuLaunchKernel', &__cuLaunchKernel, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuLaunchKernelEx' in found_functions}}
                 global __cuLaunchKernelEx
-                cuGetProcAddress('cuLaunchKernelEx', &__cuLaunchKernelEx, 11060, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuLaunchKernelEx', &__cuLaunchKernelEx, 11060, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuLaunchCooperativeKernel' in found_functions}}
                 global __cuLaunchCooperativeKernel
-                cuGetProcAddress('cuLaunchCooperativeKernel', &__cuLaunchCooperativeKernel, 9000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuLaunchCooperativeKernel', &__cuLaunchCooperativeKernel, 9000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuLaunchHostFunc' in found_functions}}
                 global __cuLaunchHostFunc
-                cuGetProcAddress('cuLaunchHostFunc', &__cuLaunchHostFunc, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuLaunchHostFunc', &__cuLaunchHostFunc, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuGraphInstantiateWithParams' in found_functions}}
                 global __cuGraphInstantiateWithParams
-                cuGetProcAddress('cuGraphInstantiateWithParams', &__cuGraphInstantiateWithParams, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuGraphInstantiateWithParams', &__cuGraphInstantiateWithParams, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuGraphUpload' in found_functions}}
                 global __cuGraphUpload
-                cuGetProcAddress('cuGraphUpload', &__cuGraphUpload, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuGraphUpload', &__cuGraphUpload, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuGraphLaunch' in found_functions}}
                 global __cuGraphLaunch
-                cuGetProcAddress('cuGraphLaunch', &__cuGraphLaunch, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuGraphLaunch', &__cuGraphLaunch, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuGraphicsMapResources' in found_functions}}
                 global __cuGraphicsMapResources
-                cuGetProcAddress('cuGraphicsMapResources', &__cuGraphicsMapResources, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuGraphicsMapResources', &__cuGraphicsMapResources, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
                 {{if 'cuGraphicsUnmapResources' in found_functions}}
                 global __cuGraphicsUnmapResources
-                cuGetProcAddress('cuGraphicsUnmapResources', &__cuGraphicsUnmapResources, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+                _F_cuGetProcAddress_v2('cuGraphicsUnmapResources', &__cuGraphicsUnmapResources, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
                 {{endif}}
             # Get remaining functions
             {{if 'cuGetErrorString' in found_functions}}
             global __cuGetErrorString
-            cuGetProcAddress('cuGetErrorString', &__cuGetErrorString, 6000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGetErrorString', &__cuGetErrorString, 6000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGetErrorName' in found_functions}}
             global __cuGetErrorName
-            cuGetProcAddress('cuGetErrorName', &__cuGetErrorName, 6000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGetErrorName', &__cuGetErrorName, 6000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuInit' in found_functions}}
             global __cuInit
-            cuGetProcAddress('cuInit', &__cuInit, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuInit', &__cuInit, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDriverGetVersion' in found_functions}}
             global __cuDriverGetVersion
-            cuGetProcAddress('cuDriverGetVersion', &__cuDriverGetVersion, 2020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDriverGetVersion', &__cuDriverGetVersion, 2020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceGet' in found_functions}}
             global __cuDeviceGet
-            cuGetProcAddress('cuDeviceGet', &__cuDeviceGet, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceGet', &__cuDeviceGet, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceGetCount' in found_functions}}
             global __cuDeviceGetCount
-            cuGetProcAddress('cuDeviceGetCount', &__cuDeviceGetCount, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceGetCount', &__cuDeviceGetCount, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceGetName' in found_functions}}
             global __cuDeviceGetName
-            cuGetProcAddress('cuDeviceGetName', &__cuDeviceGetName, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceGetName', &__cuDeviceGetName, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceGetUuid' in found_functions}}
             global __cuDeviceGetUuid
-            cuGetProcAddress('cuDeviceGetUuid', &__cuDeviceGetUuid, 9020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceGetUuid', &__cuDeviceGetUuid, 9020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceGetUuid_v2' in found_functions}}
             global __cuDeviceGetUuid_v2
-            cuGetProcAddress('cuDeviceGetUuid', &__cuDeviceGetUuid_v2, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceGetUuid', &__cuDeviceGetUuid_v2, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceGetLuid' in found_functions}}
             global __cuDeviceGetLuid
-            cuGetProcAddress('cuDeviceGetLuid', &__cuDeviceGetLuid, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceGetLuid', &__cuDeviceGetLuid, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceTotalMem_v2' in found_functions}}
             global __cuDeviceTotalMem_v2
-            cuGetProcAddress('cuDeviceTotalMem', &__cuDeviceTotalMem_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceTotalMem', &__cuDeviceTotalMem_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceGetTexture1DLinearMaxWidth' in found_functions}}
             global __cuDeviceGetTexture1DLinearMaxWidth
-            cuGetProcAddress('cuDeviceGetTexture1DLinearMaxWidth', &__cuDeviceGetTexture1DLinearMaxWidth, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceGetTexture1DLinearMaxWidth', &__cuDeviceGetTexture1DLinearMaxWidth, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceGetAttribute' in found_functions}}
             global __cuDeviceGetAttribute
-            cuGetProcAddress('cuDeviceGetAttribute', &__cuDeviceGetAttribute, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceGetAttribute', &__cuDeviceGetAttribute, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceGetNvSciSyncAttributes' in found_functions}}
             global __cuDeviceGetNvSciSyncAttributes
-            cuGetProcAddress('cuDeviceGetNvSciSyncAttributes', &__cuDeviceGetNvSciSyncAttributes, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceGetNvSciSyncAttributes', &__cuDeviceGetNvSciSyncAttributes, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceSetMemPool' in found_functions}}
             global __cuDeviceSetMemPool
-            cuGetProcAddress('cuDeviceSetMemPool', &__cuDeviceSetMemPool, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceSetMemPool', &__cuDeviceSetMemPool, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceGetMemPool' in found_functions}}
             global __cuDeviceGetMemPool
-            cuGetProcAddress('cuDeviceGetMemPool', &__cuDeviceGetMemPool, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceGetMemPool', &__cuDeviceGetMemPool, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceGetDefaultMemPool' in found_functions}}
             global __cuDeviceGetDefaultMemPool
-            cuGetProcAddress('cuDeviceGetDefaultMemPool', &__cuDeviceGetDefaultMemPool, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceGetDefaultMemPool', &__cuDeviceGetDefaultMemPool, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceGetExecAffinitySupport' in found_functions}}
             global __cuDeviceGetExecAffinitySupport
-            cuGetProcAddress('cuDeviceGetExecAffinitySupport', &__cuDeviceGetExecAffinitySupport, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceGetExecAffinitySupport', &__cuDeviceGetExecAffinitySupport, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuFlushGPUDirectRDMAWrites' in found_functions}}
             global __cuFlushGPUDirectRDMAWrites
-            cuGetProcAddress('cuFlushGPUDirectRDMAWrites', &__cuFlushGPUDirectRDMAWrites, 11030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuFlushGPUDirectRDMAWrites', &__cuFlushGPUDirectRDMAWrites, 11030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceGetProperties' in found_functions}}
             global __cuDeviceGetProperties
-            cuGetProcAddress('cuDeviceGetProperties', &__cuDeviceGetProperties, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceGetProperties', &__cuDeviceGetProperties, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceComputeCapability' in found_functions}}
             global __cuDeviceComputeCapability
-            cuGetProcAddress('cuDeviceComputeCapability', &__cuDeviceComputeCapability, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceComputeCapability', &__cuDeviceComputeCapability, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDevicePrimaryCtxRetain' in found_functions}}
             global __cuDevicePrimaryCtxRetain
-            cuGetProcAddress('cuDevicePrimaryCtxRetain', &__cuDevicePrimaryCtxRetain, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDevicePrimaryCtxRetain', &__cuDevicePrimaryCtxRetain, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDevicePrimaryCtxRelease_v2' in found_functions}}
             global __cuDevicePrimaryCtxRelease_v2
-            cuGetProcAddress('cuDevicePrimaryCtxRelease', &__cuDevicePrimaryCtxRelease_v2, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDevicePrimaryCtxRelease', &__cuDevicePrimaryCtxRelease_v2, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDevicePrimaryCtxSetFlags_v2' in found_functions}}
             global __cuDevicePrimaryCtxSetFlags_v2
-            cuGetProcAddress('cuDevicePrimaryCtxSetFlags', &__cuDevicePrimaryCtxSetFlags_v2, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDevicePrimaryCtxSetFlags', &__cuDevicePrimaryCtxSetFlags_v2, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDevicePrimaryCtxGetState' in found_functions}}
             global __cuDevicePrimaryCtxGetState
-            cuGetProcAddress('cuDevicePrimaryCtxGetState', &__cuDevicePrimaryCtxGetState, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDevicePrimaryCtxGetState', &__cuDevicePrimaryCtxGetState, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDevicePrimaryCtxReset_v2' in found_functions}}
             global __cuDevicePrimaryCtxReset_v2
-            cuGetProcAddress('cuDevicePrimaryCtxReset', &__cuDevicePrimaryCtxReset_v2, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDevicePrimaryCtxReset', &__cuDevicePrimaryCtxReset_v2, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxCreate_v2' in found_functions}}
             global __cuCtxCreate_v2
-            cuGetProcAddress('cuCtxCreate', &__cuCtxCreate_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxCreate', &__cuCtxCreate_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxCreate_v3' in found_functions}}
             global __cuCtxCreate_v3
-            cuGetProcAddress('cuCtxCreate', &__cuCtxCreate_v3, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxCreate', &__cuCtxCreate_v3, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxCreate_v4' in found_functions}}
             global __cuCtxCreate_v4
-            cuGetProcAddress('cuCtxCreate', &__cuCtxCreate_v4, 12050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxCreate', &__cuCtxCreate_v4, 12050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxDestroy_v2' in found_functions}}
             global __cuCtxDestroy_v2
-            cuGetProcAddress('cuCtxDestroy', &__cuCtxDestroy_v2, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxDestroy', &__cuCtxDestroy_v2, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxPushCurrent_v2' in found_functions}}
             global __cuCtxPushCurrent_v2
-            cuGetProcAddress('cuCtxPushCurrent', &__cuCtxPushCurrent_v2, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxPushCurrent', &__cuCtxPushCurrent_v2, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxPopCurrent_v2' in found_functions}}
             global __cuCtxPopCurrent_v2
-            cuGetProcAddress('cuCtxPopCurrent', &__cuCtxPopCurrent_v2, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxPopCurrent', &__cuCtxPopCurrent_v2, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxSetCurrent' in found_functions}}
             global __cuCtxSetCurrent
-            cuGetProcAddress('cuCtxSetCurrent', &__cuCtxSetCurrent, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxSetCurrent', &__cuCtxSetCurrent, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxGetCurrent' in found_functions}}
             global __cuCtxGetCurrent
-            cuGetProcAddress('cuCtxGetCurrent', &__cuCtxGetCurrent, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxGetCurrent', &__cuCtxGetCurrent, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxGetDevice' in found_functions}}
             global __cuCtxGetDevice
-            cuGetProcAddress('cuCtxGetDevice', &__cuCtxGetDevice, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxGetDevice', &__cuCtxGetDevice, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxGetFlags' in found_functions}}
             global __cuCtxGetFlags
-            cuGetProcAddress('cuCtxGetFlags', &__cuCtxGetFlags, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxGetFlags', &__cuCtxGetFlags, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxSetFlags' in found_functions}}
             global __cuCtxSetFlags
-            cuGetProcAddress('cuCtxSetFlags', &__cuCtxSetFlags, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxSetFlags', &__cuCtxSetFlags, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxGetId' in found_functions}}
             global __cuCtxGetId
-            cuGetProcAddress('cuCtxGetId', &__cuCtxGetId, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxGetId', &__cuCtxGetId, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxSynchronize' in found_functions}}
             global __cuCtxSynchronize
-            cuGetProcAddress('cuCtxSynchronize', &__cuCtxSynchronize, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxSynchronize', &__cuCtxSynchronize, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxSetLimit' in found_functions}}
             global __cuCtxSetLimit
-            cuGetProcAddress('cuCtxSetLimit', &__cuCtxSetLimit, 3010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxSetLimit', &__cuCtxSetLimit, 3010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxGetLimit' in found_functions}}
             global __cuCtxGetLimit
-            cuGetProcAddress('cuCtxGetLimit', &__cuCtxGetLimit, 3010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxGetLimit', &__cuCtxGetLimit, 3010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxGetCacheConfig' in found_functions}}
             global __cuCtxGetCacheConfig
-            cuGetProcAddress('cuCtxGetCacheConfig', &__cuCtxGetCacheConfig, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxGetCacheConfig', &__cuCtxGetCacheConfig, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxSetCacheConfig' in found_functions}}
             global __cuCtxSetCacheConfig
-            cuGetProcAddress('cuCtxSetCacheConfig', &__cuCtxSetCacheConfig, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxSetCacheConfig', &__cuCtxSetCacheConfig, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxGetApiVersion' in found_functions}}
             global __cuCtxGetApiVersion
-            cuGetProcAddress('cuCtxGetApiVersion', &__cuCtxGetApiVersion, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxGetApiVersion', &__cuCtxGetApiVersion, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxGetStreamPriorityRange' in found_functions}}
             global __cuCtxGetStreamPriorityRange
-            cuGetProcAddress('cuCtxGetStreamPriorityRange', &__cuCtxGetStreamPriorityRange, 5050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxGetStreamPriorityRange', &__cuCtxGetStreamPriorityRange, 5050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxResetPersistingL2Cache' in found_functions}}
             global __cuCtxResetPersistingL2Cache
-            cuGetProcAddress('cuCtxResetPersistingL2Cache', &__cuCtxResetPersistingL2Cache, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxResetPersistingL2Cache', &__cuCtxResetPersistingL2Cache, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxGetExecAffinity' in found_functions}}
             global __cuCtxGetExecAffinity
-            cuGetProcAddress('cuCtxGetExecAffinity', &__cuCtxGetExecAffinity, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxGetExecAffinity', &__cuCtxGetExecAffinity, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxRecordEvent' in found_functions}}
             global __cuCtxRecordEvent
-            cuGetProcAddress('cuCtxRecordEvent', &__cuCtxRecordEvent, 12050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxRecordEvent', &__cuCtxRecordEvent, 12050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxWaitEvent' in found_functions}}
             global __cuCtxWaitEvent
-            cuGetProcAddress('cuCtxWaitEvent', &__cuCtxWaitEvent, 12050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxWaitEvent', &__cuCtxWaitEvent, 12050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxAttach' in found_functions}}
             global __cuCtxAttach
-            cuGetProcAddress('cuCtxAttach', &__cuCtxAttach, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxAttach', &__cuCtxAttach, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxDetach' in found_functions}}
             global __cuCtxDetach
-            cuGetProcAddress('cuCtxDetach', &__cuCtxDetach, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxDetach', &__cuCtxDetach, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxGetSharedMemConfig' in found_functions}}
             global __cuCtxGetSharedMemConfig
-            cuGetProcAddress('cuCtxGetSharedMemConfig', &__cuCtxGetSharedMemConfig, 4020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxGetSharedMemConfig', &__cuCtxGetSharedMemConfig, 4020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxSetSharedMemConfig' in found_functions}}
             global __cuCtxSetSharedMemConfig
-            cuGetProcAddress('cuCtxSetSharedMemConfig', &__cuCtxSetSharedMemConfig, 4020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxSetSharedMemConfig', &__cuCtxSetSharedMemConfig, 4020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuModuleLoad' in found_functions}}
             global __cuModuleLoad
-            cuGetProcAddress('cuModuleLoad', &__cuModuleLoad, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuModuleLoad', &__cuModuleLoad, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuModuleLoadData' in found_functions}}
             global __cuModuleLoadData
-            cuGetProcAddress('cuModuleLoadData', &__cuModuleLoadData, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuModuleLoadData', &__cuModuleLoadData, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuModuleLoadDataEx' in found_functions}}
             global __cuModuleLoadDataEx
-            cuGetProcAddress('cuModuleLoadDataEx', &__cuModuleLoadDataEx, 2010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuModuleLoadDataEx', &__cuModuleLoadDataEx, 2010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuModuleLoadFatBinary' in found_functions}}
             global __cuModuleLoadFatBinary
-            cuGetProcAddress('cuModuleLoadFatBinary', &__cuModuleLoadFatBinary, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuModuleLoadFatBinary', &__cuModuleLoadFatBinary, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuModuleUnload' in found_functions}}
             global __cuModuleUnload
-            cuGetProcAddress('cuModuleUnload', &__cuModuleUnload, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuModuleUnload', &__cuModuleUnload, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuModuleGetLoadingMode' in found_functions}}
             global __cuModuleGetLoadingMode
-            cuGetProcAddress('cuModuleGetLoadingMode', &__cuModuleGetLoadingMode, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuModuleGetLoadingMode', &__cuModuleGetLoadingMode, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuModuleGetFunction' in found_functions}}
             global __cuModuleGetFunction
-            cuGetProcAddress('cuModuleGetFunction', &__cuModuleGetFunction, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuModuleGetFunction', &__cuModuleGetFunction, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuModuleGetFunctionCount' in found_functions}}
             global __cuModuleGetFunctionCount
-            cuGetProcAddress('cuModuleGetFunctionCount', &__cuModuleGetFunctionCount, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuModuleGetFunctionCount', &__cuModuleGetFunctionCount, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuModuleEnumerateFunctions' in found_functions}}
             global __cuModuleEnumerateFunctions
-            cuGetProcAddress('cuModuleEnumerateFunctions', &__cuModuleEnumerateFunctions, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuModuleEnumerateFunctions', &__cuModuleEnumerateFunctions, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuModuleGetGlobal_v2' in found_functions}}
             global __cuModuleGetGlobal_v2
-            cuGetProcAddress('cuModuleGetGlobal', &__cuModuleGetGlobal_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuModuleGetGlobal', &__cuModuleGetGlobal_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLinkCreate_v2' in found_functions}}
             global __cuLinkCreate_v2
-            cuGetProcAddress('cuLinkCreate', &__cuLinkCreate_v2, 6050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLinkCreate', &__cuLinkCreate_v2, 6050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLinkAddData_v2' in found_functions}}
             global __cuLinkAddData_v2
-            cuGetProcAddress('cuLinkAddData', &__cuLinkAddData_v2, 6050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLinkAddData', &__cuLinkAddData_v2, 6050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLinkAddFile_v2' in found_functions}}
             global __cuLinkAddFile_v2
-            cuGetProcAddress('cuLinkAddFile', &__cuLinkAddFile_v2, 6050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLinkAddFile', &__cuLinkAddFile_v2, 6050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLinkComplete' in found_functions}}
             global __cuLinkComplete
-            cuGetProcAddress('cuLinkComplete', &__cuLinkComplete, 5050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLinkComplete', &__cuLinkComplete, 5050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLinkDestroy' in found_functions}}
             global __cuLinkDestroy
-            cuGetProcAddress('cuLinkDestroy', &__cuLinkDestroy, 5050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLinkDestroy', &__cuLinkDestroy, 5050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuModuleGetTexRef' in found_functions}}
             global __cuModuleGetTexRef
-            cuGetProcAddress('cuModuleGetTexRef', &__cuModuleGetTexRef, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuModuleGetTexRef', &__cuModuleGetTexRef, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuModuleGetSurfRef' in found_functions}}
             global __cuModuleGetSurfRef
-            cuGetProcAddress('cuModuleGetSurfRef', &__cuModuleGetSurfRef, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuModuleGetSurfRef', &__cuModuleGetSurfRef, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLibraryLoadData' in found_functions}}
             global __cuLibraryLoadData
-            cuGetProcAddress('cuLibraryLoadData', &__cuLibraryLoadData, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLibraryLoadData', &__cuLibraryLoadData, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLibraryLoadFromFile' in found_functions}}
             global __cuLibraryLoadFromFile
-            cuGetProcAddress('cuLibraryLoadFromFile', &__cuLibraryLoadFromFile, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLibraryLoadFromFile', &__cuLibraryLoadFromFile, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLibraryUnload' in found_functions}}
             global __cuLibraryUnload
-            cuGetProcAddress('cuLibraryUnload', &__cuLibraryUnload, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLibraryUnload', &__cuLibraryUnload, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLibraryGetKernel' in found_functions}}
             global __cuLibraryGetKernel
-            cuGetProcAddress('cuLibraryGetKernel', &__cuLibraryGetKernel, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLibraryGetKernel', &__cuLibraryGetKernel, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLibraryGetKernelCount' in found_functions}}
             global __cuLibraryGetKernelCount
-            cuGetProcAddress('cuLibraryGetKernelCount', &__cuLibraryGetKernelCount, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLibraryGetKernelCount', &__cuLibraryGetKernelCount, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLibraryEnumerateKernels' in found_functions}}
             global __cuLibraryEnumerateKernels
-            cuGetProcAddress('cuLibraryEnumerateKernels', &__cuLibraryEnumerateKernels, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLibraryEnumerateKernels', &__cuLibraryEnumerateKernels, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLibraryGetModule' in found_functions}}
             global __cuLibraryGetModule
-            cuGetProcAddress('cuLibraryGetModule', &__cuLibraryGetModule, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLibraryGetModule', &__cuLibraryGetModule, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuKernelGetFunction' in found_functions}}
             global __cuKernelGetFunction
-            cuGetProcAddress('cuKernelGetFunction', &__cuKernelGetFunction, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuKernelGetFunction', &__cuKernelGetFunction, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuKernelGetLibrary' in found_functions}}
             global __cuKernelGetLibrary
-            cuGetProcAddress('cuKernelGetLibrary', &__cuKernelGetLibrary, 12050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuKernelGetLibrary', &__cuKernelGetLibrary, 12050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLibraryGetGlobal' in found_functions}}
             global __cuLibraryGetGlobal
-            cuGetProcAddress('cuLibraryGetGlobal', &__cuLibraryGetGlobal, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLibraryGetGlobal', &__cuLibraryGetGlobal, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLibraryGetManaged' in found_functions}}
             global __cuLibraryGetManaged
-            cuGetProcAddress('cuLibraryGetManaged', &__cuLibraryGetManaged, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLibraryGetManaged', &__cuLibraryGetManaged, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLibraryGetUnifiedFunction' in found_functions}}
             global __cuLibraryGetUnifiedFunction
-            cuGetProcAddress('cuLibraryGetUnifiedFunction', &__cuLibraryGetUnifiedFunction, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLibraryGetUnifiedFunction', &__cuLibraryGetUnifiedFunction, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuKernelGetAttribute' in found_functions}}
             global __cuKernelGetAttribute
-            cuGetProcAddress('cuKernelGetAttribute', &__cuKernelGetAttribute, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuKernelGetAttribute', &__cuKernelGetAttribute, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuKernelSetAttribute' in found_functions}}
             global __cuKernelSetAttribute
-            cuGetProcAddress('cuKernelSetAttribute', &__cuKernelSetAttribute, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuKernelSetAttribute', &__cuKernelSetAttribute, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuKernelSetCacheConfig' in found_functions}}
             global __cuKernelSetCacheConfig
-            cuGetProcAddress('cuKernelSetCacheConfig', &__cuKernelSetCacheConfig, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuKernelSetCacheConfig', &__cuKernelSetCacheConfig, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuKernelGetName' in found_functions}}
             global __cuKernelGetName
-            cuGetProcAddress('cuKernelGetName', &__cuKernelGetName, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuKernelGetName', &__cuKernelGetName, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuKernelGetParamInfo' in found_functions}}
             global __cuKernelGetParamInfo
-            cuGetProcAddress('cuKernelGetParamInfo', &__cuKernelGetParamInfo, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuKernelGetParamInfo', &__cuKernelGetParamInfo, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemGetInfo_v2' in found_functions}}
             global __cuMemGetInfo_v2
-            cuGetProcAddress('cuMemGetInfo', &__cuMemGetInfo_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemGetInfo', &__cuMemGetInfo_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemAlloc_v2' in found_functions}}
             global __cuMemAlloc_v2
-            cuGetProcAddress('cuMemAlloc', &__cuMemAlloc_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemAlloc', &__cuMemAlloc_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemAllocPitch_v2' in found_functions}}
             global __cuMemAllocPitch_v2
-            cuGetProcAddress('cuMemAllocPitch', &__cuMemAllocPitch_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemAllocPitch', &__cuMemAllocPitch_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemFree_v2' in found_functions}}
             global __cuMemFree_v2
-            cuGetProcAddress('cuMemFree', &__cuMemFree_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemFree', &__cuMemFree_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemGetAddressRange_v2' in found_functions}}
             global __cuMemGetAddressRange_v2
-            cuGetProcAddress('cuMemGetAddressRange', &__cuMemGetAddressRange_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemGetAddressRange', &__cuMemGetAddressRange_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemAllocHost_v2' in found_functions}}
             global __cuMemAllocHost_v2
-            cuGetProcAddress('cuMemAllocHost', &__cuMemAllocHost_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemAllocHost', &__cuMemAllocHost_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemFreeHost' in found_functions}}
             global __cuMemFreeHost
-            cuGetProcAddress('cuMemFreeHost', &__cuMemFreeHost, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemFreeHost', &__cuMemFreeHost, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemHostAlloc' in found_functions}}
             global __cuMemHostAlloc
-            cuGetProcAddress('cuMemHostAlloc', &__cuMemHostAlloc, 2020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemHostAlloc', &__cuMemHostAlloc, 2020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemHostGetDevicePointer_v2' in found_functions}}
             global __cuMemHostGetDevicePointer_v2
-            cuGetProcAddress('cuMemHostGetDevicePointer', &__cuMemHostGetDevicePointer_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemHostGetDevicePointer', &__cuMemHostGetDevicePointer_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemHostGetFlags' in found_functions}}
             global __cuMemHostGetFlags
-            cuGetProcAddress('cuMemHostGetFlags', &__cuMemHostGetFlags, 2030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemHostGetFlags', &__cuMemHostGetFlags, 2030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemAllocManaged' in found_functions}}
             global __cuMemAllocManaged
-            cuGetProcAddress('cuMemAllocManaged', &__cuMemAllocManaged, 6000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemAllocManaged', &__cuMemAllocManaged, 6000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceRegisterAsyncNotification' in found_functions}}
             global __cuDeviceRegisterAsyncNotification
-            cuGetProcAddress('cuDeviceRegisterAsyncNotification', &__cuDeviceRegisterAsyncNotification, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceRegisterAsyncNotification', &__cuDeviceRegisterAsyncNotification, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceUnregisterAsyncNotification' in found_functions}}
             global __cuDeviceUnregisterAsyncNotification
-            cuGetProcAddress('cuDeviceUnregisterAsyncNotification', &__cuDeviceUnregisterAsyncNotification, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceUnregisterAsyncNotification', &__cuDeviceUnregisterAsyncNotification, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceGetByPCIBusId' in found_functions}}
             global __cuDeviceGetByPCIBusId
-            cuGetProcAddress('cuDeviceGetByPCIBusId', &__cuDeviceGetByPCIBusId, 4010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceGetByPCIBusId', &__cuDeviceGetByPCIBusId, 4010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceGetPCIBusId' in found_functions}}
             global __cuDeviceGetPCIBusId
-            cuGetProcAddress('cuDeviceGetPCIBusId', &__cuDeviceGetPCIBusId, 4010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceGetPCIBusId', &__cuDeviceGetPCIBusId, 4010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuIpcGetEventHandle' in found_functions}}
             global __cuIpcGetEventHandle
-            cuGetProcAddress('cuIpcGetEventHandle', &__cuIpcGetEventHandle, 4010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuIpcGetEventHandle', &__cuIpcGetEventHandle, 4010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuIpcOpenEventHandle' in found_functions}}
             global __cuIpcOpenEventHandle
-            cuGetProcAddress('cuIpcOpenEventHandle', &__cuIpcOpenEventHandle, 4010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuIpcOpenEventHandle', &__cuIpcOpenEventHandle, 4010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuIpcGetMemHandle' in found_functions}}
             global __cuIpcGetMemHandle
-            cuGetProcAddress('cuIpcGetMemHandle', &__cuIpcGetMemHandle, 4010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuIpcGetMemHandle', &__cuIpcGetMemHandle, 4010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuIpcOpenMemHandle_v2' in found_functions}}
             global __cuIpcOpenMemHandle_v2
-            cuGetProcAddress('cuIpcOpenMemHandle', &__cuIpcOpenMemHandle_v2, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuIpcOpenMemHandle', &__cuIpcOpenMemHandle_v2, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuIpcCloseMemHandle' in found_functions}}
             global __cuIpcCloseMemHandle
-            cuGetProcAddress('cuIpcCloseMemHandle', &__cuIpcCloseMemHandle, 4010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuIpcCloseMemHandle', &__cuIpcCloseMemHandle, 4010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemHostRegister_v2' in found_functions}}
             global __cuMemHostRegister_v2
-            cuGetProcAddress('cuMemHostRegister', &__cuMemHostRegister_v2, 6050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemHostRegister', &__cuMemHostRegister_v2, 6050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemHostUnregister' in found_functions}}
             global __cuMemHostUnregister
-            cuGetProcAddress('cuMemHostUnregister', &__cuMemHostUnregister, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemHostUnregister', &__cuMemHostUnregister, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuArrayCreate_v2' in found_functions}}
             global __cuArrayCreate_v2
-            cuGetProcAddress('cuArrayCreate', &__cuArrayCreate_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuArrayCreate', &__cuArrayCreate_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuArrayGetDescriptor_v2' in found_functions}}
             global __cuArrayGetDescriptor_v2
-            cuGetProcAddress('cuArrayGetDescriptor', &__cuArrayGetDescriptor_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuArrayGetDescriptor', &__cuArrayGetDescriptor_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuArrayGetSparseProperties' in found_functions}}
             global __cuArrayGetSparseProperties
-            cuGetProcAddress('cuArrayGetSparseProperties', &__cuArrayGetSparseProperties, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuArrayGetSparseProperties', &__cuArrayGetSparseProperties, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMipmappedArrayGetSparseProperties' in found_functions}}
             global __cuMipmappedArrayGetSparseProperties
-            cuGetProcAddress('cuMipmappedArrayGetSparseProperties', &__cuMipmappedArrayGetSparseProperties, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMipmappedArrayGetSparseProperties', &__cuMipmappedArrayGetSparseProperties, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuArrayGetMemoryRequirements' in found_functions}}
             global __cuArrayGetMemoryRequirements
-            cuGetProcAddress('cuArrayGetMemoryRequirements', &__cuArrayGetMemoryRequirements, 11060, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuArrayGetMemoryRequirements', &__cuArrayGetMemoryRequirements, 11060, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMipmappedArrayGetMemoryRequirements' in found_functions}}
             global __cuMipmappedArrayGetMemoryRequirements
-            cuGetProcAddress('cuMipmappedArrayGetMemoryRequirements', &__cuMipmappedArrayGetMemoryRequirements, 11060, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMipmappedArrayGetMemoryRequirements', &__cuMipmappedArrayGetMemoryRequirements, 11060, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuArrayGetPlane' in found_functions}}
             global __cuArrayGetPlane
-            cuGetProcAddress('cuArrayGetPlane', &__cuArrayGetPlane, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuArrayGetPlane', &__cuArrayGetPlane, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuArrayDestroy' in found_functions}}
             global __cuArrayDestroy
-            cuGetProcAddress('cuArrayDestroy', &__cuArrayDestroy, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuArrayDestroy', &__cuArrayDestroy, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuArray3DCreate_v2' in found_functions}}
             global __cuArray3DCreate_v2
-            cuGetProcAddress('cuArray3DCreate', &__cuArray3DCreate_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuArray3DCreate', &__cuArray3DCreate_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuArray3DGetDescriptor_v2' in found_functions}}
             global __cuArray3DGetDescriptor_v2
-            cuGetProcAddress('cuArray3DGetDescriptor', &__cuArray3DGetDescriptor_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuArray3DGetDescriptor', &__cuArray3DGetDescriptor_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMipmappedArrayCreate' in found_functions}}
             global __cuMipmappedArrayCreate
-            cuGetProcAddress('cuMipmappedArrayCreate', &__cuMipmappedArrayCreate, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMipmappedArrayCreate', &__cuMipmappedArrayCreate, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMipmappedArrayGetLevel' in found_functions}}
             global __cuMipmappedArrayGetLevel
-            cuGetProcAddress('cuMipmappedArrayGetLevel', &__cuMipmappedArrayGetLevel, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMipmappedArrayGetLevel', &__cuMipmappedArrayGetLevel, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMipmappedArrayDestroy' in found_functions}}
             global __cuMipmappedArrayDestroy
-            cuGetProcAddress('cuMipmappedArrayDestroy', &__cuMipmappedArrayDestroy, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMipmappedArrayDestroy', &__cuMipmappedArrayDestroy, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemGetHandleForAddressRange' in found_functions}}
             global __cuMemGetHandleForAddressRange
-            cuGetProcAddress('cuMemGetHandleForAddressRange', &__cuMemGetHandleForAddressRange, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemGetHandleForAddressRange', &__cuMemGetHandleForAddressRange, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemAddressReserve' in found_functions}}
             global __cuMemAddressReserve
-            cuGetProcAddress('cuMemAddressReserve', &__cuMemAddressReserve, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemAddressReserve', &__cuMemAddressReserve, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemAddressFree' in found_functions}}
             global __cuMemAddressFree
-            cuGetProcAddress('cuMemAddressFree', &__cuMemAddressFree, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemAddressFree', &__cuMemAddressFree, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemCreate' in found_functions}}
             global __cuMemCreate
-            cuGetProcAddress('cuMemCreate', &__cuMemCreate, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemCreate', &__cuMemCreate, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemRelease' in found_functions}}
             global __cuMemRelease
-            cuGetProcAddress('cuMemRelease', &__cuMemRelease, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemRelease', &__cuMemRelease, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemMap' in found_functions}}
             global __cuMemMap
-            cuGetProcAddress('cuMemMap', &__cuMemMap, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemMap', &__cuMemMap, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemUnmap' in found_functions}}
             global __cuMemUnmap
-            cuGetProcAddress('cuMemUnmap', &__cuMemUnmap, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemUnmap', &__cuMemUnmap, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemSetAccess' in found_functions}}
             global __cuMemSetAccess
-            cuGetProcAddress('cuMemSetAccess', &__cuMemSetAccess, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemSetAccess', &__cuMemSetAccess, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemGetAccess' in found_functions}}
             global __cuMemGetAccess
-            cuGetProcAddress('cuMemGetAccess', &__cuMemGetAccess, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemGetAccess', &__cuMemGetAccess, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemExportToShareableHandle' in found_functions}}
             global __cuMemExportToShareableHandle
-            cuGetProcAddress('cuMemExportToShareableHandle', &__cuMemExportToShareableHandle, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemExportToShareableHandle', &__cuMemExportToShareableHandle, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemImportFromShareableHandle' in found_functions}}
             global __cuMemImportFromShareableHandle
-            cuGetProcAddress('cuMemImportFromShareableHandle', &__cuMemImportFromShareableHandle, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemImportFromShareableHandle', &__cuMemImportFromShareableHandle, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemGetAllocationGranularity' in found_functions}}
             global __cuMemGetAllocationGranularity
-            cuGetProcAddress('cuMemGetAllocationGranularity', &__cuMemGetAllocationGranularity, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemGetAllocationGranularity', &__cuMemGetAllocationGranularity, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemGetAllocationPropertiesFromHandle' in found_functions}}
             global __cuMemGetAllocationPropertiesFromHandle
-            cuGetProcAddress('cuMemGetAllocationPropertiesFromHandle', &__cuMemGetAllocationPropertiesFromHandle, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemGetAllocationPropertiesFromHandle', &__cuMemGetAllocationPropertiesFromHandle, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemRetainAllocationHandle' in found_functions}}
             global __cuMemRetainAllocationHandle
-            cuGetProcAddress('cuMemRetainAllocationHandle', &__cuMemRetainAllocationHandle, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemRetainAllocationHandle', &__cuMemRetainAllocationHandle, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemPoolTrimTo' in found_functions}}
             global __cuMemPoolTrimTo
-            cuGetProcAddress('cuMemPoolTrimTo', &__cuMemPoolTrimTo, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemPoolTrimTo', &__cuMemPoolTrimTo, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemPoolSetAttribute' in found_functions}}
             global __cuMemPoolSetAttribute
-            cuGetProcAddress('cuMemPoolSetAttribute', &__cuMemPoolSetAttribute, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemPoolSetAttribute', &__cuMemPoolSetAttribute, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemPoolGetAttribute' in found_functions}}
             global __cuMemPoolGetAttribute
-            cuGetProcAddress('cuMemPoolGetAttribute', &__cuMemPoolGetAttribute, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemPoolGetAttribute', &__cuMemPoolGetAttribute, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemPoolSetAccess' in found_functions}}
             global __cuMemPoolSetAccess
-            cuGetProcAddress('cuMemPoolSetAccess', &__cuMemPoolSetAccess, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemPoolSetAccess', &__cuMemPoolSetAccess, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemPoolGetAccess' in found_functions}}
             global __cuMemPoolGetAccess
-            cuGetProcAddress('cuMemPoolGetAccess', &__cuMemPoolGetAccess, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemPoolGetAccess', &__cuMemPoolGetAccess, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemPoolCreate' in found_functions}}
             global __cuMemPoolCreate
-            cuGetProcAddress('cuMemPoolCreate', &__cuMemPoolCreate, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemPoolCreate', &__cuMemPoolCreate, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemPoolDestroy' in found_functions}}
             global __cuMemPoolDestroy
-            cuGetProcAddress('cuMemPoolDestroy', &__cuMemPoolDestroy, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemPoolDestroy', &__cuMemPoolDestroy, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemPoolExportToShareableHandle' in found_functions}}
             global __cuMemPoolExportToShareableHandle
-            cuGetProcAddress('cuMemPoolExportToShareableHandle', &__cuMemPoolExportToShareableHandle, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemPoolExportToShareableHandle', &__cuMemPoolExportToShareableHandle, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemPoolImportFromShareableHandle' in found_functions}}
             global __cuMemPoolImportFromShareableHandle
-            cuGetProcAddress('cuMemPoolImportFromShareableHandle', &__cuMemPoolImportFromShareableHandle, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemPoolImportFromShareableHandle', &__cuMemPoolImportFromShareableHandle, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemPoolExportPointer' in found_functions}}
             global __cuMemPoolExportPointer
-            cuGetProcAddress('cuMemPoolExportPointer', &__cuMemPoolExportPointer, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemPoolExportPointer', &__cuMemPoolExportPointer, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemPoolImportPointer' in found_functions}}
             global __cuMemPoolImportPointer
-            cuGetProcAddress('cuMemPoolImportPointer', &__cuMemPoolImportPointer, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemPoolImportPointer', &__cuMemPoolImportPointer, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMulticastCreate' in found_functions}}
             global __cuMulticastCreate
-            cuGetProcAddress('cuMulticastCreate', &__cuMulticastCreate, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMulticastCreate', &__cuMulticastCreate, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMulticastAddDevice' in found_functions}}
             global __cuMulticastAddDevice
-            cuGetProcAddress('cuMulticastAddDevice', &__cuMulticastAddDevice, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMulticastAddDevice', &__cuMulticastAddDevice, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMulticastBindMem' in found_functions}}
             global __cuMulticastBindMem
-            cuGetProcAddress('cuMulticastBindMem', &__cuMulticastBindMem, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMulticastBindMem', &__cuMulticastBindMem, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMulticastBindAddr' in found_functions}}
             global __cuMulticastBindAddr
-            cuGetProcAddress('cuMulticastBindAddr', &__cuMulticastBindAddr, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMulticastBindAddr', &__cuMulticastBindAddr, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMulticastUnbind' in found_functions}}
             global __cuMulticastUnbind
-            cuGetProcAddress('cuMulticastUnbind', &__cuMulticastUnbind, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMulticastUnbind', &__cuMulticastUnbind, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMulticastGetGranularity' in found_functions}}
             global __cuMulticastGetGranularity
-            cuGetProcAddress('cuMulticastGetGranularity', &__cuMulticastGetGranularity, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMulticastGetGranularity', &__cuMulticastGetGranularity, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuPointerGetAttribute' in found_functions}}
             global __cuPointerGetAttribute
-            cuGetProcAddress('cuPointerGetAttribute', &__cuPointerGetAttribute, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuPointerGetAttribute', &__cuPointerGetAttribute, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemAdvise' in found_functions}}
             global __cuMemAdvise
-            cuGetProcAddress('cuMemAdvise', &__cuMemAdvise, 8000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemAdvise', &__cuMemAdvise, 8000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemAdvise_v2' in found_functions}}
             global __cuMemAdvise_v2
-            cuGetProcAddress('cuMemAdvise', &__cuMemAdvise_v2, 12020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemAdvise', &__cuMemAdvise_v2, 12020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemRangeGetAttribute' in found_functions}}
             global __cuMemRangeGetAttribute
-            cuGetProcAddress('cuMemRangeGetAttribute', &__cuMemRangeGetAttribute, 8000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemRangeGetAttribute', &__cuMemRangeGetAttribute, 8000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuMemRangeGetAttributes' in found_functions}}
             global __cuMemRangeGetAttributes
-            cuGetProcAddress('cuMemRangeGetAttributes', &__cuMemRangeGetAttributes, 8000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuMemRangeGetAttributes', &__cuMemRangeGetAttributes, 8000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuPointerSetAttribute' in found_functions}}
             global __cuPointerSetAttribute
-            cuGetProcAddress('cuPointerSetAttribute', &__cuPointerSetAttribute, 6000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuPointerSetAttribute', &__cuPointerSetAttribute, 6000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuPointerGetAttributes' in found_functions}}
             global __cuPointerGetAttributes
-            cuGetProcAddress('cuPointerGetAttributes', &__cuPointerGetAttributes, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuPointerGetAttributes', &__cuPointerGetAttributes, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuStreamCreate' in found_functions}}
             global __cuStreamCreate
-            cuGetProcAddress('cuStreamCreate', &__cuStreamCreate, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuStreamCreate', &__cuStreamCreate, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuStreamCreateWithPriority' in found_functions}}
             global __cuStreamCreateWithPriority
-            cuGetProcAddress('cuStreamCreateWithPriority', &__cuStreamCreateWithPriority, 5050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuStreamCreateWithPriority', &__cuStreamCreateWithPriority, 5050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuThreadExchangeStreamCaptureMode' in found_functions}}
             global __cuThreadExchangeStreamCaptureMode
-            cuGetProcAddress('cuThreadExchangeStreamCaptureMode', &__cuThreadExchangeStreamCaptureMode, 10010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuThreadExchangeStreamCaptureMode', &__cuThreadExchangeStreamCaptureMode, 10010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuStreamDestroy_v2' in found_functions}}
             global __cuStreamDestroy_v2
-            cuGetProcAddress('cuStreamDestroy', &__cuStreamDestroy_v2, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuStreamDestroy', &__cuStreamDestroy_v2, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuEventCreate' in found_functions}}
             global __cuEventCreate
-            cuGetProcAddress('cuEventCreate', &__cuEventCreate, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuEventCreate', &__cuEventCreate, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuEventQuery' in found_functions}}
             global __cuEventQuery
-            cuGetProcAddress('cuEventQuery', &__cuEventQuery, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuEventQuery', &__cuEventQuery, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuEventSynchronize' in found_functions}}
             global __cuEventSynchronize
-            cuGetProcAddress('cuEventSynchronize', &__cuEventSynchronize, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuEventSynchronize', &__cuEventSynchronize, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuEventDestroy_v2' in found_functions}}
             global __cuEventDestroy_v2
-            cuGetProcAddress('cuEventDestroy', &__cuEventDestroy_v2, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuEventDestroy', &__cuEventDestroy_v2, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuEventElapsedTime' in found_functions}}
             global __cuEventElapsedTime
-            cuGetProcAddress('cuEventElapsedTime', &__cuEventElapsedTime, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuEventElapsedTime', &__cuEventElapsedTime, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuEventElapsedTime_v2' in found_functions}}
             global __cuEventElapsedTime_v2
-            cuGetProcAddress('cuEventElapsedTime', &__cuEventElapsedTime_v2, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuEventElapsedTime', &__cuEventElapsedTime_v2, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuImportExternalMemory' in found_functions}}
             global __cuImportExternalMemory
-            cuGetProcAddress('cuImportExternalMemory', &__cuImportExternalMemory, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuImportExternalMemory', &__cuImportExternalMemory, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuExternalMemoryGetMappedBuffer' in found_functions}}
             global __cuExternalMemoryGetMappedBuffer
-            cuGetProcAddress('cuExternalMemoryGetMappedBuffer', &__cuExternalMemoryGetMappedBuffer, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuExternalMemoryGetMappedBuffer', &__cuExternalMemoryGetMappedBuffer, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuExternalMemoryGetMappedMipmappedArray' in found_functions}}
             global __cuExternalMemoryGetMappedMipmappedArray
-            cuGetProcAddress('cuExternalMemoryGetMappedMipmappedArray', &__cuExternalMemoryGetMappedMipmappedArray, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuExternalMemoryGetMappedMipmappedArray', &__cuExternalMemoryGetMappedMipmappedArray, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDestroyExternalMemory' in found_functions}}
             global __cuDestroyExternalMemory
-            cuGetProcAddress('cuDestroyExternalMemory', &__cuDestroyExternalMemory, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDestroyExternalMemory', &__cuDestroyExternalMemory, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuImportExternalSemaphore' in found_functions}}
             global __cuImportExternalSemaphore
-            cuGetProcAddress('cuImportExternalSemaphore', &__cuImportExternalSemaphore, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuImportExternalSemaphore', &__cuImportExternalSemaphore, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDestroyExternalSemaphore' in found_functions}}
             global __cuDestroyExternalSemaphore
-            cuGetProcAddress('cuDestroyExternalSemaphore', &__cuDestroyExternalSemaphore, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDestroyExternalSemaphore', &__cuDestroyExternalSemaphore, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuFuncGetAttribute' in found_functions}}
             global __cuFuncGetAttribute
-            cuGetProcAddress('cuFuncGetAttribute', &__cuFuncGetAttribute, 2020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuFuncGetAttribute', &__cuFuncGetAttribute, 2020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuFuncSetAttribute' in found_functions}}
             global __cuFuncSetAttribute
-            cuGetProcAddress('cuFuncSetAttribute', &__cuFuncSetAttribute, 9000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuFuncSetAttribute', &__cuFuncSetAttribute, 9000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuFuncSetCacheConfig' in found_functions}}
             global __cuFuncSetCacheConfig
-            cuGetProcAddress('cuFuncSetCacheConfig', &__cuFuncSetCacheConfig, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuFuncSetCacheConfig', &__cuFuncSetCacheConfig, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuFuncGetModule' in found_functions}}
             global __cuFuncGetModule
-            cuGetProcAddress('cuFuncGetModule', &__cuFuncGetModule, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuFuncGetModule', &__cuFuncGetModule, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuFuncGetName' in found_functions}}
             global __cuFuncGetName
-            cuGetProcAddress('cuFuncGetName', &__cuFuncGetName, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuFuncGetName', &__cuFuncGetName, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuFuncGetParamInfo' in found_functions}}
             global __cuFuncGetParamInfo
-            cuGetProcAddress('cuFuncGetParamInfo', &__cuFuncGetParamInfo, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuFuncGetParamInfo', &__cuFuncGetParamInfo, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuFuncIsLoaded' in found_functions}}
             global __cuFuncIsLoaded
-            cuGetProcAddress('cuFuncIsLoaded', &__cuFuncIsLoaded, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuFuncIsLoaded', &__cuFuncIsLoaded, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuFuncLoad' in found_functions}}
             global __cuFuncLoad
-            cuGetProcAddress('cuFuncLoad', &__cuFuncLoad, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuFuncLoad', &__cuFuncLoad, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLaunchCooperativeKernelMultiDevice' in found_functions}}
             global __cuLaunchCooperativeKernelMultiDevice
-            cuGetProcAddress('cuLaunchCooperativeKernelMultiDevice', &__cuLaunchCooperativeKernelMultiDevice, 9000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLaunchCooperativeKernelMultiDevice', &__cuLaunchCooperativeKernelMultiDevice, 9000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuFuncSetBlockShape' in found_functions}}
             global __cuFuncSetBlockShape
-            cuGetProcAddress('cuFuncSetBlockShape', &__cuFuncSetBlockShape, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuFuncSetBlockShape', &__cuFuncSetBlockShape, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuFuncSetSharedSize' in found_functions}}
             global __cuFuncSetSharedSize
-            cuGetProcAddress('cuFuncSetSharedSize', &__cuFuncSetSharedSize, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuFuncSetSharedSize', &__cuFuncSetSharedSize, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuParamSetSize' in found_functions}}
             global __cuParamSetSize
-            cuGetProcAddress('cuParamSetSize', &__cuParamSetSize, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuParamSetSize', &__cuParamSetSize, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuParamSeti' in found_functions}}
             global __cuParamSeti
-            cuGetProcAddress('cuParamSeti', &__cuParamSeti, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuParamSeti', &__cuParamSeti, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuParamSetf' in found_functions}}
             global __cuParamSetf
-            cuGetProcAddress('cuParamSetf', &__cuParamSetf, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuParamSetf', &__cuParamSetf, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuParamSetv' in found_functions}}
             global __cuParamSetv
-            cuGetProcAddress('cuParamSetv', &__cuParamSetv, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuParamSetv', &__cuParamSetv, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLaunch' in found_functions}}
             global __cuLaunch
-            cuGetProcAddress('cuLaunch', &__cuLaunch, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLaunch', &__cuLaunch, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLaunchGrid' in found_functions}}
             global __cuLaunchGrid
-            cuGetProcAddress('cuLaunchGrid', &__cuLaunchGrid, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLaunchGrid', &__cuLaunchGrid, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLaunchGridAsync' in found_functions}}
             global __cuLaunchGridAsync
-            cuGetProcAddress('cuLaunchGridAsync', &__cuLaunchGridAsync, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLaunchGridAsync', &__cuLaunchGridAsync, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuParamSetTexRef' in found_functions}}
             global __cuParamSetTexRef
-            cuGetProcAddress('cuParamSetTexRef', &__cuParamSetTexRef, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuParamSetTexRef', &__cuParamSetTexRef, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuFuncSetSharedMemConfig' in found_functions}}
             global __cuFuncSetSharedMemConfig
-            cuGetProcAddress('cuFuncSetSharedMemConfig', &__cuFuncSetSharedMemConfig, 4020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuFuncSetSharedMemConfig', &__cuFuncSetSharedMemConfig, 4020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphCreate' in found_functions}}
             global __cuGraphCreate
-            cuGetProcAddress('cuGraphCreate', &__cuGraphCreate, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphCreate', &__cuGraphCreate, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphAddKernelNode_v2' in found_functions}}
             global __cuGraphAddKernelNode_v2
-            cuGetProcAddress('cuGraphAddKernelNode', &__cuGraphAddKernelNode_v2, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphAddKernelNode', &__cuGraphAddKernelNode_v2, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphKernelNodeGetParams_v2' in found_functions}}
             global __cuGraphKernelNodeGetParams_v2
-            cuGetProcAddress('cuGraphKernelNodeGetParams', &__cuGraphKernelNodeGetParams_v2, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphKernelNodeGetParams', &__cuGraphKernelNodeGetParams_v2, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphKernelNodeSetParams_v2' in found_functions}}
             global __cuGraphKernelNodeSetParams_v2
-            cuGetProcAddress('cuGraphKernelNodeSetParams', &__cuGraphKernelNodeSetParams_v2, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphKernelNodeSetParams', &__cuGraphKernelNodeSetParams_v2, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphAddMemcpyNode' in found_functions}}
             global __cuGraphAddMemcpyNode
-            cuGetProcAddress('cuGraphAddMemcpyNode', &__cuGraphAddMemcpyNode, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphAddMemcpyNode', &__cuGraphAddMemcpyNode, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphMemcpyNodeGetParams' in found_functions}}
             global __cuGraphMemcpyNodeGetParams
-            cuGetProcAddress('cuGraphMemcpyNodeGetParams', &__cuGraphMemcpyNodeGetParams, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphMemcpyNodeGetParams', &__cuGraphMemcpyNodeGetParams, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphMemcpyNodeSetParams' in found_functions}}
             global __cuGraphMemcpyNodeSetParams
-            cuGetProcAddress('cuGraphMemcpyNodeSetParams', &__cuGraphMemcpyNodeSetParams, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphMemcpyNodeSetParams', &__cuGraphMemcpyNodeSetParams, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphAddMemsetNode' in found_functions}}
             global __cuGraphAddMemsetNode
-            cuGetProcAddress('cuGraphAddMemsetNode', &__cuGraphAddMemsetNode, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphAddMemsetNode', &__cuGraphAddMemsetNode, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphMemsetNodeGetParams' in found_functions}}
             global __cuGraphMemsetNodeGetParams
-            cuGetProcAddress('cuGraphMemsetNodeGetParams', &__cuGraphMemsetNodeGetParams, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphMemsetNodeGetParams', &__cuGraphMemsetNodeGetParams, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphMemsetNodeSetParams' in found_functions}}
             global __cuGraphMemsetNodeSetParams
-            cuGetProcAddress('cuGraphMemsetNodeSetParams', &__cuGraphMemsetNodeSetParams, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphMemsetNodeSetParams', &__cuGraphMemsetNodeSetParams, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphAddHostNode' in found_functions}}
             global __cuGraphAddHostNode
-            cuGetProcAddress('cuGraphAddHostNode', &__cuGraphAddHostNode, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphAddHostNode', &__cuGraphAddHostNode, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphHostNodeGetParams' in found_functions}}
             global __cuGraphHostNodeGetParams
-            cuGetProcAddress('cuGraphHostNodeGetParams', &__cuGraphHostNodeGetParams, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphHostNodeGetParams', &__cuGraphHostNodeGetParams, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphHostNodeSetParams' in found_functions}}
             global __cuGraphHostNodeSetParams
-            cuGetProcAddress('cuGraphHostNodeSetParams', &__cuGraphHostNodeSetParams, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphHostNodeSetParams', &__cuGraphHostNodeSetParams, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphAddChildGraphNode' in found_functions}}
             global __cuGraphAddChildGraphNode
-            cuGetProcAddress('cuGraphAddChildGraphNode', &__cuGraphAddChildGraphNode, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphAddChildGraphNode', &__cuGraphAddChildGraphNode, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphChildGraphNodeGetGraph' in found_functions}}
             global __cuGraphChildGraphNodeGetGraph
-            cuGetProcAddress('cuGraphChildGraphNodeGetGraph', &__cuGraphChildGraphNodeGetGraph, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphChildGraphNodeGetGraph', &__cuGraphChildGraphNodeGetGraph, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphAddEmptyNode' in found_functions}}
             global __cuGraphAddEmptyNode
-            cuGetProcAddress('cuGraphAddEmptyNode', &__cuGraphAddEmptyNode, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphAddEmptyNode', &__cuGraphAddEmptyNode, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphAddEventRecordNode' in found_functions}}
             global __cuGraphAddEventRecordNode
-            cuGetProcAddress('cuGraphAddEventRecordNode', &__cuGraphAddEventRecordNode, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphAddEventRecordNode', &__cuGraphAddEventRecordNode, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphEventRecordNodeGetEvent' in found_functions}}
             global __cuGraphEventRecordNodeGetEvent
-            cuGetProcAddress('cuGraphEventRecordNodeGetEvent', &__cuGraphEventRecordNodeGetEvent, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphEventRecordNodeGetEvent', &__cuGraphEventRecordNodeGetEvent, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphEventRecordNodeSetEvent' in found_functions}}
             global __cuGraphEventRecordNodeSetEvent
-            cuGetProcAddress('cuGraphEventRecordNodeSetEvent', &__cuGraphEventRecordNodeSetEvent, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphEventRecordNodeSetEvent', &__cuGraphEventRecordNodeSetEvent, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphAddEventWaitNode' in found_functions}}
             global __cuGraphAddEventWaitNode
-            cuGetProcAddress('cuGraphAddEventWaitNode', &__cuGraphAddEventWaitNode, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphAddEventWaitNode', &__cuGraphAddEventWaitNode, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphEventWaitNodeGetEvent' in found_functions}}
             global __cuGraphEventWaitNodeGetEvent
-            cuGetProcAddress('cuGraphEventWaitNodeGetEvent', &__cuGraphEventWaitNodeGetEvent, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphEventWaitNodeGetEvent', &__cuGraphEventWaitNodeGetEvent, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphEventWaitNodeSetEvent' in found_functions}}
             global __cuGraphEventWaitNodeSetEvent
-            cuGetProcAddress('cuGraphEventWaitNodeSetEvent', &__cuGraphEventWaitNodeSetEvent, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphEventWaitNodeSetEvent', &__cuGraphEventWaitNodeSetEvent, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphAddExternalSemaphoresSignalNode' in found_functions}}
             global __cuGraphAddExternalSemaphoresSignalNode
-            cuGetProcAddress('cuGraphAddExternalSemaphoresSignalNode', &__cuGraphAddExternalSemaphoresSignalNode, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphAddExternalSemaphoresSignalNode', &__cuGraphAddExternalSemaphoresSignalNode, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphExternalSemaphoresSignalNodeGetParams' in found_functions}}
             global __cuGraphExternalSemaphoresSignalNodeGetParams
-            cuGetProcAddress('cuGraphExternalSemaphoresSignalNodeGetParams', &__cuGraphExternalSemaphoresSignalNodeGetParams, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphExternalSemaphoresSignalNodeGetParams', &__cuGraphExternalSemaphoresSignalNodeGetParams, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphExternalSemaphoresSignalNodeSetParams' in found_functions}}
             global __cuGraphExternalSemaphoresSignalNodeSetParams
-            cuGetProcAddress('cuGraphExternalSemaphoresSignalNodeSetParams', &__cuGraphExternalSemaphoresSignalNodeSetParams, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphExternalSemaphoresSignalNodeSetParams', &__cuGraphExternalSemaphoresSignalNodeSetParams, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphAddExternalSemaphoresWaitNode' in found_functions}}
             global __cuGraphAddExternalSemaphoresWaitNode
-            cuGetProcAddress('cuGraphAddExternalSemaphoresWaitNode', &__cuGraphAddExternalSemaphoresWaitNode, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphAddExternalSemaphoresWaitNode', &__cuGraphAddExternalSemaphoresWaitNode, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphExternalSemaphoresWaitNodeGetParams' in found_functions}}
             global __cuGraphExternalSemaphoresWaitNodeGetParams
-            cuGetProcAddress('cuGraphExternalSemaphoresWaitNodeGetParams', &__cuGraphExternalSemaphoresWaitNodeGetParams, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphExternalSemaphoresWaitNodeGetParams', &__cuGraphExternalSemaphoresWaitNodeGetParams, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphExternalSemaphoresWaitNodeSetParams' in found_functions}}
             global __cuGraphExternalSemaphoresWaitNodeSetParams
-            cuGetProcAddress('cuGraphExternalSemaphoresWaitNodeSetParams', &__cuGraphExternalSemaphoresWaitNodeSetParams, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphExternalSemaphoresWaitNodeSetParams', &__cuGraphExternalSemaphoresWaitNodeSetParams, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphAddBatchMemOpNode' in found_functions}}
             global __cuGraphAddBatchMemOpNode
-            cuGetProcAddress('cuGraphAddBatchMemOpNode', &__cuGraphAddBatchMemOpNode, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphAddBatchMemOpNode', &__cuGraphAddBatchMemOpNode, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphBatchMemOpNodeGetParams' in found_functions}}
             global __cuGraphBatchMemOpNodeGetParams
-            cuGetProcAddress('cuGraphBatchMemOpNodeGetParams', &__cuGraphBatchMemOpNodeGetParams, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphBatchMemOpNodeGetParams', &__cuGraphBatchMemOpNodeGetParams, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphBatchMemOpNodeSetParams' in found_functions}}
             global __cuGraphBatchMemOpNodeSetParams
-            cuGetProcAddress('cuGraphBatchMemOpNodeSetParams', &__cuGraphBatchMemOpNodeSetParams, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphBatchMemOpNodeSetParams', &__cuGraphBatchMemOpNodeSetParams, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphExecBatchMemOpNodeSetParams' in found_functions}}
             global __cuGraphExecBatchMemOpNodeSetParams
-            cuGetProcAddress('cuGraphExecBatchMemOpNodeSetParams', &__cuGraphExecBatchMemOpNodeSetParams, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphExecBatchMemOpNodeSetParams', &__cuGraphExecBatchMemOpNodeSetParams, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphAddMemAllocNode' in found_functions}}
             global __cuGraphAddMemAllocNode
-            cuGetProcAddress('cuGraphAddMemAllocNode', &__cuGraphAddMemAllocNode, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphAddMemAllocNode', &__cuGraphAddMemAllocNode, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphMemAllocNodeGetParams' in found_functions}}
             global __cuGraphMemAllocNodeGetParams
-            cuGetProcAddress('cuGraphMemAllocNodeGetParams', &__cuGraphMemAllocNodeGetParams, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphMemAllocNodeGetParams', &__cuGraphMemAllocNodeGetParams, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphAddMemFreeNode' in found_functions}}
             global __cuGraphAddMemFreeNode
-            cuGetProcAddress('cuGraphAddMemFreeNode', &__cuGraphAddMemFreeNode, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphAddMemFreeNode', &__cuGraphAddMemFreeNode, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphMemFreeNodeGetParams' in found_functions}}
             global __cuGraphMemFreeNodeGetParams
-            cuGetProcAddress('cuGraphMemFreeNodeGetParams', &__cuGraphMemFreeNodeGetParams, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphMemFreeNodeGetParams', &__cuGraphMemFreeNodeGetParams, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceGraphMemTrim' in found_functions}}
             global __cuDeviceGraphMemTrim
-            cuGetProcAddress('cuDeviceGraphMemTrim', &__cuDeviceGraphMemTrim, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceGraphMemTrim', &__cuDeviceGraphMemTrim, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceGetGraphMemAttribute' in found_functions}}
             global __cuDeviceGetGraphMemAttribute
-            cuGetProcAddress('cuDeviceGetGraphMemAttribute', &__cuDeviceGetGraphMemAttribute, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceGetGraphMemAttribute', &__cuDeviceGetGraphMemAttribute, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceSetGraphMemAttribute' in found_functions}}
             global __cuDeviceSetGraphMemAttribute
-            cuGetProcAddress('cuDeviceSetGraphMemAttribute', &__cuDeviceSetGraphMemAttribute, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceSetGraphMemAttribute', &__cuDeviceSetGraphMemAttribute, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphClone' in found_functions}}
             global __cuGraphClone
-            cuGetProcAddress('cuGraphClone', &__cuGraphClone, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphClone', &__cuGraphClone, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphNodeFindInClone' in found_functions}}
             global __cuGraphNodeFindInClone
-            cuGetProcAddress('cuGraphNodeFindInClone', &__cuGraphNodeFindInClone, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphNodeFindInClone', &__cuGraphNodeFindInClone, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphNodeGetType' in found_functions}}
             global __cuGraphNodeGetType
-            cuGetProcAddress('cuGraphNodeGetType', &__cuGraphNodeGetType, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphNodeGetType', &__cuGraphNodeGetType, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphGetNodes' in found_functions}}
             global __cuGraphGetNodes
-            cuGetProcAddress('cuGraphGetNodes', &__cuGraphGetNodes, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphGetNodes', &__cuGraphGetNodes, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphGetRootNodes' in found_functions}}
             global __cuGraphGetRootNodes
-            cuGetProcAddress('cuGraphGetRootNodes', &__cuGraphGetRootNodes, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphGetRootNodes', &__cuGraphGetRootNodes, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphGetEdges' in found_functions}}
             global __cuGraphGetEdges
-            cuGetProcAddress('cuGraphGetEdges', &__cuGraphGetEdges, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphGetEdges', &__cuGraphGetEdges, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphGetEdges_v2' in found_functions}}
             global __cuGraphGetEdges_v2
-            cuGetProcAddress('cuGraphGetEdges', &__cuGraphGetEdges_v2, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphGetEdges', &__cuGraphGetEdges_v2, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphNodeGetDependencies' in found_functions}}
             global __cuGraphNodeGetDependencies
-            cuGetProcAddress('cuGraphNodeGetDependencies', &__cuGraphNodeGetDependencies, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphNodeGetDependencies', &__cuGraphNodeGetDependencies, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphNodeGetDependencies_v2' in found_functions}}
             global __cuGraphNodeGetDependencies_v2
-            cuGetProcAddress('cuGraphNodeGetDependencies', &__cuGraphNodeGetDependencies_v2, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphNodeGetDependencies', &__cuGraphNodeGetDependencies_v2, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphNodeGetDependentNodes' in found_functions}}
             global __cuGraphNodeGetDependentNodes
-            cuGetProcAddress('cuGraphNodeGetDependentNodes', &__cuGraphNodeGetDependentNodes, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphNodeGetDependentNodes', &__cuGraphNodeGetDependentNodes, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphNodeGetDependentNodes_v2' in found_functions}}
             global __cuGraphNodeGetDependentNodes_v2
-            cuGetProcAddress('cuGraphNodeGetDependentNodes', &__cuGraphNodeGetDependentNodes_v2, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphNodeGetDependentNodes', &__cuGraphNodeGetDependentNodes_v2, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphAddDependencies' in found_functions}}
             global __cuGraphAddDependencies
-            cuGetProcAddress('cuGraphAddDependencies', &__cuGraphAddDependencies, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphAddDependencies', &__cuGraphAddDependencies, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphAddDependencies_v2' in found_functions}}
             global __cuGraphAddDependencies_v2
-            cuGetProcAddress('cuGraphAddDependencies', &__cuGraphAddDependencies_v2, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphAddDependencies', &__cuGraphAddDependencies_v2, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphRemoveDependencies' in found_functions}}
             global __cuGraphRemoveDependencies
-            cuGetProcAddress('cuGraphRemoveDependencies', &__cuGraphRemoveDependencies, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphRemoveDependencies', &__cuGraphRemoveDependencies, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphRemoveDependencies_v2' in found_functions}}
             global __cuGraphRemoveDependencies_v2
-            cuGetProcAddress('cuGraphRemoveDependencies', &__cuGraphRemoveDependencies_v2, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphRemoveDependencies', &__cuGraphRemoveDependencies_v2, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphDestroyNode' in found_functions}}
             global __cuGraphDestroyNode
-            cuGetProcAddress('cuGraphDestroyNode', &__cuGraphDestroyNode, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphDestroyNode', &__cuGraphDestroyNode, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphInstantiateWithFlags' in found_functions}}
             global __cuGraphInstantiateWithFlags
-            cuGetProcAddress('cuGraphInstantiateWithFlags', &__cuGraphInstantiateWithFlags, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphInstantiateWithFlags', &__cuGraphInstantiateWithFlags, 11040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphExecGetFlags' in found_functions}}
             global __cuGraphExecGetFlags
-            cuGetProcAddress('cuGraphExecGetFlags', &__cuGraphExecGetFlags, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphExecGetFlags', &__cuGraphExecGetFlags, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphExecKernelNodeSetParams_v2' in found_functions}}
             global __cuGraphExecKernelNodeSetParams_v2
-            cuGetProcAddress('cuGraphExecKernelNodeSetParams', &__cuGraphExecKernelNodeSetParams_v2, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphExecKernelNodeSetParams', &__cuGraphExecKernelNodeSetParams_v2, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphExecMemcpyNodeSetParams' in found_functions}}
             global __cuGraphExecMemcpyNodeSetParams
-            cuGetProcAddress('cuGraphExecMemcpyNodeSetParams', &__cuGraphExecMemcpyNodeSetParams, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphExecMemcpyNodeSetParams', &__cuGraphExecMemcpyNodeSetParams, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphExecMemsetNodeSetParams' in found_functions}}
             global __cuGraphExecMemsetNodeSetParams
-            cuGetProcAddress('cuGraphExecMemsetNodeSetParams', &__cuGraphExecMemsetNodeSetParams, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphExecMemsetNodeSetParams', &__cuGraphExecMemsetNodeSetParams, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphExecHostNodeSetParams' in found_functions}}
             global __cuGraphExecHostNodeSetParams
-            cuGetProcAddress('cuGraphExecHostNodeSetParams', &__cuGraphExecHostNodeSetParams, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphExecHostNodeSetParams', &__cuGraphExecHostNodeSetParams, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphExecChildGraphNodeSetParams' in found_functions}}
             global __cuGraphExecChildGraphNodeSetParams
-            cuGetProcAddress('cuGraphExecChildGraphNodeSetParams', &__cuGraphExecChildGraphNodeSetParams, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphExecChildGraphNodeSetParams', &__cuGraphExecChildGraphNodeSetParams, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphExecEventRecordNodeSetEvent' in found_functions}}
             global __cuGraphExecEventRecordNodeSetEvent
-            cuGetProcAddress('cuGraphExecEventRecordNodeSetEvent', &__cuGraphExecEventRecordNodeSetEvent, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphExecEventRecordNodeSetEvent', &__cuGraphExecEventRecordNodeSetEvent, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphExecEventWaitNodeSetEvent' in found_functions}}
             global __cuGraphExecEventWaitNodeSetEvent
-            cuGetProcAddress('cuGraphExecEventWaitNodeSetEvent', &__cuGraphExecEventWaitNodeSetEvent, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphExecEventWaitNodeSetEvent', &__cuGraphExecEventWaitNodeSetEvent, 11010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphExecExternalSemaphoresSignalNodeSetParams' in found_functions}}
             global __cuGraphExecExternalSemaphoresSignalNodeSetParams
-            cuGetProcAddress('cuGraphExecExternalSemaphoresSignalNodeSetParams', &__cuGraphExecExternalSemaphoresSignalNodeSetParams, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphExecExternalSemaphoresSignalNodeSetParams', &__cuGraphExecExternalSemaphoresSignalNodeSetParams, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphExecExternalSemaphoresWaitNodeSetParams' in found_functions}}
             global __cuGraphExecExternalSemaphoresWaitNodeSetParams
-            cuGetProcAddress('cuGraphExecExternalSemaphoresWaitNodeSetParams', &__cuGraphExecExternalSemaphoresWaitNodeSetParams, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphExecExternalSemaphoresWaitNodeSetParams', &__cuGraphExecExternalSemaphoresWaitNodeSetParams, 11020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphNodeSetEnabled' in found_functions}}
             global __cuGraphNodeSetEnabled
-            cuGetProcAddress('cuGraphNodeSetEnabled', &__cuGraphNodeSetEnabled, 11060, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphNodeSetEnabled', &__cuGraphNodeSetEnabled, 11060, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphNodeGetEnabled' in found_functions}}
             global __cuGraphNodeGetEnabled
-            cuGetProcAddress('cuGraphNodeGetEnabled', &__cuGraphNodeGetEnabled, 11060, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphNodeGetEnabled', &__cuGraphNodeGetEnabled, 11060, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphExecDestroy' in found_functions}}
             global __cuGraphExecDestroy
-            cuGetProcAddress('cuGraphExecDestroy', &__cuGraphExecDestroy, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphExecDestroy', &__cuGraphExecDestroy, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphDestroy' in found_functions}}
             global __cuGraphDestroy
-            cuGetProcAddress('cuGraphDestroy', &__cuGraphDestroy, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphDestroy', &__cuGraphDestroy, 10000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphExecUpdate_v2' in found_functions}}
             global __cuGraphExecUpdate_v2
-            cuGetProcAddress('cuGraphExecUpdate', &__cuGraphExecUpdate_v2, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphExecUpdate', &__cuGraphExecUpdate_v2, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphKernelNodeCopyAttributes' in found_functions}}
             global __cuGraphKernelNodeCopyAttributes
-            cuGetProcAddress('cuGraphKernelNodeCopyAttributes', &__cuGraphKernelNodeCopyAttributes, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphKernelNodeCopyAttributes', &__cuGraphKernelNodeCopyAttributes, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphKernelNodeGetAttribute' in found_functions}}
             global __cuGraphKernelNodeGetAttribute
-            cuGetProcAddress('cuGraphKernelNodeGetAttribute', &__cuGraphKernelNodeGetAttribute, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphKernelNodeGetAttribute', &__cuGraphKernelNodeGetAttribute, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphKernelNodeSetAttribute' in found_functions}}
             global __cuGraphKernelNodeSetAttribute
-            cuGetProcAddress('cuGraphKernelNodeSetAttribute', &__cuGraphKernelNodeSetAttribute, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphKernelNodeSetAttribute', &__cuGraphKernelNodeSetAttribute, 11000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphDebugDotPrint' in found_functions}}
             global __cuGraphDebugDotPrint
-            cuGetProcAddress('cuGraphDebugDotPrint', &__cuGraphDebugDotPrint, 11030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphDebugDotPrint', &__cuGraphDebugDotPrint, 11030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuUserObjectCreate' in found_functions}}
             global __cuUserObjectCreate
-            cuGetProcAddress('cuUserObjectCreate', &__cuUserObjectCreate, 11030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuUserObjectCreate', &__cuUserObjectCreate, 11030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuUserObjectRetain' in found_functions}}
             global __cuUserObjectRetain
-            cuGetProcAddress('cuUserObjectRetain', &__cuUserObjectRetain, 11030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuUserObjectRetain', &__cuUserObjectRetain, 11030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuUserObjectRelease' in found_functions}}
             global __cuUserObjectRelease
-            cuGetProcAddress('cuUserObjectRelease', &__cuUserObjectRelease, 11030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuUserObjectRelease', &__cuUserObjectRelease, 11030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphRetainUserObject' in found_functions}}
             global __cuGraphRetainUserObject
-            cuGetProcAddress('cuGraphRetainUserObject', &__cuGraphRetainUserObject, 11030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphRetainUserObject', &__cuGraphRetainUserObject, 11030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphReleaseUserObject' in found_functions}}
             global __cuGraphReleaseUserObject
-            cuGetProcAddress('cuGraphReleaseUserObject', &__cuGraphReleaseUserObject, 11030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphReleaseUserObject', &__cuGraphReleaseUserObject, 11030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphAddNode' in found_functions}}
             global __cuGraphAddNode
-            cuGetProcAddress('cuGraphAddNode', &__cuGraphAddNode, 12020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphAddNode', &__cuGraphAddNode, 12020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphAddNode_v2' in found_functions}}
             global __cuGraphAddNode_v2
-            cuGetProcAddress('cuGraphAddNode', &__cuGraphAddNode_v2, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphAddNode', &__cuGraphAddNode_v2, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphNodeSetParams' in found_functions}}
             global __cuGraphNodeSetParams
-            cuGetProcAddress('cuGraphNodeSetParams', &__cuGraphNodeSetParams, 12020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphNodeSetParams', &__cuGraphNodeSetParams, 12020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphExecNodeSetParams' in found_functions}}
             global __cuGraphExecNodeSetParams
-            cuGetProcAddress('cuGraphExecNodeSetParams', &__cuGraphExecNodeSetParams, 12020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphExecNodeSetParams', &__cuGraphExecNodeSetParams, 12020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphConditionalHandleCreate' in found_functions}}
             global __cuGraphConditionalHandleCreate
-            cuGetProcAddress('cuGraphConditionalHandleCreate', &__cuGraphConditionalHandleCreate, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphConditionalHandleCreate', &__cuGraphConditionalHandleCreate, 12030, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuOccupancyMaxActiveBlocksPerMultiprocessor' in found_functions}}
             global __cuOccupancyMaxActiveBlocksPerMultiprocessor
-            cuGetProcAddress('cuOccupancyMaxActiveBlocksPerMultiprocessor', &__cuOccupancyMaxActiveBlocksPerMultiprocessor, 6050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuOccupancyMaxActiveBlocksPerMultiprocessor', &__cuOccupancyMaxActiveBlocksPerMultiprocessor, 6050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags' in found_functions}}
             global __cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags
-            cuGetProcAddress('cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags', &__cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags', &__cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuOccupancyMaxPotentialBlockSize' in found_functions}}
             global __cuOccupancyMaxPotentialBlockSize
-            cuGetProcAddress('cuOccupancyMaxPotentialBlockSize', &__cuOccupancyMaxPotentialBlockSize, 6050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuOccupancyMaxPotentialBlockSize', &__cuOccupancyMaxPotentialBlockSize, 6050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuOccupancyMaxPotentialBlockSizeWithFlags' in found_functions}}
             global __cuOccupancyMaxPotentialBlockSizeWithFlags
-            cuGetProcAddress('cuOccupancyMaxPotentialBlockSizeWithFlags', &__cuOccupancyMaxPotentialBlockSizeWithFlags, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuOccupancyMaxPotentialBlockSizeWithFlags', &__cuOccupancyMaxPotentialBlockSizeWithFlags, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuOccupancyAvailableDynamicSMemPerBlock' in found_functions}}
             global __cuOccupancyAvailableDynamicSMemPerBlock
-            cuGetProcAddress('cuOccupancyAvailableDynamicSMemPerBlock', &__cuOccupancyAvailableDynamicSMemPerBlock, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuOccupancyAvailableDynamicSMemPerBlock', &__cuOccupancyAvailableDynamicSMemPerBlock, 10020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuOccupancyMaxPotentialClusterSize' in found_functions}}
             global __cuOccupancyMaxPotentialClusterSize
-            cuGetProcAddress('cuOccupancyMaxPotentialClusterSize', &__cuOccupancyMaxPotentialClusterSize, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuOccupancyMaxPotentialClusterSize', &__cuOccupancyMaxPotentialClusterSize, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuOccupancyMaxActiveClusters' in found_functions}}
             global __cuOccupancyMaxActiveClusters
-            cuGetProcAddress('cuOccupancyMaxActiveClusters', &__cuOccupancyMaxActiveClusters, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuOccupancyMaxActiveClusters', &__cuOccupancyMaxActiveClusters, 11070, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefSetArray' in found_functions}}
             global __cuTexRefSetArray
-            cuGetProcAddress('cuTexRefSetArray', &__cuTexRefSetArray, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefSetArray', &__cuTexRefSetArray, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefSetMipmappedArray' in found_functions}}
             global __cuTexRefSetMipmappedArray
-            cuGetProcAddress('cuTexRefSetMipmappedArray', &__cuTexRefSetMipmappedArray, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefSetMipmappedArray', &__cuTexRefSetMipmappedArray, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefSetAddress_v2' in found_functions}}
             global __cuTexRefSetAddress_v2
-            cuGetProcAddress('cuTexRefSetAddress', &__cuTexRefSetAddress_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefSetAddress', &__cuTexRefSetAddress_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefSetAddress2D_v3' in found_functions}}
             global __cuTexRefSetAddress2D_v3
-            cuGetProcAddress('cuTexRefSetAddress2D', &__cuTexRefSetAddress2D_v3, 4010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefSetAddress2D', &__cuTexRefSetAddress2D_v3, 4010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefSetFormat' in found_functions}}
             global __cuTexRefSetFormat
-            cuGetProcAddress('cuTexRefSetFormat', &__cuTexRefSetFormat, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefSetFormat', &__cuTexRefSetFormat, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefSetAddressMode' in found_functions}}
             global __cuTexRefSetAddressMode
-            cuGetProcAddress('cuTexRefSetAddressMode', &__cuTexRefSetAddressMode, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefSetAddressMode', &__cuTexRefSetAddressMode, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefSetFilterMode' in found_functions}}
             global __cuTexRefSetFilterMode
-            cuGetProcAddress('cuTexRefSetFilterMode', &__cuTexRefSetFilterMode, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefSetFilterMode', &__cuTexRefSetFilterMode, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefSetMipmapFilterMode' in found_functions}}
             global __cuTexRefSetMipmapFilterMode
-            cuGetProcAddress('cuTexRefSetMipmapFilterMode', &__cuTexRefSetMipmapFilterMode, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefSetMipmapFilterMode', &__cuTexRefSetMipmapFilterMode, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefSetMipmapLevelBias' in found_functions}}
             global __cuTexRefSetMipmapLevelBias
-            cuGetProcAddress('cuTexRefSetMipmapLevelBias', &__cuTexRefSetMipmapLevelBias, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefSetMipmapLevelBias', &__cuTexRefSetMipmapLevelBias, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefSetMipmapLevelClamp' in found_functions}}
             global __cuTexRefSetMipmapLevelClamp
-            cuGetProcAddress('cuTexRefSetMipmapLevelClamp', &__cuTexRefSetMipmapLevelClamp, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefSetMipmapLevelClamp', &__cuTexRefSetMipmapLevelClamp, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefSetMaxAnisotropy' in found_functions}}
             global __cuTexRefSetMaxAnisotropy
-            cuGetProcAddress('cuTexRefSetMaxAnisotropy', &__cuTexRefSetMaxAnisotropy, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefSetMaxAnisotropy', &__cuTexRefSetMaxAnisotropy, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefSetBorderColor' in found_functions}}
             global __cuTexRefSetBorderColor
-            cuGetProcAddress('cuTexRefSetBorderColor', &__cuTexRefSetBorderColor, 8000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefSetBorderColor', &__cuTexRefSetBorderColor, 8000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefSetFlags' in found_functions}}
             global __cuTexRefSetFlags
-            cuGetProcAddress('cuTexRefSetFlags', &__cuTexRefSetFlags, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefSetFlags', &__cuTexRefSetFlags, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefGetAddress_v2' in found_functions}}
             global __cuTexRefGetAddress_v2
-            cuGetProcAddress('cuTexRefGetAddress', &__cuTexRefGetAddress_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefGetAddress', &__cuTexRefGetAddress_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefGetArray' in found_functions}}
             global __cuTexRefGetArray
-            cuGetProcAddress('cuTexRefGetArray', &__cuTexRefGetArray, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefGetArray', &__cuTexRefGetArray, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefGetMipmappedArray' in found_functions}}
             global __cuTexRefGetMipmappedArray
-            cuGetProcAddress('cuTexRefGetMipmappedArray', &__cuTexRefGetMipmappedArray, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefGetMipmappedArray', &__cuTexRefGetMipmappedArray, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefGetAddressMode' in found_functions}}
             global __cuTexRefGetAddressMode
-            cuGetProcAddress('cuTexRefGetAddressMode', &__cuTexRefGetAddressMode, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefGetAddressMode', &__cuTexRefGetAddressMode, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefGetFilterMode' in found_functions}}
             global __cuTexRefGetFilterMode
-            cuGetProcAddress('cuTexRefGetFilterMode', &__cuTexRefGetFilterMode, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefGetFilterMode', &__cuTexRefGetFilterMode, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefGetFormat' in found_functions}}
             global __cuTexRefGetFormat
-            cuGetProcAddress('cuTexRefGetFormat', &__cuTexRefGetFormat, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefGetFormat', &__cuTexRefGetFormat, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefGetMipmapFilterMode' in found_functions}}
             global __cuTexRefGetMipmapFilterMode
-            cuGetProcAddress('cuTexRefGetMipmapFilterMode', &__cuTexRefGetMipmapFilterMode, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefGetMipmapFilterMode', &__cuTexRefGetMipmapFilterMode, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefGetMipmapLevelBias' in found_functions}}
             global __cuTexRefGetMipmapLevelBias
-            cuGetProcAddress('cuTexRefGetMipmapLevelBias', &__cuTexRefGetMipmapLevelBias, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefGetMipmapLevelBias', &__cuTexRefGetMipmapLevelBias, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefGetMipmapLevelClamp' in found_functions}}
             global __cuTexRefGetMipmapLevelClamp
-            cuGetProcAddress('cuTexRefGetMipmapLevelClamp', &__cuTexRefGetMipmapLevelClamp, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefGetMipmapLevelClamp', &__cuTexRefGetMipmapLevelClamp, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefGetMaxAnisotropy' in found_functions}}
             global __cuTexRefGetMaxAnisotropy
-            cuGetProcAddress('cuTexRefGetMaxAnisotropy', &__cuTexRefGetMaxAnisotropy, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefGetMaxAnisotropy', &__cuTexRefGetMaxAnisotropy, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefGetBorderColor' in found_functions}}
             global __cuTexRefGetBorderColor
-            cuGetProcAddress('cuTexRefGetBorderColor', &__cuTexRefGetBorderColor, 8000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefGetBorderColor', &__cuTexRefGetBorderColor, 8000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefGetFlags' in found_functions}}
             global __cuTexRefGetFlags
-            cuGetProcAddress('cuTexRefGetFlags', &__cuTexRefGetFlags, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefGetFlags', &__cuTexRefGetFlags, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefCreate' in found_functions}}
             global __cuTexRefCreate
-            cuGetProcAddress('cuTexRefCreate', &__cuTexRefCreate, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefCreate', &__cuTexRefCreate, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexRefDestroy' in found_functions}}
             global __cuTexRefDestroy
-            cuGetProcAddress('cuTexRefDestroy', &__cuTexRefDestroy, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexRefDestroy', &__cuTexRefDestroy, 2000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuSurfRefSetArray' in found_functions}}
             global __cuSurfRefSetArray
-            cuGetProcAddress('cuSurfRefSetArray', &__cuSurfRefSetArray, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuSurfRefSetArray', &__cuSurfRefSetArray, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuSurfRefGetArray' in found_functions}}
             global __cuSurfRefGetArray
-            cuGetProcAddress('cuSurfRefGetArray', &__cuSurfRefGetArray, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuSurfRefGetArray', &__cuSurfRefGetArray, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexObjectCreate' in found_functions}}
             global __cuTexObjectCreate
-            cuGetProcAddress('cuTexObjectCreate', &__cuTexObjectCreate, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexObjectCreate', &__cuTexObjectCreate, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexObjectDestroy' in found_functions}}
             global __cuTexObjectDestroy
-            cuGetProcAddress('cuTexObjectDestroy', &__cuTexObjectDestroy, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexObjectDestroy', &__cuTexObjectDestroy, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexObjectGetResourceDesc' in found_functions}}
             global __cuTexObjectGetResourceDesc
-            cuGetProcAddress('cuTexObjectGetResourceDesc', &__cuTexObjectGetResourceDesc, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexObjectGetResourceDesc', &__cuTexObjectGetResourceDesc, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexObjectGetTextureDesc' in found_functions}}
             global __cuTexObjectGetTextureDesc
-            cuGetProcAddress('cuTexObjectGetTextureDesc', &__cuTexObjectGetTextureDesc, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexObjectGetTextureDesc', &__cuTexObjectGetTextureDesc, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTexObjectGetResourceViewDesc' in found_functions}}
             global __cuTexObjectGetResourceViewDesc
-            cuGetProcAddress('cuTexObjectGetResourceViewDesc', &__cuTexObjectGetResourceViewDesc, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTexObjectGetResourceViewDesc', &__cuTexObjectGetResourceViewDesc, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuSurfObjectCreate' in found_functions}}
             global __cuSurfObjectCreate
-            cuGetProcAddress('cuSurfObjectCreate', &__cuSurfObjectCreate, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuSurfObjectCreate', &__cuSurfObjectCreate, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuSurfObjectDestroy' in found_functions}}
             global __cuSurfObjectDestroy
-            cuGetProcAddress('cuSurfObjectDestroy', &__cuSurfObjectDestroy, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuSurfObjectDestroy', &__cuSurfObjectDestroy, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuSurfObjectGetResourceDesc' in found_functions}}
             global __cuSurfObjectGetResourceDesc
-            cuGetProcAddress('cuSurfObjectGetResourceDesc', &__cuSurfObjectGetResourceDesc, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuSurfObjectGetResourceDesc', &__cuSurfObjectGetResourceDesc, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTensorMapEncodeTiled' in found_functions}}
             global __cuTensorMapEncodeTiled
-            cuGetProcAddress('cuTensorMapEncodeTiled', &__cuTensorMapEncodeTiled, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTensorMapEncodeTiled', &__cuTensorMapEncodeTiled, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTensorMapEncodeIm2col' in found_functions}}
             global __cuTensorMapEncodeIm2col
-            cuGetProcAddress('cuTensorMapEncodeIm2col', &__cuTensorMapEncodeIm2col, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTensorMapEncodeIm2col', &__cuTensorMapEncodeIm2col, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTensorMapEncodeIm2colWide' in found_functions}}
             global __cuTensorMapEncodeIm2colWide
-            cuGetProcAddress('cuTensorMapEncodeIm2colWide', &__cuTensorMapEncodeIm2colWide, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTensorMapEncodeIm2colWide', &__cuTensorMapEncodeIm2colWide, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuTensorMapReplaceAddress' in found_functions}}
             global __cuTensorMapReplaceAddress
-            cuGetProcAddress('cuTensorMapReplaceAddress', &__cuTensorMapReplaceAddress, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuTensorMapReplaceAddress', &__cuTensorMapReplaceAddress, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceCanAccessPeer' in found_functions}}
             global __cuDeviceCanAccessPeer
-            cuGetProcAddress('cuDeviceCanAccessPeer', &__cuDeviceCanAccessPeer, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceCanAccessPeer', &__cuDeviceCanAccessPeer, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxEnablePeerAccess' in found_functions}}
             global __cuCtxEnablePeerAccess
-            cuGetProcAddress('cuCtxEnablePeerAccess', &__cuCtxEnablePeerAccess, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxEnablePeerAccess', &__cuCtxEnablePeerAccess, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxDisablePeerAccess' in found_functions}}
             global __cuCtxDisablePeerAccess
-            cuGetProcAddress('cuCtxDisablePeerAccess', &__cuCtxDisablePeerAccess, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxDisablePeerAccess', &__cuCtxDisablePeerAccess, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceGetP2PAttribute' in found_functions}}
             global __cuDeviceGetP2PAttribute
-            cuGetProcAddress('cuDeviceGetP2PAttribute', &__cuDeviceGetP2PAttribute, 8000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceGetP2PAttribute', &__cuDeviceGetP2PAttribute, 8000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphicsUnregisterResource' in found_functions}}
             global __cuGraphicsUnregisterResource
-            cuGetProcAddress('cuGraphicsUnregisterResource', &__cuGraphicsUnregisterResource, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphicsUnregisterResource', &__cuGraphicsUnregisterResource, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphicsSubResourceGetMappedArray' in found_functions}}
             global __cuGraphicsSubResourceGetMappedArray
-            cuGetProcAddress('cuGraphicsSubResourceGetMappedArray', &__cuGraphicsSubResourceGetMappedArray, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphicsSubResourceGetMappedArray', &__cuGraphicsSubResourceGetMappedArray, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphicsResourceGetMappedMipmappedArray' in found_functions}}
             global __cuGraphicsResourceGetMappedMipmappedArray
-            cuGetProcAddress('cuGraphicsResourceGetMappedMipmappedArray', &__cuGraphicsResourceGetMappedMipmappedArray, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphicsResourceGetMappedMipmappedArray', &__cuGraphicsResourceGetMappedMipmappedArray, 5000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphicsResourceGetMappedPointer_v2' in found_functions}}
             global __cuGraphicsResourceGetMappedPointer_v2
-            cuGetProcAddress('cuGraphicsResourceGetMappedPointer', &__cuGraphicsResourceGetMappedPointer_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphicsResourceGetMappedPointer', &__cuGraphicsResourceGetMappedPointer_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGraphicsResourceSetMapFlags_v2' in found_functions}}
             global __cuGraphicsResourceSetMapFlags_v2
-            cuGetProcAddress('cuGraphicsResourceSetMapFlags', &__cuGraphicsResourceSetMapFlags_v2, 6050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphicsResourceSetMapFlags', &__cuGraphicsResourceSetMapFlags_v2, 6050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGetProcAddress_v2' in found_functions}}
             global __cuGetProcAddress_v2
-            cuGetProcAddress('cuGetProcAddress', &__cuGetProcAddress_v2, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGetProcAddress', &__cuGetProcAddress_v2, 12000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCoredumpGetAttribute' in found_functions}}
             global __cuCoredumpGetAttribute
-            cuGetProcAddress('cuCoredumpGetAttribute', &__cuCoredumpGetAttribute, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCoredumpGetAttribute', &__cuCoredumpGetAttribute, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCoredumpGetAttributeGlobal' in found_functions}}
             global __cuCoredumpGetAttributeGlobal
-            cuGetProcAddress('cuCoredumpGetAttributeGlobal', &__cuCoredumpGetAttributeGlobal, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCoredumpGetAttributeGlobal', &__cuCoredumpGetAttributeGlobal, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCoredumpSetAttribute' in found_functions}}
             global __cuCoredumpSetAttribute
-            cuGetProcAddress('cuCoredumpSetAttribute', &__cuCoredumpSetAttribute, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCoredumpSetAttribute', &__cuCoredumpSetAttribute, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCoredumpSetAttributeGlobal' in found_functions}}
             global __cuCoredumpSetAttributeGlobal
-            cuGetProcAddress('cuCoredumpSetAttributeGlobal', &__cuCoredumpSetAttributeGlobal, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCoredumpSetAttributeGlobal', &__cuCoredumpSetAttributeGlobal, 12010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGetExportTable' in found_functions}}
             global __cuGetExportTable
-            cuGetProcAddress('cuGetExportTable', &__cuGetExportTable, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGetExportTable', &__cuGetExportTable, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGreenCtxCreate' in found_functions}}
             global __cuGreenCtxCreate
-            cuGetProcAddress('cuGreenCtxCreate', &__cuGreenCtxCreate, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGreenCtxCreate', &__cuGreenCtxCreate, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGreenCtxDestroy' in found_functions}}
             global __cuGreenCtxDestroy
-            cuGetProcAddress('cuGreenCtxDestroy', &__cuGreenCtxDestroy, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGreenCtxDestroy', &__cuGreenCtxDestroy, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxFromGreenCtx' in found_functions}}
             global __cuCtxFromGreenCtx
-            cuGetProcAddress('cuCtxFromGreenCtx', &__cuCtxFromGreenCtx, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxFromGreenCtx', &__cuCtxFromGreenCtx, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDeviceGetDevResource' in found_functions}}
             global __cuDeviceGetDevResource
-            cuGetProcAddress('cuDeviceGetDevResource', &__cuDeviceGetDevResource, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDeviceGetDevResource', &__cuDeviceGetDevResource, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCtxGetDevResource' in found_functions}}
             global __cuCtxGetDevResource
-            cuGetProcAddress('cuCtxGetDevResource', &__cuCtxGetDevResource, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCtxGetDevResource', &__cuCtxGetDevResource, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGreenCtxGetDevResource' in found_functions}}
             global __cuGreenCtxGetDevResource
-            cuGetProcAddress('cuGreenCtxGetDevResource', &__cuGreenCtxGetDevResource, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGreenCtxGetDevResource', &__cuGreenCtxGetDevResource, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDevSmResourceSplitByCount' in found_functions}}
             global __cuDevSmResourceSplitByCount
-            cuGetProcAddress('cuDevSmResourceSplitByCount', &__cuDevSmResourceSplitByCount, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDevSmResourceSplitByCount', &__cuDevSmResourceSplitByCount, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuDevResourceGenerateDesc' in found_functions}}
             global __cuDevResourceGenerateDesc
-            cuGetProcAddress('cuDevResourceGenerateDesc', &__cuDevResourceGenerateDesc, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuDevResourceGenerateDesc', &__cuDevResourceGenerateDesc, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGreenCtxRecordEvent' in found_functions}}
             global __cuGreenCtxRecordEvent
-            cuGetProcAddress('cuGreenCtxRecordEvent', &__cuGreenCtxRecordEvent, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGreenCtxRecordEvent', &__cuGreenCtxRecordEvent, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGreenCtxWaitEvent' in found_functions}}
             global __cuGreenCtxWaitEvent
-            cuGetProcAddress('cuGreenCtxWaitEvent', &__cuGreenCtxWaitEvent, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGreenCtxWaitEvent', &__cuGreenCtxWaitEvent, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuStreamGetGreenCtx' in found_functions}}
             global __cuStreamGetGreenCtx
-            cuGetProcAddress('cuStreamGetGreenCtx', &__cuStreamGetGreenCtx, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuStreamGetGreenCtx', &__cuStreamGetGreenCtx, 12040, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuGreenCtxStreamCreate' in found_functions}}
             global __cuGreenCtxStreamCreate
-            cuGetProcAddress('cuGreenCtxStreamCreate', &__cuGreenCtxStreamCreate, 12050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGreenCtxStreamCreate', &__cuGreenCtxStreamCreate, 12050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLogsRegisterCallback' in found_functions}}
             global __cuLogsRegisterCallback
-            cuGetProcAddress('cuLogsRegisterCallback', &__cuLogsRegisterCallback, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLogsRegisterCallback', &__cuLogsRegisterCallback, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLogsUnregisterCallback' in found_functions}}
             global __cuLogsUnregisterCallback
-            cuGetProcAddress('cuLogsUnregisterCallback', &__cuLogsUnregisterCallback, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLogsUnregisterCallback', &__cuLogsUnregisterCallback, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLogsCurrent' in found_functions}}
             global __cuLogsCurrent
-            cuGetProcAddress('cuLogsCurrent', &__cuLogsCurrent, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLogsCurrent', &__cuLogsCurrent, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLogsDumpToFile' in found_functions}}
             global __cuLogsDumpToFile
-            cuGetProcAddress('cuLogsDumpToFile', &__cuLogsDumpToFile, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLogsDumpToFile', &__cuLogsDumpToFile, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuLogsDumpToMemory' in found_functions}}
             global __cuLogsDumpToMemory
-            cuGetProcAddress('cuLogsDumpToMemory', &__cuLogsDumpToMemory, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuLogsDumpToMemory', &__cuLogsDumpToMemory, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCheckpointProcessGetRestoreThreadId' in found_functions}}
             global __cuCheckpointProcessGetRestoreThreadId
-            cuGetProcAddress('cuCheckpointProcessGetRestoreThreadId', &__cuCheckpointProcessGetRestoreThreadId, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCheckpointProcessGetRestoreThreadId', &__cuCheckpointProcessGetRestoreThreadId, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCheckpointProcessGetState' in found_functions}}
             global __cuCheckpointProcessGetState
-            cuGetProcAddress('cuCheckpointProcessGetState', &__cuCheckpointProcessGetState, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCheckpointProcessGetState', &__cuCheckpointProcessGetState, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCheckpointProcessLock' in found_functions}}
             global __cuCheckpointProcessLock
-            cuGetProcAddress('cuCheckpointProcessLock', &__cuCheckpointProcessLock, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCheckpointProcessLock', &__cuCheckpointProcessLock, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCheckpointProcessCheckpoint' in found_functions}}
             global __cuCheckpointProcessCheckpoint
-            cuGetProcAddress('cuCheckpointProcessCheckpoint', &__cuCheckpointProcessCheckpoint, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCheckpointProcessCheckpoint', &__cuCheckpointProcessCheckpoint, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCheckpointProcessRestore' in found_functions}}
             global __cuCheckpointProcessRestore
-            cuGetProcAddress('cuCheckpointProcessRestore', &__cuCheckpointProcessRestore, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCheckpointProcessRestore', &__cuCheckpointProcessRestore, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuCheckpointProcessUnlock' in found_functions}}
             global __cuCheckpointProcessUnlock
-            cuGetProcAddress('cuCheckpointProcessUnlock', &__cuCheckpointProcessUnlock, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuCheckpointProcessUnlock', &__cuCheckpointProcessUnlock, 12080, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuProfilerStart' in found_functions}}
             global __cuProfilerStart
-            cuGetProcAddress('cuProfilerStart', &__cuProfilerStart, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuProfilerStart', &__cuProfilerStart, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if 'cuProfilerStop' in found_functions}}
             global __cuProfilerStop
-            cuGetProcAddress('cuProfilerStop', &__cuProfilerStop, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuProfilerStop', &__cuProfilerStop, 4000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if True}}
             global __cuGraphicsEGLRegisterImage
-            cuGetProcAddress('cuGraphicsEGLRegisterImage', &__cuGraphicsEGLRegisterImage, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphicsEGLRegisterImage', &__cuGraphicsEGLRegisterImage, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if True}}
             global __cuEGLStreamConsumerConnect
-            cuGetProcAddress('cuEGLStreamConsumerConnect', &__cuEGLStreamConsumerConnect, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuEGLStreamConsumerConnect', &__cuEGLStreamConsumerConnect, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if True}}
             global __cuEGLStreamConsumerConnectWithFlags
-            cuGetProcAddress('cuEGLStreamConsumerConnectWithFlags', &__cuEGLStreamConsumerConnectWithFlags, 8000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuEGLStreamConsumerConnectWithFlags', &__cuEGLStreamConsumerConnectWithFlags, 8000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if True}}
             global __cuEGLStreamConsumerDisconnect
-            cuGetProcAddress('cuEGLStreamConsumerDisconnect', &__cuEGLStreamConsumerDisconnect, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuEGLStreamConsumerDisconnect', &__cuEGLStreamConsumerDisconnect, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if True}}
             global __cuEGLStreamConsumerAcquireFrame
-            cuGetProcAddress('cuEGLStreamConsumerAcquireFrame', &__cuEGLStreamConsumerAcquireFrame, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuEGLStreamConsumerAcquireFrame', &__cuEGLStreamConsumerAcquireFrame, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if True}}
             global __cuEGLStreamConsumerReleaseFrame
-            cuGetProcAddress('cuEGLStreamConsumerReleaseFrame', &__cuEGLStreamConsumerReleaseFrame, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuEGLStreamConsumerReleaseFrame', &__cuEGLStreamConsumerReleaseFrame, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if True}}
             global __cuEGLStreamProducerConnect
-            cuGetProcAddress('cuEGLStreamProducerConnect', &__cuEGLStreamProducerConnect, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuEGLStreamProducerConnect', &__cuEGLStreamProducerConnect, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if True}}
             global __cuEGLStreamProducerDisconnect
-            cuGetProcAddress('cuEGLStreamProducerDisconnect', &__cuEGLStreamProducerDisconnect, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuEGLStreamProducerDisconnect', &__cuEGLStreamProducerDisconnect, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if True}}
             global __cuEGLStreamProducerPresentFrame
-            cuGetProcAddress('cuEGLStreamProducerPresentFrame', &__cuEGLStreamProducerPresentFrame, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuEGLStreamProducerPresentFrame', &__cuEGLStreamProducerPresentFrame, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if True}}
             global __cuEGLStreamProducerReturnFrame
-            cuGetProcAddress('cuEGLStreamProducerReturnFrame', &__cuEGLStreamProducerReturnFrame, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuEGLStreamProducerReturnFrame', &__cuEGLStreamProducerReturnFrame, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if True}}
             global __cuGraphicsResourceGetMappedEglFrame
-            cuGetProcAddress('cuGraphicsResourceGetMappedEglFrame', &__cuGraphicsResourceGetMappedEglFrame, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphicsResourceGetMappedEglFrame', &__cuGraphicsResourceGetMappedEglFrame, 7000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if True}}
             global __cuEventCreateFromEGLSync
-            cuGetProcAddress('cuEventCreateFromEGLSync', &__cuEventCreateFromEGLSync, 9000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuEventCreateFromEGLSync', &__cuEventCreateFromEGLSync, 9000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if True}}
             global __cuGraphicsGLRegisterBuffer
-            cuGetProcAddress('cuGraphicsGLRegisterBuffer', &__cuGraphicsGLRegisterBuffer, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphicsGLRegisterBuffer', &__cuGraphicsGLRegisterBuffer, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if True}}
             global __cuGraphicsGLRegisterImage
-            cuGetProcAddress('cuGraphicsGLRegisterImage', &__cuGraphicsGLRegisterImage, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphicsGLRegisterImage', &__cuGraphicsGLRegisterImage, 3000, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if True}}
             global __cuGLGetDevices_v2
-            cuGetProcAddress('cuGLGetDevices', &__cuGLGetDevices_v2, 6050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGLGetDevices', &__cuGLGetDevices_v2, 6050, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if True}}
             global __cuVDPAUGetDevice
-            cuGetProcAddress('cuVDPAUGetDevice', &__cuVDPAUGetDevice, 3010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuVDPAUGetDevice', &__cuVDPAUGetDevice, 3010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if True}}
             global __cuVDPAUCtxCreate_v2
-            cuGetProcAddress('cuVDPAUCtxCreate', &__cuVDPAUCtxCreate_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuVDPAUCtxCreate', &__cuVDPAUCtxCreate_v2, 3020, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if True}}
             global __cuGraphicsVDPAURegisterVideoSurface
-            cuGetProcAddress('cuGraphicsVDPAURegisterVideoSurface', &__cuGraphicsVDPAURegisterVideoSurface, 3010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphicsVDPAURegisterVideoSurface', &__cuGraphicsVDPAURegisterVideoSurface, 3010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
             {{if True}}
             global __cuGraphicsVDPAURegisterOutputSurface
-            cuGetProcAddress('cuGraphicsVDPAURegisterOutputSurface', &__cuGraphicsVDPAURegisterOutputSurface, 3010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
+            _F_cuGetProcAddress_v2('cuGraphicsVDPAURegisterOutputSurface', &__cuGraphicsVDPAURegisterOutputSurface, 3010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
+
+            __cuPythonInit = True
             return 0
     
         {{if 'Windows' == platform.system()}}
@@ -8939,6 +8944,7 @@ cdef int cuPythonInit() except -1 nogil:
         {{endif}}
         {{endif}}
 
+        __cuPythonInit = True
         return 0
 
 {{if 'cuGetErrorString' in found_functions}}

--- a/cuda_bindings/cuda/bindings/_bindings/cynvrtc.pyx.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cynvrtc.pyx.in
@@ -43,12 +43,11 @@ cdef bint __cuPythonInit = False
 
 cdef int cuPythonInit() except -1 nogil:
     global __cuPythonInit
+    if __cuPythonInit:
+        return 0
 
     # Load library
     with gil, __symbol_lock:
-        if __cuPythonInit:
-            return 0
-
         {{if 'Windows' == platform.system()}}
         handle = load_nvidia_dynamic_lib("nvrtc")._handle_uint
 
@@ -237,7 +236,7 @@ cdef int cuPythonInit() except -1 nogil:
         {{endif}}
 
         {{else}}
-        handle = <void*><uintptr_t>load_nvidia_dynamic_lib("nvrtc")._handle_uint
+        handle = <void*><uintptr_t>(load_nvidia_dynamic_lib("nvrtc")._handle_uint)
 
         # Load function
         {{if 'nvrtcGetErrorString' in found_functions}}

--- a/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx
@@ -79,12 +79,13 @@ cdef void* load_library(const int driver_ver) except* with gil:
 
 cdef int _check_or_init_cufile() except -1 nogil:
     global __py_cufile_init
+    if __py_cufile_init:
+        return 0
+
+    cdef void* handle = NULL
     cdef int err, driver_ver = 0
 
     with gil, __symbol_lock:
-        if __py_cufile_init:
-            return 0
-
         # Load driver to check version
         handle = dlopen('libcuda.so.1', RTLD_NOW | RTLD_GLOBAL)
         if handle == NULL:

--- a/cuda_bindings/cuda/bindings/_internal/nvjitlink_linux.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvjitlink_linux.pyx
@@ -61,12 +61,13 @@ cdef void* load_library(int driver_ver) except* with gil:
 
 cdef int _check_or_init_nvjitlink() except -1 nogil:
     global __py_nvjitlink_init
+    if __py_nvjitlink_init:
+        return 0
+
+    cdef void* handle = NULL
     cdef int err, driver_ver = 0
 
     with gil, __symbol_lock:
-        if __py_nvjitlink_init:
-            return 0
-
         # Load driver to check version
         handle = dlopen('libcuda.so.1', RTLD_NOW | RTLD_GLOBAL)
         if handle == NULL:

--- a/cuda_bindings/cuda/bindings/_internal/nvjitlink_windows.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvjitlink_windows.pyx
@@ -43,12 +43,12 @@ cdef void* __nvJitLinkVersion = NULL
 
 cdef int _check_or_init_nvjitlink() except -1 nogil:
     global __py_nvjitlink_init
+    if __py_nvjitlink_init:
+        return 0
+
     cdef int err, driver_ver = 0
 
     with gil, __symbol_lock:
-        if __py_nvjitlink_init:
-            return 0
-
         # Load driver to check version
         try:
             handle = win32api.LoadLibraryEx("nvcuda.dll", 0, LOAD_LIBRARY_SEARCH_SYSTEM32)

--- a/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx
@@ -60,12 +60,13 @@ cdef void* load_library(const int driver_ver) except* with gil:
 
 cdef int _check_or_init_nvvm() except -1 nogil:
     global __py_nvvm_init
+    if __py_nvvm_init:
+        return 0
+
+    cdef void* handle = NULL
     cdef int err, driver_ver = 0
 
     with gil, __symbol_lock:
-        if __py_nvvm_init:
-            return 0
-
         # Load driver to check version
         handle = dlopen('libcuda.so.1', RTLD_NOW | RTLD_GLOBAL)
         if handle == NULL:

--- a/cuda_bindings/cuda/bindings/_internal/nvvm_windows.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvvm_windows.pyx
@@ -42,12 +42,12 @@ cdef void* __nvvmGetProgramLog = NULL
 
 cdef int _check_or_init_nvvm() except -1 nogil:
     global __py_nvvm_init
+    if __py_nvvm_init:
+        return 0
+
     cdef int err, driver_ver = 0
 
     with gil, __symbol_lock:
-        if __py_nvvm_init:
-            return 0
-
         # Load driver to check version
         try:
             handle = win32api.LoadLibraryEx("nvcuda.dll", 0, LOAD_LIBRARY_SEARCH_SYSTEM32)


### PR DESCRIPTION
## Description

xref: #835

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

