### PR TITLE
Update the CUDA runtime to 13.0.2

### DIFF
--- a/ci/test-matrix.json
+++ b/ci/test-matrix.json
@@ -5,31 +5,31 @@
   "linux": {
     "pull-request": [
       { "ARCH": "amd64", "PY_VER": "3.9",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.9",  "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.9",  "CUDA_VER": "13.0.2", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.10", "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.10", "CUDA_VER": "13.0.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.10", "CUDA_VER": "13.0.2", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.11", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.11", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.11", "CUDA_VER": "13.0.2", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.12", "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.12", "CUDA_VER": "13.0.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.12", "CUDA_VER": "13.0.2", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.13", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.13", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.13t", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.14", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.14t", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.13", "CUDA_VER": "13.0.2", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.13t", "CUDA_VER": "13.0.2", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.14", "CUDA_VER": "13.0.2", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.14t", "CUDA_VER": "13.0.2", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "arm64", "PY_VER": "3.9",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "a100", "DRIVER": "latest" },
-      { "ARCH": "arm64", "PY_VER": "3.9",  "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "a100", "DRIVER": "latest" },
+      { "ARCH": "arm64", "PY_VER": "3.9",  "CUDA_VER": "13.0.2", "LOCAL_CTK": "1", "GPU": "a100", "DRIVER": "latest" },
       { "ARCH": "arm64", "PY_VER": "3.10", "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "a100", "DRIVER": "latest" },
-      { "ARCH": "arm64", "PY_VER": "3.10", "CUDA_VER": "13.0.1", "LOCAL_CTK": "0", "GPU": "a100", "DRIVER": "latest" },
+      { "ARCH": "arm64", "PY_VER": "3.10", "CUDA_VER": "13.0.2", "LOCAL_CTK": "0", "GPU": "a100", "DRIVER": "latest" },
       { "ARCH": "arm64", "PY_VER": "3.11", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "a100", "DRIVER": "latest" },
-      { "ARCH": "arm64", "PY_VER": "3.11", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "a100", "DRIVER": "latest" },
+      { "ARCH": "arm64", "PY_VER": "3.11", "CUDA_VER": "13.0.2", "LOCAL_CTK": "1", "GPU": "a100", "DRIVER": "latest" },
       { "ARCH": "arm64", "PY_VER": "3.12", "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "a100", "DRIVER": "latest" },
-      { "ARCH": "arm64", "PY_VER": "3.12", "CUDA_VER": "13.0.1", "LOCAL_CTK": "0", "GPU": "a100", "DRIVER": "latest" },
+      { "ARCH": "arm64", "PY_VER": "3.12", "CUDA_VER": "13.0.2", "LOCAL_CTK": "0", "GPU": "a100", "DRIVER": "latest" },
       { "ARCH": "arm64", "PY_VER": "3.13", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "a100", "DRIVER": "latest" },
-      { "ARCH": "arm64", "PY_VER": "3.13", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "a100", "DRIVER": "latest" },
-      { "ARCH": "arm64", "PY_VER": "3.13t", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "a100", "DRIVER": "latest" },
-      { "ARCH": "arm64", "PY_VER": "3.14", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "a100", "DRIVER": "latest" },
-      { "ARCH": "arm64", "PY_VER": "3.14t", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "a100", "DRIVER": "latest" }
+      { "ARCH": "arm64", "PY_VER": "3.13", "CUDA_VER": "13.0.2", "LOCAL_CTK": "1", "GPU": "a100", "DRIVER": "latest" },
+      { "ARCH": "arm64", "PY_VER": "3.13t", "CUDA_VER": "13.0.2", "LOCAL_CTK": "1", "GPU": "a100", "DRIVER": "latest" },
+      { "ARCH": "arm64", "PY_VER": "3.14", "CUDA_VER": "13.0.2", "LOCAL_CTK": "1", "GPU": "a100", "DRIVER": "latest" },
+      { "ARCH": "arm64", "PY_VER": "3.14t", "CUDA_VER": "13.0.2", "LOCAL_CTK": "1", "GPU": "a100", "DRIVER": "latest" }
     ],
     "nightly": [
       { "ARCH": "amd64", "PY_VER": "3.9",  "CUDA_VER": "11.8.0", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "earliest" },
@@ -85,7 +85,7 @@
     ],
     "special_runners": {
       "amd64": [
-        { "ARCH": "amd64", "PY_VER": "3.13", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "H100", "DRIVER": "latest" }
+        { "ARCH": "amd64", "PY_VER": "3.13", "CUDA_VER": "13.0.2", "LOCAL_CTK": "1", "GPU": "H100", "DRIVER": "latest" }
       ]
     }
   },
@@ -93,22 +93,22 @@
     "pull-request": [
       { "ARCH": "amd64", "PY_VER": "3.12", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.12", "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "t4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.13", "CUDA_VER": "13.0.1", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.13", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.13t", "CUDA_VER": "13.0.1", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.13t", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.14", "CUDA_VER": "13.0.1", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.14", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.14t", "CUDA_VER": "13.0.1", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.14t", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" }
+      { "ARCH": "amd64", "PY_VER": "3.13", "CUDA_VER": "13.0.2", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.13", "CUDA_VER": "13.0.2", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.13t", "CUDA_VER": "13.0.2", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.13t", "CUDA_VER": "13.0.2", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.14", "CUDA_VER": "13.0.2", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.14", "CUDA_VER": "13.0.2", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.14t", "CUDA_VER": "13.0.2", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.14t", "CUDA_VER": "13.0.2", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" }
     ],
     "nightly": [
       { "ARCH": "amd64", "PY_VER": "3.12", "CUDA_VER": "11.8.0", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.12", "CUDA_VER": "11.8.0", "LOCAL_CTK": "1", "GPU": "t4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.12", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.12", "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.13t", "CUDA_VER": "13.0.1", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.13t", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" }
+      { "ARCH": "amd64", "PY_VER": "3.13t", "CUDA_VER": "13.0.2", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.13t", "CUDA_VER": "13.0.2", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" }
     ]
   }
 }

--- a/ci/versions.json
+++ b/ci/versions.json
@@ -1,7 +1,7 @@
 {
   "cuda": {
     "build": {
-      "version": "13.0.1"
+      "version": "13.0.2"
     },
     "prev_build": {
       "version": "12.9.1"

--- a/cuda_bindings/cuda/bindings/_internal/cufile.pxd
+++ b/cuda_bindings/cuda/bindings/_internal/cufile.pxd
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.9.0 to 13.0.1. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.0 to 13.0.2. Do not modify it directly.
 
 from ..cycufile cimport *
 

--- a/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.9.0 to 13.0.1. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.0 to 13.0.2. Do not modify it directly.
 
 from libc.stdint cimport intptr_t, uintptr_t
 import threading
@@ -17,6 +17,8 @@ import cython
 ###############################################################################
 # Extern
 ###############################################################################
+
+# You must 'from .utils import NotSupportedError' before using this template
 
 cdef extern from "<dlfcn.h>" nogil:
     void* dlopen(const char*, int)
@@ -49,6 +51,7 @@ cdef int get_cuda_version():
         raise RuntimeError(f'cuDriverGetVersion returned error code {err}')
 
     return driver_ver
+
 
 
 ###############################################################################

--- a/cuda_bindings/cuda/bindings/_internal/nvjitlink.pxd
+++ b/cuda_bindings/cuda/bindings/_internal/nvjitlink.pxd
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.0.1 to 13.0.1. Do not modify it directly.
+# This code was automatically generated across versions from 12.0.1 to 13.0.2. Do not modify it directly.
 
 from ..cynvjitlink cimport *
 

--- a/cuda_bindings/cuda/bindings/_internal/nvjitlink_linux.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvjitlink_linux.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.0.1 to 13.0.1. Do not modify it directly.
+# This code was automatically generated across versions from 12.0.1 to 13.0.2. Do not modify it directly.
 
 from libc.stdint cimport intptr_t, uintptr_t
 
@@ -15,6 +15,8 @@ from cuda.pathfinder import load_nvidia_dynamic_lib
 ###############################################################################
 # Extern
 ###############################################################################
+
+# You must 'from .utils import NotSupportedError' before using this template
 
 cdef extern from "<dlfcn.h>" nogil:
     void* dlopen(const char*, int)
@@ -47,6 +49,7 @@ cdef int get_cuda_version():
         raise RuntimeError(f'cuDriverGetVersion returned error code {err}')
 
     return driver_ver
+
 
 
 ###############################################################################

--- a/cuda_bindings/cuda/bindings/_internal/nvjitlink_windows.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvjitlink_windows.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.0.1 to 13.0.1. Do not modify it directly.
+# This code was automatically generated across versions from 12.0.1 to 13.0.2. Do not modify it directly.
 
 from libc.stdint cimport intptr_t
 
@@ -15,7 +15,7 @@ from libc.stddef cimport wchar_t
 from libc.stdint cimport uintptr_t
 from cpython cimport PyUnicode_AsWideCharString, PyMem_Free
 
-from .utils import NotSupportedError
+# You must 'from .utils import NotSupportedError' before using this template
 
 cdef extern from "windows.h" nogil:
     ctypedef void* HMODULE
@@ -61,10 +61,10 @@ cdef int get_cuda_version():
         raise NotSupportedError('CUDA driver is not found')
     cuDriverGetVersion = GetProcAddress(handle, 'cuDriverGetVersion')
     if cuDriverGetVersion == NULL:
-        raise RuntimeError('something went wrong')
+        raise RuntimeError('Did not find cuDriverGetVersion symbol in nvcuda.dll')
     err = (<int (*)(int*) noexcept nogil>cuDriverGetVersion)(&driver_ver)
     if err != 0:
-        raise RuntimeError('something went wrong')
+        raise RuntimeError(f'cuDriverGetVersion returned error code {err}')
 
     return driver_ver
 
@@ -95,8 +95,6 @@ cdef void* __nvJitLinkVersion = NULL
 
 cdef int __check_or_init_nvjitlink() except -1 nogil:
     global __py_nvjitlink_init
-    if __py_nvjitlink_init:
-        return 0
 
     with gil, __symbol_lock:
         # Load library

--- a/cuda_bindings/cuda/bindings/_internal/nvvm.pxd
+++ b/cuda_bindings/cuda/bindings/_internal/nvvm.pxd
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.0.1 to 13.0.1. Do not modify it directly.
+# This code was automatically generated across versions from 12.0.1 to 13.0.2. Do not modify it directly.
 
 from ..cynvvm cimport *
 

--- a/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.0.1 to 13.0.1. Do not modify it directly.
+# This code was automatically generated across versions from 12.0.1 to 13.0.2. Do not modify it directly.
 
 from libc.stdint cimport intptr_t, uintptr_t
 
@@ -15,6 +15,8 @@ from cuda.pathfinder import load_nvidia_dynamic_lib
 ###############################################################################
 # Extern
 ###############################################################################
+
+# You must 'from .utils import NotSupportedError' before using this template
 
 cdef extern from "<dlfcn.h>" nogil:
     void* dlopen(const char*, int)
@@ -47,6 +49,7 @@ cdef int get_cuda_version():
         raise RuntimeError(f'cuDriverGetVersion returned error code {err}')
 
     return driver_ver
+
 
 
 ###############################################################################

--- a/cuda_bindings/cuda/bindings/_internal/nvvm_windows.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvvm_windows.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.0.1 to 13.0.1. Do not modify it directly.
+# This code was automatically generated across versions from 12.0.1 to 13.0.2. Do not modify it directly.
 
 from libc.stdint cimport intptr_t
 
@@ -15,7 +15,7 @@ from libc.stddef cimport wchar_t
 from libc.stdint cimport uintptr_t
 from cpython cimport PyUnicode_AsWideCharString, PyMem_Free
 
-from .utils import NotSupportedError
+# You must 'from .utils import NotSupportedError' before using this template
 
 cdef extern from "windows.h" nogil:
     ctypedef void* HMODULE
@@ -61,10 +61,10 @@ cdef int get_cuda_version():
         raise NotSupportedError('CUDA driver is not found')
     cuDriverGetVersion = GetProcAddress(handle, 'cuDriverGetVersion')
     if cuDriverGetVersion == NULL:
-        raise RuntimeError('something went wrong')
+        raise RuntimeError('Did not find cuDriverGetVersion symbol in nvcuda.dll')
     err = (<int (*)(int*) noexcept nogil>cuDriverGetVersion)(&driver_ver)
     if err != 0:
-        raise RuntimeError('something went wrong')
+        raise RuntimeError(f'cuDriverGetVersion returned error code {err}')
 
     return driver_ver
 

--- a/cuda_bindings/cuda/bindings/cufile.pxd
+++ b/cuda_bindings/cuda/bindings/cufile.pxd
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.9.0 to 13.0.1. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.0 to 13.0.2. Do not modify it directly.
 
 from libc.stdint cimport intptr_t
 

--- a/cuda_bindings/cuda/bindings/cufile.pyx
+++ b/cuda_bindings/cuda/bindings/cufile.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.9.0 to 13.0.1. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.0 to 13.0.2. Do not modify it directly.
 
 cimport cython  # NOQA
 from libc cimport errno
@@ -1022,8 +1022,8 @@ cpdef intptr_t handle_register(intptr_t descr) except? 0:
     """
     cdef Handle fh
     with nogil:
-        status = cuFileHandleRegister(&fh, <CUfileDescr_t*>descr)
-    check_status(status)
+        __status__ = cuFileHandleRegister(&fh, <CUfileDescr_t*>descr)
+    check_status(__status__)
     return <intptr_t>fh
 
 
@@ -1049,8 +1049,8 @@ cpdef buf_register(intptr_t buf_ptr_base, size_t length, int flags):
     .. seealso:: `cuFileBufRegister`
     """
     with nogil:
-        status = cuFileBufRegister(<const void*>buf_ptr_base, length, flags)
-    check_status(status)
+        __status__ = cuFileBufRegister(<const void*>buf_ptr_base, length, flags)
+    check_status(__status__)
 
 
 cpdef buf_deregister(intptr_t buf_ptr_base):
@@ -1062,8 +1062,8 @@ cpdef buf_deregister(intptr_t buf_ptr_base):
     .. seealso:: `cuFileBufDeregister`
     """
     with nogil:
-        status = cuFileBufDeregister(<const void*>buf_ptr_base)
-    check_status(status)
+        __status__ = cuFileBufDeregister(<const void*>buf_ptr_base)
+    check_status(__status__)
 
 
 cpdef read(intptr_t fh, intptr_t buf_ptr_base, size_t size, off_t file_offset, off_t buf_ptr_offset):
@@ -1079,8 +1079,8 @@ cpdef read(intptr_t fh, intptr_t buf_ptr_base, size_t size, off_t file_offset, o
     .. seealso:: `cuFileRead`
     """
     with nogil:
-        status = cuFileRead(<Handle>fh, <void*>buf_ptr_base, size, file_offset, buf_ptr_offset)
-    check_status(status)
+        __status__ = cuFileRead(<Handle>fh, <void*>buf_ptr_base, size, file_offset, buf_ptr_offset)
+    check_status(__status__)
 
 
 cpdef write(intptr_t fh, intptr_t buf_ptr_base, size_t size, off_t file_offset, off_t buf_ptr_offset):
@@ -1096,8 +1096,8 @@ cpdef write(intptr_t fh, intptr_t buf_ptr_base, size_t size, off_t file_offset, 
     .. seealso:: `cuFileWrite`
     """
     with nogil:
-        status = cuFileWrite(<Handle>fh, <const void*>buf_ptr_base, size, file_offset, buf_ptr_offset)
-    check_status(status)
+        __status__ = cuFileWrite(<Handle>fh, <const void*>buf_ptr_base, size, file_offset, buf_ptr_offset)
+    check_status(__status__)
 
 
 cpdef driver_open():
@@ -1106,8 +1106,8 @@ cpdef driver_open():
     .. seealso:: `cuFileDriverOpen`
     """
     with nogil:
-        status = cuFileDriverOpen()
-    check_status(status)
+        __status__ = cuFileDriverOpen()
+    check_status(__status__)
 
 
 cpdef use_count():
@@ -1116,8 +1116,8 @@ cpdef use_count():
     .. seealso:: `cuFileUseCount`
     """
     with nogil:
-        status = cuFileUseCount()
-    check_status(status)
+        __status__ = cuFileUseCount()
+    check_status(__status__)
 
 
 cpdef driver_get_properties(intptr_t props):
@@ -1129,8 +1129,8 @@ cpdef driver_get_properties(intptr_t props):
     .. seealso:: `cuFileDriverGetProperties`
     """
     with nogil:
-        status = cuFileDriverGetProperties(<CUfileDrvProps_t*>props)
-    check_status(status)
+        __status__ = cuFileDriverGetProperties(<CUfileDrvProps_t*>props)
+    check_status(__status__)
 
 
 cpdef driver_set_poll_mode(bint poll, size_t poll_threshold_size):
@@ -1143,8 +1143,8 @@ cpdef driver_set_poll_mode(bint poll, size_t poll_threshold_size):
     .. seealso:: `cuFileDriverSetPollMode`
     """
     with nogil:
-        status = cuFileDriverSetPollMode(<cpp_bool>poll, poll_threshold_size)
-    check_status(status)
+        __status__ = cuFileDriverSetPollMode(<cpp_bool>poll, poll_threshold_size)
+    check_status(__status__)
 
 
 cpdef driver_set_max_direct_io_size(size_t max_direct_io_size):
@@ -1156,8 +1156,8 @@ cpdef driver_set_max_direct_io_size(size_t max_direct_io_size):
     .. seealso:: `cuFileDriverSetMaxDirectIOSize`
     """
     with nogil:
-        status = cuFileDriverSetMaxDirectIOSize(max_direct_io_size)
-    check_status(status)
+        __status__ = cuFileDriverSetMaxDirectIOSize(max_direct_io_size)
+    check_status(__status__)
 
 
 cpdef driver_set_max_cache_size(size_t max_cache_size):
@@ -1169,8 +1169,8 @@ cpdef driver_set_max_cache_size(size_t max_cache_size):
     .. seealso:: `cuFileDriverSetMaxCacheSize`
     """
     with nogil:
-        status = cuFileDriverSetMaxCacheSize(max_cache_size)
-    check_status(status)
+        __status__ = cuFileDriverSetMaxCacheSize(max_cache_size)
+    check_status(__status__)
 
 
 cpdef driver_set_max_pinned_mem_size(size_t max_pinned_size):
@@ -1182,34 +1182,34 @@ cpdef driver_set_max_pinned_mem_size(size_t max_pinned_size):
     .. seealso:: `cuFileDriverSetMaxPinnedMemSize`
     """
     with nogil:
-        status = cuFileDriverSetMaxPinnedMemSize(max_pinned_size)
-    check_status(status)
+        __status__ = cuFileDriverSetMaxPinnedMemSize(max_pinned_size)
+    check_status(__status__)
 
 
 cpdef intptr_t batch_io_set_up(unsigned nr) except? 0:
     cdef BatchHandle batch_idp
     with nogil:
-        status = cuFileBatchIOSetUp(&batch_idp, nr)
-    check_status(status)
+        __status__ = cuFileBatchIOSetUp(&batch_idp, nr)
+    check_status(__status__)
     return <intptr_t>batch_idp
 
 
 cpdef batch_io_submit(intptr_t batch_idp, unsigned nr, intptr_t iocbp, unsigned int flags):
     with nogil:
-        status = cuFileBatchIOSubmit(<BatchHandle>batch_idp, nr, <CUfileIOParams_t*>iocbp, flags)
-    check_status(status)
+        __status__ = cuFileBatchIOSubmit(<BatchHandle>batch_idp, nr, <CUfileIOParams_t*>iocbp, flags)
+    check_status(__status__)
 
 
 cpdef batch_io_get_status(intptr_t batch_idp, unsigned min_nr, intptr_t nr, intptr_t iocbp, intptr_t timeout):
     with nogil:
-        status = cuFileBatchIOGetStatus(<BatchHandle>batch_idp, min_nr, <unsigned*>nr, <CUfileIOEvents_t*>iocbp, <timespec*>timeout)
-    check_status(status)
+        __status__ = cuFileBatchIOGetStatus(<BatchHandle>batch_idp, min_nr, <unsigned*>nr, <CUfileIOEvents_t*>iocbp, <timespec*>timeout)
+    check_status(__status__)
 
 
 cpdef batch_io_cancel(intptr_t batch_idp):
     with nogil:
-        status = cuFileBatchIOCancel(<BatchHandle>batch_idp)
-    check_status(status)
+        __status__ = cuFileBatchIOCancel(<BatchHandle>batch_idp)
+    check_status(__status__)
 
 
 cpdef void batch_io_destroy(intptr_t batch_idp) except*:
@@ -1218,49 +1218,56 @@ cpdef void batch_io_destroy(intptr_t batch_idp) except*:
 
 cpdef read_async(intptr_t fh, intptr_t buf_ptr_base, intptr_t size_p, intptr_t file_offset_p, intptr_t buf_ptr_offset_p, intptr_t bytes_read_p, intptr_t stream):
     with nogil:
-        status = cuFileReadAsync(<Handle>fh, <void*>buf_ptr_base, <size_t*>size_p, <off_t*>file_offset_p, <off_t*>buf_ptr_offset_p, <ssize_t*>bytes_read_p, <void*>stream)
-    check_status(status)
+        __status__ = cuFileReadAsync(<Handle>fh, <void*>buf_ptr_base, <size_t*>size_p, <off_t*>file_offset_p, <off_t*>buf_ptr_offset_p, <ssize_t*>bytes_read_p, <void*>stream)
+    check_status(__status__)
 
 
 cpdef write_async(intptr_t fh, intptr_t buf_ptr_base, intptr_t size_p, intptr_t file_offset_p, intptr_t buf_ptr_offset_p, intptr_t bytes_written_p, intptr_t stream):
     with nogil:
-        status = cuFileWriteAsync(<Handle>fh, <void*>buf_ptr_base, <size_t*>size_p, <off_t*>file_offset_p, <off_t*>buf_ptr_offset_p, <ssize_t*>bytes_written_p, <void*>stream)
-    check_status(status)
+        __status__ = cuFileWriteAsync(<Handle>fh, <void*>buf_ptr_base, <size_t*>size_p, <off_t*>file_offset_p, <off_t*>buf_ptr_offset_p, <ssize_t*>bytes_written_p, <void*>stream)
+    check_status(__status__)
 
 
 cpdef stream_register(intptr_t stream, unsigned flags):
     with nogil:
-        status = cuFileStreamRegister(<void*>stream, flags)
-    check_status(status)
+        __status__ = cuFileStreamRegister(<void*>stream, flags)
+    check_status(__status__)
 
 
 cpdef stream_deregister(intptr_t stream):
     with nogil:
-        status = cuFileStreamDeregister(<void*>stream)
-    check_status(status)
+        __status__ = cuFileStreamDeregister(<void*>stream)
+    check_status(__status__)
 
 
 cpdef int get_version() except? 0:
+    """Get the cuFile library version.
+
+    Returns:
+        int: Pointer to an integer where the version will be stored.
+
+    .. seealso:: `cuFileGetVersion`
+    """
     cdef int version
     with nogil:
-        status = cuFileGetVersion(&version)
-    check_status(status)
+        __status__ = cuFileGetVersion(&version)
+    check_status(__status__)
     return version
 
 
 cpdef size_t get_parameter_size_t(int param) except? 0:
     cdef size_t value
     with nogil:
-        status = cuFileGetParameterSizeT(<_SizeTConfigParameter>param, &value)
-    check_status(status)
+        __status__ = cuFileGetParameterSizeT(<_SizeTConfigParameter>param, &value)
+    check_status(__status__)
     return value
 
 
 cpdef bint get_parameter_bool(int param) except? 0:
     cdef cpp_bool value
     with nogil:
-        status = cuFileGetParameterBool(<_BoolConfigParameter>param, &value)
-    check_status(status)
+        __status__ = cuFileGetParameterBool(<_BoolConfigParameter>param, &value)
+    check_status(__status__)
     return <bint>value
 
 
@@ -1268,27 +1275,27 @@ cpdef str get_parameter_string(int param, int len):
     cdef bytes _desc_str_ = bytes(len)
     cdef char* desc_str = _desc_str_
     with nogil:
-        status = cuFileGetParameterString(<_StringConfigParameter>param, desc_str, len)
-    check_status(status)
+        __status__ = cuFileGetParameterString(<_StringConfigParameter>param, desc_str, len)
+    check_status(__status__)
     return _desc_str_.decode()
 
 
 cpdef set_parameter_size_t(int param, size_t value):
     with nogil:
-        status = cuFileSetParameterSizeT(<_SizeTConfigParameter>param, value)
-    check_status(status)
+        __status__ = cuFileSetParameterSizeT(<_SizeTConfigParameter>param, value)
+    check_status(__status__)
 
 
 cpdef set_parameter_bool(int param, bint value):
     with nogil:
-        status = cuFileSetParameterBool(<_BoolConfigParameter>param, <cpp_bool>value)
-    check_status(status)
+        __status__ = cuFileSetParameterBool(<_BoolConfigParameter>param, <cpp_bool>value)
+    check_status(__status__)
 
 
 cpdef set_parameter_string(int param, intptr_t desc_str):
     with nogil:
-        status = cuFileSetParameterString(<_StringConfigParameter>param, <const char*>desc_str)
-    check_status(status)
+        __status__ = cuFileSetParameterString(<_StringConfigParameter>param, <const char*>desc_str)
+    check_status(__status__)
 
 
 cpdef str op_status_error(int status):

--- a/cuda_bindings/cuda/bindings/cycufile.pxd
+++ b/cuda_bindings/cuda/bindings/cycufile.pxd
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.9.0 to 13.0.1. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.0 to 13.0.2. Do not modify it directly.
 
 from libc.stdint cimport uint32_t, uint64_t
 from libc.time cimport time_t

--- a/cuda_bindings/cuda/bindings/cycufile.pyx
+++ b/cuda_bindings/cuda/bindings/cycufile.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.9.0 to 13.0.1. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.0 to 13.0.2. Do not modify it directly.
 
 from ._internal cimport cufile as _cufile
 

--- a/cuda_bindings/cuda/bindings/cynvjitlink.pxd
+++ b/cuda_bindings/cuda/bindings/cynvjitlink.pxd
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.0.1 to 13.0.1. Do not modify it directly.
+# This code was automatically generated across versions from 12.0.1 to 13.0.2. Do not modify it directly.
 
 from libc.stdint cimport intptr_t, uint32_t
 

--- a/cuda_bindings/cuda/bindings/cynvjitlink.pyx
+++ b/cuda_bindings/cuda/bindings/cynvjitlink.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.0.1 to 13.0.1. Do not modify it directly.
+# This code was automatically generated across versions from 12.0.1 to 13.0.2. Do not modify it directly.
 
 from ._internal cimport nvjitlink as _nvjitlink
 

--- a/cuda_bindings/cuda/bindings/cynvvm.pxd
+++ b/cuda_bindings/cuda/bindings/cynvvm.pxd
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.0.1 to 13.0.1. Do not modify it directly.
+# This code was automatically generated across versions from 12.0.1 to 13.0.2. Do not modify it directly.
 
 
 ###############################################################################

--- a/cuda_bindings/cuda/bindings/cynvvm.pyx
+++ b/cuda_bindings/cuda/bindings/cynvvm.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.0.1 to 13.0.1. Do not modify it directly.
+# This code was automatically generated across versions from 12.0.1 to 13.0.2. Do not modify it directly.
 
 from ._internal cimport nvvm as _nvvm
 

--- a/cuda_bindings/cuda/bindings/nvjitlink.pxd
+++ b/cuda_bindings/cuda/bindings/nvjitlink.pxd
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.0.1 to 13.0.1. Do not modify it directly.
+# This code was automatically generated across versions from 12.0.1 to 13.0.2. Do not modify it directly.
 
 from libc.stdint cimport intptr_t, uint32_t
 

--- a/cuda_bindings/cuda/bindings/nvjitlink.pyx
+++ b/cuda_bindings/cuda/bindings/nvjitlink.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.0.1 to 13.0.1. Do not modify it directly.
+# This code was automatically generated across versions from 12.0.1 to 13.0.2. Do not modify it directly.
 
 cimport cython  # NOQA
 
@@ -116,8 +116,8 @@ cpdef intptr_t create(uint32_t num_options, options) except -1:
     get_nested_resource_ptr[char](_options_, options, <char*>NULL)
     cdef Handle handle
     with nogil:
-        status = nvJitLinkCreate(&handle, num_options, <const char**>(_options_.ptrs.data()))
-    check_status(status)
+        __status__ = nvJitLinkCreate(&handle, num_options, <const char**>(_options_.ptrs.data()))
+    check_status(__status__)
     return <intptr_t>handle
 
 
@@ -139,8 +139,8 @@ cpdef add_data(intptr_t handle, int input_type, data, size_t size, name):
     cdef bytes _temp_name_ = (<str>name).encode()
     cdef char* _name_ = _temp_name_
     with nogil:
-        status = nvJitLinkAddData(<Handle>handle, <_InputType>input_type, <const void*>_data_, size, <const char*>_name_)
-    check_status(status)
+        __status__ = nvJitLinkAddData(<Handle>handle, <_InputType>input_type, <const void*>_data_, size, <const char*>_name_)
+    check_status(__status__)
 
 
 cpdef add_file(intptr_t handle, int input_type, file_name):
@@ -158,8 +158,8 @@ cpdef add_file(intptr_t handle, int input_type, file_name):
     cdef bytes _temp_file_name_ = (<str>file_name).encode()
     cdef char* _file_name_ = _temp_file_name_
     with nogil:
-        status = nvJitLinkAddFile(<Handle>handle, <_InputType>input_type, <const char*>_file_name_)
-    check_status(status)
+        __status__ = nvJitLinkAddFile(<Handle>handle, <_InputType>input_type, <const char*>_file_name_)
+    check_status(__status__)
 
 
 cpdef complete(intptr_t handle):
@@ -171,8 +171,8 @@ cpdef complete(intptr_t handle):
     .. seealso:: `nvJitLinkComplete`
     """
     with nogil:
-        status = nvJitLinkComplete(<Handle>handle)
-    check_status(status)
+        __status__ = nvJitLinkComplete(<Handle>handle)
+    check_status(__status__)
 
 
 cpdef size_t get_linked_cubin_size(intptr_t handle) except? 0:
@@ -188,8 +188,8 @@ cpdef size_t get_linked_cubin_size(intptr_t handle) except? 0:
     """
     cdef size_t size
     with nogil:
-        status = nvJitLinkGetLinkedCubinSize(<Handle>handle, &size)
-    check_status(status)
+        __status__ = nvJitLinkGetLinkedCubinSize(<Handle>handle, &size)
+    check_status(__status__)
     return size
 
 
@@ -204,8 +204,8 @@ cpdef get_linked_cubin(intptr_t handle, cubin):
     """
     cdef void* _cubin_ = get_buffer_pointer(cubin, -1, readonly=False)
     with nogil:
-        status = nvJitLinkGetLinkedCubin(<Handle>handle, <void*>_cubin_)
-    check_status(status)
+        __status__ = nvJitLinkGetLinkedCubin(<Handle>handle, <void*>_cubin_)
+    check_status(__status__)
 
 
 cpdef size_t get_linked_ptx_size(intptr_t handle) except? 0:
@@ -221,8 +221,8 @@ cpdef size_t get_linked_ptx_size(intptr_t handle) except? 0:
     """
     cdef size_t size
     with nogil:
-        status = nvJitLinkGetLinkedPtxSize(<Handle>handle, &size)
-    check_status(status)
+        __status__ = nvJitLinkGetLinkedPtxSize(<Handle>handle, &size)
+    check_status(__status__)
     return size
 
 
@@ -237,8 +237,8 @@ cpdef get_linked_ptx(intptr_t handle, ptx):
     """
     cdef void* _ptx_ = get_buffer_pointer(ptx, -1, readonly=False)
     with nogil:
-        status = nvJitLinkGetLinkedPtx(<Handle>handle, <char*>_ptx_)
-    check_status(status)
+        __status__ = nvJitLinkGetLinkedPtx(<Handle>handle, <char*>_ptx_)
+    check_status(__status__)
 
 
 cpdef size_t get_error_log_size(intptr_t handle) except? 0:
@@ -254,8 +254,8 @@ cpdef size_t get_error_log_size(intptr_t handle) except? 0:
     """
     cdef size_t size
     with nogil:
-        status = nvJitLinkGetErrorLogSize(<Handle>handle, &size)
-    check_status(status)
+        __status__ = nvJitLinkGetErrorLogSize(<Handle>handle, &size)
+    check_status(__status__)
     return size
 
 
@@ -270,8 +270,8 @@ cpdef get_error_log(intptr_t handle, log):
     """
     cdef void* _log_ = get_buffer_pointer(log, -1, readonly=False)
     with nogil:
-        status = nvJitLinkGetErrorLog(<Handle>handle, <char*>_log_)
-    check_status(status)
+        __status__ = nvJitLinkGetErrorLog(<Handle>handle, <char*>_log_)
+    check_status(__status__)
 
 
 cpdef size_t get_info_log_size(intptr_t handle) except? 0:
@@ -287,8 +287,8 @@ cpdef size_t get_info_log_size(intptr_t handle) except? 0:
     """
     cdef size_t size
     with nogil:
-        status = nvJitLinkGetInfoLogSize(<Handle>handle, &size)
-    check_status(status)
+        __status__ = nvJitLinkGetInfoLogSize(<Handle>handle, &size)
+    check_status(__status__)
     return size
 
 
@@ -303,8 +303,8 @@ cpdef get_info_log(intptr_t handle, log):
     """
     cdef void* _log_ = get_buffer_pointer(log, -1, readonly=False)
     with nogil:
-        status = nvJitLinkGetInfoLog(<Handle>handle, <char*>_log_)
-    check_status(status)
+        __status__ = nvJitLinkGetInfoLog(<Handle>handle, <char*>_log_)
+    check_status(__status__)
 
 
 cpdef tuple version():
@@ -321,6 +321,6 @@ cpdef tuple version():
     cdef unsigned int major
     cdef unsigned int minor
     with nogil:
-        status = nvJitLinkVersion(&major, &minor)
-    check_status(status)
+        __status__ = nvJitLinkVersion(&major, &minor)
+    check_status(__status__)
     return (major, minor)

--- a/cuda_bindings/cuda/bindings/nvvm.pxd
+++ b/cuda_bindings/cuda/bindings/nvvm.pxd
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.0.1 to 13.0.1. Do not modify it directly.
+# This code was automatically generated across versions from 12.0.1 to 13.0.2. Do not modify it directly.
 
 from libc.stdint cimport intptr_t
 

--- a/cuda_bindings/cuda/bindings/nvvm.pyx
+++ b/cuda_bindings/cuda/bindings/nvvm.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.0.1 to 13.0.1. Do not modify it directly.
+# This code was automatically generated across versions from 12.0.1 to 13.0.2. Do not modify it directly.
 
 cimport cython  # NOQA
 
@@ -100,8 +100,8 @@ cpdef tuple version():
     cdef int major
     cdef int minor
     with nogil:
-        status = nvvmVersion(&major, &minor)
-    check_status(status)
+        __status__ = nvvmVersion(&major, &minor)
+    check_status(__status__)
     return (major, minor)
 
 
@@ -123,8 +123,8 @@ cpdef tuple ir_version():
     cdef int major_dbg
     cdef int minor_dbg
     with nogil:
-        status = nvvmIRVersion(&major_ir, &minor_ir, &major_dbg, &minor_dbg)
-    check_status(status)
+        __status__ = nvvmIRVersion(&major_ir, &minor_ir, &major_dbg, &minor_dbg)
+    check_status(__status__)
     return (major_ir, minor_ir, major_dbg, minor_dbg)
 
 
@@ -138,8 +138,8 @@ cpdef intptr_t create_program() except? 0:
     """
     cdef Program prog
     with nogil:
-        status = nvvmCreateProgram(&prog)
-    check_status(status)
+        __status__ = nvvmCreateProgram(&prog)
+    check_status(__status__)
     return <intptr_t>prog
 
 
@@ -160,8 +160,8 @@ cpdef add_module_to_program(intptr_t prog, buffer, size_t size, name):
     cdef bytes _temp_name_ = (<str>name).encode()
     cdef char* _name_ = _temp_name_
     with nogil:
-        status = nvvmAddModuleToProgram(<Program>prog, <const char*>_buffer_, size, <const char*>_name_)
-    check_status(status)
+        __status__ = nvvmAddModuleToProgram(<Program>prog, <const char*>_buffer_, size, <const char*>_name_)
+    check_status(__status__)
 
 
 cpdef lazy_add_module_to_program(intptr_t prog, buffer, size_t size, name):
@@ -181,8 +181,8 @@ cpdef lazy_add_module_to_program(intptr_t prog, buffer, size_t size, name):
     cdef bytes _temp_name_ = (<str>name).encode()
     cdef char* _name_ = _temp_name_
     with nogil:
-        status = nvvmLazyAddModuleToProgram(<Program>prog, <const char*>_buffer_, size, <const char*>_name_)
-    check_status(status)
+        __status__ = nvvmLazyAddModuleToProgram(<Program>prog, <const char*>_buffer_, size, <const char*>_name_)
+    check_status(__status__)
 
 
 cpdef compile_program(intptr_t prog, int num_options, options):
@@ -204,8 +204,8 @@ cpdef compile_program(intptr_t prog, int num_options, options):
     cdef nested_resource[ char ] _options_
     get_nested_resource_ptr[char](_options_, options, <char*>NULL)
     with nogil:
-        status = nvvmCompileProgram(<Program>prog, num_options, <const char**>(_options_.ptrs.data()))
-    check_status(status)
+        __status__ = nvvmCompileProgram(<Program>prog, num_options, <const char**>(_options_.ptrs.data()))
+    check_status(__status__)
 
 
 cpdef verify_program(intptr_t prog, int num_options, options):
@@ -227,8 +227,8 @@ cpdef verify_program(intptr_t prog, int num_options, options):
     cdef nested_resource[ char ] _options_
     get_nested_resource_ptr[char](_options_, options, <char*>NULL)
     with nogil:
-        status = nvvmVerifyProgram(<Program>prog, num_options, <const char**>(_options_.ptrs.data()))
-    check_status(status)
+        __status__ = nvvmVerifyProgram(<Program>prog, num_options, <const char**>(_options_.ptrs.data()))
+    check_status(__status__)
 
 
 cpdef size_t get_compiled_result_size(intptr_t prog) except? 0:
@@ -244,8 +244,8 @@ cpdef size_t get_compiled_result_size(intptr_t prog) except? 0:
     """
     cdef size_t buffer_size_ret
     with nogil:
-        status = nvvmGetCompiledResultSize(<Program>prog, &buffer_size_ret)
-    check_status(status)
+        __status__ = nvvmGetCompiledResultSize(<Program>prog, &buffer_size_ret)
+    check_status(__status__)
     return buffer_size_ret
 
 
@@ -260,8 +260,8 @@ cpdef get_compiled_result(intptr_t prog, buffer):
     """
     cdef void* _buffer_ = get_buffer_pointer(buffer, -1, readonly=False)
     with nogil:
-        status = nvvmGetCompiledResult(<Program>prog, <char*>_buffer_)
-    check_status(status)
+        __status__ = nvvmGetCompiledResult(<Program>prog, <char*>_buffer_)
+    check_status(__status__)
 
 
 cpdef size_t get_program_log_size(intptr_t prog) except? 0:
@@ -277,8 +277,8 @@ cpdef size_t get_program_log_size(intptr_t prog) except? 0:
     """
     cdef size_t buffer_size_ret
     with nogil:
-        status = nvvmGetProgramLogSize(<Program>prog, &buffer_size_ret)
-    check_status(status)
+        __status__ = nvvmGetProgramLogSize(<Program>prog, &buffer_size_ret)
+    check_status(__status__)
     return buffer_size_ret
 
 
@@ -293,5 +293,5 @@ cpdef get_program_log(intptr_t prog, buffer):
     """
     cdef void* _buffer_ = get_buffer_pointer(buffer, -1, readonly=False)
     with nogil:
-        status = nvvmGetProgramLog(<Program>prog, <char*>_buffer_)
-    check_status(status)
+        __status__ = nvvmGetProgramLog(<Program>prog, <char*>_buffer_)
+    check_status(__status__)

--- a/cuda_bindings/docs/source/release/13.X.Y-notes.rst
+++ b/cuda_bindings/docs/source/release/13.X.Y-notes.rst
@@ -1,0 +1,22 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
+
+.. module:: cuda.bindings
+
+``cuda-bindings`` 13.X.Y Release notes
+======================================
+
+
+
+Highlights
+----------
+
+* Updated the ``cuda.bindings.runtime`` module to statically link against the CUDA Runtime library from CUDA Toolkit 13.0.2.
+
+Bug fixes
+---------
+
+
+
+Known issues
+------------


### PR DESCRIPTION
## Description

Fixes #1129.

Updates the statically linked CUDA runtime to 13.0.2

I used https://github.com/NVIDIA/cuda-python/pull/960 as a template for this.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
