### PR TITLE
fix: remove incorrect noexcept from resource handle functions

### DIFF
--- a/cuda_core/cuda/core/_cpp/resource_handles.hpp
+++ b/cuda_core/cuda/core/_cpp/resource_handles.hpp
@@ -75,15 +75,15 @@ using MemoryPoolHandle = std::shared_ptr<const CUmemoryPool>;
 // ============================================================================
 
 // Function to create a non-owning context handle (references existing context).
-ContextHandle create_context_handle_ref(CUcontext ctx) noexcept;
+ContextHandle create_context_handle_ref(CUcontext ctx);
 
 // Get handle to the primary context for a device (with thread-local caching)
 // Returns empty handle on error (caller must check)
-ContextHandle get_primary_context(int device_id) noexcept;
+ContextHandle get_primary_context(int device_id);
 
 // Get handle to the current CUDA context
 // Returns empty handle if no context is current (caller must check)
-ContextHandle get_current_context() noexcept;
+ContextHandle get_current_context();
 
 // ============================================================================
 // Stream handle functions
@@ -93,26 +93,26 @@ ContextHandle get_current_context() noexcept;
 // The stream structurally depends on the provided context handle.
 // When the last reference is released, cuStreamDestroy is called automatically.
 // Returns empty handle on error (caller must check).
-StreamHandle create_stream_handle(ContextHandle h_ctx, unsigned int flags, int priority) noexcept;
+StreamHandle create_stream_handle(ContextHandle h_ctx, unsigned int flags, int priority);
 
 // Create a non-owning stream handle (references existing stream).
 // Use for borrowed streams (from foreign code) or built-in streams.
 // The stream will NOT be destroyed when the handle is released.
 // Caller is responsible for keeping the stream's context alive.
-StreamHandle create_stream_handle_ref(CUstream stream) noexcept;
+StreamHandle create_stream_handle_ref(CUstream stream);
 
 // Create a non-owning stream handle that prevents a Python owner from being GC'd.
 // The owner's refcount is incremented; decremented when handle is released.
 // The owner is responsible for keeping the stream's context alive.
-StreamHandle create_stream_handle_with_owner(CUstream stream, PyObject* owner) noexcept;
+StreamHandle create_stream_handle_with_owner(CUstream stream, PyObject* owner);
 
 // Get non-owning handle to the legacy default stream (CU_STREAM_LEGACY)
 // Note: Legacy stream has no specific context dependency.
-StreamHandle get_legacy_stream() noexcept;
+StreamHandle get_legacy_stream();
 
 // Get non-owning handle to the per-thread default stream (CU_STREAM_PER_THREAD)
 // Note: Per-thread stream has no specific context dependency.
-StreamHandle get_per_thread_stream() noexcept;
+StreamHandle get_per_thread_stream();
 
 // ============================================================================
 // Event handle functions
@@ -122,19 +122,19 @@ StreamHandle get_per_thread_stream() noexcept;
 // The event structurally depends on the provided context handle.
 // When the last reference is released, cuEventDestroy is called automatically.
 // Returns empty handle on error (caller must check).
-EventHandle create_event_handle(ContextHandle h_ctx, unsigned int flags) noexcept;
+EventHandle create_event_handle(ContextHandle h_ctx, unsigned int flags);
 
 // Create an owning event handle without context dependency.
 // Use for temporary events that are created and destroyed in the same scope.
 // When the last reference is released, cuEventDestroy is called automatically.
 // Returns empty handle on error (caller must check).
-EventHandle create_event_handle_noctx(unsigned int flags) noexcept;
+EventHandle create_event_handle_noctx(unsigned int flags);
 
 // Create an owning event handle from an IPC handle.
 // The originating process owns the event and its context.
 // When the last reference is released, cuEventDestroy is called automatically.
 // Returns empty handle on error (caller must check).
-EventHandle create_event_handle_ipc(const CUipcEventHandle& ipc_handle) noexcept;
+EventHandle create_event_handle_ipc(const CUipcEventHandle& ipc_handle);
 
 // ============================================================================
 // Memory pool handle functions
