### PR TITLE
test: replace cuda driver, device, and context setup with fixtures where relevant

### DIFF
--- a/cuda_bindings/pixi.lock
+++ b/cuda_bindings/pixi.lock
@@ -962,7 +962,7 @@ packages:
   - python_abi 3.14.* *_cp314
   license: LicenseRef-NVIDIA-SOFTWARE-LICENSE
   input:
-    hash: 225edd459102d1f609dc61be2335826c3aaec36d76fb657faf6559efe1937aca
+    hash: 551bbbc879e5fefd687d45528e4876eb2383a17c2d292c200e92b369eead4289
     globs:
     - pyproject.toml
 - conda: .
@@ -985,7 +985,7 @@ packages:
   - python_abi 3.14.* *_cp314
   license: LicenseRef-NVIDIA-SOFTWARE-LICENSE
   input:
-    hash: 225edd459102d1f609dc61be2335826c3aaec36d76fb657faf6559efe1937aca
+    hash: 551bbbc879e5fefd687d45528e4876eb2383a17c2d292c200e92b369eead4289
     globs:
     - pyproject.toml
 - conda: .
@@ -1005,7 +1005,7 @@ packages:
   - python_abi 3.14.* *_cp314
   license: LicenseRef-NVIDIA-SOFTWARE-LICENSE
   input:
-    hash: 225edd459102d1f609dc61be2335826c3aaec36d76fb657faf6559efe1937aca
+    hash: 551bbbc879e5fefd687d45528e4876eb2383a17c2d292c200e92b369eead4289
     globs:
     - pyproject.toml
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-13.0.85-ha770c72_0.conda

--- a/cuda_bindings/tests/conftest.py
+++ b/cuda_bindings/tests/conftest.py
@@ -18,7 +18,7 @@ def device(cuda_driver):
     return device
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module", autouse=True)
 def ctx(device):
     # Construct context
     err, ctx = cuda.cuCtxCreate(None, 0, device)

--- a/cuda_bindings/tests/test_cuda.py
+++ b/cuda_bindings/tests/test_cuda.py
@@ -38,7 +38,6 @@ def callableBinary(name):
     return shutil.which(name) is not None
 
 
-@pytest.mark.usefixtures("ctx")
 def test_cuda_memcpy():
     # Get device
 
@@ -68,7 +67,6 @@ def test_cuda_memcpy():
     assert err == cuda.CUresult.CUDA_SUCCESS
 
 
-@pytest.mark.usefixtures("ctx")
 def test_cuda_array():
     # No context created
     desc = cuda.CUDA_ARRAY_DESCRIPTOR()
@@ -167,7 +165,6 @@ def test_cuda_repr_pointer(ctx):
     assert hex(b2d_cb) == hex(func)
 
 
-@pytest.mark.usefixtures("ctx")
 def test_cuda_uuid_list_access(device):
     err, uuid = cuda.cuDeviceGetUuid(device)
     assert err == cuda.CUresult.CUDA_SUCCESS
@@ -183,7 +180,6 @@ def test_cuda_uuid_list_access(device):
     }
 
 
