### PR TITLE
ci: fix misspelling that lead to code never being executed to verify free-threaded build

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -208,7 +208,7 @@ jobs:
           allow-prereleases: true
 
       - name: verify free-threaded build
-        if: endsWith(matrix.python-verison, 't')
+        if: endsWith(matrix.python-version, 't')
         run: python -c 'import sys; assert not sys._is_gil_enabled()'
 
       - name: Set up Python include paths


### PR DESCRIPTION
Fixes a misspelling that lead to a job step that never executed