### PR TITLE
Adopt `--group test-cu12`, `test-cu13` organization from PR #1090

### DIFF
--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -283,7 +283,7 @@ jobs:
         run: |
           set -euo pipefail
           pushd cuda_pathfinder
-          pip install --only-binary=:all: -v . --group "test_nvidia_wheels_cu${TEST_CUDA_MAJOR}" --group test_nvidia_wheels_host
+          pip install --only-binary=:all: -v . --group "test-cu${TEST_CUDA_MAJOR}"
           pip list
           popd
 

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -256,7 +256,7 @@ jobs:
         shell: bash --noprofile --norc -xeuo pipefail {0}
         run: |
           pushd cuda_pathfinder
-          pip install --only-binary=:all: -v . --group "test_nvidia_wheels_cu${TEST_CUDA_MAJOR}" --group test_nvidia_wheels_host
+          pip install --only-binary=:all: -v . --group "test-cu${TEST_CUDA_MAJOR}"
           pip list
           popd
 

--- a/cuda_pathfinder/pyproject.toml
+++ b/cuda_pathfinder/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = []
 test = [
     "pytest>=6.2.4",
 ]
-test_nvidia_wheels_cu12 = [
+# Internal organization of test dependencies.
+cu12 = [
     "cuda-toolkit[nvcc,cublas,nvrtc,cudart,cufft,curand,cusolver,cusparse,npp,nvfatbin,nvjitlink,nvjpeg,cccl]==12.*",
     "cuda-toolkit[cufile]==12.*; sys_platform != 'win32'",
     "nvidia-cublasmp-cu12; sys_platform != 'win32'",
@@ -24,7 +25,7 @@ test_nvidia_wheels_cu12 = [
     "nvidia-nccl-cu12; sys_platform != 'win32'",
     "nvidia-nvshmem-cu12; sys_platform != 'win32'",
 ]
-test_nvidia_wheels_cu13 = [
+cu13 = [
     "cuda-toolkit[nvcc,cublas,nvrtc,cudart,cufft,curand,cusolver,cusparse,npp,nvfatbin,nvjitlink,nvjpeg,cccl,nvvm]==13.*",
     "cuda-toolkit[cufile]==13.*; sys_platform != 'win32'",
     "nvidia-cublasmp-cu13; sys_platform != 'win32'",
@@ -32,8 +33,20 @@ test_nvidia_wheels_cu13 = [
     "nvidia-nccl-cu13; sys_platform != 'win32'",
     "nvidia-nvshmem-cu13; sys_platform != 'win32'",
 ]
-test_nvidia_wheels_host = [
+host = [
     "nvpl-fft; platform_system == 'Linux' and platform_machine == 'aarch64'",
+]
+
+# User-facing dependencies, e.g. pip install --group test-cu13
+test-cu12 = [
+    { include-group = "test" },
+    { include-group = "cu12" },
+    { include-group = "host" },
+]
+test-cu13 = [
+    { include-group = "test" },
+    { include-group = "cu13" },
+    { include-group = "host" },
 ]
 
 [project.urls]

--- a/toolshed/collect_site_packages_dll_files.ps1
+++ b/toolshed/collect_site_packages_dll_files.ps1
@@ -23,11 +23,11 @@ function Fresh-Venv {
 Set-Location -Path 'cuda_pathfinder'
 
 Fresh-Venv -Path '..\TmpCp12Venv'
-pip install --only-binary=:all: -e '.[test,test_nvidia_wheels_cu12,test_nvidia_wheels_host]'
+pip install --only-binary=:all: -e . --group test-cu12
 deactivate
 
 Fresh-Venv -Path '..\TmpCp13Venv'
-pip install --only-binary=:all: -e '.[test,test_nvidia_wheels_cu13,test_nvidia_wheels_host]'
+pip install --only-binary=:all: -e . --group test-cu13
 deactivate
 
 Set-Location -Path '..'

--- a/toolshed/collect_site_packages_so_files.sh
+++ b/toolshed/collect_site_packages_so_files.sh
@@ -17,12 +17,12 @@ fresh_venv() {
 cd cuda_pathfinder/
 fresh_venv ../TmpCp12Venv
 set -x
-pip install --only-binary=:all: -e . --group test --group test_nvidia_wheels_cu12 --group test_nvidia_wheels_host
+pip install --only-binary=:all: -e . --group test-cu12
 set +x
 deactivate
 fresh_venv ../TmpCp13Venv
 set -x
-pip install --only-binary=:all: -e . --group test --group test_nvidia_wheels_cu13 --group test_nvidia_wheels_host
+pip install --only-binary=:all: -e . --group test-cu13
 set +x
 deactivate
 cd ..


### PR DESCRIPTION
Take full advantage of the `pip` `--group` feature, to make the test commands simpler and uniform on all platforms.

Based on experience gathered while working on PR #1090, but this PR leaves out all pixi-related changes.