-@pytest.mark.usefixtures("ctx")
 def test_cuda_cuModuleLoadDataEx():
     option_keys = [
         cuda.CUjit_option.CU_JIT_INFO_LOG_BUFFER,
@@ -264,7 +260,6 @@ def test_cuda_CUstreamBatchMemOpParams():
 @pytest.mark.skipif(
     driverVersionLessThan(11030) or not supportsMemoryPool(), reason="When new attributes were introduced"
 )
-@pytest.mark.usefixtures("ctx")
 def test_cuda_memPool_attr():
     poolProps = cuda.CUmemPoolProps()
     poolProps.allocType = cuda.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_PINNED
@@ -327,7 +322,6 @@ def test_cuda_memPool_attr():
 @pytest.mark.skipif(
     driverVersionLessThan(11030) or not supportsManagedMemory(), reason="When new attributes were introduced"
 )
-@pytest.mark.usefixtures("ctx")
 def test_cuda_pointer_attr():
     err, ptr = cuda.cuMemAllocManaged(0x1000, cuda.CUmemAttach_flags.CU_MEM_ATTACH_GLOBAL.value)
     assert err == cuda.CUresult.CUDA_SUCCESS
@@ -377,7 +371,6 @@ def test_cuda_pointer_attr():
 
 
 @pytest.mark.skipif(not supportsManagedMemory(), reason="When new attributes were introduced")
-@pytest.mark.usefixtures("ctx")
 def test_cuda_mem_range_attr(device):
     size = 0x1000
     location_device = cuda.CUmemLocation()
@@ -441,7 +434,6 @@ def test_cuda_mem_range_attr(device):
 
 
 @pytest.mark.skipif(driverVersionLessThan(11040) or not supportsMemoryPool(), reason="Mempool for graphs not supported")
-@pytest.mark.usefixtures("ctx")
 def test_cuda_graphMem_attr(device):
     err, stream = cuda.cuStreamCreate(0)
     assert err == cuda.CUresult.CUDA_SUCCESS
@@ -498,7 +490,6 @@ def test_cuda_graphMem_attr(device):
     or not supportsCudaAPI("cuCoredumpGetAttributeGlobal"),
     reason="Coredump API not present",
 )
-@pytest.mark.usefixtures("ctx")
 def test_cuda_coredump_attr():
     attr_list = [None] * 6
 
@@ -529,13 +520,7 @@ def test_cuda_coredump_attr():
     assert attr_list[3] is True
 
 
-@pytest.mark.usefixtures("cuda_driver")
 def test_get_error_name_and_string():
-    err, device = cuda.cuDeviceGet(0)
-    assert err == cuda.CUresult.CUDA_SUCCESS
-    err, ctx = cuda.cuCtxCreate(None, 0, device)
-    assert err == cuda.CUresult.CUDA_SUCCESS
-
     err, device = cuda.cuDeviceGet(0)
     _, s = cuda.cuGetErrorString(err)
     assert s == b"no error"
@@ -550,7 +535,6 @@ def test_get_error_name_and_string():
 
 
 @pytest.mark.skipif(not callableBinary("nvidia-smi"), reason="Binary existence needed")
-@pytest.mark.usefixtures("ctx")
 def test_device_get_name(device):
     # TODO: Refactor this test once we have nvml bindings to avoid the use of subprocess
     import subprocess
@@ -579,7 +563,6 @@ def test_stream_capture():
     pass
 
 
-@pytest.mark.usefixtures("ctx")
 def test_profiler():
     (err,) = cuda.cuProfilerStart()
     assert err == cuda.CUresult.CUDA_SUCCESS
@@ -661,7 +644,6 @@ def test_invalid_repr_attribute():
     or not supportsCudaAPI("cuGraphExecNodeSetParams"),
     reason="Polymorphic graph APIs required",
 )
-@pytest.mark.usefixtures("ctx")
 def test_graph_poly():
     err, stream = cuda.cuStreamCreate(0)
     assert err == cuda.CUresult.CUDA_SUCCESS
@@ -771,7 +753,6 @@ def test_graph_poly():
     driverVersionLessThan(12040) or not supportsCudaAPI("cuDeviceGetDevResource"),
     reason="Polymorphic graph APIs required",
 )
-@pytest.mark.usefixtures("ctx")
 def test_cuDeviceGetDevResource(device):
     err, resource_in = cuda.cuDeviceGetDevResource(device, cuda.CUdevResourceType.CU_DEV_RESOURCE_TYPE_SM)
 

--- a/cuda_bindings/tests/test_interoperability.py
+++ b/cuda_bindings/tests/test_interoperability.py
@@ -12,7 +12,6 @@ def supportsMemoryPool():
     return err == cudart.cudaError_t.cudaSuccess and isSupported
 
 
-@pytest.mark.usefixtures("ctx")
 def test_interop_stream():
     # DRV to RT
     err_dr, stream = cuda.cuStreamCreate(0)
@@ -27,7 +26,6 @@ def test_interop_stream():
     assert err_dr == cuda.CUresult.CUDA_SUCCESS
 
 
-@pytest.mark.usefixtures("ctx")
 def test_interop_event():
     # DRV to RT
     err_dr, event = cuda.cuEventCreate(0)
