### PR TITLE
[no-ci] [chore] Fix the actionlint so shellcheck doesn't run even if installed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,11 +73,11 @@ repos:
         files: ^cuda_pathfinder/cuda/.*\.py$  # Exclude tests directory
         args: [--config-file=cuda_pathfinder/pyproject.toml]
 
-  # TODO: Reinstate after the workflows have been corrected.  See #1146
-  # - repo: https://github.com/rhysd/actionlint
-  #   rev: "03d0035246f3e81f36aed592ffb4bebf33a03106"  # frozen: v1.7.7
-  #   hooks:
-  #     - id: actionlint
+  - repo: https://github.com/rhysd/actionlint
+    rev: "03d0035246f3e81f36aed592ffb4bebf33a03106"  # frozen: v1.7.7
+    hooks:
+      - id: actionlint
+        args: ["-shellcheck="]
 
   - repo: https://github.com/MarcoGorelli/cython-lint
     rev: "d9ff7ce99ef4f2ae8fba93079ca9d76c4651d4ac"  # frozen: v0.18.0


### PR DESCRIPTION
`actionlint` runs `shellcheck` if it's installed.  However, our Github Actions `run` sections don't currently conform to `shellcheck`.  We can decide later if we want to do that, but in the meantime, this disables `shellcheck` so the pre-commit hooks don't fail if it's installed.