@@ -144,22 +144,22 @@ EventHandle create_event_handle_ipc(const CUipcEventHandle& ipc_handle) noexcept
 // Memory pools are device-scoped (not context-scoped).
 // When the last reference is released, cuMemPoolDestroy is called automatically.
 // Returns empty handle on error (caller must check).
-MemoryPoolHandle create_mempool_handle(const CUmemPoolProps& props) noexcept;
+MemoryPoolHandle create_mempool_handle(const CUmemPoolProps& props);
 
 // Create a non-owning memory pool handle (references existing pool).
 // Use for device default/current pools that are managed by the driver.
 // The pool will NOT be destroyed when the handle is released.
-MemoryPoolHandle create_mempool_handle_ref(CUmemoryPool pool) noexcept;
+MemoryPoolHandle create_mempool_handle_ref(CUmemoryPool pool);
 
 // Get non-owning handle to the current memory pool for a device.
 // Returns empty handle on error (caller must check).
-MemoryPoolHandle get_device_mempool(int device_id) noexcept;
+MemoryPoolHandle get_device_mempool(int device_id);
 
 // Create an owning memory pool handle from an IPC import.
 // The file descriptor is NOT owned by this handle (caller manages FD separately).
 // When the last reference is released, cuMemPoolDestroy is called automatically.
 // Returns empty handle on error (caller must check).
-MemoryPoolHandle create_mempool_handle_ipc(int fd, CUmemAllocationHandleType handle_type) noexcept;
+MemoryPoolHandle create_mempool_handle_ipc(int fd, CUmemAllocationHandleType handle_type);
 
 // ============================================================================
 // Device pointer handle functions
@@ -174,33 +174,33 @@ using DevicePtrHandle = std::shared_ptr<const CUdeviceptr>;
 DevicePtrHandle deviceptr_alloc_from_pool(
     size_t size,
     MemoryPoolHandle h_pool,
-    StreamHandle h_stream) noexcept;
+    StreamHandle h_stream);
 
 // Allocate device memory asynchronously via cuMemAllocAsync.
 // When the last reference is released, cuMemFreeAsync is called on the stored stream.
 // Returns empty handle on error (caller must check).
-DevicePtrHandle deviceptr_alloc_async(size_t size, StreamHandle h_stream) noexcept;
+DevicePtrHandle deviceptr_alloc_async(size_t size, StreamHandle h_stream);
 
 // Allocate device memory synchronously via cuMemAlloc.
 // When the last reference is released, cuMemFree is called.
 // Returns empty handle on error (caller must check).
-DevicePtrHandle deviceptr_alloc(size_t size) noexcept;
+DevicePtrHandle deviceptr_alloc(size_t size);
 
 // Allocate pinned host memory via cuMemAllocHost.
 // When the last reference is released, cuMemFreeHost is called.
 // Returns empty handle on error (caller must check).
-DevicePtrHandle deviceptr_alloc_host(size_t size) noexcept;
+DevicePtrHandle deviceptr_alloc_host(size_t size);
 
 // Create a non-owning device pointer handle (references existing pointer).
 // Use for foreign pointers (e.g., from external libraries).
 // The pointer will NOT be freed when the handle is released.
-DevicePtrHandle deviceptr_create_ref(CUdeviceptr ptr) noexcept;
+DevicePtrHandle deviceptr_create_ref(CUdeviceptr ptr);
 
 // Create a non-owning device pointer handle that prevents a Python owner from being GC'd.
 // The owner's refcount is incremented; decremented when handle is released.
 // The pointer will NOT be freed when the handle is released.
 // If owner is nullptr, equivalent to deviceptr_create_ref.
-DevicePtrHandle deviceptr_create_with_owner(CUdeviceptr ptr, PyObject* owner) noexcept;
+DevicePtrHandle deviceptr_create_with_owner(CUdeviceptr ptr, PyObject* owner);
 
 // Import a device pointer from IPC via cuMemPoolImportPointer.
 // When the last reference is released, cuMemFreeAsync is called on the stored stream.
@@ -209,7 +209,7 @@ DevicePtrHandle deviceptr_create_with_owner(CUdeviceptr ptr, PyObject* owner) no
 DevicePtrHandle deviceptr_import_ipc(
     MemoryPoolHandle h_pool,
     const void* export_data,
-    StreamHandle h_stream) noexcept;
+    StreamHandle h_stream);
 
 // Access the deallocation stream for a device pointer handle (read-only).
 // For non-owning handles, the stream is not used but can still be accessed.

