### PR TITLE
test_persistence_mode_enabled: xfail nvml.NoPermissionError

### DIFF
--- a/cuda_core/tests/system/test_system_device.py
+++ b/cuda_core/tests/system/test_system_device.py
@@ -253,6 +253,9 @@ def test_persistence_mode_enabled():
         assert isinstance(is_enabled, bool)
         try:
             device.persistence_mode_enabled = False
+        except nvml.NoPermissionError as e:
+            pytest.xfail(f"nvml.NoPermissionError: {e}")
+        try:
             assert device.persistence_mode_enabled is False
         finally:
             device.persistence_mode_enabled = is_enabled


### PR DESCRIPTION
Resolves this error (error seen and fix validated on Ubuntu 24.04, linux-64):

```
=================================== FAILURES =================================== ________________________ test_persistence_mode_enabled _________________________

    @pytest.mark.skipif(helpers.IS_WSL or helpers.IS_WINDOWS, reason="Persistence mode not supported on WSL or Windows")
    def test_persistence_mode_enabled():
        for device in system.Device.get_all_devices():
            is_enabled = device.persistence_mode_enabled
            assert isinstance(is_enabled, bool)
            try:
>               device.persistence_mode_enabled = False
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

device     = <cuda.core.system._device.Device object at 0x7e6ca2dcb990>
is_enabled = False

tests/system/test_system_device.py:255:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ cuda/core/system/_device.pyx:589: in cuda.core.system._device.Device.persistence_mode_enabled.__set__
    nvml.device_set_persistence_mode(
cuda/bindings/_nvml.pyx:23818: in cuda.bindings._nvml.device_set_persistence_mode
    ???
cuda/bindings/_nvml.pyx:23829: in cuda.bindings._nvml.device_set_persistence_mode
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   cuda.bindings._nvml.NoPermissionError: Insufficient Permissions

cuda/bindings/_nvml.pyx:1811: NoPermissionError

During handling of the above exception, another exception occurred:

    @pytest.mark.skipif(helpers.IS_WSL or helpers.IS_WINDOWS, reason="Persistence mode not supported on WSL or Windows")
    def test_persistence_mode_enabled():
        for device in system.Device.get_all_devices():
            is_enabled = device.persistence_mode_enabled
            assert isinstance(is_enabled, bool)
            try:
                device.persistence_mode_enabled = False
                assert device.persistence_mode_enabled is False
            finally:
>               device.persistence_mode_enabled = is_enabled
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

device     = <cuda.core.system._device.Device object at 0x7e6ca2dcb990>
is_enabled = False

tests/system/test_system_device.py:258:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ cuda/core/system/_device.pyx:589: in cuda.core.system._device.Device.persistence_mode_enabled.__set__
    nvml.device_set_persistence_mode(
cuda/bindings/_nvml.pyx:23818: in cuda.bindings._nvml.device_set_persistence_mode
    ???
cuda/bindings/_nvml.pyx:23829: in cuda.bindings._nvml.device_set_persistence_mode
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   cuda.bindings._nvml.NoPermissionError: Insufficient Permissions

cuda/bindings/_nvml.pyx:1811: NoPermissionError
```
