### PR TITLE
VMM: purge support of win32 + add warning

### DIFF
--- a/cuda_core/cuda/core/experimental/_memory/_virtual_memory_resource.py
+++ b/cuda_core/cuda/core/experimental/_memory/_virtual_memory_resource.py
@@ -128,8 +128,7 @@ class VirtualMemoryResourceOptions:
     @staticmethod
     def _handle_type_to_driver(spec: str):
         if spec == "win32":
-            raise NotImplementedError(
-                "win32 is currently not supported, please reach out to the CUDA Python team")
+            raise NotImplementedError("win32 is currently not supported, please reach out to the CUDA Python team")
         handle_type = VirtualMemoryResourceOptions._handle_types.get(spec)
         if handle_type is None:
             raise ValueError(f"Unsupported handle_type: {spec!r}")

--- a/cuda_core/tests/test_memory.py
+++ b/cuda_core/tests/test_memory.py
@@ -3,7 +3,6 @@
 
 import ctypes
 import sys
-from ctypes import wintypes
 
 try:
     from cuda.bindings import driver


### PR DESCRIPTION
## Description

For context, see https://github.com/NVIDIA/cuda-python/issues/1263#issuecomment-3568578074.

- close #1263 
- close #1276
   - alternative solution to #1277 (by not supporting the `win32` handle type at all)

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
