### PR TITLE
Adopt PEP 563 annotations and modern union syntax

### DIFF
--- a/cuda_core/cuda/core/_device.pyx
+++ b/cuda_core/cuda/core/_device.pyx
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 cimport cpython
 from libc.stdint cimport uintptr_t
 
@@ -9,7 +11,6 @@ from cuda.bindings cimport cydriver
 from cuda.core._utils.cuda_utils cimport HANDLE_RETURN
 
 import threading
-from typing import TYPE_CHECKING
 
 from cuda.core._context cimport Context
 from cuda.core._context import ContextOptions
@@ -33,9 +34,6 @@ from cuda.core._utils.cuda_utils import (
     runtime,
 )
 from cuda.core._stream cimport default_stream
-
-if TYPE_CHECKING:
-    from cuda.core._memory import Buffer, MemoryResource
 
 # TODO: I prefer to type these as "cdef object" and avoid accessing them from within Python,
 # but it seems it is very convenient to expose them for testing purposes...

--- a/cuda_core/cuda/core/_event.pyx
+++ b/cuda_core/cuda/core/_event.pyx
@@ -26,14 +26,11 @@ from cuda.core._utils.cuda_utils cimport (
 import cython
 from dataclasses import dataclass
 import multiprocessing
-from typing import TYPE_CHECKING, Optional
 
 from cuda.core._utils.cuda_utils import (
     CUDAError,
     check_multiprocessing_start_method,
 )
-if TYPE_CHECKING:
-    import cuda.bindings
 
 
 @dataclass
@@ -56,9 +53,9 @@ cdef class EventOptions:
 
     """
 
-    enable_timing: Optional[bool] = False
-    busy_waited_sync: Optional[bool] = False
-    ipc_enabled: Optional[bool] = False
+    enable_timing: bool | None = False
+    busy_waited_sync: bool | None = False
+    ipc_enabled: bool | None = False
 
 
 cdef class Event:

--- a/cuda_core/cuda/core/_graph.py
+++ b/cuda_core/cuda/core/_graph.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from cuda.core._stream import Stream
+
 from cuda.core._utils.cuda_utils import (
     driver,
     get_binding_version,

--- a/cuda_core/cuda/core/_linker.py
+++ b/cuda_core/cuda/core/_linker.py
@@ -191,10 +191,10 @@ class LinkerOptions:
     prec_div: bool | None = None
     prec_sqrt: bool | None = None
     fma: bool | None = None
-    kernels_used: Union[str, tuple[str], list[str]] | None = None
-    variables_used: Union[str, tuple[str], list[str]] | None = None
+    kernels_used: str | tuple[str] | list[str] | None = None
+    variables_used: str | tuple[str] | list[str] | None = None
     optimize_unused_variables: bool | None = None
-    ptxas_options: Union[str, tuple[str], list[str]] | None = None
+    ptxas_options: str | tuple[str] | list[str] | None = None
     split_compile: int | None = None
     split_compile_extended: int | None = None
     no_cache: bool | None = None
@@ -203,7 +203,7 @@ class LinkerOptions:
         _lazy_init()
         self._name = self.name.encode()
 
-    def _prepare_nvjitlink_options(self, as_bytes: bool = False) -> Union[list[bytes], list[str]]:
+    def _prepare_nvjitlink_options(self, as_bytes: bool = False) -> list[bytes] | list[str]:
         options = []
 
         if self.arch is not None:

--- a/cuda_core/cuda/core/_memory/_buffer.pyx
+++ b/cuda_core/cuda/core/_memory/_buffer.pyx
@@ -26,7 +26,7 @@ from cuda.core._stream cimport Stream_accept, Stream
 from cuda.core._utils.cuda_utils cimport HANDLE_RETURN
 
 import sys
-from typing import TypeVar, Union
+from typing import TypeVar
 
 if sys.version_info >= (3, 12):
     from collections.abc import Buffer as BufferProtocol
@@ -40,7 +40,7 @@ from cuda.core._device import Device
 __all__ = ['Buffer', 'MemoryResource']
 
 
-DevicePointerT = Union[driver.CUdeviceptr, int, None]
+DevicePointerT = driver.CUdeviceptr | int | None
 """
 A type union of :obj:`~driver.CUdeviceptr`, `int` and `None` for hinting
 :attr:`Buffer.handle`.

--- a/cuda_core/cuda/core/_memory/_device_memory_resource.pyx
+++ b/cuda_core/cuda/core/_memory/_device_memory_resource.pyx
@@ -15,15 +15,11 @@ from cuda.core._utils.cuda_utils cimport (
 
 from dataclasses import dataclass
 import multiprocessing
-from typing import TYPE_CHECKING
 import platform  # no-cython-lint
 import uuid
 
 from cuda.core._utils.cuda_utils import check_multiprocessing_start_method
 from cuda.core._resource_handles cimport as_cu
-
-if TYPE_CHECKING:
-    from .._device import Device
 
 __all__ = ['DeviceMemoryResource', 'DeviceMemoryResourceOptions']
 

--- a/cuda_core/cuda/core/_memory/_graph_memory_resource.pyx
+++ b/cuda_core/cuda/core/_memory/_graph_memory_resource.pyx
@@ -18,10 +18,6 @@ from cuda.core._stream cimport default_stream, Stream_accept, Stream
 from cuda.core._utils.cuda_utils cimport HANDLE_RETURN
 
 from functools import cache
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from cuda.core._memory.buffer import DevicePointerT
 
 __all__ = ['GraphMemoryResource']
 

--- a/cuda_core/cuda/core/_memory/_legacy.py
+++ b/cuda_core/cuda/core/_memory/_legacy.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+if TYPE_CHECKING:
+    from cuda.core._memory._buffer import DevicePointerT
+
 from cuda.core._memory._buffer import Buffer, MemoryResource
 from cuda.core._utils.cuda_utils import (
     _check_driver_error as raise_if_driver_error,
@@ -13,9 +16,6 @@ from cuda.core._utils.cuda_utils import (
 from cuda.core._utils.cuda_utils import (
     driver,
 )
-
-if TYPE_CHECKING:
-    from cuda.core._memory.buffer import DevicePointerT
 
 __all__ = ["LegacyPinnedMemoryResource", "_SynchronousMemoryResource"]
 

--- a/cuda_core/cuda/core/_memory/_managed_memory_resource.pyx
+++ b/cuda_core/cuda/core/_memory/_managed_memory_resource.pyx
@@ -11,7 +11,6 @@ from cuda.core._utils.cuda_utils cimport (
 )
 
 from dataclasses import dataclass
-from typing import Optional
 
 __all__ = ['ManagedMemoryResource', 'ManagedMemoryResourceOptions']
 
@@ -28,7 +27,7 @@ cdef class ManagedMemoryResourceOptions:
         or None to let the driver decide.
         (Default to None)
     """
-    preferred_location : Optional[int] = None
+    preferred_location: int | None = None
 
 
 cdef class ManagedMemoryResource(_MemPool):

--- a/cuda_core/cuda/core/_memory/_memory_pool.pyx
+++ b/cuda_core/cuda/core/_memory/_memory_pool.pyx
@@ -28,15 +28,10 @@ from cuda.core._utils.cuda_utils cimport (
     HANDLE_RETURN,
 )
 
-from typing import TYPE_CHECKING
 import platform  # no-cython-lint
 import weakref
 
 from cuda.core._utils.cuda_utils import driver
-
-if TYPE_CHECKING:
-    from cuda.core._memory.buffer import DevicePointerT
-    from .._device import Device
 
 
 cdef class _MemPoolOptions:
@@ -302,7 +297,7 @@ cdef class _MemPool(MemoryResource):
         return self._ipc_data is not None and self._ipc_data._is_mapped
 
     @property
-    def uuid(self) -> Optional[uuid.UUID]:
+    def uuid(self) -> uuid.UUID | None:
         """
         A universally unique identifier for this memory resource. Meaningful
         only for IPC-enabled memory resources.

--- a/cuda_core/cuda/core/_memory/_virtual_memory_resource.py
+++ b/cuda_core/cuda/core/_memory/_virtual_memory_resource.py
@@ -5,7 +5,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Iterable, Literal, Union
+from typing import TYPE_CHECKING, Iterable, Literal
+
+if TYPE_CHECKING:
+    from cuda.core._stream import Stream
 
 from cuda.core._device import Device
 from cuda.core._memory._buffer import Buffer, MemoryResource
@@ -19,15 +22,12 @@ from cuda.core._utils.cuda_utils import (
     _check_driver_error as raise_if_driver_error,
 )
 
-if TYPE_CHECKING:
-    from cuda.core._stream import Stream
-
 __all__ = ["VirtualMemoryResourceOptions", "VirtualMemoryResource"]
 
-VirtualMemoryHandleTypeT = Union[Literal["posix_fd", "generic", "win32_kmt", "fabric"], None]
+VirtualMemoryHandleTypeT = Literal["posix_fd", "generic", "win32_kmt", "fabric"] | None
 VirtualMemoryLocationTypeT = Literal["device", "host", "host_numa", "host_numa_current"]
 VirtualMemoryGranularityT = Literal["minimum", "recommended"]
-VirtualMemoryAccessTypeT = Union[Literal["rw", "r"], None]
+VirtualMemoryAccessTypeT = Literal["rw", "r"] | None
 VirtualMemoryAllocationTypeT = Literal["pinned", "managed"]
 
 

--- a/cuda_core/cuda/core/_memoryview.pyx
+++ b/cuda_core/cuda/core/_memoryview.pyx
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from ._dlpack cimport *
 from libc.stdint cimport intptr_t
 from cuda.core._layout cimport _StridedLayout
@@ -9,7 +11,6 @@ from cuda.core._stream import Stream
 
 import functools
 import warnings
-from typing import Optional
 
 import numpy
 
@@ -321,14 +322,14 @@ cdef class StridedMemoryView:
         return self.get_layout().get_shape_tuple()
 
     @property
-    def strides(self) -> Optional[tuple[int, ...]]:
+    def strides(self) -> tuple[int, ...] | None:
         """
         Strides of the tensor (in **counts**, not bytes).
         """
         return self.get_layout().get_strides_tuple()
 
     @property
-    def dtype(self) -> Optional[numpy.dtype]:
+    def dtype(self) -> numpy.dtype | None:
         """
         Data type of the tensor.
         """

--- a/cuda_core/cuda/core/_module.py
+++ b/cuda_core/cuda/core/_module.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import functools
 import threading
 import weakref
 from collections import namedtuple
-from typing import Union
 
 from cuda.core._device import Device
 from cuda.core._launch_config import LaunchConfig, _to_native_launch_config
@@ -292,7 +293,7 @@ class KernelOccupancy:
         )
 
     def max_potential_block_size(
-        self, dynamic_shared_memory_needed: Union[int, driver.CUoccupancyB2DSize], block_size_limit: int
+        self, dynamic_shared_memory_needed: int | driver.CUoccupancyB2DSize, block_size_limit: int
     ) -> MaxPotentialBlockSizeOccupancyResult:
         """MaxPotentialBlockSizeOccupancyResult: Suggested launch configuration for reasonable occupancy.
 
@@ -487,7 +488,7 @@ class Kernel:
         return self._occupancy
 
     @staticmethod
-    def from_handle(handle: int, mod: "ObjectCode" = None) -> "Kernel":
+    def from_handle(handle: int, mod: ObjectCode = None) -> Kernel:
         """Creates a new :obj:`Kernel` object from a foreign kernel handle.
 
         Uses a CUkernel pointer address to create a new :obj:`Kernel` object.
@@ -528,7 +529,7 @@ class Kernel:
         return Kernel._from_obj(kernel_obj, mod)
 
 
-CodeTypeT = Union[bytes, bytearray, str]
+CodeTypeT = bytes | bytearray | str
 
 
 class ObjectCode:
@@ -582,7 +583,7 @@ class ObjectCode:
         return ObjectCode._reduce_helper, (self._module, self._code_type, self._name, self._sym_map)
 
     @staticmethod
-    def from_cubin(module: Union[bytes, str], *, name: str = "", symbol_mapping: dict | None = None) -> "ObjectCode":
+    def from_cubin(module: bytes | str, *, name: str = "", symbol_mapping: dict | None = None) -> ObjectCode:
         """Create an :class:`ObjectCode` instance from an existing cubin.
 
         Parameters
@@ -600,7 +601,7 @@ class ObjectCode:
         return ObjectCode._init(module, "cubin", name=name, symbol_mapping=symbol_mapping)
 
     @staticmethod
-    def from_ptx(module: Union[bytes, str], *, name: str = "", symbol_mapping: dict | None = None) -> "ObjectCode":
+    def from_ptx(module: bytes | str, *, name: str = "", symbol_mapping: dict | None = None) -> ObjectCode:
         """Create an :class:`ObjectCode` instance from an existing PTX.
 
         Parameters
@@ -618,7 +619,7 @@ class ObjectCode:
         return ObjectCode._init(module, "ptx", name=name, symbol_mapping=symbol_mapping)
 
     @staticmethod
-    def from_ltoir(module: Union[bytes, str], *, name: str = "", symbol_mapping: dict | None = None) -> "ObjectCode":
+    def from_ltoir(module: bytes | str, *, name: str = "", symbol_mapping: dict | None = None) -> ObjectCode:
         """Create an :class:`ObjectCode` instance from an existing LTOIR.
 
         Parameters
@@ -636,7 +637,7 @@ class ObjectCode:
         return ObjectCode._init(module, "ltoir", name=name, symbol_mapping=symbol_mapping)
 
     @staticmethod
-    def from_fatbin(module: Union[bytes, str], *, name: str = "", symbol_mapping: dict | None = None) -> "ObjectCode":
+    def from_fatbin(module: bytes | str, *, name: str = "", symbol_mapping: dict | None = None) -> ObjectCode:
         """Create an :class:`ObjectCode` instance from an existing fatbin.
 
         Parameters
@@ -654,7 +655,7 @@ class ObjectCode:
         return ObjectCode._init(module, "fatbin", name=name, symbol_mapping=symbol_mapping)
 
     @staticmethod
-    def from_object(module: Union[bytes, str], *, name: str = "", symbol_mapping: dict | None = None) -> "ObjectCode":
+    def from_object(module: bytes | str, *, name: str = "", symbol_mapping: dict | None = None) -> ObjectCode:
         """Create an :class:`ObjectCode` instance from an existing object code.
 
         Parameters
@@ -672,7 +673,7 @@ class ObjectCode:
         return ObjectCode._init(module, "object", name=name, symbol_mapping=symbol_mapping)
 
     @staticmethod
-    def from_library(module: Union[bytes, str], *, name: str = "", symbol_mapping: dict | None = None) -> "ObjectCode":
+    def from_library(module: bytes | str, *, name: str = "", symbol_mapping: dict | None = None) -> ObjectCode:
         """Create an :class:`ObjectCode` instance from an existing library.
 
         Parameters

--- a/cuda_core/cuda/core/_program.py
+++ b/cuda_core/cuda/core/_program.py
@@ -301,7 +301,7 @@ class ProgramOptions:
     debug: bool | None = None
     lineinfo: bool | None = None
     device_code_optimize: bool | None = None
-    ptxas_options: Union[str, list[str], tuple[str]] | None = None
+    ptxas_options: str | list[str] | tuple[str] | None = None
     max_register_count: int | None = None
     ftz: bool | None = None
     prec_sqrt: bool | None = None
@@ -311,12 +311,10 @@ class ProgramOptions:
     extra_device_vectorization: bool | None = None
     link_time_optimization: bool | None = None
     gen_opt_lto: bool | None = None
-    define_macro: (
-        Union[str, tuple[str, str], list[Union[str, tuple[str, str]]], tuple[Union[str, tuple[str, str]]]] | None
-    ) = None
-    undefine_macro: Union[str, list[str], tuple[str]] | None = None
-    include_path: Union[str, list[str], tuple[str]] | None = None
-    pre_include: Union[str, list[str], tuple[str]] | None = None
+    define_macro: str | tuple[str, str] | list[str | tuple[str, str]] | tuple[str | tuple[str, str], ...] | None = None
+    undefine_macro: str | list[str] | tuple[str] | None = None
+    include_path: str | list[str] | tuple[str] | None = None
+    pre_include: str | list[str] | tuple[str] | None = None
     no_source_include: bool | None = None
     std: str | None = None
     builtin_move_forward: bool | None = None
@@ -327,9 +325,9 @@ class ProgramOptions:
     device_int128: bool | None = None
     optimization_info: str | None = None
     no_display_error_number: bool | None = None
-    diag_error: Union[int, list[int], tuple[int]] | None = None
-    diag_suppress: Union[int, list[int], tuple[int]] | None = None
-    diag_warn: Union[int, list[int], tuple[int]] | None = None
+    diag_error: int | list[int] | tuple[int] | None = None
+    diag_suppress: int | list[int] | tuple[int] | None = None
+    diag_warn: int | list[int] | tuple[int] | None = None
     brief_diagnostics: bool | None = None
     time: str | None = None
     split_compile: int | None = None
@@ -492,7 +490,7 @@ class ProgramOptions:
             options.append("--numba-debug")
         return [o.encode() for o in options]
 
-    def _prepare_nvvm_options(self, as_bytes: bool = True) -> Union[list[bytes], list[str]]:
+    def _prepare_nvvm_options(self, as_bytes: bool = True) -> list[bytes] | list[str]:
         options = []
 
         # Options supported by NVVM

--- a/cuda_core/cuda/core/_stream.pyx
+++ b/cuda_core/cuda/core/_stream.pyx
@@ -18,11 +18,8 @@ from cuda.core._utils.cuda_utils cimport (
 import cython
 import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Protocol, Union
+from typing import Protocol
 
-if TYPE_CHECKING:
-    import cuda.bindings
-    from cuda.core._device import Device
 from cuda.core._context cimport Context
 from cuda.core._event import Event, EventOptions
 from cuda.core._resource_handles cimport (
@@ -59,7 +56,7 @@ cdef class StreamOptions:
     """
 
     nonblocking : cython.bint = True
-    priority: Optional[int] = None
+    priority: int | None = None
 
 
 class IsStreamT(Protocol):
@@ -296,7 +293,7 @@ cdef class Stream:
             HANDLE_RETURN(cydriver.cuEventRecord(e, as_cu(self._h_stream)))
         return event
 
-    def wait(self, event_or_stream: Union[Event, Stream]):
+    def wait(self, event_or_stream: Event | Stream):
         """Wait for a CUDA event or a CUDA stream.
 
         Waiting for an event or a stream establishes a stream order.


### PR DESCRIPTION
## Summary
- Use `from __future__ import annotations` consistently across cuda.core
- Replace `Union[X, Y]` with `X | Y` and `Optional[X]` with `X | None` in type annotations
- Remove redundant `TYPE_CHECKING` blocks where the imports are no longer needed
- Retain `TYPE_CHECKING` blocks only where needed for forward references (circular imports)

## Changes
- 15 files updated with modern type annotation syntax
- Net reduction of ~20 lines

## Test Coverage
- All existing tests pass
- No new tests needed (type annotation changes only)