### PR TITLE
Revert "Reverting removing  function"

### DIFF
--- a/cuda_pathfinder/tests/conftest.py
+++ b/cuda_pathfinder/tests/conftest.py
@@ -9,13 +9,6 @@ def pytest_configure(config):
     config.custom_info = []
 
 
-def pytest_terminal_summary(terminalreporter, exitstatus, config):  # noqa: ARG001
-    if config.custom_info:
-        terminalreporter.write_sep("=", "INFO summary")
-        for msg in config.custom_info:
-            terminalreporter.line(f"INFO {msg}")
-
-
 @pytest.fixture
 def info_summary_append(request):
     def _append(message):


### PR DESCRIPTION
This partially reverts commit de5c843c7bccf96aa940267317fa4eaec732d310.  It brings back the `pytest_terminal_summary` function that was incorrectly removed.
