### PR TITLE
Add `cuda_pathfinder/DESCRIPTION.rst` and prepare for `v1.2.0` release

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Check cuda.pathfinder wheel
         if: ${{ strategy.job-index == 0 && inputs.host-platform == 'linux-64' }}
         run: |
-          twine check cuda_pathfinder/*.whl
+          twine check --strict cuda_pathfinder/*.whl
 
       - name: Upload cuda.pathfinder build artifacts
         if: ${{ strategy.job-index == 0 && inputs.host-platform == 'linux-64' }}

--- a/cuda_pathfinder/DESCRIPTION.rst
+++ b/cuda_pathfinder/DESCRIPTION.rst
@@ -1,0 +1,30 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+*******************************************************
+cuda-pathfinder: Utilities for locating CUDA components
+*******************************************************
+
+`cuda.pathfinder <https://nvidia.github.io/cuda-python/cuda-pathfinder/>`_
+aims to be a one-stop solution for locating CUDA components. Currently
+it supports locating and loading dynamic libraries (``.so``, ``.dll``);
+support for headers and other artifacts is in progress.
+
+* `Documentation <https://nvidia.github.io/cuda-python/cuda-pathfinder/>`_
+* `Releases <https://nvidia.github.io/cuda-python/cuda-pathfinder/latest/release.html>`_
+* `Repository <https://github.com/NVIDIA/cuda-python/tree/main/cuda_pathfinder/>`_
+* `Issue tracker <https://github.com/NVIDIA/cuda-python/issues/>`_ (select component ``cuda.pathfinder``)
+
+``cuda.pathfinder`` is under active development. Feedback and suggestions are welcome.
+
+
+Installation
+============
+
+.. code-block:: bash
+
+   pip install cuda-pathfinder
+
+``cuda-pathfinder`` is `CUDA Toolkit (CTK) <https://developer.nvidia.com/cuda-toolkit>`_
+version-agnostic. It follows the general CUDA Toolkit support policy: the
+two most recent major versions are supported simultaneously.

--- a/cuda_pathfinder/cuda/pathfinder/_version.py
+++ b/cuda_pathfinder/cuda/pathfinder/_version.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "1.2.0a0"
+__version__ = "1.2.0"

--- a/cuda_pathfinder/docs/nv-versions.json
+++ b/cuda_pathfinder/docs/nv-versions.json
@@ -2,5 +2,9 @@
     {
         "version": "latest",
         "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/latest/"
+    },
+    {
+        "version": "1.2.0",
+        "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/1.2.0/"
     }
 ]

--- a/cuda_pathfinder/docs/source/release.rst
+++ b/cuda_pathfinder/docs/source/release.rst
@@ -7,6 +7,6 @@ Release Notes
 .. toctree::
    :maxdepth: 3
 
-   1.X.Y <release/1.X.Y-notes>
+   1.2.0 <release/1.2.0-notes>
    1.1.0 <release/1.1.0-notes>
    1.0.0 <release/1.0.0-notes>

--- a/cuda_pathfinder/docs/source/release/1.2.0-notes.rst
+++ b/cuda_pathfinder/docs/source/release/1.2.0-notes.rst
@@ -3,10 +3,10 @@
 
 .. module:: cuda.pathfinder
 
-``cuda-pathfinder`` 1.X.Y Release notes
+``cuda-pathfinder`` 1.2.0 Release notes
 ========================================
 
-Released on TBD
+Released on Aug 29, 2025
 
 
 Highlights

--- a/cuda_pathfinder/pyproject.toml
+++ b/cuda_pathfinder/pyproject.toml
@@ -7,7 +7,7 @@ description = "Pathfinder for CUDA components"
 authors = [{ name = "NVIDIA Corporation", email = "cuda-python-conduct@nvidia.com" }]
 license = "Apache-2.0"
 requires-python = ">=3.9"
-dynamic = ["version"]
+dynamic = ["version", "readme"]
 dependencies = []
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Description
Closes #761

`cuda_pathfinder/DESCRIPTION.rst` is referenced in `cuda_pathfinder/pyproject.toml` for some time, but due to an oversight it was never added to the repo.

Bump cuda-pathfinder version to `1.2.0` for release.