### PR TITLE
Add `test_` prefix in `cuda_pathfinder/pyproject.toml`

### DIFF
--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -283,7 +283,7 @@ jobs:
         run: |
           set -euo pipefail
           pushd cuda_pathfinder
-          pip install --only-binary=:all: -v ".[nvidia_wheels_cu${TEST_CUDA_MAJOR},nvidia_wheels_host]"
+          pip install --only-binary=:all: -v ".[test_nvidia_wheels_cu${TEST_CUDA_MAJOR},test_nvidia_wheels_host]"
           pip list
           popd
 

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -256,7 +256,7 @@ jobs:
         shell: bash --noprofile --norc -xeuo pipefail {0}
         run: |
           pushd cuda_pathfinder
-          pip install --only-binary=:all: -v ".[nvidia_wheels_cu${TEST_CUDA_MAJOR},nvidia_wheels_host]"
+          pip install --only-binary=:all: -v ".[test_nvidia_wheels_cu${TEST_CUDA_MAJOR},test_nvidia_wheels_host]"
           pip list
           popd
 

--- a/cuda_pathfinder/pyproject.toml
+++ b/cuda_pathfinder/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = []
 test = [
     "pytest>=6.2.4",
 ]
-nvidia_wheels_cu12 = [
+test_nvidia_wheels_cu12 = [
     "cuda-toolkit[nvcc,cublas,nvrtc,cudart,cufft,curand,cusolver,cusparse,npp,nvfatbin,nvjitlink,nvjpeg]==12.*",
     "cuda-toolkit[cufile]==12.*; sys_platform != 'win32'",
     "nvidia-cudss-cu12",
@@ -23,13 +23,13 @@ nvidia_wheels_cu12 = [
     "nvidia-nccl-cu12; sys_platform != 'win32'",
     "nvidia-nvshmem-cu12; sys_platform != 'win32'",
 ]
-nvidia_wheels_cu13 = [
+test_nvidia_wheels_cu13 = [
     "cuda-toolkit[nvcc,cublas,nvrtc,cudart,cufft,curand,cusolver,cusparse,npp,nvfatbin,nvjitlink,nvjpeg,nvvm]==13.*",
     "cuda-toolkit[cufile]==13.*; sys_platform != 'win32'",
     "nvidia-nccl-cu13; sys_platform != 'win32'",
     "nvidia-nvshmem-cu13; sys_platform != 'win32'",
 ]
-nvidia_wheels_host = [
+test_nvidia_wheels_host = [
     "nvpl-fft; platform_system == 'Linux' and platform_machine == 'aarch64'",
 ]
 

--- a/toolshed/collect_site_packages_dll_files.ps1
+++ b/toolshed/collect_site_packages_dll_files.ps1
@@ -23,11 +23,11 @@ function Fresh-Venv {
 Set-Location -Path 'cuda_pathfinder'
 
 Fresh-Venv -Path '..\TmpCp12Venv'
-pip install --only-binary=:all: -e '.[test,nvidia_wheels_cu12,nvidia_wheels_host]'
+pip install --only-binary=:all: -e '.[test,test_nvidia_wheels_cu12,test_nvidia_wheels_host]'
 deactivate
 
 Fresh-Venv -Path '..\TmpCp13Venv'
-pip install --only-binary=:all: -e '.[test,nvidia_wheels_cu13,nvidia_wheels_host]'
+pip install --only-binary=:all: -e '.[test,test_nvidia_wheels_cu13,test_nvidia_wheels_host]'
 deactivate
 
 Set-Location -Path '..'

--- a/toolshed/collect_site_packages_so_files.sh
+++ b/toolshed/collect_site_packages_so_files.sh
@@ -17,12 +17,12 @@ fresh_venv() {
 cd cuda_pathfinder/
 fresh_venv ../TmpCp12Venv
 set -x
-pip install --only-binary=:all: -e .[test,nvidia_wheels_cu12,nvidia_wheels_host]
+pip install --only-binary=:all: -e .[test,test_nvidia_wheels_cu12,test_nvidia_wheels_host]
 set +x
 deactivate
 fresh_venv ../TmpCp13Venv
 set -x
-pip install --only-binary=:all: -e .[test,nvidia_wheels_cu13,nvidia_wheels_host]
+pip install --only-binary=:all: -e .[test,test_nvidia_wheels_cu13,test_nvidia_wheels_host]
 set +x
 deactivate
 cd ..


### PR DESCRIPTION
xref: https://github.com/NVIDIA/cuda-python/pull/956#discussion_r2341678776

There @leofang wrote:

> I noticed that several popular websites tracking wheel releases, including PyPI itself (on the left panel of https://pypi.org/project/cuda-pathfinder/), would list the optional dependencies. Some may argue this is a part of public APIs that we offer, but I don't think it was ever our intent.

