### PR TITLE
[no-ci] pre-commit: exclude soft-linked `cuda_python/README.md` from `end-of-file-fixer`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
     - id: check-yaml
     - id: debug-statements
     - id: end-of-file-fixer
-      exclude: &gen_exclude '^(?:cuda_bindings/cuda/bindings/.*\.in?|cuda_bindings/docs/source/module/.*\.rst?)$'
+      exclude: &gen_exclude '^(?:cuda_python/README\.md|cuda_bindings/cuda/bindings/.*\.in?|cuda_bindings/docs/source/module/.*\.rst?)$'
     - id: mixed-line-ending
     - id: trailing-whitespace
       exclude: *gen_exclude


### PR DESCRIPTION
On Linux (including WSL) the file `cuda_python/README.md` is a real symlink, whereas on Windows Git it is checked out as a plain file containing `../README.md` (without a trailing LF). When pre-commit runs under WSL, the end-of-file-fixer hook rewrites this file, and Git Bash can no longer handle the symlink-emulation file correctly, resulting in errors on subsequent git operations.