### PR TITLE
Add `--strict` option to all `twine check` commands

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Check cuda.core wheel
         run: |
-          twine check ${{ env.CUDA_CORE_ARTIFACTS_DIR }}/*.whl
+          twine check --strict ${{ env.CUDA_CORE_ARTIFACTS_DIR }}/*.whl
 
       - name: Upload cuda.core build artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
@@ -179,7 +179,7 @@ jobs:
 
       - name: Check cuda.bindings wheel
         run: |
-          twine check ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl
+          twine check --strict ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl
 
       - name: Upload cuda.bindings build artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
@@ -194,7 +194,7 @@ jobs:
         run: |
           pushd cuda_python
           pip wheel -v --no-deps .
-          twine check *.whl
+          twine check --strict *.whl
           popd
 
       - name: List the cuda-python artifacts directory


### PR DESCRIPTION
## Description

Good to have this systematically. I didn't do this in PR #926 to avoid the risk of derailing that PR.