### PR TITLE
Bump `cuda.bindings` to 12.9.3

### DIFF
--- a/cuda_bindings/cuda/bindings/_version.py
+++ b/cuda_bindings/cuda/bindings/_version.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-__version__ = "12.9.2"
+__version__ = "12.9.3"


### PR DESCRIPTION
## Description

no need to change `docs/nv-versions.json` because we don't build docs for the backport branch (except for the release notes, which is done in the main branch).

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
