### PR TITLE
Improve #449: Improve StridedMemoryView creation time

### DIFF
--- a/cuda_core/cuda/core/experimental/_memoryview.pyx
+++ b/cuda_core/cuda/core/experimental/_memoryview.pyx
@@ -213,7 +213,6 @@ cdef StridedMemoryView view_as_dlpack(obj, stream_ptr, view=None):
     cdef StridedMemoryView buf = StridedMemoryView() if view is None else view
     buf.ptr = <intptr_t>(dl_tensor.data)
     
-    # Construct shape and strides tuples using the Python/C API for speed
     buf.shape = cuda_utils.carray_int64_t_to_tuple(dl_tensor.shape, dl_tensor.ndim)
     if dl_tensor.strides:
         buf.strides = cuda_utils.carray_int64_t_to_tuple(dl_tensor.strides, dl_tensor.ndim)

--- a/cuda_core/cuda/core/experimental/_utils/cuda_utils.pxd
+++ b/cuda_core/cuda/core/experimental/_utils/cuda_utils.pxd
@@ -14,6 +14,7 @@ cpdef check_or_create_options(type cls, options, str options_description=*, bint
 
 
 cdef inline tuple carray_int64_t_to_tuple(libc.stdint.int64_t *ptr, int length):
+    # Construct shape and strides tuples using the Python/C API for speed
     result = cpython.PyTuple_New(length)
     for i in range(length):
         cpython.PyTuple_SET_ITEM(result, i, cpython.PyLong_FromLongLong(ptr[i]))


### PR DESCRIPTION
Two changes:

1. Refactor the versioned/non-versioned paths to reduce the number of branches.
2. Create shape and strides tuples using Python/C API

The second change has a significant impact:

- Before: 1.23 us +- 0.06 us
- After: 1.02 us +- 0.06 us

<details>
<summary>Measured using this pyperf benchmark, based on the one in #449</summary>

```
import pyperf
import time


import cupy as cp
from cuda.core.experimental.utils import StridedMemoryView


inner_loops = 100_000


def bench_strided_memory_view(loops, x):
    range_it = range(loops * inner_loops)
    t0 = time.perf_counter()

    for _ in range_it:
        s = StridedMemoryView(x, -1)

    return time.perf_counter() - t0


runner = pyperf.Runner()
x = cp.empty((23, 4))
runner.bench_time_func('StridedMemoryView', bench_strided_memory_view, x, inner_loops=inner_loops)
```
</details>

## Description

Improves #449

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [x] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