--- a/cuda_core/cuda/core/_resource_handles.pxd
+++ b/cuda_core/cuda/core/_resource_handles.pxd
@@ -56,41 +56,41 @@ cdef cydriver.CUresult peek_last_error() noexcept nogil
 cdef void clear_last_error() noexcept nogil
 
 # Context handles
-cdef ContextHandle create_context_handle_ref(cydriver.CUcontext ctx) noexcept nogil
-cdef ContextHandle get_primary_context(int device_id) noexcept nogil
-cdef ContextHandle get_current_context() noexcept nogil
+cdef ContextHandle create_context_handle_ref(cydriver.CUcontext ctx) nogil except+
+cdef ContextHandle get_primary_context(int device_id) nogil except+
+cdef ContextHandle get_current_context() nogil except+
 
 # Stream handles
 cdef StreamHandle create_stream_handle(
-    ContextHandle h_ctx, unsigned int flags, int priority) noexcept nogil
-cdef StreamHandle create_stream_handle_ref(cydriver.CUstream stream) noexcept nogil
-cdef StreamHandle create_stream_handle_with_owner(cydriver.CUstream stream, object owner) noexcept nogil
-cdef StreamHandle get_legacy_stream() noexcept nogil
-cdef StreamHandle get_per_thread_stream() noexcept nogil
+    ContextHandle h_ctx, unsigned int flags, int priority) nogil except+
+cdef StreamHandle create_stream_handle_ref(cydriver.CUstream stream) nogil except+
+cdef StreamHandle create_stream_handle_with_owner(cydriver.CUstream stream, object owner) nogil except+
+cdef StreamHandle get_legacy_stream() nogil except+
+cdef StreamHandle get_per_thread_stream() nogil except+
 
 # Event handles
-cdef EventHandle create_event_handle(ContextHandle h_ctx, unsigned int flags) noexcept nogil
-cdef EventHandle create_event_handle_noctx(unsigned int flags) noexcept nogil
+cdef EventHandle create_event_handle(ContextHandle h_ctx, unsigned int flags) nogil except+
+cdef EventHandle create_event_handle_noctx(unsigned int flags) nogil except+
 cdef EventHandle create_event_handle_ipc(
-    const cydriver.CUipcEventHandle& ipc_handle) noexcept nogil
+    const cydriver.CUipcEventHandle& ipc_handle) nogil except+
 
 # Memory pool handles
 cdef MemoryPoolHandle create_mempool_handle(
-    const cydriver.CUmemPoolProps& props) noexcept nogil
-cdef MemoryPoolHandle create_mempool_handle_ref(cydriver.CUmemoryPool pool) noexcept nogil
-cdef MemoryPoolHandle get_device_mempool(int device_id) noexcept nogil
+    const cydriver.CUmemPoolProps& props) nogil except+
+cdef MemoryPoolHandle create_mempool_handle_ref(cydriver.CUmemoryPool pool) nogil except+
+cdef MemoryPoolHandle get_device_mempool(int device_id) nogil except+
 cdef MemoryPoolHandle create_mempool_handle_ipc(
-    int fd, cydriver.CUmemAllocationHandleType handle_type) noexcept nogil
+    int fd, cydriver.CUmemAllocationHandleType handle_type) nogil except+
 
 # Device pointer handles
 cdef DevicePtrHandle deviceptr_alloc_from_pool(
-    size_t size, MemoryPoolHandle h_pool, StreamHandle h_stream) noexcept nogil
-cdef DevicePtrHandle deviceptr_alloc_async(size_t size, StreamHandle h_stream) noexcept nogil
-cdef DevicePtrHandle deviceptr_alloc(size_t size) noexcept nogil
-cdef DevicePtrHandle deviceptr_alloc_host(size_t size) noexcept nogil
-cdef DevicePtrHandle deviceptr_create_ref(cydriver.CUdeviceptr ptr) noexcept nogil
-cdef DevicePtrHandle deviceptr_create_with_owner(cydriver.CUdeviceptr ptr, object owner) noexcept nogil
+    size_t size, MemoryPoolHandle h_pool, StreamHandle h_stream) nogil except+
+cdef DevicePtrHandle deviceptr_alloc_async(size_t size, StreamHandle h_stream) nogil except+
+cdef DevicePtrHandle deviceptr_alloc(size_t size) nogil except+
+cdef DevicePtrHandle deviceptr_alloc_host(size_t size) nogil except+
+cdef DevicePtrHandle deviceptr_create_ref(cydriver.CUdeviceptr ptr) nogil except+
+cdef DevicePtrHandle deviceptr_create_with_owner(cydriver.CUdeviceptr ptr, object owner) nogil except+
 cdef DevicePtrHandle deviceptr_import_ipc(
-    MemoryPoolHandle h_pool, const void* export_data, StreamHandle h_stream) noexcept nogil
+    MemoryPoolHandle h_pool, const void* export_data, StreamHandle h_stream) nogil except+
 cdef StreamHandle deallocation_stream(const DevicePtrHandle& h) noexcept nogil
 cdef void set_deallocation_stream(const DevicePtrHandle& h, StreamHandle h_stream) noexcept nogil

