### PR TITLE
Improve speed of init functions in cybind-generated bindings

### DIFF
--- a/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx
@@ -108,10 +108,8 @@ cdef void* load_library() except* with gil:
     return <void*>handle
 
 
-cdef int _check_or_init_cufile() except -1 nogil:
+cdef int __check_or_init_cufile() except -1 nogil:
     global __py_cufile_init
-    if __py_cufile_init:
-        return 0
 
     cdef void* handle = NULL
 
@@ -420,6 +418,13 @@ cdef int _check_or_init_cufile() except -1 nogil:
 
         __py_cufile_init = True
         return 0
+
+
+cdef inline int _check_or_init_cufile() except -1 nogil:
+    if __py_cufile_init:
+        return 0
+
+    return __check_or_init_cufile()
 
 
 cdef dict func_ptrs = None

--- a/cuda_bindings/cuda/bindings/_internal/nvjitlink_linux.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvjitlink_linux.pyx
@@ -77,10 +77,8 @@ cdef void* load_library() except* with gil:
     return <void*>handle
 
 
-cdef int _check_or_init_nvjitlink() except -1 nogil:
+cdef int __check_or_init_nvjitlink() except -1 nogil:
     global __py_nvjitlink_init
-    if __py_nvjitlink_init:
-        return 0
 
     cdef void* handle = NULL
 
@@ -187,6 +185,12 @@ cdef int _check_or_init_nvjitlink() except -1 nogil:
         __py_nvjitlink_init = True
         return 0
 
+
+cdef inline int _check_or_init_nvjitlink() except -1 nogil:
+    if __py_nvjitlink_init:
+        return 0
+
+    return __check_or_init_nvjitlink()
 
 cdef dict func_ptrs = None
 

--- a/cuda_bindings/cuda/bindings/_internal/nvjitlink_windows.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvjitlink_windows.pyx
@@ -93,7 +93,7 @@ cdef void* __nvJitLinkGetInfoLog = NULL
 cdef void* __nvJitLinkVersion = NULL
 
 
-cdef int _check_or_init_nvjitlink() except -1 nogil:
+cdef int __check_or_init_nvjitlink() except -1 nogil:
     global __py_nvjitlink_init
     if __py_nvjitlink_init:
         return 0
@@ -147,6 +147,13 @@ cdef int _check_or_init_nvjitlink() except -1 nogil:
 
         __py_nvjitlink_init = True
         return 0
+
+
+cdef inline int _check_or_init_nvjitlink() except -1 nogil:
+    if __py_nvjitlink_init:
+        return 0
+
+    return __check_or_init_nvjitlink()
 
 
 cdef dict func_ptrs = None

--- a/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx
@@ -76,10 +76,8 @@ cdef void* load_library() except* with gil:
     return <void*>handle
 
 
-cdef int _check_or_init_nvvm() except -1 nogil:
+cdef int __check_or_init_nvvm() except -1 nogil:
     global __py_nvvm_init
-    if __py_nvvm_init:
-        return 0
 
     cdef void* handle = NULL
 
@@ -178,6 +176,13 @@ cdef int _check_or_init_nvvm() except -1 nogil:
 
         __py_nvvm_init = True
         return 0
+
+
+cdef inline int _check_or_init_nvvm() except -1 nogil:
+    if __py_nvvm_init:
+        return 0
+
+    return __check_or_init_nvvm()
 
 
 cdef dict func_ptrs = None

--- a/cuda_bindings/cuda/bindings/_internal/nvvm_windows.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvvm_windows.pyx
@@ -92,10 +92,8 @@ cdef void* __nvvmGetProgramLogSize = NULL
 cdef void* __nvvmGetProgramLog = NULL
 
 
-cdef int _check_or_init_nvvm() except -1 nogil:
+cdef int __check_or_init_nvvm() except -1 nogil:
     global __py_nvvm_init
-    if __py_nvvm_init:
-        return 0
 
     with gil, __symbol_lock:
         # Load library
@@ -143,6 +141,13 @@ cdef int _check_or_init_nvvm() except -1 nogil:
 
         __py_nvvm_init = True
         return 0
+
+
+cdef inline int _check_or_init_nvvm() except -1 nogil:
+    if __py_nvvm_init:
+        return 0
+
+    return __check_or_init_nvvm()
 
 
 cdef dict func_ptrs = None


### PR DESCRIPTION
This is applying the same trick in https://github.com/NVIDIA/cuda-python/pull/894 to the cybind-generated bindings.

Essentially, by inlining the boolean check in every call, we can avoid the much more expensive call through a C function pointer on every single API call.