### PR TITLE
Produce `INFO summary` only if `pytest -v` option is present and `--iterations` is not present

### DIFF
--- a/cuda_pathfinder/tests/conftest.py
+++ b/cuda_pathfinder/tests/conftest.py
@@ -9,7 +9,16 @@ def pytest_configure(config):
     config.custom_info = []
 
 
+def _cli_has_flag(args, flag):
+    return any(arg == flag or arg.startswith(flag + "=") for arg in args)
+
+
 def pytest_terminal_summary(terminalreporter, exitstatus, config):  # noqa: ARG001
+    if not config.getoption("verbose"):
+        return
+    if _cli_has_flag(config.invocation_params.args, "--iterations"):
+        return
+
     if config.custom_info:
         terminalreporter.write_sep("=", "INFO summary")
         for msg in config.custom_info:

--- a/cuda_pathfinder/tests/conftest.py
+++ b/cuda_pathfinder/tests/conftest.py
@@ -9,14 +9,12 @@ def pytest_configure(config):
     config.custom_info = []
 
 
-def _cli_has_flag(args, flag):
-    return any(arg == flag or arg.startswith(flag + "=") for arg in args)
-
-
 def pytest_terminal_summary(terminalreporter, exitstatus, config):  # noqa: ARG001
     if not config.getoption("verbose"):
         return
-    if _cli_has_flag(config.invocation_params.args, "--iterations"):
+    if hasattr(config.option, "iterations"):  # pytest-freethreaded runs all tests at least twice
+        return
+    if getattr(config.option, "count", 1) > 1:  # pytest-repeat
         return
 
     if config.custom_info:


### PR DESCRIPTION
See #1034 for background.

This compromise approach should prevent distracting unwanted output while retaining the concise summary that makes it easy to see at a glance that all found `abs_path`s line up.