### PR TITLE
Add __cuda_stream__ protocol to driver.CUStream class

### DIFF
--- a/cuda_bindings/cuda/bindings/driver.pyx.in
+++ b/cuda_bindings/cuda/bindings/driver.pyx.in
@@ -7101,7 +7101,10 @@ cdef class CUstream:
         return <void_ptr>self._pvt_ptr[0]
     def getPtr(self):
         return <void_ptr>self._pvt_ptr
+    def __cuda_stream__(self):
+        return (0, <uintptr_t><void_ptr>(self._pvt_ptr[0]))
 {{endif}}
+
 
 {{if 'CUgraphicsResource' in found_types}}
 


### PR DESCRIPTION
## Description

Adds `__cuda_stream__` protocol to the `driver.CUstream` class. Need to add tests.

## Checklist

- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
