### PR TITLE
Add `"-arch=compute_100"` to `nvvm.compile_program` options and restore testing with llvmlite-generated IRs

### DIFF
--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -42,6 +42,7 @@ test = [
     "numpy>=1.21.1",
     "pytest>=6.2.4",
     "pytest-benchmark>=3.4.1",
+    "llvmlite",
 ]
 
 [project.urls]


### PR DESCRIPTION
* Puts us in a good position to generate `MINIMAL_NVVMIR_BITCODE_STATIC` entries as needed.
* Preserves testing with llvmlite-generated IRs.

This could also work:
* Completely remove `llvmlite` from test_nvvm.py
* Move the code for generating new `MINIMAL_NVVMIR_BITCODE_STATIC` entries to a toolshed/ script.