### PR TITLE
Fix intermittent ruff `I001` error for pathfinder `_version` import

### DIFF
--- a/cuda_pathfinder/cuda/pathfinder/__init__.py
+++ b/cuda_pathfinder/cuda/pathfinder/__init__.py
@@ -3,8 +3,6 @@
 
 """cuda.pathfinder public APIs"""
 
-from cuda.pathfinder._version import __version__  # noqa: F401
-
 from cuda.pathfinder._dynamic_libs.load_dl_common import DynamicLibNotFoundError as DynamicLibNotFoundError
 from cuda.pathfinder._dynamic_libs.load_dl_common import LoadedDL as LoadedDL
 from cuda.pathfinder._dynamic_libs.load_nvidia_dynamic_lib import load_nvidia_dynamic_lib as load_nvidia_dynamic_lib
@@ -13,6 +11,8 @@ from cuda.pathfinder._dynamic_libs.supported_nvidia_libs import (
 )
 from cuda.pathfinder._headers.find_nvidia_headers import find_nvidia_header_directory as find_nvidia_header_directory
 from cuda.pathfinder._headers.supported_nvidia_headers import SUPPORTED_HEADERS_CTK as _SUPPORTED_HEADERS_CTK
+
+from cuda.pathfinder._version import __version__  # isort: skip  # noqa: F401
 
 # Indirections to help Sphinx find the docstrings.
 #: Mapping from short CUDA Toolkit (CTK) library names to their canonical


### PR DESCRIPTION
Add `# isort: skip` comment to the `_version` import in `cuda_pathfinder/cuda/pathfinder/__init__.py` to prevent ruff from inconsistently reordering the import based on whether `_version.py` exists.

## Problem

Ruff's import sorting (I001) behavior is inconsistent when imports cannot be resolved. The `_version.py` file is generated by `setuptools-scm` during the build process, so its existence depends on build state:

- **When `_version.py` EXISTS (after a build):**
  Ruff can resolve the import and wants to sort it alphabetically. Since `_version` comes after `_headers` alphabetically, ruff expects the import order: `_dynamic_libs`, `_headers`, `_version`.

- **When `_version.py` DOESN'T EXIST (after `git clean -fdx` or fresh clone):**
  Ruff cannot resolve the import and may skip checking it entirely, especially if cached as "unresolvable". This leads to inconsistent behavior where the same code passes or fails depending on build state.

## Root Cause

Ruff caches import resolution results. If the cache has stale data where `_version.py` didn't exist, ruff may skip checking that import. When the cache is refreshed or `_version.py` exists, ruff resolves it and wants to sort it, triggering I001 errors inconsistently.

Example (before this PR):

```
smc120-0004.ipp2a2.colossus.nvidia.com:/wrk/forked/cuda-python $ pre-commit run --all-files
ruff check...............................................................Failed
- hook id: ruff-check
- files were modified by this hook

Fixed 1 error:
- cuda_pathfinder/cuda/pathfinder/__init__.py:
    1 × I001 (unsorted-imports)

Found 1 error (1 fixed, 0 remaining).

ruff format..............................................................Passed
Check SPDX Headers.......................................................Passed
...
```

## Solution

Add `# isort: skip` comment to explicitly tell ruff to skip sorting this import, regardless of file existence or cache state. This ensures consistent behavior in all scenarios:

- After builds (when `_version.py` exists)
- After `git clean` (when `_version.py` doesn't exist)
- With fresh clones
- With stale ruff cache

The import is placed after the other imports (where it logically belongs alphabetically) with the skip directive to prevent ruff from moving it.

## Changes

- Move `_version` import from top of file to after `_headers` imports
- Add `# isort: skip` comment to prevent ruff from reordering the import

Note: This PR was extracted from PR #1454