### PR TITLE
Avoid manual cleanup of object attributes

### DIFF
--- a/cuda_core/cuda/core/experimental/_memory.pyx
+++ b/cuda_core/cuda/core/experimental/_memory.pyx
@@ -160,9 +160,6 @@ cdef class Buffer(_cyBuffer, MemoryResourceAttributes):
                 s = <cyStream>stream
             self._mr._deallocate(self._ptr, self._size, s)
             self._ptr = 0
-            self._mr = None
-            self._ptr_obj = None
-            self._alloc_stream = None
 
     @property
     def handle(self) -> DevicePointerT:
@@ -763,12 +760,9 @@ cdef class DeviceMemoryResource(MemoryResource):
                 self.unregister()
             self._dev_id = cydriver.CU_DEVICE_INVALID
             self._mempool_handle = NULL
-            self._attributes = None
             self._ipc_handle_type = cydriver.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_MAX
             self._mempool_owned = False
             self._is_mapped = False
-            self._uuid = None
-            self._alloc_handle = None
 
     def __reduce__(self):
         return DeviceMemoryResource.from_registry, (self.uuid,)


### PR DESCRIPTION
## Description

Try to avoid cleanup errors like this
```
Traceback (most recent call last):
  File "cuda/core/experimental/_memory.pyx", line 138, in cuda.core.experimental._memory.Buffer.close
SystemError: Objects/dictobject.c:2395: bad argument to internal function
Traceback (most recent call last):
  File "cuda/core/experimental/_memory.pyx", line 751, in cuda.core.experimental._memory.DeviceMemoryResource.close
SystemError: Objects/dictobject.c:2395: bad argument to internal function
Exception ignored in: 'cuda.core.experimental._memory.DeviceMemoryResource.__dealloc__'
```

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
