### PR TITLE
Reduce overhead of bindings requiring `cuPythonInit()`

### DIFF
--- a/cuda_bindings/cuda/bindings/_bindings/cydriver.pyx.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cydriver.pyx.in
@@ -8882,8 +8882,8 @@ cdef int _cuPythonInit() except -1 nogil:
         return 0
 
 # Create a very small function to check whether we are init'ed, so the C
-# compiler is more likely to inline it.
-cdef int cuPythonInit() except -1 nogil:
+# compiler can inline it.
+cdef inline int cuPythonInit() except -1 nogil:
     if __cuPythonInit:
         return 0
     

--- a/cuda_bindings/cuda/bindings/_bindings/cydriver.pyx.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cydriver.pyx.in
@@ -490,10 +490,8 @@ cdef bint __cuPythonInit = False
 ctypedef CUresult (*__cuGetProcAddress_v2_T)(const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*) except?CUDA_ERROR_NOT_FOUND nogil
 cdef __cuGetProcAddress_v2_T _F_cuGetProcAddress_v2 = NULL
 
-cdef int cuPythonInit() except -1 nogil:
+cdef int _cuPythonInit() except -1 nogil:
     global __cuPythonInit
-    if __cuPythonInit:
-        return 0
 
     cdef bint usePTDS
     cdef char libPath[260]
@@ -8882,6 +8880,14 @@ cdef int cuPythonInit() except -1 nogil:
 
         __cuPythonInit = True
         return 0
+
+# Create a very small function to check whether we are init'ed, so the C
+# compiler is more likely to inline it.
+cdef int cuPythonInit() except -1 nogil:
+    if __cuPythonInit:
+        return 0
+    
+    return _cuPythonInit()
 
 {{if 'cuGetErrorString' in found_functions}}
 

--- a/cuda_bindings/cuda/bindings/_bindings/cynvrtc.pyx.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cynvrtc.pyx.in
@@ -323,8 +323,8 @@ cdef int _cuPythonInit() except -1 nogil:
         return 0
 
 # Create a very small function to check whether we are init'ed, so the C
-# compiler is more likely to inline it.
-cdef int cuPythonInit() except -1 nogil:
+# compiler can inline it.
+cdef inline int cuPythonInit() except -1 nogil:
     if __cuPythonInit:
         return 0
 

--- a/cuda_bindings/cuda/bindings/_bindings/cynvrtc.pyx.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cynvrtc.pyx.in
@@ -40,10 +40,8 @@ cdef bint __cuPythonInit = False
 {{if 'nvrtcGetPCHHeapSizeRequired' in found_functions}}cdef void *__nvrtcGetPCHHeapSizeRequired = NULL{{endif}}
 {{if 'nvrtcSetFlowCallback' in found_functions}}cdef void *__nvrtcSetFlowCallback = NULL{{endif}}
 
-cdef int cuPythonInit() except -1 nogil:
+cdef int _cuPythonInit() except -1 nogil:
     global __cuPythonInit
-    if __cuPythonInit:
-        return 0
 
     with gil, __symbol_lock:
         {{if 'Windows' == platform.system()}}
@@ -323,6 +321,14 @@ cdef int cuPythonInit() except -1 nogil:
 
         __cuPythonInit = True
         return 0
+
+# Create a very small function to check whether we are init'ed, so the C
+# compiler is more likely to inline it.
+cdef int cuPythonInit() except -1 nogil:
+    if __cuPythonInit:
+        return 0
+
+    return _cuPythonInit()
 
 {{if 'nvrtcGetErrorString' in found_functions}}
 

--- a/cuda_bindings/cuda/bindings/_bindings/cyruntime.pyx.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cyruntime.pyx.in
@@ -10,15 +10,21 @@ cimport cython
 
 cdef bint __cudaPythonInit = False
 cdef bint __usePTDS = False
-cdef int cudaPythonInit() except -1 nogil:
+cdef int _cudaPythonInit() except -1 nogil:
         global __cudaPythonInit
         global __usePTDS
-        if __cudaPythonInit:
-            return __usePTDS
         with gil:
             __usePTDS = os.getenv('CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM', default=False)
         __cudaPythonInit = True
         return __usePTDS
+
+# Create a very small function to check whether we are init'ed, so the C
+# compiler is more likely to inline it.
+cdef int cudaPythonInit() except -1 nogil:
+    if __cudaPythonInit:
+        return __usePTDS
+
+    return _cudaPythonInit()
 
 {{if 'cudaDeviceReset' in found_functions}}
 

--- a/cuda_bindings/cuda/bindings/_bindings/cyruntime.pyx.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cyruntime.pyx.in
@@ -19,8 +19,8 @@ cdef int _cudaPythonInit() except -1 nogil:
         return __usePTDS
 
 # Create a very small function to check whether we are init'ed, so the C
-# compiler is more likely to inline it.
-cdef int cudaPythonInit() except -1 nogil:
+# compiler can inline it.
+cdef inline int cudaPythonInit() except -1 nogil:
     if __cudaPythonInit:
         return __usePTDS
 

--- a/cuda_bindings/docs/source/release/13.X.Y-notes.rst
+++ b/cuda_bindings/docs/source/release/13.X.Y-notes.rst
@@ -14,6 +14,8 @@ Highlights
 
 * Automatic CUDA library path detection based on ``CUDA_HOME``, eliminating the need to manually set ``LIBRARY_PATH`` environment variables for installation.
 
+* The Python overhead of calling functions in CUDA bindings in `driver`, `runtime` and `nvrtc` has been reduced by approximately 30%.
+
 
 Known issues
 ------------


### PR DESCRIPTION
## Description

This reduces the calling overhead of binding functions that require `cuPythonInit` or `cudaPythonInit` to be called.

This reduces the time it takes to call `driver.cuDeviceGet(0)` (for example) by about 50ns (on my machine):

- Base: Mean +- std dev: 149 ns +- 8 ns
- This PR: Mean +- std dev: 101 ns +- 2 ns

Note that these times include the work done by the actual underlying `cuDeviceGet` call, not just the function call overhead.

## Why this works

The `cuPythonInit` function is extremely large, so no C compiler is likely to ever inline it.  By creating a small wrapper function just to check the `init` flag and then delegate to the big function, the C compiler inlines it.  This not only removes a C function call, but probably helps out the branch predictor when checking the flag.

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

