### PR TITLE
Fix an apparent mistake in GraphBuilder.add_child

### DIFF
--- a/cuda_core/cuda/core/experimental/_graph.py
+++ b/cuda_core/cuda/core/experimental/_graph.py
@@ -683,11 +683,14 @@ class GraphBuilder:
             driver.cuStreamGetCaptureInfo(stream_handle)
         )
 
+        # See https://github.com/NVIDIA/cuda-python/pull/879#issuecomment-3211054159
+        # for rationale
+        deps_info_trimmed = deps_info_out[:num_dependencies_out]
         deps_info_update = [
             [
                 handle_return(
                     driver.cuGraphAddChildGraphNode(
-                        graph_out, *deps_info_out, num_dependencies_out, child_graph._mnff.graph
+                        graph_out, *deps_info_trimmed, num_dependencies_out, child_graph._mnff.graph
                     )
                 )
             ]

--- a/cuda_core/cuda/core/experimental/_graph.py
+++ b/cuda_core/cuda/core/experimental/_graph.py
@@ -687,7 +687,7 @@ class GraphBuilder:
             [
                 handle_return(
                     driver.cuGraphAddChildGraphNode(
-                        graph_out, deps_info_out[0], num_dependencies_out, child_graph._mnff.graph
+                        graph_out, *deps_info_out, num_dependencies_out, child_graph._mnff.graph
                     )
                 )
             ]


### PR DESCRIPTION
While working on C++ stand-alone code executing what `test_graph.py` does in gh-843, I noticed that `add_child` passes dependendencies extracted from capturing stream inconsistently with num_dependencies parameter obtained in the same cuStreamGetCaptureInfo call.

Incidentally, after correcting this error, I can no longer reproduce errors reported in gh-843

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #843

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

