### PR TITLE
revert: feat: add from_* style constructor classmethods to StridedMemoryView and make constructor amenable to future from_*-style constructors (#1224)

### DIFF
--- a/cuda_core/tests/test_memory.py
+++ b/cuda_core/tests/test_memory.py
@@ -609,7 +609,7 @@ def test_strided_memory_view_leak():
     arr = np.zeros(1048576, dtype=np.uint8)
     before = sys.getrefcount(arr)
     for idx in range(10):
-        StridedMemoryView.from_any_interface(arr, stream_ptr=-1)
+        StridedMemoryView(arr, stream_ptr=-1)
     after = sys.getrefcount(arr)
     assert before == after
 
@@ -617,7 +617,7 @@ def test_strided_memory_view_leak():
 def test_strided_memory_view_refcnt():
     # Use Fortran ordering so strides is used
     a = np.zeros((64, 4), dtype=np.uint8, order="F")
-    av = StridedMemoryView.from_any_interface(a, stream_ptr=-1)
+    av = StridedMemoryView(a, stream_ptr=-1)
     # segfaults if refcnt is wrong
     assert av.shape[0] == 64
     assert sys.getrefcount(av.shape) >= 2

--- a/cuda_core/tests/test_utils.py
+++ b/cuda_core/tests/test_utils.py
@@ -14,6 +14,7 @@ import cuda.core.experimental
 import numpy as np
 import pytest
 from cuda.core.experimental import Device
+from cuda.core.experimental._memoryview import view_as_cai
 from cuda.core.experimental.utils import StridedMemoryView, args_viewable_as_strided_memory
 
 
@@ -77,7 +78,7 @@ class TestViewCPU:
 
     def test_strided_memory_view_cpu(self, in_arr):
         # stream_ptr=-1 means "the consumer does not care"
-        view = StridedMemoryView.from_any_interface(in_arr, stream_ptr=-1)
+        view = StridedMemoryView(in_arr, stream_ptr=-1)
         self._check_view(view, in_arr)
 
     def _check_view(self, view, in_arr):
@@ -146,7 +147,7 @@ class TestViewGPU:
         # This is the consumer stream
         s = dev.create_stream() if use_stream else None
 
-        view = StridedMemoryView.from_any_interface(in_arr, stream_ptr=s.handle if s else -1)
+        view = StridedMemoryView(in_arr, stream_ptr=s.handle if s else -1)
         self._check_view(view, in_arr, dev)
 
     def _check_view(self, view, in_arr, dev):
@@ -178,7 +179,7 @@ class TestViewCudaArrayInterfaceGPU:
         # The usual path in `StridedMemoryView` prefers the DLPack interface
         # over __cuda_array_interface__, so we call `view_as_cai` directly
         # here so we can test the CAI code path.
-        view = StridedMemoryView.from_cuda_array_interface(in_arr, stream_ptr=s.handle if s else -1)
+        view = view_as_cai(in_arr, stream_ptr=s.handle if s else -1)
         self._check_view(view, in_arr, dev)
 
     def _check_view(self, view, in_arr, dev):


### PR DESCRIPTION
Reverts #1224. Will follow up tomorrow with a redo and deprecation of the current `__init__`.