### PR TITLE
fix: add init_cuda fixture to tests requiring CUDA context

### DIFF
--- a/cuda_core/tests/test_utils.py
+++ b/cuda_core/tests/test_utils.py
@@ -345,7 +345,7 @@ def _get_ptr(array):
         for view_as in ["dlpack", "cai"]
     ],
 )
-def test_view_sliced_external(shape, slices, stride_order, view_as):
+def test_view_sliced_external(init_cuda, shape, slices, stride_order, view_as):
     if view_as == "dlpack":
         if np is None:
             pytest.skip("NumPy is not installed")
@@ -380,7 +380,7 @@ def test_view_sliced_external(shape, slices, stride_order, view_as):
     ("stride_order", "view_as"),
     [(stride_order, view_as) for stride_order in ["C", "F"] for view_as in ["dlpack", "cai"]],
 )
-def test_view_sliced_external_negative_offset(stride_order, view_as):
+def test_view_sliced_external_negative_offset(init_cuda, stride_order, view_as):
     shape = (5,)
     if view_as == "dlpack":
         if np is None:
@@ -422,7 +422,7 @@ def test_view_sliced_external_negative_offset(stride_order, view_as):
 )
 @pytest.mark.parametrize("shape", [(0,), (0, 0), (0, 0, 0)])
 @pytest.mark.parametrize("dtype", [np.int64, np.uint8, np.float64])
-def test_view_zero_size_array(api, shape, dtype):
+def test_view_zero_size_array(init_cuda, api, shape, dtype):
     cp = pytest.importorskip("cupy")
 
     x = cp.empty(shape, dtype=dtype)
@@ -446,7 +446,7 @@ def test_from_buffer_with_non_power_of_two_itemsize():
     assert view.dtype == dtype
 
 
-def test_struct_array():
+def test_struct_array(init_cuda):
     cp = pytest.importorskip("cupy")
 
     x = np.array([(1.0, 2), (2.0, 3)], dtype=[("array1", np.float64), ("array2", np.int64)])


### PR DESCRIPTION
## Summary

Four tests in `test_utils.py` relied on CuPy implicitly creating a CUDA context but failed intermittently when `pytest-randomly` ordered them after tests using the `init_cuda` fixture, which pops the context on cleanup.

The affected tests are:
- `test_view_sliced_external`
- `test_view_sliced_external_negative_offset`
- `test_view_zero_size_array`
- `test_struct_array`

## Root Cause

The `init_cuda` fixture calls `Device().set_current()` before a test and pops the context via `cuCtxPopCurrent()` after the test completes. When a CuPy-based test runs next without its own context setup, CUDA API calls (like `cuCtxGetDevice()` for zero-sized arrays) fail with `CUDA_ERROR_INVALID_CONTEXT`.

## Fix

Add the `init_cuda` fixture to all four affected tests to ensure a CUDA context is always current.

## Test Plan

- [x] Verified failure on main with seed `3529696628`
- [x] Verified fix passes with multiple random seeds
- [x] All 128 tests in `test_utils.py` pass consistently