### PR TITLE
Handle nvml.NotSupportedError on tests

### DIFF
--- a/cuda_bindings/tests/nvml/test_pynvml.py
+++ b/cuda_bindings/tests/nvml/test_pynvml.py
@@ -137,13 +137,19 @@ def test_device_get_p2p_status(handles, index):
 
 def test_device_get_power_usage(ngpus, handles):
     for i in range(ngpus):
-        power_mwatts = nvml.device_get_power_usage(handles[i])
+        try:
+            power_mwatts = nvml.device_get_power_usage(handles[i])
+        except nvml.NotSupportedError:
+            pytest.skip("device_get_power_usage not supported")
         assert power_mwatts >= 0.0
 
 
 def test_device_get_total_energy_consumption(ngpus, handles):
     for i in range(ngpus):
-        energy_mjoules1 = nvml.device_get_total_energy_consumption(handles[i])
+        try:
+            energy_mjoules1 = nvml.device_get_total_energy_consumption(handles[i])
+        except nvml.NotSupportedError:
+            pytest.skip("device_get_total_energy_consumption not supported")
         for j in range(10):  # idle for 150 ms
             time.sleep(0.015)  # and check for increase every 15 ms
             energy_mjoules2 = nvml.device_get_total_energy_consumption(handles[i])


### PR DESCRIPTION
This is a backport of #1487.