### PR TITLE
feat: support `__cuda_array_interface__` in `Buffer`

### DIFF
--- a/cuda_core/pixi.lock
+++ b/cuda_core/pixi.lock
@@ -1064,7 +1064,7 @@ packages:
   - cuda-cudart >=13.0.96,<14.0a0
   license: Apache-2.0
   input:
-    hash: 830cc430c8053b2865d6c3e8e27f4ffaefad63424a7d5834e226b1106d9977ba
+    hash: f8ac21084d5b5c4a8a41214727dc62ab4ecd2f4f7de31520cf412e16a1517929
     globs:
     - pyproject.toml
 - conda: .
@@ -1083,7 +1083,7 @@ packages:
   - cuda-cudart >=13.0.96,<14.0a0
   license: Apache-2.0
   input:
-    hash: 830cc430c8053b2865d6c3e8e27f4ffaefad63424a7d5834e226b1106d9977ba
+    hash: f8ac21084d5b5c4a8a41214727dc62ab4ecd2f4f7de31520cf412e16a1517929
     globs:
     - pyproject.toml
 - conda: .
@@ -1100,7 +1100,7 @@ packages:
   - python_abi 3.14.* *_cp314
   license: Apache-2.0
   input:
-    hash: 830cc430c8053b2865d6c3e8e27f4ffaefad63424a7d5834e226b1106d9977ba
+    hash: f8ac21084d5b5c4a8a41214727dc62ab4ecd2f4f7de31520cf412e16a1517929
     globs:
     - pyproject.toml
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-12.9.86-ha770c72_2.conda


### PR DESCRIPTION
Closes https://github.com/NVIDIA/numba-cuda/issues/152 by implementing the necessary methods and properties to construct a `StridedMemoryView` from a `Buffer` using the `__cuda_array_interface__`.