### PR TITLE
[BUG] Remove the check disabling windows support, and replace by checking for CUDA VMM API support

### DIFF
--- a/cuda_core/cuda/core/experimental/_memory.pyx
+++ b/cuda_core/cuda/core/experimental/_memory.pyx
@@ -1206,14 +1206,15 @@ class VirtualMemoryResource(MemoryResource):
         self.config = check_or_create_options(
             VirtualMemoryResourceOptions, config, "VirtualMemoryResource options", keep_none=False
         )
-        if self.config.location_type == "host":
+        # Matches ("host", "host_numa", "host_numa_current")
+        if "host" in self.config.location_type:
             self.device = None
 
-        if device and not device.properties.virtual_memory_management_supported:
-            raise RuntimeError("VirtualMemoryResource requires CUDA VMM API support")
+        if not self.device and self.config.location_type == "device":
+            raise RuntimeError("VirtualMemoryResource requires a device for device memory allocations")
 
-        if not device and self.config.location_type == "device":
-            raise ValueError("VirtualMemoryResource requires a device for device memory allocations")
+        if self.device and not self.device.properties.virtual_memory_management_supported:
+            raise RuntimeError("VirtualMemoryResource requires CUDA VMM API support")
 
         # Validate RDMA support if requested
         if self.config.gpu_direct_rdma and self.device is not None:


### PR DESCRIPTION
## Description
When we initially wrote this feature, I neglected to disable the functionality if VMM APIs are not supported, and instead disabled all Windows support because TCC Windows systems don't have this support. Instead, we should check for VMM APIs explicitly.
