### PR TITLE
ci: split build and test into vertical pipeline structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           cuda_build_ver=$(jq -r .cuda.build.version ci/versions.json)
           echo "cuda_build_ver=$cuda_build_ver" >> $GITHUB_OUTPUT
 
-  build:
+  build-linux-64:
     needs:
       - ci-vars
     strategy:
@@ -40,7 +40,37 @@ jobs:
       matrix:
         host-platform:
           - linux-64
+    name: Build ${{ matrix.host-platform }}, CUDA ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
+    if: ${{ github.repository_owner == 'nvidia' }}
+    secrets: inherit
+    uses: ./.github/workflows/build-wheel.yml
+    with:
+      host-platform: ${{ matrix.host-platform }}
+      cuda-version: ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
+
+  build-linux-aarch64:
+    needs:
+      - ci-vars
+    strategy:
+      fail-fast: false
+      matrix:
+        host-platform:
           - linux-aarch64
+    name: Build ${{ matrix.host-platform }}, CUDA ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
+    if: ${{ github.repository_owner == 'nvidia' }}
+    secrets: inherit
+    uses: ./.github/workflows/build-wheel.yml
+    with:
+      host-platform: ${{ matrix.host-platform }}
+      cuda-version: ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
+
+  build-windows:
+    needs:
+      - ci-vars
+    strategy:
+      fail-fast: false
+      matrix:
+        host-platform:
           - win-64
     name: Build ${{ matrix.host-platform }}, CUDA ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
     if: ${{ github.repository_owner == 'nvidia' }}
@@ -50,12 +80,31 @@ jobs:
       host-platform: ${{ matrix.host-platform }}
       cuda-version: ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
 
-  test-linux:
+  test-linux-64:
     strategy:
       fail-fast: false
       matrix:
         host-platform:
           - linux-64
+    name: Test ${{ matrix.host-platform }}
+    if: ${{ github.repository_owner == 'nvidia' }}
+    permissions:
+      contents: read  # This is required for actions/checkout
+    needs:
+      - ci-vars
+      - build-linux-64
+    secrets: inherit
+    uses: ./.github/workflows/test-wheel-linux.yml
+    with:
+      build-type: pull-request
+      host-platform: ${{ matrix.host-platform }}
+      build-ctk-ver: ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
+
+  test-linux-aarch64:
+    strategy:
+      fail-fast: false
+      matrix:
+        host-platform:
           - linux-aarch64
     name: Test ${{ matrix.host-platform }}
     if: ${{ github.repository_owner == 'nvidia' }}
@@ -63,7 +112,7 @@ jobs:
       contents: read  # This is required for actions/checkout
     needs:
       - ci-vars
-      - build
+      - build-linux-aarch64
     secrets: inherit
     uses: ./.github/workflows/test-wheel-linux.yml
     with:
@@ -83,7 +132,7 @@ jobs:
       contents: read  # This is required for actions/checkout
     needs:
       - ci-vars
-      - build
+      - build-windows
     secrets: inherit
     uses: ./.github/workflows/test-wheel-windows.yml
     with:
@@ -101,7 +150,9 @@ jobs:
       pull-requests: write
     needs:
       - ci-vars
-      - build
+      - build-linux-64
+      - build-linux-aarch64
+      - build-windows
     secrets: inherit
     uses: ./.github/workflows/build-docs.yml
     with:
@@ -112,8 +163,11 @@ jobs:
     permissions:
       checks: read
     needs:
-      - build
-      - test-linux
+      - build-linux-64
+      - test-linux-64
+      - build-linux-aarch64
+      - test-linux-aarch64
+      - build-windows
       - test-windows
       - doc
     secrets: inherit


### PR DESCRIPTION
This PR splits CI into a vertical pipeline, such that tests for unrelated platforms
are not waiting for builds to finish.

For example, windows tests are not waiting for linux builds to finish before running.

Yes, it's not maximally DRY. That is intentional, because I can't find
a justifiable way to deduplicate more than this workflow already is. I think
the benefit here (freeing up runners faster) outweighs any additional
maintenance burden coming from the extra code.

Not including these changes, the `ci.yml` file has only had 12 commits over six
months, so it's not changing very often.
