### PR TITLE
Fix test-wheel-windows.yml bug and harden CI test-wheel workflows

### DIFF
--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -269,17 +269,15 @@ jobs:
       - name: Ensure cuda-python installable
         run: |
           if [[ "${{ matrix.LOCAL_CTK }}" == 1 ]]; then
-            pip install cuda_python*.whl
+            pip install --only-binary=:all: cuda_python*.whl
           else
-            pip install $(ls cuda_python*.whl)[all]
+            pip install --only-binary=:all: $(ls cuda_python*.whl)[all]
           fi
 
       - name: Install cuda.pathfinder extra wheels for testing
         run: |
           set -euo pipefail
           pushd cuda_pathfinder
-          # Install pathfinder from the pre-built wheel, since building from
-          # source won't work in this context (we don't have a git checkout).
           pip install --only-binary=:all: -v ./*.whl --group "test-cu${TEST_CUDA_MAJOR}"
           pip list
           popd

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -236,16 +236,16 @@ jobs:
       - name: Ensure cuda-python installable
         run: |
           if ('${{ matrix.LOCAL_CTK }}' -eq '1') {
-            pip install (Get-ChildItem -Filter cuda_python*.whl).FullName
+            pip install --only-binary=:all: (Get-ChildItem -Filter cuda_python*.whl).FullName
           } else {
-            pip install "$((Get-ChildItem -Filter cuda_python*.whl).FullName)[all]"
+            pip install --only-binary=:all: "$((Get-ChildItem -Filter cuda_python*.whl).FullName)[all]"
           }
 
       - name: Install cuda.pathfinder extra wheels for testing
         shell: bash --noprofile --norc -xeuo pipefail {0}
         run: |
           pushd cuda_pathfinder
-          pip install --only-binary=:all: -v . --group "test-cu${TEST_CUDA_MAJOR}"
+          pip install --only-binary=:all: -v ./*.whl --group "test-cu${TEST_CUDA_MAJOR}"
           pip list
           popd
 


### PR DESCRIPTION
Fix Windows workflow bug and harden CI workflows with `--only-binary=:all:`

Fix bug in Windows workflow where pip install used `.` directory instead of wheel files, causing `setuptools-scm` to build from source in shallow clones and produce invalid fallback versions (`0.1.dev...`). The bug was noticed because pathfinder was first built with an invalid version number due to the shallow clone, and only then replaced with a wheel in a subsequent step.

Changes:
- Windows: Change `pip install .` to `pip install ./*.whl` to prevent source builds
- Linux: Already had the correct pattern, but add `--only-binary=:all:`
- Both workflows: Systematically add `--only-binary=:all:` to all `pip install` commands to make intent explicit and guard against accidental source builds

This ensures CI tests the exact artifacts that would be distributed.