### PR TITLE
Bump version & add release notes

### DIFF
--- a/cuda_core/cuda/core/_version.py
+++ b/cuda_core/cuda/core/_version.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/cuda_core/docs/nv-versions.json
+++ b/cuda_core/docs/nv-versions.json
@@ -4,6 +4,10 @@
         "url": "https://nvidia.github.io/cuda-python/cuda-core/latest/"
     },
     {
+        "version": "0.4.2",
+        "url": "https://nvidia.github.io/cuda-python/cuda-core/0.4.2/"
+    },
+    {
         "version": "0.4.1",
         "url": "https://nvidia.github.io/cuda-python/cuda-core/0.4.1/"
     },

--- a/cuda_core/docs/source/release/0.4.2-notes.rst
+++ b/cuda_core/docs/source/release/0.4.2-notes.rst
@@ -3,27 +3,36 @@
 
 .. currentmodule:: cuda.core.experimental
 
-``cuda.core`` 0.4.X Release Notes
+``cuda.core`` 0.4.2 Release Notes
 =================================
 
 
 Highlights
 ----------
 
+None.
+
 
 Breaking Changes
 ----------------
+
+None.
 
 
 New features
 ------------
 
+None.
+
 
 New examples
 ------------
+
+None.
 
 
 Fixes and enhancements
 ----------------------
 
-- Fixed a segmentation fault when accessing :class:`StridedMemoryView` ``shape`` and ``strides`` members.
+- Fixed references to the ``cuda.bindings`` module mistakenly purged globally.
+- Restored compatibility with ``cuda-python`` 12.6.


### PR DESCRIPTION
## Description

To be backported to the [`release/cuda-core-0.4.2`](https://github.com/NVIDIA/cuda-python/tree/release/cuda-core-0.4.2) branch.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
