### PR TITLE
feat: add `size` property to `StridedMemoryView`

### DIFF
--- a/cuda_core/cuda/core/experimental/_memoryview.pyx
+++ b/cuda_core/cuda/core/experimental/_memoryview.pyx
@@ -297,6 +297,10 @@ cdef class StridedMemoryView:
         return self.get_layout()
 
     @property
+    def size(self) -> int:
+        return self.get_layout().get_volume()
+
+    @property
     def shape(self) -> tuple[int, ...]:
         """
         Shape of the tensor.

--- a/cuda_core/tests/test_utils.py
+++ b/cuda_core/tests/test_utils.py
@@ -92,6 +92,7 @@ class TestViewCPU:
         assert isinstance(view, StridedMemoryView)
         assert view.ptr == in_arr.ctypes.data
         assert view.shape == in_arr.shape
+        assert view.size == in_arr.size
         strides_in_counts = convert_strides_to_counts(in_arr.strides, in_arr.dtype.itemsize)
         if in_arr.flags.c_contiguous:
             assert view.strides is None
@@ -172,6 +173,7 @@ class TestViewGPU:
         assert isinstance(view, StridedMemoryView)
         assert view.ptr == gpu_array_ptr(in_arr)
         assert view.shape == in_arr.shape
+        assert view.size == in_arr.size
         strides_in_counts = convert_strides_to_counts(in_arr.strides, in_arr.dtype.itemsize)
         if in_arr.flags["C_CONTIGUOUS"]:
             assert view.strides in (None, strides_in_counts)
@@ -204,6 +206,7 @@ class TestViewCudaArrayInterfaceGPU:
         assert isinstance(view, StridedMemoryView)
         assert view.ptr == gpu_array_ptr(in_arr)
         assert view.shape == in_arr.shape
+        assert view.size == in_arr.size
         strides_in_counts = convert_strides_to_counts(in_arr.strides, in_arr.dtype.itemsize)
         if in_arr.flags["C_CONTIGUOUS"]:
             assert view.strides is None


### PR DESCRIPTION
Add a `size` property to `StridedMemoryView` to avoid having dig into `layout` to get this information.