### PR TITLE
Adds the cython-gen generated changes for upgrade to CUDA 13.0.2

### DIFF
--- a/cuda_bindings/cuda/bindings/driver.pyx.in
+++ b/cuda_bindings/cuda/bindings/driver.pyx.in
@@ -4822,7 +4822,8 @@ class CUmemPool_attribute(IntEnum):
 
     #: (value type = int) Allow cuMemAllocAsync to insert new stream
     #: dependencies in order to establish the stream ordering required to
-    #: reuse a piece of memory released by cuFreeAsync (default enabled).
+    #: reuse a piece of memory released by cuMemFreeAsync (default
+    #: enabled).
     CU_MEMPOOL_ATTR_REUSE_ALLOW_INTERNAL_DEPENDENCIES = cydriver.CUmemPool_attribute_enum.CU_MEMPOOL_ATTR_REUSE_ALLOW_INTERNAL_DEPENDENCIES{{endif}}
     {{if 'CU_MEMPOOL_ATTR_RELEASE_THRESHOLD' in found_values}}
 

--- a/cuda_bindings/docs/source/module/driver.rst
+++ b/cuda_bindings/docs/source/module/driver.rst
@@ -4851,7 +4851,7 @@ Data types used by CUDA driver
     .. autoattribute:: cuda.bindings.driver.CUmemPool_attribute.CU_MEMPOOL_ATTR_REUSE_ALLOW_INTERNAL_DEPENDENCIES
 
 
-        (value type = int) Allow cuMemAllocAsync to insert new stream dependencies in order to establish the stream ordering required to reuse a piece of memory released by cuFreeAsync (default enabled).
+        (value type = int) Allow cuMemAllocAsync to insert new stream dependencies in order to establish the stream ordering required to reuse a piece of memory released by cuMemFreeAsync (default enabled).
 
 
     .. autoattribute:: cuda.bindings.driver.CUmemPool_attribute.CU_MEMPOOL_ATTR_RELEASE_THRESHOLD


### PR DESCRIPTION
As @rwgk [pointed out](https://github.com/NVIDIA/cuda-python/pull/1132#issuecomment-3402447062), we also need to update the `cython-gen` -generated files when updating the CTK version.  There was a docstring bugfix in those headers between 13.0.1 and 13.0.2 that is now reflected here.
