### PR TITLE
Remove `llvmlite` from `test` dependencies in `cuda_bindings/pyproject.toml`

### DIFF
--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -42,7 +42,6 @@ test = [
     "numpy>=1.21.1",
     "pytest>=6.2.4",
     "pytest-benchmark>=3.4.1",
-    "llvmlite"
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR simply removes `llvmlite` from the `test` dependencies, with leads to turning off the failing tests.

Our existing `MINIMAL_NVVMIR_BITCODE_STATIC` dictionary is currently sufficient to exercise the `nvvm` bindings on all platforms.

For easy future reference, the [`llvmlite==0.45` release](https://pypi.org/project/llvmlite/0.45.0/) caused these test failures:

```
cuda/bindings/nvvm.pyx:54: nvvmError
============================================================================== short test summary info ==============================================================================
FAILED tests/test_nvvm.py::test_compile_program_with_minimal_nvvm_ir[bitcode_dynamic-options0] - RuntimeError: FileNameHere.ll: parse Invalid value (Producer: 'LLVM20.1.8' Reader: 'LLVM 7.0.1')
FAILED tests/test_nvvm.py::test_compile_program_with_minimal_nvvm_ir[bitcode_dynamic-options1] - RuntimeError: FileNameHere.ll: parse Invalid value (Producer: 'LLVM20.1.8' Reader: 'LLVM 7.0.1')
FAILED tests/test_nvvm.py::test_compile_program_with_minimal_nvvm_ir[bitcode_dynamic-options2] - RuntimeError: FileNameHere.ll: parse Invalid value (Producer: 'LLVM20.1.8' Reader: 'LLVM 7.0.1')
FAILED tests/test_nvvm.py::test_verify_program_with_minimal_nvvm_ir[bitcode_dynamic-options0] - cuda.bindings.nvvm.nvvmError: ERROR_INVALID_IR (6)
FAILED tests/test_nvvm.py::test_verify_program_with_minimal_nvvm_ir[bitcode_dynamic-options1] - cuda.bindings.nvvm.nvvmError: ERROR_INVALID_IR (6)
FAILED tests/test_nvvm.py::test_verify_program_with_minimal_nvvm_ir[bitcode_dynamic-options2] - cuda.bindings.nvvm.nvvmError: ERROR_INVALID_IR (6)
=========================================================================== 6 failed, 30 passed in 0.22s ============================================================================
```