### PR TITLE
perf: remove warnings calls in smv constructor methods

### DIFF
--- a/cuda_core/cuda/core/_memoryview.pyx
+++ b/cuda_core/cuda/core/_memoryview.pyx
@@ -137,30 +137,19 @@ cdef class StridedMemoryView:
 
     @classmethod
     def from_dlpack(cls, obj: object, stream_ptr: int | None=None) -> StridedMemoryView:
-        cdef StridedMemoryView buf
-        with warnings.catch_warnings():
-            # ignore the warning triggered by calling the constructor
-            # inside the library we're allowed to do this
-            warnings.simplefilter("ignore", DeprecationWarning)
-            buf = cls()
+        cdef StridedMemoryView buf = StridedMemoryView.__new__(cls)
         view_as_dlpack(obj, stream_ptr, buf)
         return buf
 
     @classmethod
     def from_cuda_array_interface(cls, obj: object, stream_ptr: int | None=None) -> StridedMemoryView:
-        cdef StridedMemoryView buf
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            buf = cls()
+        cdef StridedMemoryView buf = StridedMemoryView.__new__(cls)
         view_as_cai(obj, stream_ptr, buf)
         return buf
 
     @classmethod
     def from_array_interface(cls, obj: object) -> StridedMemoryView:
-        cdef StridedMemoryView buf
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            buf = cls()
+        cdef StridedMemoryView buf = StridedMemoryView.__new__(cls)
         view_as_array_interface(obj, buf)
         return buf
 


### PR DESCRIPTION
Remove warnings used in SMV constructor methods. These actually add significant overhead when called in a loop.