### PR TITLE
Update with whitespace-only changes from cython-gen

### DIFF
--- a/cuda_bindings/cuda/bindings/_bindings/cydriver.pyx.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cydriver.pyx.in
@@ -12,9 +12,10 @@ cimport cuda.bindings._lib.dlfcn as dlfcn
 from libc.stdint cimport intptr_t
 import os
 import sys
-import threading
 cimport cuda.bindings._bindings.loader as loader
-cdef object __symbol_lock = threading.RLock()
+import threading
+
+cdef object __symbol_lock = threading.Lock()
 cdef bint __cuPythonInit = False
 {{if 'cuGetErrorString' in found_functions}}cdef void *__cuGetErrorString = NULL{{endif}}
 {{if 'cuGetErrorName' in found_functions}}cdef void *__cuGetErrorName = NULL{{endif}}
@@ -510,7 +511,7 @@ cdef int _cuPythonInit() except -1 nogil:
             {{else}}
             path = 'libcuda.so.1'
             {{endif}}
-    
+
         {{if 'Windows' == platform.system()}}
         LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800
         try:
@@ -522,7 +523,7 @@ cdef int _cuPythonInit() except -1 nogil:
         if (handle == NULL):
             raise RuntimeError('Failed to dlopen ' + path)
         {{endif}}
-    
+
         # Get latest __cuGetProcAddress_v2
         global __cuGetProcAddress_v2
         {{if 'Windows' == platform.system()}}
@@ -533,7 +534,7 @@ cdef int _cuPythonInit() except -1 nogil:
         {{else}}
         __cuGetProcAddress_v2 = dlfcn.dlsym(handle, 'cuGetProcAddress_v2')
         {{endif}}
-    
+
         # Load using cuGetProcAddress if available
         if __cuGetProcAddress_v2 != NULL:
             _F_cuGetProcAddress_v2 = <__cuGetProcAddress_v2_T>__cuGetProcAddress_v2
@@ -2760,10 +2761,9 @@ cdef int _cuPythonInit() except -1 nogil:
             global __cuGraphicsVDPAURegisterOutputSurface
             _F_cuGetProcAddress_v2('cuGraphicsVDPAURegisterOutputSurface', &__cuGraphicsVDPAURegisterOutputSurface, 3010, CU_GET_PROC_ADDRESS_DEFAULT, NULL)
             {{endif}}
-
             __cuPythonInit = True
             return 0
-    
+
         {{if 'Windows' == platform.system()}}
         # Load using win32GetAddr
         if usePTDS:
@@ -8877,7 +8877,6 @@ cdef int _cuPythonInit() except -1 nogil:
         __cuGraphicsVDPAURegisterOutputSurface = dlfcn.dlsym(handle, 'cuGraphicsVDPAURegisterOutputSurface')
         {{endif}}
         {{endif}}
-
         __cuPythonInit = True
         return 0
 
@@ -8886,7 +8885,6 @@ cdef int _cuPythonInit() except -1 nogil:
 cdef inline int cuPythonInit() except -1 nogil:
     if __cuPythonInit:
         return 0
-    
     return _cuPythonInit()
 
 {{if 'cuGetErrorString' in found_functions}}

--- a/cuda_bindings/cuda/bindings/_bindings/cynvrtc.pyx.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cynvrtc.pyx.in
@@ -43,6 +43,7 @@ cdef bint __cuPythonInit = False
 cdef int _cuPythonInit() except -1 nogil:
     global __cuPythonInit
 
+    # Load library
     with gil, __symbol_lock:
         {{if 'Windows' == platform.system()}}
         handle = load_nvidia_dynamic_lib("nvrtc")._handle_uint
@@ -317,8 +318,8 @@ cdef int _cuPythonInit() except -1 nogil:
         global __nvrtcSetFlowCallback
         __nvrtcSetFlowCallback = dlfcn.dlsym(handle, 'nvrtcSetFlowCallback')
         {{endif}}
-        {{endif}}
 
+        {{endif}}
         __cuPythonInit = True
         return 0
 
@@ -327,7 +328,6 @@ cdef int _cuPythonInit() except -1 nogil:
 cdef inline int cuPythonInit() except -1 nogil:
     if __cuPythonInit:
         return 0
-
     return _cuPythonInit()
 
 {{if 'nvrtcGetErrorString' in found_functions}}

--- a/cuda_bindings/cuda/bindings/_bindings/cyruntime.pxd.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cyruntime.pxd.in
@@ -3,6 +3,7 @@
 
 # This code was automatically generated with version 13.0.0. Do not modify it directly.
 include "../cyruntime_types.pxi"
+
 include "../_lib/cyruntime/cyruntime.pxd"
 
 {{if 'cudaDeviceReset' in found_functions}}

--- a/cuda_bindings/cuda/bindings/_bindings/cyruntime.pyx.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cyruntime.pyx.in
@@ -13,6 +13,7 @@ cdef bint __usePTDS = False
 cdef int _cudaPythonInit() except -1 nogil:
         global __cudaPythonInit
         global __usePTDS
+
         with gil:
             __usePTDS = os.getenv('CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM', default=False)
         __cudaPythonInit = True
@@ -23,7 +24,6 @@ cdef int _cudaPythonInit() except -1 nogil:
 cdef inline int cudaPythonInit() except -1 nogil:
     if __cudaPythonInit:
         return __usePTDS
-
     return _cudaPythonInit()
 
 {{if 'cudaDeviceReset' in found_functions}}
@@ -2671,5 +2671,6 @@ cdef cudaError_t _cudaProfilerStop() except ?cudaErrorCallRequiresNewerDriver no
         return ptds._cudaProfilerStop()
     return cudaProfilerStop()
 {{endif}}
+
 
 include "../_lib/cyruntime/cyruntime.pxi"


### PR DESCRIPTION
This just commits to main the results from the latest version of the generator that are whitespace only.  I think we got in this state because some "written by hand" changes to the generated code were merged, and then the ports to the generator didn't match that exactly.  While none of these changes should have any effect, this will just help future runs of the generator apply cleanly.
