### PR TITLE
Dependabot: consolidate GitHub Actions updates to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,15 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: "monthly"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+
+    # Keep churn down: only one open PR from this ecosystem at a time
+    open-pull-requests-limit: 1
+
+    groups:
+      actions-monthly:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/cuda_bindings/docs/source/release/13.X.Y-notes.rst
+++ b/cuda_bindings/docs/source/release/13.X.Y-notes.rst
@@ -16,7 +16,7 @@ Highlights
 * Automatic CUDA library path detection based on ``CUDA_HOME``, eliminating the need to manually set ``LIBRARY_PATH`` environment variables for installation.
 * The ``[all]`` optional dependencies now use ``cuda-toolkit`` with appropriate extras instead of individual packages. The NVCC compiler is no longer automatically installed with ``pip install cuda-python[all]`` as it was previously included only to access the NVVM library, which now has its own dedicated wheel. Users who need the NVCC compiler should explicitly install it with ``pip install cuda-toolkit[nvcc]==X.Y`` with the appropriate version for their needs.
 
-* The Python overhead of calling functions in CUDA bindings in `driver`, `runtime` and `nvrtc` has been reduced by approximately 30%.
+* The Python overhead of calling functions in CUDA bindings in ``driver``, ``runtime`` and ``nvrtc`` has been reduced by approximately 30%.
 
 
 Known issues


### PR DESCRIPTION
## Description

Update Dependabot configuration to reduce update churn.

Changes

* Switch schedule from weekly to monthly (9:00 PT).

* Limit to one open PR at a time.

* Add a group rule to bundle all minor/patch GitHub Actions updates into a single monthly PR.

This should cut down on review noise while still keeping dependencies reasonably up to date.
___

Piggy-backed: Fix existing (on `main`) pre-commit error