### PR TITLE
ci: avoid cache save during racy cancellation of GitHub Actions jobs

### DIFF
--- a/.github/actions/fetch_ctk/action.yml
+++ b/.github/actions/fetch_ctk/action.yml
@@ -140,7 +140,7 @@ runs:
         ls -l $CUDA_PATH
 
     - name: Upload CTK cache
-      if: ${{ always() &&
+      if: ${{ !cancelled() &&
               steps.ctk-get-cache.outputs.cache-hit != 'true' }}
       uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
       with:


### PR DESCRIPTION
This PR addresses an issue with our caching.

Currently, it's possible for a step in a job to run **after** it's been cancelled:

https://github.com/NVIDIA/cuda-python/actions/runs/18283715504/job/52053054074

There, the `actions/cache/save` action runs after being cancelled by a higher priority
job.

All well and good, except that the condition of running the `Upload CTK cache`--the step that uses `actions/cache/save`--
contains `always()`.

According to [the GitHub documentation for `always()`](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#always), that includes possibly running a step even if its parent job is cancelled.

Thankfully, they provide a solution there as well, which is to slightly refine the condition to `!cancelled()`, which is
what I've implemented here.
