### PR TITLE
Skip IPC mempool tests on WSL

### DIFF
--- a/cuda_core/tests/conftest.py
+++ b/cuda_core/tests/conftest.py
@@ -1,17 +1,35 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import multiprocessing
+import os
+
 import helpers
+import pytest
 
 try:
     from cuda.bindings import driver
 except ImportError:
     from cuda import cuda as driver
-import multiprocessing
-
-import pytest
 from cuda.core.experimental import Device, _device
 from cuda.core.experimental._utils.cuda_utils import handle_return
+
+
+def _detect_wsl() -> bool:
+    try:
+        with open("/proc/sys/kernel/osrelease") as f:
+            data = f.read().lower()
+        if "microsoft" in data or "wsl" in data:
+            return True
+    except Exception:
+        pass
+    # Fallback: env hints sometimes present in CI or shells
+    if any(os.environ.get(k) for k in ("WSL_DISTRO_NAME", "WSL_INTEROP")):
+        return True
+    return False
+
+
+IS_WSL = _detect_wsl()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/cuda_core/tests/test_ipc_mempool.py
+++ b/cuda_core/tests/test_ipc_mempool.py
@@ -11,6 +11,7 @@ import multiprocessing
 
 import pytest
 from cuda.core.experimental import Buffer, Device, DeviceMemoryResource, IPCChannel, MemoryResource
+from conftest import IS_WSL
 from cuda.core.experimental._utils.cuda_utils import handle_return
 
 CHILD_TIMEOUT_SEC = 10
@@ -33,9 +34,12 @@ def ipc_device():
     if not device.properties.handle_type_posix_file_descriptor_supported:
         pytest.skip("Device does not support IPC")
 
+    # On WSL, this test is skipped via decorator; on other platforms it runs.
+
     return device
 
 
+@pytest.mark.skipif(IS_WSL, reason="WSL does not support CUDA IPC mempool sharing")
 def test_ipc_mempool(ipc_device):
     """Test IPC with memory pools."""
     # Set up the IPC-enabled memory pool and share it.
@@ -83,6 +87,7 @@ def child_main1(channel, queue):
     stream.sync()
 
 
+@pytest.mark.skipif(IS_WSL, reason="WSL does not support CUDA IPC mempool sharing")
 def test_shared_pool_errors(ipc_device):
     """Test expected errors with allocating from a shared IPC memory pool."""
     # Set up the IPC-enabled memory pool and share it.

--- a/cuda_core/tests/test_memory.py
+++ b/cuda_core/tests/test_memory.py
@@ -13,6 +13,7 @@ import pytest
 from cuda.core.experimental import Buffer, Device, DeviceMemoryResource, MemoryResource
 from cuda.core.experimental._memory import DLDeviceType, IPCBufferDescriptor
 from cuda.core.experimental._utils.cuda_utils import handle_return
+from conftest import IS_WSL
 
 POOL_SIZE = 2097152  # 2MB size
 
@@ -359,7 +360,13 @@ def test_mempool(mempool_device):
     buffer.close()
 
 
-@pytest.mark.parametrize("ipc_enabled", [True, False])
+@pytest.mark.parametrize(
+    "ipc_enabled",
+    [
+        pytest.param(True, marks=pytest.mark.skipif(IS_WSL, reason="WSL does not support CUDA IPC mempool sharing")),
+        False,
+    ],
+)
 @pytest.mark.parametrize(
     "property_name,expected_type",
     [


### PR DESCRIPTION
Skip IPC mempool tests on WSL

- Skip IPC mempool tests on WSL using pytest.skipif(IS_WSL, ...).

On WSL2, cuMemPoolCreate with POSIX handle returns CUDA_ERROR_INVALID_VALUE despite capability flags indicating support. This is a platform/driver limitation, not a bug in our code. 

On my machine I confirmed the failures are driver-related rather than a bug in our code. The host is WSL2 (kernel “microsoft-standard-WSL2”) with NVIDIA driver 581.15 (CUDA 13.0). Device attributes report mempools and POSIX FD handle support, yet a minimal, direct driver repro calling cuMemPoolCreate with handleTypes=CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR consistently returns CUDA_ERROR_INVALID_VALUE, while the same call with handleTypes=CU_MEM_HANDLE_TYPE_NONE succeeds. 

```

Because this reproduces outside our code with the same CUmemPoolProps we set, the issue lies in the driver/runtime path under WSL2 (consistent with known IPC limitations there), not our implementation. Therefore, we skip IPC mempool tests on WSL to keep the suite portable and green, while leaving the tests enabled on native Linux and other environments where the driver accepts IPC pools.