### PR TITLE
Remove context dependency from __hash__ and __eq__

### DIFF
--- a/cuda_core/cuda/core/_event.pyx
+++ b/cuda_core/cuda/core/_event.pyx
@@ -172,7 +172,7 @@ cdef class Event:
             raise RuntimeError(explanation)
 
     def __hash__(self) -> int:
-        return hash((type(self), as_intptr(self._h_context), as_intptr(self._h_event)))
+        return hash((type(self), as_intptr(self._h_event)))
 
     def __eq__(self, other) -> bool:
         # Note: using isinstance because `Event` can be subclassed.

--- a/cuda_core/cuda/core/_stream.pyx
+++ b/cuda_core/cuda/core/_stream.pyx
@@ -217,22 +217,12 @@ cdef class Stream:
         return (0, as_intptr(self._h_stream))
 
     def __hash__(self) -> int:
-        # Ensure context is initialized for hash consistency
-        Stream_ensure_ctx(self)
-        return hash((as_intptr(self._h_context), as_intptr(self._h_stream)))
+        return hash(as_intptr(self._h_stream))
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, Stream):
             return NotImplemented
-        cdef Stream _other = <Stream>other
-        # Fast path: compare handles first
-        if as_intptr(self._h_stream) != as_intptr(_other._h_stream):
-            return False
-        # Ensure contexts are initialized for both streams
-        Stream_ensure_ctx(self)
-        Stream_ensure_ctx(_other)
-        # Compare contexts as well
-        return as_intptr(self._h_context) == as_intptr(_other._h_context)
+        return as_intptr(self._h_stream) == as_intptr((<Stream>other)._h_stream)
 
     @property
     def handle(self) -> cuda.bindings.driver.CUstream:


### PR DESCRIPTION
## Summary

- Simplify `Stream.__hash__` and `Stream.__eq__` to use pointer comparison only, removing expensive `Stream_ensure_ctx` calls
- Fix `Event.__hash__` to be consistent with `Event.__eq__` by removing context from hash

## Changes

- `_stream.pyx`: Remove `Stream_ensure_ctx` calls and context comparison from `__hash__` and `__eq__`
- `_event.pyx`: Remove `_h_context` from `__hash__` (was inconsistent with `__eq__` which only compares event handle)

## Motivation

As reported in #1480, requiring CUDA context for hash/equality is problematic because:
1. For foreign streams, we may not know the associated CUDA context
2. Triggering context lookup is expensive
3. Some objects are independent of CUDA contexts

This follows the cccl-rt principle of simple pointer comparison.

Closes #1480