### PR TITLE
Upgrade Cython dependency to 3.2

### DIFF
--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 [build-system]
-requires = ["setuptools>=77.0.0", "cython>=3.1,<3.2", "pyclibrary>=0.1.7"]
+requires = ["setuptools>=77.0.0", "cython>=3.2,<3.3", "pyclibrary>=0.1.7"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -35,7 +35,7 @@ all = [
 
 [dependency-groups]
 test = [
-    "cython>=3.1,<3.2",
+    "cython>=3.2,<3.3",
     "setuptools>=77.0.0",
     "numpy>=1.21.1",
     "pytest>=6.2.4",

--- a/cuda_core/pyproject.toml
+++ b/cuda_core/pyproject.toml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
-requires = ["setuptools>=77.0.0", "Cython>=3.1"]
+requires = ["setuptools>=77.0.0", "Cython>=3.2,<3.3"]
 build-backend = "build_hooks"
 backend-path = ["."]
 
@@ -51,7 +51,7 @@ cu12 = ["cuda-bindings[all]==12.*"]
 cu13 = ["cuda-bindings[all]==13.*"]
 
 [dependency-groups]
-test = ["cython>=3.1", "setuptools", "pytest>=6.2.4"]
+test = ["cython>=3.2,<3.3", "setuptools", "pytest>=6.2.4"]
 test-cu12 = ["cuda-core[test]", "cupy-cuda12x; python_version < '3.14'", "cuda-toolkit[cudart]==12.*"]  # runtime headers needed by CuPy
 test-cu13 = ["cuda-core[test]", "cupy-cuda13x; python_version < '3.14'", "cuda-toolkit[cudart]==13.*"]  # runtime headers needed by CuPy
 # free threaded build, cupy doesn't support free-threaded builds yet, so avoid installing it for now


### PR DESCRIPTION
The NVML bindings are so large that they are hitting [this bug](https://github.com/cython/cython/commit/c3594439237fe694021b684e525775fcfb14fc44), which was fixed in Cython 3.2.  I'm upgrading to Cython 3.2 here to see if that breaks anything in our CI.