### PR TITLE
Fixed typo in cuda-core API reference

### DIFF
--- a/cuda_core/docs/source/api.rst
+++ b/cuda_core/docs/source/api.rst
@@ -7,7 +7,7 @@
 ========================================
 
 All of the APIs listed (or cross-referenced from) below are considered *experimental*
-and subject to future changes without deprecation notice. Once stablized they will be
+and subject to future changes without deprecation notice. Once stabilized they will be
 moved out of the ``experimental`` namespace.
 
 


### PR DESCRIPTION
## Description

Changed "stablized" to "stabilized"

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

