### PR TITLE
Bump version to 12.9.6

### DIFF
--- a/cuda_bindings/cuda/bindings/_version.py
+++ b/cuda_bindings/cuda/bindings/_version.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-__version__ = "12.9.5"
+__version__ = "12.9.6"


### PR DESCRIPTION
We don't plan to do this release immediately, but bumping the version now will let us write correct version checks in cuda_core against prereleased features in cuda_bindings.