### PR TITLE
Add `skipif` `IS_WINDOWS` for `test_patterngen_seeds`

### DIFF
--- a/cuda_core/tests/test_helpers.py
+++ b/cuda_core/tests/test_helpers.py
@@ -48,6 +48,10 @@ def test_latchkernel():
 
 
 @pytest.mark.skipif(
+    IS_WINDOWS,
+    reason="Extremely slow on Windows (issue #1455).",
+)
+@pytest.mark.skipif(
     under_compute_sanitizer(),
     reason="Too slow under compute-sanitizer (UVM-heavy test).",
 )


### PR DESCRIPTION
## Skip `test_patterngen_seeds` on Windows to restore CI performance

### Problem
The `test_patterngen_seeds` test runs extremely slowly on Windows platforms (up to ~945 seconds / ~15 minutes) compared to Linux (~12-15 seconds), significantly slowing down our CI and severely impeding local testing. See issue #1455 for detailed performance numbers.

### Solution
Add a `@pytest.mark.skipif` decorator to skip this test on Windows platforms. This restores CI and local testing speed while we work on investigating and fixing the root cause.

### Changes
- Added Windows skip condition to `test_patterngen_seeds` in `cuda_core/tests/test_helpers.py`
- Skip message references issue #1455 for tracking
- Test continues to run normally on Linux and other platforms