--- a/cuda_core/cuda/core/_resource_handles.pyx
+++ b/cuda_core/cuda/core/_resource_handles.pyx
@@ -40,52 +40,52 @@ cdef extern from "_cpp/resource_handles.hpp" namespace "cuda_core":
 
     # Context handles
     ContextHandle create_context_handle_ref "cuda_core::create_context_handle_ref" (
-        cydriver.CUcontext ctx) noexcept nogil
+        cydriver.CUcontext ctx) nogil except+
     ContextHandle get_primary_context "cuda_core::get_primary_context" (
-        int device_id) noexcept nogil
-    ContextHandle get_current_context "cuda_core::get_current_context" () noexcept nogil
+        int device_id) nogil except+
+    ContextHandle get_current_context "cuda_core::get_current_context" () nogil except+
 
     # Stream handles
     StreamHandle create_stream_handle "cuda_core::create_stream_handle" (
-        ContextHandle h_ctx, unsigned int flags, int priority) noexcept nogil
+        ContextHandle h_ctx, unsigned int flags, int priority) nogil except+
     StreamHandle create_stream_handle_ref "cuda_core::create_stream_handle_ref" (
-        cydriver.CUstream stream) noexcept nogil
+        cydriver.CUstream stream) nogil except+
     StreamHandle create_stream_handle_with_owner "cuda_core::create_stream_handle_with_owner" (
-        cydriver.CUstream stream, object owner) noexcept nogil
-    StreamHandle get_legacy_stream "cuda_core::get_legacy_stream" () noexcept nogil
-    StreamHandle get_per_thread_stream "cuda_core::get_per_thread_stream" () noexcept nogil
+        cydriver.CUstream stream, object owner) nogil except+
+    StreamHandle get_legacy_stream "cuda_core::get_legacy_stream" () nogil except+
+    StreamHandle get_per_thread_stream "cuda_core::get_per_thread_stream" () nogil except+
 
     # Event handles (note: _create_event_handle* are internal due to C++ overloading)
     EventHandle create_event_handle "cuda_core::create_event_handle" (
-        ContextHandle h_ctx, unsigned int flags) noexcept nogil
+        ContextHandle h_ctx, unsigned int flags) nogil except+
     EventHandle create_event_handle_noctx "cuda_core::create_event_handle_noctx" (
-        unsigned int flags) noexcept nogil
+        unsigned int flags) nogil except+
     EventHandle create_event_handle_ipc "cuda_core::create_event_handle_ipc" (
-        const cydriver.CUipcEventHandle& ipc_handle) noexcept nogil
+        const cydriver.CUipcEventHandle& ipc_handle) nogil except+
 
     # Memory pool handles
     MemoryPoolHandle create_mempool_handle "cuda_core::create_mempool_handle" (
-        const cydriver.CUmemPoolProps& props) noexcept nogil
+        const cydriver.CUmemPoolProps& props) nogil except+
     MemoryPoolHandle create_mempool_handle_ref "cuda_core::create_mempool_handle_ref" (
-        cydriver.CUmemoryPool pool) noexcept nogil
+        cydriver.CUmemoryPool pool) nogil except+
     MemoryPoolHandle get_device_mempool "cuda_core::get_device_mempool" (
-        int device_id) noexcept nogil
+        int device_id) nogil except+
     MemoryPoolHandle create_mempool_handle_ipc "cuda_core::create_mempool_handle_ipc" (
-        int fd, cydriver.CUmemAllocationHandleType handle_type) noexcept nogil
+        int fd, cydriver.CUmemAllocationHandleType handle_type) nogil except+
 
     # Device pointer handles
     DevicePtrHandle deviceptr_alloc_from_pool "cuda_core::deviceptr_alloc_from_pool" (
-        size_t size, MemoryPoolHandle h_pool, StreamHandle h_stream) noexcept nogil
+        size_t size, MemoryPoolHandle h_pool, StreamHandle h_stream) nogil except+
     DevicePtrHandle deviceptr_alloc_async "cuda_core::deviceptr_alloc_async" (
-        size_t size, StreamHandle h_stream) noexcept nogil
-    DevicePtrHandle deviceptr_alloc "cuda_core::deviceptr_alloc" (size_t size) noexcept nogil
-    DevicePtrHandle deviceptr_alloc_host "cuda_core::deviceptr_alloc_host" (size_t size) noexcept nogil
+        size_t size, StreamHandle h_stream) nogil except+
+    DevicePtrHandle deviceptr_alloc "cuda_core::deviceptr_alloc" (size_t size) nogil except+
+    DevicePtrHandle deviceptr_alloc_host "cuda_core::deviceptr_alloc_host" (size_t size) nogil except+
     DevicePtrHandle deviceptr_create_ref "cuda_core::deviceptr_create_ref" (
-        cydriver.CUdeviceptr ptr) noexcept nogil
+        cydriver.CUdeviceptr ptr) nogil except+
     DevicePtrHandle deviceptr_create_with_owner "cuda_core::deviceptr_create_with_owner" (
-        cydriver.CUdeviceptr ptr, object owner) noexcept nogil
+        cydriver.CUdeviceptr ptr, object owner) nogil except+
     DevicePtrHandle deviceptr_import_ipc "cuda_core::deviceptr_import_ipc" (
-        MemoryPoolHandle h_pool, const void* export_data, StreamHandle h_stream) noexcept nogil
+        MemoryPoolHandle h_pool, const void* export_data, StreamHandle h_stream) nogil except+
     StreamHandle deallocation_stream "cuda_core::deallocation_stream" (
         const DevicePtrHandle& h) noexcept nogil
     void set_deallocation_stream "cuda_core::set_deallocation_stream" (


### PR DESCRIPTION
## Summary
- Remove `noexcept` from C++ resource handle functions that can throw
- Update Cython declarations to use `nogil except+` for proper exception translation
- Ensure all custom deleters are exception-safe

## Changes

### 1. Remove incorrect `noexcept` from throwing functions

Functions that allocate memory (via `new`, `std::make_shared`, or container operations) can throw `std::bad_alloc`. Marking them `noexcept` causes `std::terminate` on OOM instead of allowing graceful error handling.

**Remove `noexcept` from 22 functions:**
- All `create_*` functions (context, stream, event, mempool, deviceptr)
- All `deviceptr_alloc*` functions
- `get_primary_context`, `get_current_context`, `get_device_mempool`
- `get_legacy_stream`, `get_per_thread_stream`

**Keep `noexcept` on 5 functions that truly cannot throw:**
- `get_last_error`, `peek_last_error`, `clear_last_error`
- `deallocation_stream`, `set_deallocation_stream`

### 2. Update Cython declarations

Change from `noexcept nogil` to `nogil except+` for all throwing functions, allowing Cython to translate C++ exceptions to Python exceptions.

### 3. Fix exception-unsafe deleters

Custom `shared_ptr` deleters must not throw (undefined behavior per C++ standard). Two deleters had potential issues:

- **`clear_mempool_peer_access`**: Uses `std::vector` which can throw `std::bad_alloc`. Wrapped in try-catch.
- **IPC cache deleter**: Uses `std::lock_guard` which can throw `std::system_error`. Wrapped cache operations in try-catch.
