### PR TITLE
Set CU_CTX_SCHED_BLOCKING_SYNC option in tests.

### DIFF
--- a/cuda_core/tests/conftest.py
+++ b/cuda_core/tests/conftest.py
@@ -32,7 +32,7 @@ def init_cuda():
     device.set_current()
 
     # Set option to avoid spin-waiting on synchronization.
-    if os.environ.get("CUDA_CORE_TEST_BLOCKING_SYNC") is not None:
+    if int(os.environ.get("CUDA_CORE_TEST_BLOCKING_SYNC", 0)) != 0:
         handle_return(
             driver.cuDevicePrimaryCtxSetFlags(device.device_id, driver.CUctx_flags.CU_CTX_SCHED_BLOCKING_SYNC)
         )


### PR DESCRIPTION
By default, CPU threads spin while waiting for GPU synchronization. This changes the option to block instead while testing.

See [cuDevicePrimaryCtxSetFlags](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__PRIMARY__CTX.html#group__CUDA__PRIMARY__CTX_1gd779a84f17acdad0d9143d9fe719cfdf) for details.