### PR TITLE
[no-ci] Hot fix: skip check-tag for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
       contents: write
       pull-requests: write
     needs:
-      - check-tag
+      #- check-tag
       - determine-run-id
     secrets: inherit
     uses: ./.github/workflows/build-docs.yml
@@ -133,7 +133,7 @@ jobs:
     permissions:
       contents: write
     needs:
-      - check-tag
+      #- check-tag
       - determine-run-id
     secrets: inherit
     uses: ./.github/workflows/release-upload.yml
@@ -146,7 +146,7 @@ jobs:
     name: Publish wheels
     runs-on: ubuntu-latest
     needs:
-      - check-tag
+      #- check-tag
       - determine-run-id
     environment:
       name: ${{ inputs.wheel-dst }}


### PR DESCRIPTION
## Description

While @mdboom was releasing wheels, I undrafted the 13.0.3 release notes, causing the `check-tag` job to fail.

To work around (it seems I can't turn a public release back to a draft), I cloned the `main` branch to `release/13.0.3`, against which this PR targets. We simply let the rest of the jobs run and ignore `check-tag`.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
