### PR TITLE
refactor: remove unneeded import from `cuda/core/__init__.py`

### DIFF
--- a/cuda_core/cuda/core/__init__.py
+++ b/cuda_core/cuda/core/__init__.py
@@ -15,15 +15,6 @@ else:
 
 import importlib
 
-# The _resource_handles module exports a PyCapsule dispatch table that other
-# extension modules access via PyCapsule_Import. We import it here to ensure
-# it's loaded before other modules try to use it.
-#
-# We use importlib.import_module with the full path to avoid triggering
-# circular import issues that can occur with relative imports during
-# package initialization.
-_resource_handles = importlib.import_module("cuda.core._resource_handles")
-
 subdir = f"cu{cuda_major}"
 try:
     versioned_mod = importlib.import_module(f".{subdir}", __package__)


### PR DESCRIPTION
Noticed that this import was not necessary given that the module will be importable as is without this code.