### PR TITLE
chore(dev-tools): only check specific files when checking for markdown in docs/source [no-ci]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,10 +33,11 @@ repos:
       - id: no-markdown-in-docs-source
         name: Prevent markdown files in docs/source directories
         entry: bash -c
-        args: ['if find . -path "*/docs/source/*.md" -not -path "./docs/README.md" | grep -q .; then echo "ERROR: Markdown files found in docs/source/ directories. Use reST (.rst) instead."; exit 1; fi']
+        args:
+          - 'for file in "$@"; do >&2 echo "error: markdown file "$file" found in a docs/source directory. Only reST (.rst) is allowed"; done && exit 1'
+          - "_" # fake script name, because bash considers $0 (the first argument) to be the script name
         language: system
-        pass_filenames: false
-        always_run: true
+        files: '^.*/docs/source/.*\.md$'
 
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
This speeds up the markdown file disallowance when running pre-commit. This is noticeably slower when searching through hidden `.pixi` directories because it scans every single file in the directory. We only need to check that new markdown files are not introduced, so we only need to look at passed filenames.