### PR TITLE
Fix references to `cuda.bindings` purged globally

### DIFF
--- a/cuda_core/cuda/core/experimental/__init__.py
+++ b/cuda_core/cuda/core/experimental/__init__.py
@@ -3,11 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 try:
-    import cuda.bindings
+    from cuda import bindings
 except ImportError:
     raise ImportError("cuda.bindings 12.x or 13.x must be installed") from None
 else:
-    cuda_major, cuda_minor = cuda.bindings.__version__.split(".")[:2]
+    cuda_major, cuda_minor = bindings.__version__.split(".")[:2]
     if cuda_major not in ("12", "13"):
         raise ImportError("cuda.bindings 12.x or 13.x must be installed")
 
@@ -24,7 +24,7 @@ except ImportError:
 else:
     del versioned_mod
 finally:
-    del cuda.bindings, importlib, subdir, cuda_major, cuda_minor
+    del bindings, importlib, subdir, cuda_major, cuda_minor
 
 from cuda.core.experimental import utils  # noqa: E402
 from cuda.core.experimental._device import Device  # noqa: E402


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