@@ -42,7 +40,6 @@ def test_interop_event():
     assert err_dr == cuda.CUresult.CUDA_SUCCESS
 
 
-@pytest.mark.usefixtures("ctx")
 def test_interop_graph():
     # DRV to RT
     err_dr, graph = cuda.cuGraphCreate(0)
@@ -57,7 +54,6 @@ def test_interop_graph():
     assert err_dr == cuda.CUresult.CUDA_SUCCESS
 
 
-@pytest.mark.usefixtures("ctx")
 def test_interop_graphNode():
     err_dr, graph = cuda.cuGraphCreate(0)
     assert err_dr == cuda.CUresult.CUDA_SUCCESS
@@ -87,7 +83,6 @@ def test_interop_graphNode():
 
 
 @pytest.mark.skipif(not supportsMemoryPool(), reason="Requires mempool operations")
-@pytest.mark.usefixtures("ctx")
 def test_interop_memPool():
     # DRV to RT
     err_dr, pool = cuda.cuDeviceGetDefaultMemPool(0)
@@ -102,7 +97,6 @@ def test_interop_memPool():
     assert err_dr == cuda.CUresult.CUDA_SUCCESS
 
 
-@pytest.mark.usefixtures("ctx")
 def test_interop_graphExec():
     err_dr, graph = cuda.cuGraphCreate(0)
     assert err_dr == cuda.CUresult.CUDA_SUCCESS
@@ -125,7 +119,6 @@ def test_interop_graphExec():
     assert err_rt == cudart.cudaError_t.cudaSuccess
 
 
-@pytest.mark.usefixtures("ctx")
 def test_interop_deviceptr():
     # Allocate dev memory
     size = 1024 * np.uint8().itemsize

--- a/cuda_bindings/tests/test_kernelParams.py
+++ b/cuda_bindings/tests/test_kernelParams.py
@@ -69,7 +69,6 @@ def common_nvrtc(allKernelStrings, dev):
     return module
 
 
-@pytest.mark.usefixtures("ctx")
 def test_kernelParams_empty(device):
     kernelString = """\
     static __device__ bool isDone;
@@ -137,7 +136,6 @@ def test_kernelParams_empty(device):
 
 
 @pytest.mark.parametrize("use_ctypes_as_values", [False, True], ids=["no-ctypes", "ctypes"])
-@pytest.mark.usefixtures("ctx")
 def test_kernelParams(use_ctypes_as_values, device):
     if use_ctypes_as_values:
         assertValues_host = (
@@ -409,7 +407,6 @@ def test_kernelParams(use_ctypes_as_values, device):
     ASSERT_DRV(err)
 
 
-@pytest.mark.usefixtures("ctx")
 def test_kernelParams_types_cuda(device):
     err, uvaSupported = cuda.cuDeviceGetAttribute(
         cuda.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING, device
@@ -532,7 +529,6 @@ def test_kernelParams_types_cuda(device):
     ASSERT_DRV(err)
 
 
-@pytest.mark.usefixtures("ctx")
 def test_kernelParams_struct_custom(device):
     err, uvaSupported = cuda.cuDeviceGetAttribute(
         cuda.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING, device
@@ -605,7 +601,6 @@ def test_kernelParams_struct_custom(device):
 
 
 @pytest.mark.parametrize("pass_by_address", [False, True], ids=["by-address", "not-by-address"])
-@pytest.mark.usefixtures("ctx")
 def test_kernelParams_buffer_protocol(pass_by_address, device):
     err, uvaSupported = cuda.cuDeviceGetAttribute(
         cuda.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING, device
@@ -705,7 +700,6 @@ def test_kernelParams_buffer_protocol(pass_by_address, device):
     ASSERT_DRV(err)
 
 
-@pytest.mark.usefixtures("ctx")
 def test_kernelParams_buffer_protocol_numpy(device):
     err, uvaSupported = cuda.cuDeviceGetAttribute(
         cuda.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING, device


### PR DESCRIPTION
Factor out repetitive cuda setup in `cuda_bindings` into pytest fixtures.