### PR TITLE
Add conda-specific search into `load_nvidia_dynamic_lib()`

### DIFF
--- a/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/find_nvidia_dynamic_lib.py
+++ b/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/find_nvidia_dynamic_lib.py
@@ -167,7 +167,7 @@ class _FindNvidiaDynamicLib:
                     self.attachments,
                 )
 
-    def retry_with_cuda_home_priority_last(self) -> None:
+    def try_with_cuda_home(self) -> None:
         cuda_home_lib_dir = _find_lib_dir_using_cuda_home(self.libname)
         if cuda_home_lib_dir is not None:
             if IS_WINDOWS:

--- a/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/load_nvidia_dynamic_lib.py
+++ b/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/load_nvidia_dynamic_lib.py
@@ -44,7 +44,7 @@ def _load_lib_no_cache(libname: str) -> LoadedDL:
         loaded = load_with_system_search(libname)
         if loaded is not None:
             return loaded
-        found.retry_with_cuda_home_priority_last()
+        found.try_with_cuda_home()
         found.raise_if_abs_path_is_None()
 
     assert found.abs_path is not None  # for mypy

--- a/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/load_nvidia_dynamic_lib.py
+++ b/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/load_nvidia_dynamic_lib.py
@@ -77,21 +77,19 @@ def load_nvidia_dynamic_lib(libname: str) -> LoadedDL:
            - Scan installed distributions (``site-packages``) to find libraries
              shipped in NVIDIA wheels.
 
-        2. **OS default mechanisms / Conda environments**
+        2. **Conda environment**
+
+           - Conda installations are discovered via ``CONDA_PREFIX``, which is
+             predefined in activated conda environments (see
+             https://docs.conda.io/projects/conda-build/en/stable/user-guide/environment-variables.html).
+
+        3. **OS default mechanisms**
 
            - Fall back to the native loader:
 
              - Linux: ``dlopen()``
 
              - Windows: ``LoadLibraryW()``
-
-           - Conda installations are commonly discovered via:
-
-             - Linux: ``$ORIGIN/../lib`` in the ``RPATH`` of the ``python`` binary
-               (note: this can take precedence over ``LD_LIBRARY_PATH`` and
-               ``/etc/ld.so.conf.d/``).
-
-             - Windows: ``%CONDA_PREFIX%\\Library\\bin`` on the system ``PATH``.
 
            - CUDA Toolkit (CTK) system installs with system config updates are often
              discovered via:
@@ -101,7 +99,7 @@ def load_nvidia_dynamic_lib(libname: str) -> LoadedDL:
              - Windows: ``C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\vX.Y\\bin``
                on the system ``PATH``.
 
-        3. **Environment variables**
+        4. **Environment variables**
 
            - If set, use ``CUDA_HOME`` or ``CUDA_PATH`` (in that order).
 

--- a/cuda_pathfinder/cuda/pathfinder/_version.py
+++ b/cuda_pathfinder/cuda/pathfinder/_version.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "1.2.3"
+__version__ = "1.2.4a0"


### PR DESCRIPTION
WIP — Local testing works on Linux, but there are subtle issues under Windows, e.g.:

```
INFO test_load_nvidia_dynamic_lib[cudart]: abs_path='C:\\Users\\rgrossekunst\\AppData\\Local\\miniforge3\\envs\\ctk1301_py313\\Library\\bin\\cudart64_13.dll'
...
INFO test_load_nvidia_dynamic_lib[nvvm]: abs_path='C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v13.0\\nvvm\\bin\\x64\\nvvm64_40_0.dll'
...
INFO test_load_nvidia_dynamic_lib[curand]: abs_path='C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v13.0\\bin\\x64\\curand64_10.dll'
```

Will debug asap.