### PR TITLE
cuda.bindings.nvml: Correctly handle a test requiring root

### DIFF
--- a/cuda_bindings/tests/nvml/test_compute_mode.py
+++ b/cuda_bindings/tests/nvml/test_compute_mode.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 
@@ -25,8 +25,11 @@ def test_compute_mode_supported_nonroot(all_devices):
             continue
 
         for cm in COMPUTE_MODES:
-            with pytest.raises(nvml.NoPermissionError):
+            try:
                 nvml.device_set_compute_mode(device, cm)
+            except nvml.NoPermissionError:
+                skip_reasons.add(f"nvmlDeviceSetComputeMode requires root for device {device}")
+                continue
             assert original_compute_mode == nvml.device_get_compute_mode(device), "Compute mode shouldn't have changed"
 
     if skip_reasons:


### PR DESCRIPTION
The `cuda.bindings.nvml` tests were written with the assumption that they would be run by a non-root user (as is the case in our CI).  SWQA seemingly is running some tests as root, which then causes the test to fail.  This change makes the test robust to either situation.