### PR TITLE
Adds path for the CUDA static library based on CUDA_HOME

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -157,11 +157,9 @@ jobs:
           # CIBW mounts the host filesystem under /host
           CIBW_ENVIRONMENT_LINUX: >
             CUDA_PATH=/host/${{ env.CUDA_PATH }}
-            LIBRARY_PATH=/host/${{ env.CUDA_PATH }}/lib
             CUDA_PYTHON_PARALLEL_LEVEL=${{ env.CUDA_PYTHON_PARALLEL_LEVEL }}
           CIBW_ENVIRONMENT_WINDOWS: >
             CUDA_HOME="$(cygpath -w ${{ env.CUDA_PATH }})"
-            LIB="${CUDA_HOME}\\lib\\x64;${LIB}"
             CUDA_PYTHON_PARALLEL_LEVEL=${{ env.CUDA_PYTHON_PARALLEL_LEVEL }}
           CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --namespace-pkg cuda -w {dest_dir} {wheel}"

--- a/cuda_bindings/setup.py
+++ b/cuda_bindings/setup.py
@@ -31,6 +31,7 @@ if not CUDA_HOME:
     raise RuntimeError("Environment variable CUDA_HOME or CUDA_PATH is not set")
 
 CUDA_HOME = CUDA_HOME.split(os.pathsep)
+
 if os.environ.get("PARALLEL_LEVEL") is not None:
     warn(
         "Environment variable PARALLEL_LEVEL is deprecated. Use CUDA_PYTHON_PARALLEL_LEVEL instead",
@@ -238,6 +239,8 @@ include_dirs = [
     os.path.dirname(sysconfig.get_path("include")),
 ] + include_path_list
 library_dirs = [sysconfig.get_path("platlib"), os.path.join(os.sys.prefix, "lib")]
+cudalib_subdir = r"lib\x64" if sys.platform == "win32" else "lib64"
+library_dirs.extend(os.path.join(prefix, cudalib_subdir) for prefix in CUDA_HOME)
 
 extra_compile_args = []
 extra_cythonize_kwargs = {}

--- a/cuda_bindings/setup.py
+++ b/cuda_bindings/setup.py
@@ -239,8 +239,8 @@ include_dirs = [
     os.path.dirname(sysconfig.get_path("include")),
 ] + include_path_list
 library_dirs = [sysconfig.get_path("platlib"), os.path.join(os.sys.prefix, "lib")]
-cudalib_subdir = r"lib\x64" if sys.platform == "win32" else "lib64"
-library_dirs.extend(os.path.join(prefix, cudalib_subdir) for prefix in CUDA_HOME)
+cudalib_subdirs = [r"lib\x64"] if sys.platform == "win32" else ["lib64", "lib"]
+library_dirs.extend(os.path.join(prefix, subdir) for prefix in CUDA_HOME for subdir in cudalib_subdirs)
 
 extra_compile_args = []
 extra_cythonize_kwargs = {}


### PR DESCRIPTION
Both CUDA_HOME (or CUDA_PATH) and LIBRARY_PATH are required to be set in the environment during installation. There was already a check for CUDA_HOME in setup.py, but no check for LIBRARY_PATH. This change adds a check to make sure LIBRARY_PATH is set.

When LIBRARY_PATH is not set, the installation fails at link time and indicates that cudart_static could not be found.