### PR TITLE
Search conda environment before general system search in cuda-pathfinder

### DIFF
--- a/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/find_nvidia_dynamic_lib.py
+++ b/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/find_nvidia_dynamic_lib.py
@@ -27,7 +27,7 @@ def _no_such_file_in_sub_dirs(
             attachments.append(f"    {node}")
 
 
-def _find_so_using_nvidia_lib_dirs(
+def _find_so_using_nvidia_wheel_lib_dirs(
     libname: str, so_basename: str, error_messages: list[str], attachments: list[str]
 ) -> Optional[str]:
     rel_dirs = SITE_PACKAGES_LIBDIRS_LINUX.get(libname)
@@ -61,7 +61,7 @@ def _find_dll_under_dir(dirpath: str, file_wild: str) -> Optional[str]:
     return None
 
 
-def _find_dll_using_nvidia_bin_dirs(
+def _find_dll_using_nvidia_wheel_bin_dirs(
     libname: str, lib_searched_for: str, error_messages: list[str], attachments: list[str]
 ) -> Optional[str]:
     rel_dirs = SITE_PACKAGES_LIBDIRS_WINDOWS.get(libname)
@@ -157,7 +157,7 @@ class _FindNvidiaDynamicLib:
         if IS_WINDOWS:
             self.lib_searched_for = f"{libname}*.dll"
             if self.abs_path is None:
-                self.abs_path = _find_dll_using_nvidia_bin_dirs(
+                self.abs_path = _find_dll_using_nvidia_wheel_bin_dirs(
                     libname,
                     self.lib_searched_for,
                     self.error_messages,
@@ -166,7 +166,7 @@ class _FindNvidiaDynamicLib:
         else:
             self.lib_searched_for = f"lib{libname}.so"
             if self.abs_path is None:
-                self.abs_path = _find_so_using_nvidia_lib_dirs(
+                self.abs_path = _find_so_using_nvidia_wheel_lib_dirs(
                     libname,
                     self.lib_searched_for,
                     self.error_messages,

--- a/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/load_nvidia_dynamic_lib.py
+++ b/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/load_nvidia_dynamic_lib.py
@@ -82,7 +82,12 @@ def load_nvidia_dynamic_lib(libname: str) -> LoadedDL:
            - Scan installed distributions (``site-packages``) to find libraries
              shipped in NVIDIA wheels.
 
-        2. **OS default mechanisms / Conda environments**
+        2. **Conda environment**
+
+           - Detects if in a conda environment and searches for libraries in the expected locations within the conda
+             environment.
+
+        3. **OS default mechanisms**
 
            - Fall back to the native loader:
 

--- a/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/load_nvidia_dynamic_lib.py
+++ b/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/load_nvidia_dynamic_lib.py
@@ -13,12 +13,14 @@ if IS_WINDOWS:
     from cuda.pathfinder._dynamic_libs.load_dl_windows import (
         check_if_already_loaded_from_elsewhere,
         load_with_abs_path,
+        load_with_conda_search,
         load_with_system_search,
     )
 else:
     from cuda.pathfinder._dynamic_libs.load_dl_linux import (
         check_if_already_loaded_from_elsewhere,
         load_with_abs_path,
+        load_with_conda_search,
         load_with_system_search,
     )
 
@@ -41,6 +43,9 @@ def _load_lib_no_cache(libname: str) -> LoadedDL:
         return loaded
 
     if not have_abs_path:
+        loaded = load_with_conda_search(libname)
+        if loaded is not None:
+            return loaded
         loaded = load_with_system_search(libname)
         if loaded is not None:
             return loaded

--- a/cuda_pathfinder/docs/source/release/1.X.Y-notes.rst
+++ b/cuda_pathfinder/docs/source/release/1.X.Y-notes.rst
@@ -23,3 +23,8 @@ Highlights
   - Improves stability in general and supports nvmath specifically
   - Proactive change to improve library loading consistency
   - Drops boilerplate docstrings for private functions
+
+* Add conda search path prioritization for ``load_nvidia_dynamic_lib()`` (`PR #856 <https://github.com/NVIDIA/cuda-python/pull/856>`_)
+
+  - Enables loading libraries from conda environments before system paths
+  - Handles version mismatches between the conda environment and the system CTK


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
Fixes #839

<!-- Provide a standalone description of changes in this PR. -->
Adds functions for searching in conda environments for libraries and uses the functions before doing the general system search. This should resolve the problem for when you have mismatched versions between a conda environment and the underlying system CTK and pathfinder picks up the system library.

There's still a lot of TODOs with some open questions in this PR and I didn't add any testing yet, but figured I should open this to drive some conversation.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
