### PR TITLE
ci: enable running ci against release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
     branches:
       - "pull-request/[0-9]+"
       - "main"
+      - "release/*"
 
 jobs:
   ci-vars:


### PR DESCRIPTION
Run CI on release branches.
