### PR TITLE
chore(deps): bump precommit versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ ci:
 # pre-commit autoupdate --freeze
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 0b19ef1fd6ad680ed7752d6daba883ce1265a6de  # frozen: v0.12.2
+    rev: f298305809c552671cc47e0fec0ba43e96c146a2  # frozen: v0.13.2
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]
@@ -40,7 +40,7 @@ repos:
 
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v5.0.0"
+    rev: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c"  # frozen: v6.0.0
     hooks:
     - id: check-added-large-files
     - id: check-case-conflict
@@ -58,14 +58,14 @@ repos:
 
   # Checking for common mistakes
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: "v1.10.0"
+    rev: "3a6eb0fadf60b3cccfd80bad9dbb6fae7e47b316"  # frozen: v1.10.0
     hooks:
     - id: rst-backticks
     - id: rst-directive-colons
     - id: rst-inline-touching-normal
 
   - repo: https://github.com/PyCQA/bandit
-    rev: "36fd65054fc8864b4037d0918904f9331512feb5"  # frozen: 1.7.10 KEEP IN SYNC WITH .github/workflows/bandit.yml
+    rev: "2d0b675b04c80ae42277e10500db06a0a37bae17"  # frozen: 1.8.6
     hooks:
       - id: bandit
         args:
@@ -73,7 +73,7 @@ repos:
           - .bandit
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 0f86793af5ef5f6dc63c8d04a3cabfa3ea8f9c6a  # frozen: v1.16.1
+    rev: 9f70dc58c23dfcca1b97af99eaeee3140a807c7e  # frozen: v1.18.2
     hooks:
       - id: mypy
         name: mypy-pathfinder

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,14 +64,6 @@ repos:
     - id: rst-directive-colons
     - id: rst-inline-touching-normal
 
-  - repo: https://github.com/PyCQA/bandit
-    rev: "2d0b675b04c80ae42277e10500db06a0a37bae17"  # frozen: 1.8.6
-    hooks:
-      - id: bandit
-        args:
-          - --ini
-          - .bandit
-
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 9f70dc58c23dfcca1b97af99eaeee3140a807c7e  # frozen: v1.18.2
     hooks:


### PR DESCRIPTION
Run autoupdate freeze on pre-commit and autofixed the lints produced by a newer version of ruff.