### PR TITLE
ci: remove pwd and ls commands that add noise to CI output

### DIFF
--- a/ci/tools/run-tests
+++ b/ci/tools/run-tests
@@ -47,7 +47,7 @@ elif [[ "${test_module}" == "bindings" ]]; then
   fi
   popd
   pushd ./cuda_bindings
-  echo "Running bindinds tests"
+  echo "Running bindings tests"
   ${SANITIZER_CMD} pytest -rxXs -v tests/
   if [[ "${SKIP_CYTHON_TEST}" == 0 ]]; then
     ${SANITIZER_CMD} pytest -rxXs -v tests/cython

--- a/ci/tools/run-tests
+++ b/ci/tools/run-tests
@@ -24,8 +24,6 @@ test_module=${1}
 # (it is a direct dependency of bindings, and a transitive dependency of core)
 pushd ./cuda_pathfinder
 echo "Installing pathfinder wheel"
-pwd
-ls
 pip install $(ls *.whl)[test]
 popd
 
@@ -34,7 +32,6 @@ if [[ "${test_module}" == "pathfinder" ]]; then
   echo "Running pathfinder tests with " \
       "LD:${CUDA_PATHFINDER_TEST_LOAD_NVIDIA_DYNAMIC_LIB_STRICTNESS} " \
       "FH:${CUDA_PATHFINDER_TEST_FIND_NVIDIA_HEADERS_STRICTNESS}"
-  pwd
   pytest -ra -s -v tests/ |& tee /tmp/pathfinder_test_log.txt
   # Fail if no "INFO test_" lines are found; capture line count otherwise
   line_count=$(grep '^INFO test_' /tmp/pathfinder_test_log.txt | wc -l)
@@ -43,10 +40,7 @@ if [[ "${test_module}" == "pathfinder" ]]; then
 elif [[ "${test_module}" == "bindings" ]]; then
   pushd "${CUDA_BINDINGS_ARTIFACTS_DIR}"
   echo "Installing bindings wheel"
-  pwd
-  ls
   if [[ "${LOCAL_CTK}" == 1 ]]; then
-    ls "${CUDA_PATH}"
     pip install $(ls *.whl)[test]
   else
     pip install $(ls *.whl)[all,test]
@@ -54,7 +48,6 @@ elif [[ "${test_module}" == "bindings" ]]; then
   popd
   pushd ./cuda_bindings
   echo "Running bindinds tests"
-  pwd
   ${SANITIZER_CMD} pytest -rxXs -v tests/
   if [[ "${SKIP_CYTHON_TEST}" == 0 ]]; then
     ${SANITIZER_CMD} pytest -rxXs -v tests/cython
@@ -66,8 +59,6 @@ elif [[ "${test_module}" == "core" ]]; then
   if [[ "${SKIP_CUDA_BINDINGS_TEST}" == 1 ]]; then
     pushd "${CUDA_BINDINGS_ARTIFACTS_DIR}"
     echo "Installing bindings wheel"
-    pwd
-    ls
     if [[ "${LOCAL_CTK}" == 1 ]]; then
       pip install *.whl
     else
@@ -78,8 +69,6 @@ elif [[ "${test_module}" == "core" ]]; then
   TEST_CUDA_MAJOR="$(cut -d '.' -f 1 <<< ${CUDA_VER})"
   pushd "${CUDA_CORE_ARTIFACTS_DIR}"
   echo "Installing core wheel"
-  pwd
-  ls
 
   FREE_THREADING=""
   if python -c 'import sys; assert not sys._is_gil_enabled()' 2> /dev/null; then
@@ -96,7 +85,6 @@ elif [[ "${test_module}" == "core" ]]; then
   popd
   pushd ./cuda_core
   echo "Running core tests"
-  pwd
   ${SANITIZER_CMD} pytest -rxXs -v tests/
   # Currently our CI always installs the latest bindings (from either major version).
   # This is not compatible with the test requirements.


### PR DESCRIPTION
Small QoL enhancement to reduce the amount of noise coming out of the `run-tests` CI script