### PR TITLE
cuda.core.system: Document everything, and make it easier to scale

### DIFF
--- a/cuda_core/cuda/core/system/__init__.py
+++ b/cuda_core/cuda/core/system/__init__.py
@@ -23,16 +23,11 @@ __all__ = [
 from ._system import *
 
 if CUDA_BINDINGS_NVML_IS_COMPATIBLE:
-    from ._device import Device, DeviceArchitecture
+    from ._device import *
+    from ._device import __all__ as _device_all
     from .exceptions import *
     from .exceptions import __all__ as _exceptions_all
 
-    __all__.extend(
-        [
-            "get_nvml_version",
-            "Device",
-            "DeviceArchitecture",
-        ]
-    )
-
+    __all__.append("get_nvml_version")
+    __all__.extend(_device_all)
     __all__.extend(_exceptions_all)

--- a/cuda_core/cuda/core/system/_device.pyx
+++ b/cuda_core/cuda/core/system/_device.pyx
@@ -175,7 +175,7 @@ cdef class Device:
     """
     Representation of a device.
 
-    ``cuda.core.system.Device`` provides access to various pieces of metadata
+    :class:`cuda.core.system.Device` provides access to various pieces of metadata
     about devices and their topology, as provided by the NVIDIA Management
     Library (NVML).  To use CUDA with a device, use :class:`cuda.core.Device`.
 
@@ -312,3 +312,12 @@ cdef class Device:
         board serial identifier.
         """
         return nvml.device_get_uuid(self._handle)
+
+
+__all__ = [
+    "BAR1MemoryInfo",
+    "Device",
+    "DeviceArchitecture",
+    "MemoryInfo",
+    "PciInfo",
+]

--- a/cuda_core/docs/source/api.rst
+++ b/cuda_core/docs/source/api.rst
@@ -79,6 +79,10 @@ CUDA system information and NVIDIA Management Library (NVML)
    :template: autosummary/cyclass.rst
 
    system.Device
+   system.DeviceArchitecture
+   system.MemoryInfo
+   system.BAR1MemoryInfo
+   system.PciInfo
 
 
 .. module:: cuda.core.utils


### PR DESCRIPTION
This is just a minor follow-up to #1393 to:

a) Document all the classes in `_device.pyx`
b) Reduce some duplication in `__init__.py`