### PR TITLE
Make pathfinder `add_dll_directory()`, `load_dependencies()` side-effects more deterministic.

### DIFF
--- a/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/load_dl_linux.py
+++ b/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/load_dl_linux.py
@@ -127,21 +127,7 @@ def get_candidate_sonames(libname: str) -> list[str]:
     return candidate_sonames
 
 
-def check_if_already_loaded_from_elsewhere(libname: str) -> Optional[LoadedDL]:
-    """Check if the library is already loaded in the process.
-
-    Args:
-        libname: The name of the library to check
-
-    Returns:
-        A LoadedDL object if the library is already loaded, None otherwise
-
-    Example:
-        >>> loaded = check_if_already_loaded_from_elsewhere("cudart")
-        >>> if loaded is not None:
-        ...     print(f"Library already loaded from {loaded.abs_path}")
-    """
-
+def check_if_already_loaded_from_elsewhere(libname: str, _have_abs_path: bool) -> Optional[LoadedDL]:
     for soname in get_candidate_sonames(libname):
         try:
             handle = ctypes.CDLL(soname, mode=os.RTLD_NOLOAD)

--- a/cuda_pathfinder/cuda/pathfinder/_version.py
+++ b/cuda_pathfinder/cuda/pathfinder/_version.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "1.1.1a1"
+__version__ = "1.1.1a2"


### PR DESCRIPTION
Closes #821 

Proactive change to improve stability in general, but also in support of `nvmath` specifically.

Bump cuda-pathfinder version to `1.1.1a2`

Dropping boilerplate docstrings for private functions (these are more distracting than helpful).