### PR TITLE
Add `--showlocals` to all `pytest` configurations

### DIFF
--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -69,5 +69,5 @@ repair-wheel-command = "delvewheel repair --namespace-pkg cuda -w {dest_dir} {wh
 
 [tool.pytest.ini_options]
 required_plugins = "pytest-benchmark"
-addopts = "--benchmark-disable"
+addopts = "--benchmark-disable --showlocals"
 norecursedirs = ["tests/cython", "examples"]

--- a/cuda_core/pytest.ini
+++ b/cuda_core/pytest.ini
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 [pytest]
+addopts = --showlocals
 norecursedirs = cython

--- a/cuda_pathfinder/pyproject.toml
+++ b/cuda_pathfinder/pyproject.toml
@@ -68,6 +68,9 @@ readme = { file = ["DESCRIPTION.rst"], content-type = "text/x-rst" }
 requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.pytest.ini_options]
+addopts = "--showlocals"
+
 [tool.ruff]
 line-length = 120
 preview = true

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [pytest]
+addopts = --showlocals
 norecursedirs =
     cuda_bindings/examples
     cuda_core/examples


### PR DESCRIPTION
Add `--showlocals` option to `pytest` configurations across all projects to ensure consistent behavior when displaying local variables in test failures.

`pytest` does not merge `addopts` across configuration files - it uses the first configuration found. When running `pytest` from a subdirectory, the local `pytest.ini` or `pyproject.toml` takes precedence over the root config. To ensure `--showlocals` applies regardless of where `pytest` is invoked, we add it to each project's configuration:

- Root `pytest.ini`: applies when running from repository root
- `cuda_core/pytest.ini`: applies when running from `cuda_core` directory
- `cuda_bindings/pyproject.toml`: appended to existing `addopts`
- `cuda_pathfinder/pyproject.toml`: added new `pytest.ini_options` section

This approach ensures uniform `pytest` behavior across all projects while maintaining the ability to run tests from any directory.

Example behavior with `--showlocals`:

```
    def test_a_minus_b():
        a = float('inf')
        b = 1
        c = a - b
>       assert math.isfinite(c)
E       assert False
E        +  where False = <built-in function isfinite>(inf)
E        +    where <built-in function isfinite> = math.isfinite

a          = inf
b          = 1
c          = inf

tests/test_demo.py:5: AssertionError
```