### PR TITLE
Don't strip symbols when building in --debug mode

### DIFF
--- a/cuda_bindings/setup.py
+++ b/cuda_bindings/setup.py
@@ -390,7 +390,7 @@ class ParallelBuildExtensions(build_ext):
             self.parallel = nthreads
 
     def build_extension(self, ext):
-        if building_wheel and sys.platform == "linux":
+        if building_wheel and sys.platform == "linux" and "--debug" not in sys.argv:
             # Strip binaries to remove debug symbols
             ext.extra_link_args.append("-Wl,--strip-all")
         super().build_extension(ext)


### PR DESCRIPTION
## Description

In cuda_bindings, the debug symbols are stripped from the `.so` files, even when passing the `--debug` flag.  This makes it harder to debug in `gdb` or use `valgrind` etc.