### PR TITLE
[NVVM IR] NVVM IR Integration

### DIFF
--- a/cuda_core/cuda/core/experimental/_module.py
+++ b/cuda_core/cuda/core/experimental/_module.py
@@ -544,6 +544,24 @@ class ObjectCode:
             them (default to no mappings).
         """
         return ObjectCode._init(module, "ltoir", name=name, symbol_mapping=symbol_mapping)
+    
+    @staticmethod
+    def from_nvvm(module: Union[bytes, str], *, name: str = "", symbol_mapping: Optional[dict] = None) -> "ObjectCode":
+        """Create an :class:`ObjectCode` instance from an existing NVVM IR.
+
+        Parameters
+        ----------
+        module : Union[bytes, str]
+            Either a bytes object containing the in-memory NVVM IR code to load, or
+            a file path string pointing to the on-disk NVVM IR file to load.
+        name : Optional[str]
+            A human-readable identifier representing this code object.
+        symbol_mapping : Optional[dict]
+            A dictionary specifying how the unmangled symbol names (as keys)
+            should be mapped to the mangled names before trying to retrieve
+            them (default to no mappings).
+        """
+        return ObjectCode._init(module, "nvvm", name=name, symbol_mapping=symbol_mapping)
 
     @staticmethod
     def from_fatbin(


### PR DESCRIPTION
## Description

Abstract : The cuda/bindings backend of Cuda python has NVVM support through libnvvm api . However the frontend of cuda python does not support nvvm ir as input source. Since cuda python allows users to leverage a "pythonic dsl" format for writing the host code (taking care of launch parameters etc), it makes sense to also allow NVVM IR as an alternative input to the already included list of inputs {ptx, c++, lto ir} etc.

Discussion Link: #906 

Changes made {to be made} in this PR:

- Added cuda core linkage to cuda bindings nvvm counterpart 
- Cosmetic changes in user interface to use existing nvvm backend of cuda bindings.

## Checklist

- [ TBD ] New tests needed to be added to cover these changes.
- [ TBD ] The documentation needs to be  updated with these changes.

cc @leofang 