### PR TITLE
Fix #1051: Make _graph.py compatible with cuda-python==12.6.* and fix tests

### DIFF
--- a/cuda_core/cuda/core/experimental/_graph.py
+++ b/cuda_core/cuda/core/experimental/_graph.py
@@ -318,7 +318,10 @@ class GraphBuilder:
             raise RuntimeError(
                 "Instantiation for device launch failed due to the nodes belonging to different contexts."
             )
-        elif params.result_out == driver.CUgraphInstantiateResult.CUDA_GRAPH_INSTANTIATE_CONDITIONAL_HANDLE_UNUSED:
+        elif (
+            _py_major_minor >= (12, 8)
+            and params.result_out == driver.CUgraphInstantiateResult.CUDA_GRAPH_INSTANTIATE_CONDITIONAL_HANDLE_UNUSED
+        ):
             raise RuntimeError("One or more conditional handles are not associated with conditional builders.")
         elif params.result_out != driver.CUgraphInstantiateResult.CUDA_GRAPH_INSTANTIATE_SUCCESS:
             raise RuntimeError(f"Graph instantiation failed with unexpected error code: {params.result_out}")

--- a/cuda_core/tests/test_graph.py
+++ b/cuda_core/tests/test_graph.py
@@ -304,7 +304,7 @@ def test_graph_conditional_if_else(init_cuda, condition_value):
     try:
         gb_if, gb_else = gb.if_else(handle)
     except RuntimeError as e:
-        with pytest.raises(RuntimeError, match="^Driver version"):
+        with pytest.raises(RuntimeError, match="^(Driver|Binding) version"):
             raise e
         gb.end_building()
         b.close()
@@ -377,7 +377,7 @@ def test_graph_conditional_switch(init_cuda, condition_value):
     try:
         gb_case = list(gb.switch(handle, 3))
     except RuntimeError as e:
-        with pytest.raises(RuntimeError, match="^Driver version"):
+        with pytest.raises(RuntimeError, match="^(Driver|Binding) version"):
             raise e
         gb.end_building()
         b.close()
@@ -568,7 +568,7 @@ def test_graph_update(init_cuda):
         try:
             gb_case = list(gb.switch(handle, 3))
         except Exception as e:
-            with pytest.raises(RuntimeError, match="^Driver version"):
+            with pytest.raises(RuntimeError, match="^(Driver|Binding) version"):
                 raise e
             gb.end_building()
             raise e
@@ -599,7 +599,7 @@ def test_graph_update(init_cuda):
     try:
         graph_variants = [build_graph(0), build_graph(1), build_graph(2)]
     except Exception as e:
-        with pytest.raises(RuntimeError, match="^Driver version"):
+        with pytest.raises(RuntimeError, match="^(Driver|Binding) version"):
             raise e
         b.close()
         pytest.skip("Driver does not support conditional switch")


### PR DESCRIPTION
There were two independent issues here:

- The `driver.CUgraphInstantiateResult.CUDA_GRAPH_INSTANTIATE_CONDITIONAL_HANDLE_UNUSED` enum was added in CUDA 12.8, so we can't handle it as a result type on earlier versions

- There are a number of features not supported on 12.6, and they are getting properly gated, if the driver supports the feature and the bindings don't, the exception raised will say `Bindings version (12, 6) does not support X` rather than `Driver version (12, 6) does not support X`.  For these I have just updated the tests to accept either string.

I have confirmed this makes the tests pass in a local venv where I have installed `cuda-python==12.6.2-post1` and a local checkout of `cuda_core`.  However, I don't think this is exercised in our CI.  Should we add that?