### PR TITLE
[no-ci] Fix comment and skip message in `test_memory.py::test_vmm_allocator_policy_configuration`

### DIFF
--- a/cuda_core/tests/test_memory.py
+++ b/cuda_core/tests/test_memory.py
@@ -396,9 +396,9 @@ def test_vmm_allocator_policy_configuration():
     if not device.properties.virtual_memory_management_supported:
         pytest.skip("Virtual memory management is not supported on this device")
 
-    # Skip if GPU Direct RDMA is supported (we want to test the unsupported case)
+    # Skip if GPU Direct RDMA is not supported
     if not device.properties.gpu_direct_rdma_supported:
-        pytest.skip("This test requires a device that doesn't support GPU Direct RDMA")
+        pytest.skip("This test requires a device that supports GPU Direct RDMA")
 
     # Test with custom VMM config
     custom_config = VirtualMemoryResourceOptions(


### PR DESCRIPTION
This appears to be a copy-paste mishap between

https://github.com/NVIDIA/cuda-python/blob/c4079ddfb6b6dcdd7c9773b727530f122021fa9e/cuda_core/tests/test_memory.py#L399-L401

and

https://github.com/NVIDIA/cuda-python/blob/c4079ddfb6b6dcdd7c9773b727530f122021fa9e/cuda_core/tests/test_memory.py#L512-L514

introduced with PR #1179.

It's inconsequential, except that the skip message is very confusing.