### PR TITLE
Fix #1336: Correct CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL type

### DIFF
--- a/cuda_bindings/cuda/bindings/_lib/utils.pxd.in
+++ b/cuda_bindings/cuda/bindings/_lib/utils.pxd.in
@@ -50,6 +50,7 @@ cdef class _HelperCUpointer_attribute:
     # Return values
     cdef driver.CUcontext _ctx
     cdef unsigned int _uint
+    cdef int _int
     cdef driver.CUdeviceptr _devptr
     cdef void** _void
     cdef driver.CUDA_POINTER_ATTRIBUTE_P2P_TOKENS _token

--- a/cuda_bindings/cuda/bindings/_lib/utils.pxi.in
+++ b/cuda_bindings/cuda/bindings/_lib/utils.pxi.in
@@ -247,12 +247,14 @@ cdef class _HelperCUpointer_attribute:
             else:
                 self._cptr = <void*><void_ptr>init_value.getPtr()
         elif self._attr in ({{if 'CU_POINTER_ATTRIBUTE_MEMORY_TYPE'}}cydriver.CUpointer_attribute_enum.CU_POINTER_ATTRIBUTE_MEMORY_TYPE,{{endif}}
-                            {{if 'CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL'}}cydriver.CUpointer_attribute_enum.CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,{{endif}}
                             {{if 'CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES'}}cydriver.CUpointer_attribute_enum.CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES,{{endif}}
                             {{if 'CU_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE'}}cydriver.CUpointer_attribute_enum.CU_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE,{{endif}}
                             {{if 'CU_POINTER_ATTRIBUTE_ACCESS_FLAGS'}}cydriver.CUpointer_attribute_enum.CU_POINTER_ATTRIBUTE_ACCESS_FLAGS,{{endif}}):
             self._uint = init_value
             self._cptr = <void*>&self._uint
+        elif self._attr in ({{if 'CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL'}}cydriver.CUpointer_attribute_enum.CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,{{endif}}):
+            self._int = init_value
+            self._cptr = <void*>&self._int
         elif self._attr in ({{if 'CU_POINTER_ATTRIBUTE_DEVICE_POINTER'}}cydriver.CUpointer_attribute_enum.CU_POINTER_ATTRIBUTE_DEVICE_POINTER,{{endif}}
                             {{if 'CU_POINTER_ATTRIBUTE_RANGE_START_ADDR'}}cydriver.CUpointer_attribute_enum.CU_POINTER_ATTRIBUTE_RANGE_START_ADDR,{{endif}}):
             if self._is_getter:

--- a/cuda_bindings/docs/source/release/13.1.X-notes.rst
+++ b/cuda_bindings/docs/source/release/13.1.X-notes.rst
@@ -1,0 +1,26 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
+
+.. module:: cuda.bindings
+
+``cuda-bindings`` 13.1.X Release notes
+======================================
+
+Highlights
+----------
+
+Experimental
+------------
+
+Bugfixes
+--------
+
+* Fixed an issue where the ``CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL`` attribute was
+  retrieved as an unsigned int, rather than a signed int.
+  (`PR #1336 <https://github.com/NVIDIA/cuda-python/pull/1336>`_)
+
+Known issues
+------------
+
+* Updating from older versions (v12.6.2.post1 and below) via ``pip install -U cuda-python`` might not work. Please do a clean re-installation by uninstalling ``pip uninstall -y cuda-python`` followed by installing ``pip install cuda-python``.
+* The graphics APIs in ``cuda.bindings.runtime`` are inadvertently disabled in 13.0.2.  Users needing these APIs should update to 13.0.3.

--- a/cuda_bindings/tests/test_cuda.py
+++ b/cuda_bindings/tests/test_cuda.py
@@ -370,6 +370,22 @@ def test_cuda_pointer_attr():
     assert err == cuda.CUresult.CUDA_SUCCESS
 
 
+@pytest.mark.skipif(
+    driverVersionLessThan(11030) or not supportsManagedMemory(), reason="When new attributes were introduced"
+)
+def test_pointer_get_attributes_device_ordinal():
+    attributes = [
+        cuda.CUpointer_attribute.CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,
+    ]
+
+    attrs = cuda.cuPointerGetAttributes(len(attributes), attributes, 0)
+
+    # device ordinals are always small numbers.  A large number would indicate
+    # an overflow error.
+
+    assert abs(attrs[1][0]) < 256
+
+
 @pytest.mark.skipif(not supportsManagedMemory(), reason="When new attributes were introduced")
 def test_cuda_mem_range_attr(device):
     size = 0x1000


### PR DESCRIPTION
## Description

The docs for `CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL` say:

```
 * - ::CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL:
 *
 *      Returns in \p *data an integer representing a device ordinal of a device against
 *      which the memory was allocated or registered.
```

This attribute type was erroneously being converted to an unsigned int.  This simply fixes that and adds a test.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
