### PR TITLE
Removes LIBRARY_PATH environment variable from installation docs.

### DIFF
--- a/cuda_bindings/docs/source/install.md
+++ b/cuda_bindings/docs/source/install.md
@@ -57,7 +57,6 @@ Source builds require that the provided CUDA headers are of the same major.minor
 
 ```console
 $ export CUDA_HOME=/usr/local/cuda
-$ export LIBRARY_PATH=$CUDA_HOME/lib64:$LIBRARY_PATH
 ```
 
 See [Environment Variables](environment_variables.md) for a description of other build-time environment variables.


### PR DESCRIPTION
This variable is no longer needed due to fix of #608.

