### PR TITLE
BUG-FIX: Remove duplicate try_site_packages() call in load_nvidia_dynamic_lib

### DIFF
--- a/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/load_nvidia_dynamic_lib.py
+++ b/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/load_nvidia_dynamic_lib.py
@@ -26,8 +26,6 @@ else:
 def _load_lib_no_cache(libname: str) -> LoadedDL:
     finder = _FindNvidiaDynamicLib(libname)
     abs_path = finder.try_site_packages()
-
-    abs_path = finder.try_site_packages()
     if abs_path is not None:
         found_via = "site-packages"
     else:


### PR DESCRIPTION
BUG-FIX: Remove duplicate try_site_packages() call in load_nvidia_dynamic_lib

Remove redundant call to `try_site_packages()` that was immediately overwritten by the same call on the next line. This duplicate call was wasteful (unnecessary filesystem traversal).