### PR TITLE
Use faster method to get enum values

### DIFF
--- a/cuda_bindings/cuda/bindings/driver.pyx.in
+++ b/cuda_bindings/cuda/bindings/driver.pyx.in
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 # This code was automatically generated with version 13.1.0. Do not modify it directly.
@@ -8398,7 +8398,7 @@ cdef class CUstreamMemOpWaitValueParams_st:
         return _dict_CUstreamBatchMemOpType[self._pvt_ptr[0].waitValue.operation]
     @operation.setter
     def operation(self, operation not None : CUstreamBatchMemOpType):
-        self._pvt_ptr[0].waitValue.operation = operation.value
+        self._pvt_ptr[0].waitValue.operation = int(operation)
     {{endif}}
     {{if 'CUstreamBatchMemOpParams_union.waitValue.address' in found_struct}}
     @property
@@ -8588,7 +8588,7 @@ cdef class CUstreamMemOpWriteValueParams_st:
         return _dict_CUstreamBatchMemOpType[self._pvt_ptr[0].writeValue.operation]
     @operation.setter
     def operation(self, operation not None : CUstreamBatchMemOpType):
-        self._pvt_ptr[0].writeValue.operation = operation.value
+        self._pvt_ptr[0].writeValue.operation = int(operation)
     {{endif}}
     {{if 'CUstreamBatchMemOpParams_union.writeValue.address' in found_struct}}
     @property
@@ -8726,7 +8726,7 @@ cdef class CUstreamMemOpFlushRemoteWritesParams_st:
         return _dict_CUstreamBatchMemOpType[self._pvt_ptr[0].flushRemoteWrites.operation]
     @operation.setter
     def operation(self, operation not None : CUstreamBatchMemOpType):
-        self._pvt_ptr[0].flushRemoteWrites.operation = operation.value
+        self._pvt_ptr[0].flushRemoteWrites.operation = int(operation)
     {{endif}}
     {{if 'CUstreamBatchMemOpParams_union.flushRemoteWrites.flags' in found_struct}}
     @property
@@ -8792,7 +8792,7 @@ cdef class CUstreamMemOpMemoryBarrierParams_st:
         return _dict_CUstreamBatchMemOpType[self._pvt_ptr[0].memoryBarrier.operation]
     @operation.setter
     def operation(self, operation not None : CUstreamBatchMemOpType):
-        self._pvt_ptr[0].memoryBarrier.operation = operation.value
+        self._pvt_ptr[0].memoryBarrier.operation = int(operation)
     {{endif}}
     {{if 'CUstreamBatchMemOpParams_union.memoryBarrier.flags' in found_struct}}
     @property
@@ -8917,7 +8917,7 @@ cdef class CUstreamMemOpAtomicReductionParams_st:
         return _dict_CUstreamBatchMemOpType[self._pvt_ptr[0].atomicReduction.operation]
     @operation.setter
     def operation(self, operation not None : CUstreamBatchMemOpType):
-        self._pvt_ptr[0].atomicReduction.operation = operation.value
+        self._pvt_ptr[0].atomicReduction.operation = int(operation)
     {{endif}}
     {{if 'CUstreamBatchMemOpParams_union.atomicReduction.flags' in found_struct}}
     @property
@@ -8935,7 +8935,7 @@ cdef class CUstreamMemOpAtomicReductionParams_st:
         return _dict_CUstreamAtomicReductionOpType[self._pvt_ptr[0].atomicReduction.reductionOp]
     @reductionOp.setter
     def reductionOp(self, reductionOp not None : CUstreamAtomicReductionOpType):
-        self._pvt_ptr[0].atomicReduction.reductionOp = reductionOp.value
+        self._pvt_ptr[0].atomicReduction.reductionOp = int(reductionOp)
     {{endif}}
     {{if 'CUstreamBatchMemOpParams_union.atomicReduction.dataType' in found_struct}}
     @property
@@ -8945,7 +8945,7 @@ cdef class CUstreamMemOpAtomicReductionParams_st:
         return _dict_CUstreamAtomicReductionDataType[self._pvt_ptr[0].atomicReduction.dataType]
     @dataType.setter
     def dataType(self, dataType not None : CUstreamAtomicReductionDataType):
-        self._pvt_ptr[0].atomicReduction.dataType = dataType.value
+        self._pvt_ptr[0].atomicReduction.dataType = int(dataType)
     {{endif}}
     {{if 'CUstreamBatchMemOpParams_union.atomicReduction.address' in found_struct}}
     @property
@@ -9129,7 +9129,7 @@ cdef class CUstreamBatchMemOpParams_union:
         return _dict_CUstreamBatchMemOpType[self._pvt_ptr[0].operation]
     @operation.setter
     def operation(self, operation not None : CUstreamBatchMemOpType):
-        self._pvt_ptr[0].operation = operation.value
+        self._pvt_ptr[0].operation = int(operation)
     {{endif}}
     {{if 'CUstreamBatchMemOpParams_union.waitValue' in found_struct}}
     @property
@@ -9612,7 +9612,7 @@ cdef class CUasyncNotificationInfo_st:
         return _dict_CUasyncNotificationType[self._pvt_ptr[0].type]
     @type.setter
     def type(self, type not None : CUasyncNotificationType):
-        self._pvt_ptr[0].type = type.value
+        self._pvt_ptr[0].type = int(type)
     {{endif}}
     {{if 'CUasyncNotificationInfo_st.info' in found_struct}}
     @property
@@ -9961,7 +9961,7 @@ cdef class CUaccessPolicyWindow_st:
         return _dict_CUaccessProperty[self._pvt_ptr[0].hitProp]
     @hitProp.setter
     def hitProp(self, hitProp not None : CUaccessProperty):
-        self._pvt_ptr[0].hitProp = hitProp.value
+        self._pvt_ptr[0].hitProp = int(hitProp)
     {{endif}}
     {{if 'CUaccessPolicyWindow_st.missProp' in found_struct}}
     @property
@@ -9971,7 +9971,7 @@ cdef class CUaccessPolicyWindow_st:
         return _dict_CUaccessProperty[self._pvt_ptr[0].missProp]
     @missProp.setter
     def missProp(self, missProp not None : CUaccessProperty):
-        self._pvt_ptr[0].missProp = missProp.value
+        self._pvt_ptr[0].missProp = int(missProp)
     {{endif}}
 {{endif}}
 {{if 'CUDA_KERNEL_NODE_PARAMS_st' in found_struct}}
@@ -11403,7 +11403,7 @@ cdef class CUDA_CONDITIONAL_NODE_PARAMS:
         return _dict_CUgraphConditionalNodeType[self._pvt_ptr[0].type]
     @type.setter
     def type(self, type not None : CUgraphConditionalNodeType):
-        self._pvt_ptr[0].type = type.value
+        self._pvt_ptr[0].type = int(type)
     {{endif}}
     {{if 'CUDA_CONDITIONAL_NODE_PARAMS.size' in found_struct}}
     @property
@@ -11703,7 +11703,7 @@ cdef class CUDA_GRAPH_INSTANTIATE_PARAMS_st:
         return _dict_CUgraphInstantiateResult[self._pvt_ptr[0].result_out]
     @result_out.setter
     def result_out(self, result_out not None : CUgraphInstantiateResult):
-        self._pvt_ptr[0].result_out = result_out.value
+        self._pvt_ptr[0].result_out = int(result_out)
     {{endif}}
 {{endif}}
 {{if 'CUlaunchMemSyncDomainMap_st' in found_struct}}
@@ -12486,7 +12486,7 @@ cdef class CUlaunchAttributeValue_union:
         return _dict_CUsynchronizationPolicy[self._pvt_ptr[0].syncPolicy]
     @syncPolicy.setter
     def syncPolicy(self, syncPolicy not None : CUsynchronizationPolicy):
-        self._pvt_ptr[0].syncPolicy = syncPolicy.value
+        self._pvt_ptr[0].syncPolicy = int(syncPolicy)
     {{endif}}
     {{if 'CUlaunchAttributeValue_union.clusterDim' in found_struct}}
     @property
@@ -12504,7 +12504,7 @@ cdef class CUlaunchAttributeValue_union:
         return _dict_CUclusterSchedulingPolicy[self._pvt_ptr[0].clusterSchedulingPolicyPreference]
     @clusterSchedulingPolicyPreference.setter
     def clusterSchedulingPolicyPreference(self, clusterSchedulingPolicyPreference not None : CUclusterSchedulingPolicy):
-        self._pvt_ptr[0].clusterSchedulingPolicyPreference = clusterSchedulingPolicyPreference.value
+        self._pvt_ptr[0].clusterSchedulingPolicyPreference = int(clusterSchedulingPolicyPreference)
     {{endif}}
     {{if 'CUlaunchAttributeValue_union.programmaticStreamSerializationAllowed' in found_struct}}
     @property
@@ -12554,7 +12554,7 @@ cdef class CUlaunchAttributeValue_union:
         return _dict_CUlaunchMemSyncDomain[self._pvt_ptr[0].memSyncDomain]
     @memSyncDomain.setter
     def memSyncDomain(self, memSyncDomain not None : CUlaunchMemSyncDomain):
-        self._pvt_ptr[0].memSyncDomain = memSyncDomain.value
+        self._pvt_ptr[0].memSyncDomain = int(memSyncDomain)
     {{endif}}
     {{if 'CUlaunchAttributeValue_union.preferredClusterDim' in found_struct}}
     @property
@@ -12651,7 +12651,7 @@ cdef class CUlaunchAttribute_st:
         return _dict_CUlaunchAttributeID[self._pvt_ptr[0].id]
     @id.setter
     def id(self, id not None : CUlaunchAttributeID):
-        self._pvt_ptr[0].id = id.value
+        self._pvt_ptr[0].id = int(id)
     {{endif}}
     {{if 'CUlaunchAttribute_st.value' in found_struct}}
     @property
@@ -13068,7 +13068,7 @@ cdef class CUexecAffinityParam_st:
         return _dict_CUexecAffinityType[self._pvt_ptr[0].type]
     @type.setter
     def type(self, type not None : CUexecAffinityType):
-        self._pvt_ptr[0].type = type.value
+        self._pvt_ptr[0].type = int(type)
     {{endif}}
     {{if 'CUexecAffinityParam_st.param' in found_struct}}
     @property
@@ -13138,7 +13138,7 @@ cdef class CUctxCigParam_st:
         return _dict_CUcigDataType[self._pvt_ptr[0].sharedDataType]
     @sharedDataType.setter
     def sharedDataType(self, sharedDataType not None : CUcigDataType):
-        self._pvt_ptr[0].sharedDataType = sharedDataType.value
+        self._pvt_ptr[0].sharedDataType = int(sharedDataType)
     {{endif}}
     {{if 'CUctxCigParam_st.sharedData' in found_struct}}
     @property
@@ -13606,7 +13606,7 @@ cdef class CUDA_MEMCPY2D_st:
         return _dict_CUmemorytype[self._pvt_ptr[0].srcMemoryType]
     @srcMemoryType.setter
     def srcMemoryType(self, srcMemoryType not None : CUmemorytype):
-        self._pvt_ptr[0].srcMemoryType = srcMemoryType.value
+        self._pvt_ptr[0].srcMemoryType = int(srcMemoryType)
     {{endif}}
     {{if 'CUDA_MEMCPY2D_st.srcHost' in found_struct}}
     @property
@@ -13684,7 +13684,7 @@ cdef class CUDA_MEMCPY2D_st:
         return _dict_CUmemorytype[self._pvt_ptr[0].dstMemoryType]
     @dstMemoryType.setter
     def dstMemoryType(self, dstMemoryType not None : CUmemorytype):
-        self._pvt_ptr[0].dstMemoryType = dstMemoryType.value
+        self._pvt_ptr[0].dstMemoryType = int(dstMemoryType)
     {{endif}}
     {{if 'CUDA_MEMCPY2D_st.dstHost' in found_struct}}
     @property
@@ -14089,7 +14089,7 @@ cdef class CUDA_MEMCPY3D_st:
         return _dict_CUmemorytype[self._pvt_ptr[0].srcMemoryType]
     @srcMemoryType.setter
     def srcMemoryType(self, srcMemoryType not None : CUmemorytype):
-        self._pvt_ptr[0].srcMemoryType = srcMemoryType.value
+        self._pvt_ptr[0].srcMemoryType = int(srcMemoryType)
     {{endif}}
     {{if 'CUDA_MEMCPY3D_st.srcHost' in found_struct}}
     @property
@@ -14200,7 +14200,7 @@ cdef class CUDA_MEMCPY3D_st:
         return _dict_CUmemorytype[self._pvt_ptr[0].dstMemoryType]
     @dstMemoryType.setter
     def dstMemoryType(self, dstMemoryType not None : CUmemorytype):
-        self._pvt_ptr[0].dstMemoryType = dstMemoryType.value
+        self._pvt_ptr[0].dstMemoryType = int(dstMemoryType)
     {{endif}}
     {{if 'CUDA_MEMCPY3D_st.dstHost' in found_struct}}
     @property
@@ -14637,7 +14637,7 @@ cdef class CUDA_MEMCPY3D_PEER_st:
         return _dict_CUmemorytype[self._pvt_ptr[0].srcMemoryType]
     @srcMemoryType.setter
     def srcMemoryType(self, srcMemoryType not None : CUmemorytype):
-        self._pvt_ptr[0].srcMemoryType = srcMemoryType.value
+        self._pvt_ptr[0].srcMemoryType = int(srcMemoryType)
     {{endif}}
     {{if 'CUDA_MEMCPY3D_PEER_st.srcHost' in found_struct}}
     @property
@@ -14756,7 +14756,7 @@ cdef class CUDA_MEMCPY3D_PEER_st:
         return _dict_CUmemorytype[self._pvt_ptr[0].dstMemoryType]
     @dstMemoryType.setter
     def dstMemoryType(self, dstMemoryType not None : CUmemorytype):
-        self._pvt_ptr[0].dstMemoryType = dstMemoryType.value
+        self._pvt_ptr[0].dstMemoryType = int(dstMemoryType)
     {{endif}}
     {{if 'CUDA_MEMCPY3D_PEER_st.dstHost' in found_struct}}
     @property
@@ -15074,7 +15074,7 @@ cdef class CUDA_ARRAY_DESCRIPTOR_st:
         return _dict_CUarray_format[self._pvt_ptr[0].Format]
     @Format.setter
     def Format(self, Format not None : CUarray_format):
-        self._pvt_ptr[0].Format = Format.value
+        self._pvt_ptr[0].Format = int(Format)
     {{endif}}
     {{if 'CUDA_ARRAY_DESCRIPTOR_st.NumChannels' in found_struct}}
     @property
@@ -15208,7 +15208,7 @@ cdef class CUDA_ARRAY3D_DESCRIPTOR_st:
         return _dict_CUarray_format[self._pvt_ptr[0].Format]
     @Format.setter
     def Format(self, Format not None : CUarray_format):
-        self._pvt_ptr[0].Format = Format.value
+        self._pvt_ptr[0].Format = int(Format)
     {{endif}}
     {{if 'CUDA_ARRAY3D_DESCRIPTOR_st.NumChannels' in found_struct}}
     @property
@@ -15733,7 +15733,7 @@ cdef class anon_struct9:
         return _dict_CUarray_format[self._pvt_ptr[0].res.linear.format]
     @format.setter
     def format(self, format not None : CUarray_format):
-        self._pvt_ptr[0].res.linear.format = format.value
+        self._pvt_ptr[0].res.linear.format = int(format)
     {{endif}}
     {{if 'CUDA_RESOURCE_DESC_st.res.linear.numChannels' in found_struct}}
     @property
@@ -15868,7 +15868,7 @@ cdef class anon_struct10:
         return _dict_CUarray_format[self._pvt_ptr[0].res.pitch2D.format]
     @format.setter
     def format(self, format not None : CUarray_format):
-        self._pvt_ptr[0].res.pitch2D.format = format.value
+        self._pvt_ptr[0].res.pitch2D.format = int(format)
     {{endif}}
     {{if 'CUDA_RESOURCE_DESC_st.res.pitch2D.numChannels' in found_struct}}
     @property
@@ -16156,7 +16156,7 @@ cdef class CUDA_RESOURCE_DESC_st:
         return _dict_CUresourcetype[self._pvt_ptr[0].resType]
     @resType.setter
     def resType(self, resType not None : CUresourcetype):
-        self._pvt_ptr[0].resType = resType.value
+        self._pvt_ptr[0].resType = int(resType)
     {{endif}}
     {{if 'CUDA_RESOURCE_DESC_st.res' in found_struct}}
     @property
@@ -16312,7 +16312,7 @@ cdef class CUDA_TEXTURE_DESC_st:
         return [_dict_CUaddress_mode[_x] if _x in _dict_CUaddress_mode else None for _x in list(self._pvt_ptr[0].addressMode)]
     @addressMode.setter
     def addressMode(self, addressMode):
-        self._pvt_ptr[0].addressMode = [_x.value for _x in addressMode]
+        self._pvt_ptr[0].addressMode = [int(_x) for _x in addressMode]
     {{endif}}
     {{if 'CUDA_TEXTURE_DESC_st.filterMode' in found_struct}}
     @property
@@ -16322,7 +16322,7 @@ cdef class CUDA_TEXTURE_DESC_st:
         return _dict_CUfilter_mode[self._pvt_ptr[0].filterMode]
     @filterMode.setter
     def filterMode(self, filterMode not None : CUfilter_mode):
-        self._pvt_ptr[0].filterMode = filterMode.value
+        self._pvt_ptr[0].filterMode = int(filterMode)
     {{endif}}
     {{if 'CUDA_TEXTURE_DESC_st.flags' in found_struct}}
     @property
@@ -16348,7 +16348,7 @@ cdef class CUDA_TEXTURE_DESC_st:
         return _dict_CUfilter_mode[self._pvt_ptr[0].mipmapFilterMode]
     @mipmapFilterMode.setter
     def mipmapFilterMode(self, mipmapFilterMode not None : CUfilter_mode):
-        self._pvt_ptr[0].mipmapFilterMode = mipmapFilterMode.value
+        self._pvt_ptr[0].mipmapFilterMode = int(mipmapFilterMode)
     {{endif}}
     {{if 'CUDA_TEXTURE_DESC_st.mipmapLevelBias' in found_struct}}
     @property
@@ -16520,7 +16520,7 @@ cdef class CUDA_RESOURCE_VIEW_DESC_st:
         return _dict_CUresourceViewFormat[self._pvt_ptr[0].format]
     @format.setter
     def format(self, format not None : CUresourceViewFormat):
-        self._pvt_ptr[0].format = format.value
+        self._pvt_ptr[0].format = int(format)
     {{endif}}
     {{if 'CUDA_RESOURCE_VIEW_DESC_st.width' in found_struct}}
     @property
@@ -17190,7 +17190,7 @@ cdef class CUDA_EXTERNAL_MEMORY_HANDLE_DESC_st:
         return _dict_CUexternalMemoryHandleType[self._pvt_ptr[0].type]
     @type.setter
     def type(self, type not None : CUexternalMemoryHandleType):
-        self._pvt_ptr[0].type = type.value
+        self._pvt_ptr[0].type = int(type)
     {{endif}}
     {{if 'CUDA_EXTERNAL_MEMORY_HANDLE_DESC_st.handle' in found_struct}}
     @property
@@ -17673,7 +17673,7 @@ cdef class CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC_st:
         return _dict_CUexternalSemaphoreHandleType[self._pvt_ptr[0].type]
     @type.setter
     def type(self, type not None : CUexternalSemaphoreHandleType):
-        self._pvt_ptr[0].type = type.value
+        self._pvt_ptr[0].type = int(type)
     {{endif}}
     {{if 'CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC_st.handle' in found_struct}}
     @property
@@ -19574,7 +19574,7 @@ cdef class CUarrayMapInfo_st:
         return _dict_CUresourcetype[self._pvt_ptr[0].resourceType]
     @resourceType.setter
     def resourceType(self, resourceType not None : CUresourcetype):
-        self._pvt_ptr[0].resourceType = resourceType.value
+        self._pvt_ptr[0].resourceType = int(resourceType)
     {{endif}}
     {{if 'CUarrayMapInfo_st.resource' in found_struct}}
     @property
@@ -19592,7 +19592,7 @@ cdef class CUarrayMapInfo_st:
         return _dict_CUarraySparseSubresourceType[self._pvt_ptr[0].subresourceType]
     @subresourceType.setter
     def subresourceType(self, subresourceType not None : CUarraySparseSubresourceType):
-        self._pvt_ptr[0].subresourceType = subresourceType.value
+        self._pvt_ptr[0].subresourceType = int(subresourceType)
     {{endif}}
     {{if 'CUarrayMapInfo_st.subresource' in found_struct}}
     @property
@@ -19610,7 +19610,7 @@ cdef class CUarrayMapInfo_st:
         return _dict_CUmemOperationType[self._pvt_ptr[0].memOperationType]
     @memOperationType.setter
     def memOperationType(self, memOperationType not None : CUmemOperationType):
-        self._pvt_ptr[0].memOperationType = memOperationType.value
+        self._pvt_ptr[0].memOperationType = int(memOperationType)
     {{endif}}
     {{if 'CUarrayMapInfo_st.memHandleType' in found_struct}}
     @property
@@ -19620,7 +19620,7 @@ cdef class CUarrayMapInfo_st:
         return _dict_CUmemHandleType[self._pvt_ptr[0].memHandleType]
     @memHandleType.setter
     def memHandleType(self, memHandleType not None : CUmemHandleType):
-        self._pvt_ptr[0].memHandleType = memHandleType.value
+        self._pvt_ptr[0].memHandleType = int(memHandleType)
     {{endif}}
     {{if 'CUarrayMapInfo_st.memHandle' in found_struct}}
     @property
@@ -19722,7 +19722,7 @@ cdef class CUmemLocation_st:
         return _dict_CUmemLocationType[self._pvt_ptr[0].type]
     @type.setter
     def type(self, type not None : CUmemLocationType):
-        self._pvt_ptr[0].type = type.value
+        self._pvt_ptr[0].type = int(type)
     {{endif}}
     {{if 'CUmemLocation_st.id' in found_struct}}
     @property
@@ -19935,7 +19935,7 @@ cdef class CUmemAllocationProp_st:
         return _dict_CUmemAllocationType[self._pvt_ptr[0].type]
     @type.setter
     def type(self, type not None : CUmemAllocationType):
-        self._pvt_ptr[0].type = type.value
+        self._pvt_ptr[0].type = int(type)
     {{endif}}
     {{if 'CUmemAllocationProp_st.requestedHandleTypes' in found_struct}}
     @property
@@ -19945,7 +19945,7 @@ cdef class CUmemAllocationProp_st:
         return _dict_CUmemAllocationHandleType[self._pvt_ptr[0].requestedHandleTypes]
     @requestedHandleTypes.setter
     def requestedHandleTypes(self, requestedHandleTypes not None : CUmemAllocationHandleType):
-        self._pvt_ptr[0].requestedHandleTypes = requestedHandleTypes.value
+        self._pvt_ptr[0].requestedHandleTypes = int(requestedHandleTypes)
     {{endif}}
     {{if 'CUmemAllocationProp_st.location' in found_struct}}
     @property
@@ -20150,7 +20150,7 @@ cdef class CUmemAccessDesc_st:
         return _dict_CUmemAccess_flags[self._pvt_ptr[0].flags]
     @flags.setter
     def flags(self, flags not None : CUmemAccess_flags):
-        self._pvt_ptr[0].flags = flags.value
+        self._pvt_ptr[0].flags = int(flags)
     {{endif}}
 {{endif}}
 {{if 'CUgraphExecUpdateResultInfo_st' in found_struct}}
@@ -20231,7 +20231,7 @@ cdef class CUgraphExecUpdateResultInfo_st:
         return _dict_CUgraphExecUpdateResult[self._pvt_ptr[0].result]
     @result.setter
     def result(self, result not None : CUgraphExecUpdateResult):
-        self._pvt_ptr[0].result = result.value
+        self._pvt_ptr[0].result = int(result)
     {{endif}}
     {{if 'CUgraphExecUpdateResultInfo_st.errorNode' in found_struct}}
     @property
@@ -20386,7 +20386,7 @@ cdef class CUmemPoolProps_st:
         return _dict_CUmemAllocationType[self._pvt_ptr[0].allocType]
     @allocType.setter
     def allocType(self, allocType not None : CUmemAllocationType):
-        self._pvt_ptr[0].allocType = allocType.value
+        self._pvt_ptr[0].allocType = int(allocType)
     {{endif}}
     {{if 'CUmemPoolProps_st.handleTypes' in found_struct}}
     @property
@@ -20396,7 +20396,7 @@ cdef class CUmemPoolProps_st:
         return _dict_CUmemAllocationHandleType[self._pvt_ptr[0].handleTypes]
     @handleTypes.setter
     def handleTypes(self, handleTypes not None : CUmemAllocationHandleType):
-        self._pvt_ptr[0].handleTypes = handleTypes.value
+        self._pvt_ptr[0].handleTypes = int(handleTypes)
     {{endif}}
     {{if 'CUmemPoolProps_st.location' in found_struct}}
     @property
@@ -20585,7 +20585,7 @@ cdef class CUmemcpyAttributes_st:
         return _dict_CUmemcpySrcAccessOrder[self._pvt_ptr[0].srcAccessOrder]
     @srcAccessOrder.setter
     def srcAccessOrder(self, srcAccessOrder not None : CUmemcpySrcAccessOrder):
-        self._pvt_ptr[0].srcAccessOrder = srcAccessOrder.value
+        self._pvt_ptr[0].srcAccessOrder = int(srcAccessOrder)
     {{endif}}
     {{if 'CUmemcpyAttributes_st.srcLocHint' in found_struct}}
     @property
@@ -21113,7 +21113,7 @@ cdef class CUmemcpy3DOperand_st:
         return _dict_CUmemcpy3DOperandType[self._pvt_ptr[0].type]
     @type.setter
     def type(self, type not None : CUmemcpy3DOperandType):
-        self._pvt_ptr[0].type = type.value
+        self._pvt_ptr[0].type = int(type)
     {{endif}}
     {{if 'CUmemcpy3DOperand_st.op' in found_struct}}
     @property
@@ -21245,7 +21245,7 @@ cdef class CUDA_MEMCPY3D_BATCH_OP_st:
         return _dict_CUmemcpySrcAccessOrder[self._pvt_ptr[0].srcAccessOrder]
     @srcAccessOrder.setter
     def srcAccessOrder(self, srcAccessOrder not None : CUmemcpySrcAccessOrder):
-        self._pvt_ptr[0].srcAccessOrder = srcAccessOrder.value
+        self._pvt_ptr[0].srcAccessOrder = int(srcAccessOrder)
     {{endif}}
     {{if 'CUDA_MEMCPY3D_BATCH_OP_st.flags' in found_struct}}
     @property
@@ -21724,7 +21724,7 @@ cdef class CUDA_CHILD_GRAPH_NODE_PARAMS_st:
         return _dict_CUgraphChildGraphNodeOwnership[self._pvt_ptr[0].ownership]
     @ownership.setter
     def ownership(self, ownership not None : CUgraphChildGraphNodeOwnership):
-        self._pvt_ptr[0].ownership = ownership.value
+        self._pvt_ptr[0].ownership = int(ownership)
     {{endif}}
 {{endif}}
 {{if 'CUDA_EVENT_RECORD_NODE_PARAMS_st' in found_struct}}
@@ -22101,7 +22101,7 @@ cdef class CUgraphNodeParams_st:
         return _dict_CUgraphNodeType[self._pvt_ptr[0].type]
     @type.setter
     def type(self, type not None : CUgraphNodeType):
-        self._pvt_ptr[0].type = type.value
+        self._pvt_ptr[0].type = int(type)
     {{endif}}
     {{if 'CUgraphNodeParams_st.reserved0' in found_struct}}
     @property
@@ -22802,7 +22802,7 @@ cdef class CUmemDecompressParams_st:
         return _dict_CUmemDecompressAlgorithm[self._pvt_ptr[0].algo]
     @algo.setter
     def algo(self, algo not None : CUmemDecompressAlgorithm):
-        self._pvt_ptr[0].algo = algo.value
+        self._pvt_ptr[0].algo = int(algo)
     {{endif}}
     {{if 'CUmemDecompressParams_st.padding' in found_struct}}
     @property
@@ -23019,7 +23019,7 @@ cdef class CUdevWorkqueueConfigResource_st:
         return _dict_CUdevWorkqueueConfigScope[self._pvt_ptr[0].sharingScope]
     @sharingScope.setter
     def sharingScope(self, sharingScope not None : CUdevWorkqueueConfigScope):
-        self._pvt_ptr[0].sharingScope = sharingScope.value
+        self._pvt_ptr[0].sharingScope = int(sharingScope)
     {{endif}}
 {{endif}}
 {{if 'CUdevWorkqueueResource_st' in found_struct}}
@@ -23320,7 +23320,7 @@ cdef class CUdevResource_st:
         return _dict_CUdevResourceType[self._pvt_ptr[0].type]
     @type.setter
     def type(self, type not None : CUdevResourceType):
-        self._pvt_ptr[0].type = type.value
+        self._pvt_ptr[0].type = int(type)
     {{endif}}
     {{if 'CUdevResource_st._internal_padding' in found_struct}}
     @property
@@ -23667,7 +23667,7 @@ cdef class CUeglFrame_st:
         return _dict_CUeglFrameType[self._pvt_ptr[0].frameType]
     @frameType.setter
     def frameType(self, frameType not None : CUeglFrameType):
-        self._pvt_ptr[0].frameType = frameType.value
+        self._pvt_ptr[0].frameType = int(frameType)
     {{endif}}
     {{if True}}
     @property
@@ -23677,7 +23677,7 @@ cdef class CUeglFrame_st:
         return _dict_CUeglColorFormat[self._pvt_ptr[0].eglColorFormat]
     @eglColorFormat.setter
     def eglColorFormat(self, eglColorFormat not None : CUeglColorFormat):
-        self._pvt_ptr[0].eglColorFormat = eglColorFormat.value
+        self._pvt_ptr[0].eglColorFormat = int(eglColorFormat)
     {{endif}}
     {{if True}}
     @property
@@ -23687,7 +23687,7 @@ cdef class CUeglFrame_st:
         return _dict_CUarray_format[self._pvt_ptr[0].cuFormat]
     @cuFormat.setter
     def cuFormat(self, cuFormat not None : CUarray_format):
-        self._pvt_ptr[0].cuFormat = cuFormat.value
+        self._pvt_ptr[0].cuFormat = int(cuFormat)
     {{endif}}
 {{endif}}
 {{if 'cuuint32_t' in found_types}}
@@ -24145,7 +24145,7 @@ def cuGetErrorString(error not None : CUresult):
     --------
     :py:obj:`~.CUresult`, :py:obj:`~.cudaGetErrorString`
     """
-    cdef cydriver.CUresult cyerror = error.value
+    cdef cydriver.CUresult cyerror = int(error)
     cdef const char* pStr = NULL
     with nogil:
         err = cydriver.cuGetErrorString(cyerror, &pStr)
@@ -24181,7 +24181,7 @@ def cuGetErrorName(error not None : CUresult):
     --------
     :py:obj:`~.CUresult`, :py:obj:`~.cudaGetErrorName`
     """
-    cdef cydriver.CUresult cyerror = error.value
+    cdef cydriver.CUresult cyerror = int(error)
     cdef const char* pStr = NULL
     with nogil:
         err = cydriver.cuGetErrorName(cyerror, &pStr)
@@ -24524,7 +24524,7 @@ def cuDeviceGetTexture1DLinearMaxWidth(pformat not None : CUarray_format, unsign
         pdev = int(CUdevice(dev))
     cydev = <cydriver.CUdevice>pdev
     cdef size_t maxWidthInElements = 0
-    cdef cydriver.CUarray_format cypformat = pformat.value
+    cdef cydriver.CUarray_format cypformat = int(pformat)
     with nogil:
         err = cydriver.cuDeviceGetTexture1DLinearMaxWidth(&maxWidthInElements, cypformat, numChannels, cydev)
     if err != cydriver.CUDA_SUCCESS:
@@ -24568,7 +24568,7 @@ def cuDeviceGetAttribute(attrib not None : CUdevice_attribute, dev):
         pdev = int(CUdevice(dev))
     cydev = <cydriver.CUdevice>pdev
     cdef int pi = 0
-    cdef cydriver.CUdevice_attribute cyattrib = attrib.value
+    cdef cydriver.CUdevice_attribute cyattrib = int(attrib)
     with nogil:
         err = cydriver.cuDeviceGetAttribute(&pi, cyattrib, cydev)
     if err != cydriver.CUDA_SUCCESS:
@@ -24634,7 +24634,7 @@ def cuDeviceGetHostAtomicCapabilities(operations : Optional[tuple[CUatomicOperat
         cycapabilities = <unsigned int*>calloc(count, sizeof(unsigned int))
         if cycapabilities is NULL:
             raise MemoryError('Failed to allocate length x size memory: ' + str(count) + 'x' + str(sizeof(unsigned int)))
-    cdef vector[cydriver.CUatomicOperation] cyoperations = [pyoperations.value for pyoperations in (operations)]
+    cdef vector[cydriver.CUatomicOperation] cyoperations = [int(pyoperations) for pyoperations in (operations)]
     if count > len(operations): raise RuntimeError("List is too small: " + str(len(operations)) + " < " + str(count))
     with nogil:
         err = cydriver.cuDeviceGetHostAtomicCapabilities(cycapabilities, cyoperations.data(), count, cydev)
@@ -24922,7 +24922,7 @@ def cuDeviceGetExecAffinitySupport(typename not None : CUexecAffinityType, dev):
         pdev = int(CUdevice(dev))
     cydev = <cydriver.CUdevice>pdev
     cdef int pi = 0
-    cdef cydriver.CUexecAffinityType cytypename = typename.value
+    cdef cydriver.CUexecAffinityType cytypename = int(typename)
     with nogil:
         err = cydriver.cuDeviceGetExecAffinitySupport(&pi, cytypename, cydev)
     if err != cydriver.CUDA_SUCCESS:
@@ -24974,8 +24974,8 @@ def cuFlushGPUDirectRDMAWrites(target not None : CUflushGPUDirectRDMAWritesTarge
     CUresult
         :py:obj:`~.CUDA_SUCCESS`, :py:obj:`~.CUDA_ERROR_DEINITIALIZED`, :py:obj:`~.CUDA_ERROR_NOT_INITIALIZED`, :py:obj:`~.CUDA_ERROR_INVALID_CONTEXT`, :py:obj:`~.CUDA_ERROR_INVALID_VALUE`,
     """
-    cdef cydriver.CUflushGPUDirectRDMAWritesTarget cytarget = target.value
-    cdef cydriver.CUflushGPUDirectRDMAWritesScope cyscope = scope.value
+    cdef cydriver.CUflushGPUDirectRDMAWritesTarget cytarget = int(target)
+    cdef cydriver.CUflushGPUDirectRDMAWritesScope cyscope = int(scope)
     with nogil:
         err = cydriver.cuFlushGPUDirectRDMAWrites(cytarget, cyscope)
     return (_dict_CUresult[err],)
@@ -26152,7 +26152,7 @@ def cuCtxSetLimit(limit not None : CUlimit, size_t value):
     --------
     :py:obj:`~.cuCtxCreate`, :py:obj:`~.cuCtxDestroy`, :py:obj:`~.cuCtxGetApiVersion`, :py:obj:`~.cuCtxGetCacheConfig`, :py:obj:`~.cuCtxGetDevice`, :py:obj:`~.cuCtxGetFlags`, :py:obj:`~.cuCtxGetLimit`, :py:obj:`~.cuCtxPopCurrent`, :py:obj:`~.cuCtxPushCurrent`, :py:obj:`~.cuCtxSetCacheConfig`, :py:obj:`~.cuCtxSynchronize`, :py:obj:`~.cudaDeviceSetLimit`
     """
-    cdef cydriver.CUlimit cylimit = limit.value
+    cdef cydriver.CUlimit cylimit = int(limit)
     with nogil:
         err = cydriver.cuCtxSetLimit(cylimit, value)
     return (_dict_CUresult[err],)
@@ -26209,7 +26209,7 @@ def cuCtxGetLimit(limit not None : CUlimit):
     :py:obj:`~.cuCtxCreate`, :py:obj:`~.cuCtxDestroy`, :py:obj:`~.cuCtxGetApiVersion`, :py:obj:`~.cuCtxGetCacheConfig`, :py:obj:`~.cuCtxGetDevice`, :py:obj:`~.cuCtxGetFlags`, :py:obj:`~.cuCtxPopCurrent`, :py:obj:`~.cuCtxPushCurrent`, :py:obj:`~.cuCtxSetCacheConfig`, :py:obj:`~.cuCtxSetLimit`, :py:obj:`~.cuCtxSynchronize`, :py:obj:`~.cudaDeviceGetLimit`
     """
     cdef size_t pvalue = 0
-    cdef cydriver.CUlimit cylimit = limit.value
+    cdef cydriver.CUlimit cylimit = int(limit)
     with nogil:
         err = cydriver.cuCtxGetLimit(&pvalue, cylimit)
     if err != cydriver.CUDA_SUCCESS:
@@ -26317,7 +26317,7 @@ def cuCtxSetCacheConfig(config not None : CUfunc_cache):
     --------
     :py:obj:`~.cuCtxCreate`, :py:obj:`~.cuCtxDestroy`, :py:obj:`~.cuCtxGetApiVersion`, :py:obj:`~.cuCtxGetCacheConfig`, :py:obj:`~.cuCtxGetDevice`, :py:obj:`~.cuCtxGetFlags`, :py:obj:`~.cuCtxGetLimit`, :py:obj:`~.cuCtxPopCurrent`, :py:obj:`~.cuCtxPushCurrent`, :py:obj:`~.cuCtxSetLimit`, :py:obj:`~.cuCtxSynchronize`, :py:obj:`~.cuFuncSetCacheConfig`, :py:obj:`~.cudaDeviceSetCacheConfig`, :py:obj:`~.cuKernelSetCacheConfig`
     """
-    cdef cydriver.CUfunc_cache cyconfig = config.value
+    cdef cydriver.CUfunc_cache cyconfig = int(config)
     with nogil:
         err = cydriver.cuCtxSetCacheConfig(cyconfig)
     return (_dict_CUresult[err],)
@@ -26469,7 +26469,7 @@ def cuCtxGetExecAffinity(typename not None : CUexecAffinityType):
     :py:obj:`~.CUexecAffinityParam`
     """
     cdef CUexecAffinityParam pExecAffinity = CUexecAffinityParam()
-    cdef cydriver.CUexecAffinityType cytypename = typename.value
+    cdef cydriver.CUexecAffinityType cytypename = int(typename)
     with nogil:
         err = cydriver.cuCtxGetExecAffinity(<cydriver.CUexecAffinityParam*>pExecAffinity._pvt_ptr, cytypename)
     if err != cydriver.CUDA_SUCCESS:
@@ -26771,7 +26771,7 @@ def cuCtxSetSharedMemConfig(config not None : CUsharedconfig):
     --------
     :py:obj:`~.cuCtxCreate`, :py:obj:`~.cuCtxDestroy`, :py:obj:`~.cuCtxGetApiVersion`, :py:obj:`~.cuCtxGetCacheConfig`, :py:obj:`~.cuCtxGetDevice`, :py:obj:`~.cuCtxGetFlags`, :py:obj:`~.cuCtxGetLimit`, :py:obj:`~.cuCtxPopCurrent`, :py:obj:`~.cuCtxPushCurrent`, :py:obj:`~.cuCtxSetLimit`, :py:obj:`~.cuCtxSynchronize`, :py:obj:`~.cuCtxGetSharedMemConfig`, :py:obj:`~.cuFuncSetCacheConfig`, :py:obj:`~.cudaDeviceSetSharedMemConfig`
     """
-    cdef cydriver.CUsharedconfig cyconfig = config.value
+    cdef cydriver.CUsharedconfig cyconfig = int(config)
     with nogil:
         err = cydriver.cuCtxSetSharedMemConfig(cyconfig)
     return (_dict_CUresult[err],)
@@ -26895,7 +26895,7 @@ def cuModuleLoadDataEx(image, unsigned int numOptions, options : Optional[tuple[
     cdef void* cyimage_ptr = <void*><void_ptr>cyimage.cptr
     if numOptions > len(options): raise RuntimeError("List is too small: " + str(len(options)) + " < " + str(numOptions))
     if numOptions > len(optionValues): raise RuntimeError("List is too small: " + str(len(optionValues)) + " < " + str(numOptions))
-    cdef vector[cydriver.CUjit_option] cyoptions = [pyoptions.value for pyoptions in (options)]
+    cdef vector[cydriver.CUjit_option] cyoptions = [int(pyoptions) for pyoptions in (options)]
     pylist = [_HelperCUjit_option(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(options, optionValues)]
     cdef _InputVoidPtrPtrHelper voidStarHelperoptionValues = _InputVoidPtrPtrHelper(pylist)
     cdef void** cyoptionValues_ptr = <void**><void_ptr>voidStarHelperoptionValues.cptr
@@ -27263,7 +27263,7 @@ def cuLinkCreate(unsigned int numOptions, options : Optional[tuple[CUjit_option]
         raise TypeError("Argument 'options' is not instance of type (expected tuple[cydriver.CUjit_option] or list[cydriver.CUjit_option]")
     if numOptions > len(options): raise RuntimeError("List is too small: " + str(len(options)) + " < " + str(numOptions))
     if numOptions > len(optionValues): raise RuntimeError("List is too small: " + str(len(optionValues)) + " < " + str(numOptions))
-    cdef vector[cydriver.CUjit_option] cyoptions = [pyoptions.value for pyoptions in (options)]
+    cdef vector[cydriver.CUjit_option] cyoptions = [int(pyoptions) for pyoptions in (options)]
     pylist = [_HelperCUjit_option(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(options, optionValues)]
     cdef _InputVoidPtrPtrHelper voidStarHelperoptionValues = _InputVoidPtrPtrHelper(pylist)
     cdef void** cyoptionValues_ptr = <void**><void_ptr>voidStarHelperoptionValues.cptr
@@ -27338,12 +27338,12 @@ def cuLinkAddData(state, typename not None : CUjitInputType, data, size_t size, 
     else:
         pstate = int(CUlinkState(state))
     cystate = <cydriver.CUlinkState><void_ptr>pstate
-    cdef cydriver.CUjitInputType cytypename = typename.value
+    cdef cydriver.CUjitInputType cytypename = int(typename)
     cydata = _HelperInputVoidPtr(data)
     cdef void* cydata_ptr = <void*><void_ptr>cydata.cptr
     if numOptions > len(options): raise RuntimeError("List is too small: " + str(len(options)) + " < " + str(numOptions))
     if numOptions > len(optionValues): raise RuntimeError("List is too small: " + str(len(optionValues)) + " < " + str(numOptions))
-    cdef vector[cydriver.CUjit_option] cyoptions = [pyoptions.value for pyoptions in (options)]
+    cdef vector[cydriver.CUjit_option] cyoptions = [int(pyoptions) for pyoptions in (options)]
     pylist = [_HelperCUjit_option(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(options, optionValues)]
     cdef _InputVoidPtrPtrHelper voidStarHelperoptionValues = _InputVoidPtrPtrHelper(pylist)
     cdef void** cyoptionValues_ptr = <void**><void_ptr>voidStarHelperoptionValues.cptr
@@ -27410,10 +27410,10 @@ def cuLinkAddFile(state, typename not None : CUjitInputType, char* path, unsigne
     else:
         pstate = int(CUlinkState(state))
     cystate = <cydriver.CUlinkState><void_ptr>pstate
-    cdef cydriver.CUjitInputType cytypename = typename.value
+    cdef cydriver.CUjitInputType cytypename = int(typename)
     if numOptions > len(options): raise RuntimeError("List is too small: " + str(len(options)) + " < " + str(numOptions))
     if numOptions > len(optionValues): raise RuntimeError("List is too small: " + str(len(optionValues)) + " < " + str(numOptions))
-    cdef vector[cydriver.CUjit_option] cyoptions = [pyoptions.value for pyoptions in (options)]
+    cdef vector[cydriver.CUjit_option] cyoptions = [int(pyoptions) for pyoptions in (options)]
     pylist = [_HelperCUjit_option(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(options, optionValues)]
     cdef _InputVoidPtrPtrHelper voidStarHelperoptionValues = _InputVoidPtrPtrHelper(pylist)
     cdef void** cyoptionValues_ptr = <void**><void_ptr>voidStarHelperoptionValues.cptr
@@ -27678,13 +27678,13 @@ def cuLibraryLoadData(code, jitOptions : Optional[tuple[CUjit_option] | list[CUj
     cdef CUlibrary library = CUlibrary()
     cycode = _HelperInputVoidPtr(code)
     cdef void* cycode_ptr = <void*><void_ptr>cycode.cptr
-    cdef vector[cydriver.CUjit_option] cyjitOptions = [pyjitOptions.value for pyjitOptions in (jitOptions)]
+    cdef vector[cydriver.CUjit_option] cyjitOptions = [int(pyjitOptions) for pyjitOptions in (jitOptions)]
     pylist = [_HelperCUjit_option(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(jitOptions, jitOptionsValues)]
     cdef _InputVoidPtrPtrHelper voidStarHelperjitOptionsValues = _InputVoidPtrPtrHelper(pylist)
     cdef void** cyjitOptionsValues_ptr = <void**><void_ptr>voidStarHelperjitOptionsValues.cptr
     if numJitOptions > len(jitOptions): raise RuntimeError("List is too small: " + str(len(jitOptions)) + " < " + str(numJitOptions))
     if numJitOptions > len(jitOptionsValues): raise RuntimeError("List is too small: " + str(len(jitOptionsValues)) + " < " + str(numJitOptions))
-    cdef vector[cydriver.CUlibraryOption] cylibraryOptions = [pylibraryOptions.value for pylibraryOptions in (libraryOptions)]
+    cdef vector[cydriver.CUlibraryOption] cylibraryOptions = [int(pylibraryOptions) for pylibraryOptions in (libraryOptions)]
     pylist = [_HelperCUlibraryOption(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(libraryOptions, libraryOptionValues)]
     cdef _InputVoidPtrPtrHelper voidStarHelperlibraryOptionValues = _InputVoidPtrPtrHelper(pylist)
     cdef void** cylibraryOptionValues_ptr = <void**><void_ptr>voidStarHelperlibraryOptionValues.cptr
@@ -27775,13 +27775,13 @@ def cuLibraryLoadFromFile(char* fileName, jitOptions : Optional[tuple[CUjit_opti
     if not all(isinstance(_x, (CUjit_option)) for _x in jitOptions):
         raise TypeError("Argument 'jitOptions' is not instance of type (expected tuple[cydriver.CUjit_option] or list[cydriver.CUjit_option]")
     cdef CUlibrary library = CUlibrary()
-    cdef vector[cydriver.CUjit_option] cyjitOptions = [pyjitOptions.value for pyjitOptions in (jitOptions)]
+    cdef vector[cydriver.CUjit_option] cyjitOptions = [int(pyjitOptions) for pyjitOptions in (jitOptions)]
     pylist = [_HelperCUjit_option(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(jitOptions, jitOptionsValues)]
     cdef _InputVoidPtrPtrHelper voidStarHelperjitOptionsValues = _InputVoidPtrPtrHelper(pylist)
     cdef void** cyjitOptionsValues_ptr = <void**><void_ptr>voidStarHelperjitOptionsValues.cptr
     if numJitOptions > len(jitOptions): raise RuntimeError("List is too small: " + str(len(jitOptions)) + " < " + str(numJitOptions))
     if numJitOptions > len(jitOptionsValues): raise RuntimeError("List is too small: " + str(len(jitOptionsValues)) + " < " + str(numJitOptions))
-    cdef vector[cydriver.CUlibraryOption] cylibraryOptions = [pylibraryOptions.value for pylibraryOptions in (libraryOptions)]
+    cdef vector[cydriver.CUlibraryOption] cylibraryOptions = [int(pylibraryOptions) for pylibraryOptions in (libraryOptions)]
     pylist = [_HelperCUlibraryOption(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(libraryOptions, libraryOptionValues)]
     cdef _InputVoidPtrPtrHelper voidStarHelperlibraryOptionValues = _InputVoidPtrPtrHelper(pylist)
     cdef void** cylibraryOptionValues_ptr = <void**><void_ptr>voidStarHelperlibraryOptionValues.cptr
@@ -28361,7 +28361,7 @@ def cuKernelGetAttribute(attrib not None : CUfunction_attribute, kernel, dev):
         pkernel = int(CUkernel(kernel))
     cykernel = <cydriver.CUkernel><void_ptr>pkernel
     cdef int pi = 0
-    cdef cydriver.CUfunction_attribute cyattrib = attrib.value
+    cdef cydriver.CUfunction_attribute cyattrib = int(attrib)
     with nogil:
         err = cydriver.cuKernelGetAttribute(&pi, cyattrib, cykernel, cydev)
     if err != cydriver.CUDA_SUCCESS:
@@ -28478,7 +28478,7 @@ def cuKernelSetAttribute(attrib not None : CUfunction_attribute, int val, kernel
     else:
         pkernel = int(CUkernel(kernel))
     cykernel = <cydriver.CUkernel><void_ptr>pkernel
-    cdef cydriver.CUfunction_attribute cyattrib = attrib.value
+    cdef cydriver.CUfunction_attribute cyattrib = int(attrib)
     with nogil:
         err = cydriver.cuKernelSetAttribute(cyattrib, val, cykernel, cydev)
     return (_dict_CUresult[err],)
@@ -28562,7 +28562,7 @@ def cuKernelSetCacheConfig(kernel, config not None : CUfunc_cache, dev):
     else:
         pkernel = int(CUkernel(kernel))
     cykernel = <cydriver.CUkernel><void_ptr>pkernel
-    cdef cydriver.CUfunc_cache cyconfig = config.value
+    cdef cydriver.CUfunc_cache cyconfig = int(config)
     with nogil:
         err = cydriver.cuKernelSetCacheConfig(cykernel, cyconfig, cydev)
     return (_dict_CUresult[err],)
@@ -33431,7 +33431,7 @@ def cuMemGetHandleForAddressRange(dptr, size_t size, handleType not None : CUmem
     cydptr = <cydriver.CUdeviceptr><void_ptr>pdptr
     cdef int handle = 0
     cdef void* cyhandle_ptr = <void*>&handle
-    cdef cydriver.CUmemRangeHandleType cyhandleType = handleType.value
+    cdef cydriver.CUmemRangeHandleType cyhandleType = int(handleType)
     with nogil:
         err = cydriver.cuMemGetHandleForAddressRange(cyhandle_ptr, cydptr, size, cyhandleType, flags)
     if err != cydriver.CUDA_SUCCESS:
@@ -34224,7 +34224,7 @@ def cuMemExportToShareableHandle(handle, handleType not None : CUmemAllocationHa
     cyhandle = <cydriver.CUmemGenericAllocationHandle><void_ptr>phandle
     cdef _HelperCUmemAllocationHandleType cyshareableHandle = _HelperCUmemAllocationHandleType(handleType)
     cdef void* cyshareableHandle_ptr = <void*><void_ptr>cyshareableHandle.cptr
-    cdef cydriver.CUmemAllocationHandleType cyhandleType = handleType.value
+    cdef cydriver.CUmemAllocationHandleType cyhandleType = int(handleType)
     with nogil:
         err = cydriver.cuMemExportToShareableHandle(cyshareableHandle_ptr, cyhandle, cyhandleType, flags)
     if err != cydriver.CUDA_SUCCESS:
@@ -34274,7 +34274,7 @@ def cuMemImportFromShareableHandle(osHandle, shHandleType not None : CUmemAlloca
     cdef CUmemGenericAllocationHandle handle = CUmemGenericAllocationHandle()
     cyosHandle = _HelperInputVoidPtr(osHandle)
     cdef void* cyosHandle_ptr = <void*><void_ptr>cyosHandle.cptr
-    cdef cydriver.CUmemAllocationHandleType cyshHandleType = shHandleType.value
+    cdef cydriver.CUmemAllocationHandleType cyshHandleType = int(shHandleType)
     with nogil:
         err = cydriver.cuMemImportFromShareableHandle(<cydriver.CUmemGenericAllocationHandle*>handle._pvt_ptr, cyosHandle_ptr, cyshHandleType)
     if err != cydriver.CUDA_SUCCESS:
@@ -34313,7 +34313,7 @@ def cuMemGetAllocationGranularity(prop : Optional[CUmemAllocationProp], option n
     """
     cdef size_t granularity = 0
     cdef cydriver.CUmemAllocationProp* cyprop_ptr = prop._pvt_ptr if prop is not None else NULL
-    cdef cydriver.CUmemAllocationGranularity_flags cyoption = option.value
+    cdef cydriver.CUmemAllocationGranularity_flags cyoption = int(option)
     with nogil:
         err = cydriver.cuMemGetAllocationGranularity(&granularity, cyprop_ptr, cyoption)
     if err != cydriver.CUDA_SUCCESS:
@@ -34620,7 +34620,7 @@ def cuMemPoolSetAttribute(pool, attr not None : CUmemPool_attribute, value):
     else:
         ppool = int(CUmemoryPool(pool))
     cypool = <cydriver.CUmemoryPool><void_ptr>ppool
-    cdef cydriver.CUmemPool_attribute cyattr = attr.value
+    cdef cydriver.CUmemPool_attribute cyattr = int(attr)
     cdef _HelperCUmemPool_attribute cyvalue = _HelperCUmemPool_attribute(attr, value, is_getter=False)
     cdef void* cyvalue_ptr = <void*><void_ptr>cyvalue.cptr
     with nogil:
@@ -34702,7 +34702,7 @@ def cuMemPoolGetAttribute(pool, attr not None : CUmemPool_attribute):
     else:
         ppool = int(CUmemoryPool(pool))
     cypool = <cydriver.CUmemoryPool><void_ptr>ppool
-    cdef cydriver.CUmemPool_attribute cyattr = attr.value
+    cdef cydriver.CUmemPool_attribute cyattr = int(attr)
     cdef _HelperCUmemPool_attribute cyvalue = _HelperCUmemPool_attribute(attr, 0, is_getter=True)
     cdef void* cyvalue_ptr = <void*><void_ptr>cyvalue.cptr
     with nogil:
@@ -34991,7 +34991,7 @@ def cuMemGetDefaultMemPool(location : Optional[CUmemLocation], typename not None
     """
     cdef CUmemoryPool pool_out = CUmemoryPool()
     cdef cydriver.CUmemLocation* cylocation_ptr = location._pvt_ptr if location is not None else NULL
-    cdef cydriver.CUmemAllocationType cytypename = typename.value
+    cdef cydriver.CUmemAllocationType cytypename = int(typename)
     with nogil:
         err = cydriver.cuMemGetDefaultMemPool(<cydriver.CUmemoryPool*>pool_out._pvt_ptr, cylocation_ptr, cytypename)
     if err != cydriver.CUDA_SUCCESS:
@@ -35044,7 +35044,7 @@ def cuMemGetMemPool(location : Optional[CUmemLocation], typename not None : CUme
     """
     cdef CUmemoryPool pool = CUmemoryPool()
     cdef cydriver.CUmemLocation* cylocation_ptr = location._pvt_ptr if location is not None else NULL
-    cdef cydriver.CUmemAllocationType cytypename = typename.value
+    cdef cydriver.CUmemAllocationType cytypename = int(typename)
     with nogil:
         err = cydriver.cuMemGetMemPool(<cydriver.CUmemoryPool*>pool._pvt_ptr, cylocation_ptr, cytypename)
     if err != cydriver.CUDA_SUCCESS:
@@ -35112,7 +35112,7 @@ def cuMemSetMemPool(location : Optional[CUmemLocation], typename not None : CUme
         ppool = int(CUmemoryPool(pool))
     cypool = <cydriver.CUmemoryPool><void_ptr>ppool
     cdef cydriver.CUmemLocation* cylocation_ptr = location._pvt_ptr if location is not None else NULL
-    cdef cydriver.CUmemAllocationType cytypename = typename.value
+    cdef cydriver.CUmemAllocationType cytypename = int(typename)
     with nogil:
         err = cydriver.cuMemSetMemPool(cylocation_ptr, cytypename, cypool)
     return (_dict_CUresult[err],)
@@ -35226,7 +35226,7 @@ def cuMemPoolExportToShareableHandle(pool, handleType not None : CUmemAllocation
     cypool = <cydriver.CUmemoryPool><void_ptr>ppool
     cdef _HelperCUmemAllocationHandleType cyhandle_out = _HelperCUmemAllocationHandleType(handleType)
     cdef void* cyhandle_out_ptr = <void*><void_ptr>cyhandle_out.cptr
-    cdef cydriver.CUmemAllocationHandleType cyhandleType = handleType.value
+    cdef cydriver.CUmemAllocationHandleType cyhandleType = int(handleType)
     with nogil:
         err = cydriver.cuMemPoolExportToShareableHandle(cyhandle_out_ptr, cypool, cyhandleType, flags)
     if err != cydriver.CUDA_SUCCESS:
@@ -35275,7 +35275,7 @@ def cuMemPoolImportFromShareableHandle(handle, handleType not None : CUmemAlloca
     cdef CUmemoryPool pool_out = CUmemoryPool()
     cyhandle = _HelperInputVoidPtr(handle)
     cdef void* cyhandle_ptr = <void*><void_ptr>cyhandle.cptr
-    cdef cydriver.CUmemAllocationHandleType cyhandleType = handleType.value
+    cdef cydriver.CUmemAllocationHandleType cyhandleType = int(handleType)
     with nogil:
         err = cydriver.cuMemPoolImportFromShareableHandle(<cydriver.CUmemoryPool*>pool_out._pvt_ptr, cyhandle_ptr, cyhandleType, flags)
     if err != cydriver.CUDA_SUCCESS:
@@ -35949,7 +35949,7 @@ def cuMulticastGetGranularity(prop : Optional[CUmulticastObjectProp], option not
     """
     cdef size_t granularity = 0
     cdef cydriver.CUmulticastObjectProp* cyprop_ptr = prop._pvt_ptr if prop is not None else NULL
-    cdef cydriver.CUmulticastGranularity_flags cyoption = option.value
+    cdef cydriver.CUmulticastGranularity_flags cyoption = int(option)
     with nogil:
         err = cydriver.cuMulticastGetGranularity(&granularity, cyprop_ptr, cyoption)
     if err != cydriver.CUDA_SUCCESS:
@@ -36162,7 +36162,7 @@ def cuPointerGetAttribute(attribute not None : CUpointer_attribute, ptr):
     cyptr = <cydriver.CUdeviceptr><void_ptr>pptr
     cdef _HelperCUpointer_attribute cydata = _HelperCUpointer_attribute(attribute, 0, is_getter=True)
     cdef void* cydata_ptr = <void*><void_ptr>cydata.cptr
-    cdef cydriver.CUpointer_attribute cyattribute = attribute.value
+    cdef cydriver.CUpointer_attribute cyattribute = int(attribute)
     with nogil:
         err = cydriver.cuPointerGetAttribute(cydata_ptr, cyattribute, cyptr)
     if err != cydriver.CUDA_SUCCESS:
@@ -36492,7 +36492,7 @@ def cuMemAdvise(devPtr, size_t count, advice not None : CUmem_advise, location n
     else:
         pdevPtr = int(CUdeviceptr(devPtr))
     cydevPtr = <cydriver.CUdeviceptr><void_ptr>pdevPtr
-    cdef cydriver.CUmem_advise cyadvice = advice.value
+    cdef cydriver.CUmem_advise cyadvice = int(advice)
     with nogil:
         err = cydriver.cuMemAdvise(cydevPtr, count, cyadvice, location._pvt_ptr[0])
     return (_dict_CUresult[err],)
@@ -36981,7 +36981,7 @@ def cuMemRangeGetAttribute(size_t dataSize, attribute not None : CUmem_range_att
     cydevPtr = <cydriver.CUdeviceptr><void_ptr>pdevPtr
     cdef _HelperCUmem_range_attribute cydata = _HelperCUmem_range_attribute(attribute, dataSize)
     cdef void* cydata_ptr = <void*><void_ptr>cydata.cptr
-    cdef cydriver.CUmem_range_attribute cyattribute = attribute.value
+    cdef cydriver.CUmem_range_attribute cyattribute = int(attribute)
     with nogil:
         err = cydriver.cuMemRangeGetAttribute(cydata_ptr, dataSize, cyattribute, cydevPtr, count)
     if err != cydriver.CUDA_SUCCESS:
@@ -37066,7 +37066,7 @@ def cuMemRangeGetAttributes(dataSizes : tuple[int] | list[int], attributes : Opt
     cdef _InputVoidPtrPtrHelper voidStarHelperdata = _InputVoidPtrPtrHelper(pylist)
     cdef void** cyvoidStarHelper_ptr = <void**><void_ptr>voidStarHelperdata.cptr
     cdef vector[size_t] cydataSizes = dataSizes
-    cdef vector[cydriver.CUmem_range_attribute] cyattributes = [pyattributes.value for pyattributes in (attributes)]
+    cdef vector[cydriver.CUmem_range_attribute] cyattributes = [int(pyattributes) for pyattributes in (attributes)]
     if numAttributes > <size_t>len(dataSizes): raise RuntimeError("List is too small: " + str(len(dataSizes)) + " < " + str(numAttributes))
     if numAttributes > <size_t>len(attributes): raise RuntimeError("List is too small: " + str(len(attributes)) + " < " + str(numAttributes))
     with nogil:
@@ -37126,7 +37126,7 @@ def cuPointerSetAttribute(value, attribute not None : CUpointer_attribute, ptr):
     cyptr = <cydriver.CUdeviceptr><void_ptr>pptr
     cdef _HelperCUpointer_attribute cyvalue = _HelperCUpointer_attribute(attribute, value, is_getter=False)
     cdef void* cyvalue_ptr = <void*><void_ptr>cyvalue.cptr
-    cdef cydriver.CUpointer_attribute cyattribute = attribute.value
+    cdef cydriver.CUpointer_attribute cyattribute = int(attribute)
     with nogil:
         err = cydriver.cuPointerSetAttribute(cyvalue_ptr, cyattribute, cyptr)
     return (_dict_CUresult[err],)
@@ -37215,7 +37215,7 @@ def cuPointerGetAttributes(unsigned int numAttributes, attributes : Optional[tup
     if not all(isinstance(_x, (CUpointer_attribute)) for _x in attributes):
         raise TypeError("Argument 'attributes' is not instance of type (expected tuple[cydriver.CUpointer_attribute] or list[cydriver.CUpointer_attribute]")
     if numAttributes > len(attributes): raise RuntimeError("List is too small: " + str(len(attributes)) + " < " + str(numAttributes))
-    cdef vector[cydriver.CUpointer_attribute] cyattributes = [pyattributes.value for pyattributes in (attributes)]
+    cdef vector[cydriver.CUpointer_attribute] cyattributes = [int(pyattributes) for pyattributes in (attributes)]
     pylist = [_HelperCUpointer_attribute(pyattributes, 0, is_getter=True) for pyattributes in attributes]
     cdef _InputVoidPtrPtrHelper voidStarHelperdata = _InputVoidPtrPtrHelper(pylist)
     cdef void** cyvoidStarHelper_ptr = <void**><void_ptr>voidStarHelperdata.cptr
@@ -37882,7 +37882,7 @@ def cuStreamBeginCapture(hStream, mode not None : CUstreamCaptureMode):
     else:
         phStream = int(CUstream(hStream))
     cyhStream = <cydriver.CUstream><void_ptr>phStream
-    cdef cydriver.CUstreamCaptureMode cymode = mode.value
+    cdef cydriver.CUstreamCaptureMode cymode = int(mode)
     with nogil:
         err = cydriver.cuStreamBeginCapture(cyhStream, cymode)
     return (_dict_CUresult[err],)
@@ -37984,7 +37984,7 @@ def cuStreamBeginCaptureToGraph(hStream, hGraph, dependencies : Optional[tuple[C
     elif len(dependencyData) == 1:
         cydependencyData = (<CUgraphEdgeData>dependencyData[0])._pvt_ptr
     if numDependencies > <size_t>len(dependencies): raise RuntimeError("List is too small: " + str(len(dependencies)) + " < " + str(numDependencies))
-    cdef cydriver.CUstreamCaptureMode cymode = mode.value
+    cdef cydriver.CUstreamCaptureMode cymode = int(mode)
     with nogil:
         err = cydriver.cuStreamBeginCaptureToGraph(cyhStream, cyhGraph, cydependencies, cydependencyData, numDependencies, cymode)
     if len(dependencies) > 1 and cydependencies is not NULL:
@@ -38060,7 +38060,7 @@ def cuThreadExchangeStreamCaptureMode(mode not None : CUstreamCaptureMode):
     --------
     :py:obj:`~.cuStreamBeginCapture`
     """
-    cdef cydriver.CUstreamCaptureMode cymode = mode.value
+    cdef cydriver.CUstreamCaptureMode cymode = int(mode)
     with nogil:
         err = cydriver.cuThreadExchangeStreamCaptureMode(&cymode)
     if err != cydriver.CUDA_SUCCESS:
@@ -38682,7 +38682,7 @@ def cuStreamGetAttribute(hStream, attr not None : CUstreamAttrID):
     else:
         phStream = int(CUstream(hStream))
     cyhStream = <cydriver.CUstream><void_ptr>phStream
-    cdef cydriver.CUstreamAttrID cyattr = attr.value
+    cdef cydriver.CUstreamAttrID cyattr = int(attr)
     cdef CUstreamAttrValue value_out = CUstreamAttrValue()
     with nogil:
         err = cydriver.cuStreamGetAttribute(cyhStream, cyattr, <cydriver.CUstreamAttrValue*>value_out._pvt_ptr)
@@ -38727,7 +38727,7 @@ def cuStreamSetAttribute(hStream, attr not None : CUstreamAttrID, value : Option
     else:
         phStream = int(CUstream(hStream))
     cyhStream = <cydriver.CUstream><void_ptr>phStream
-    cdef cydriver.CUstreamAttrID cyattr = attr.value
+    cdef cydriver.CUstreamAttrID cyattr = int(attr)
     cdef cydriver.CUstreamAttrValue* cyvalue_ptr = value._pvt_ptr if value is not None else NULL
     with nogil:
         err = cydriver.cuStreamSetAttribute(cyhStream, cyattr, cyvalue_ptr)
@@ -40412,7 +40412,7 @@ def cuFuncGetAttribute(attrib not None : CUfunction_attribute, hfunc):
         phfunc = int(CUfunction(hfunc))
     cyhfunc = <cydriver.CUfunction><void_ptr>phfunc
     cdef int pi = 0
-    cdef cydriver.CUfunction_attribute cyattrib = attrib.value
+    cdef cydriver.CUfunction_attribute cyattrib = int(attrib)
     with nogil:
         err = cydriver.cuFuncGetAttribute(&pi, cyattrib, cyhfunc)
     if err != cydriver.CUDA_SUCCESS:
@@ -40508,7 +40508,7 @@ def cuFuncSetAttribute(hfunc, attrib not None : CUfunction_attribute, int value)
     else:
         phfunc = int(CUfunction(hfunc))
     cyhfunc = <cydriver.CUfunction><void_ptr>phfunc
-    cdef cydriver.CUfunction_attribute cyattrib = attrib.value
+    cdef cydriver.CUfunction_attribute cyattrib = int(attrib)
     with nogil:
         err = cydriver.cuFuncSetAttribute(cyhfunc, cyattrib, value)
     return (_dict_CUresult[err],)
@@ -40574,7 +40574,7 @@ def cuFuncSetCacheConfig(hfunc, config not None : CUfunc_cache):
     else:
         phfunc = int(CUfunction(hfunc))
     cyhfunc = <cydriver.CUfunction><void_ptr>phfunc
-    cdef cydriver.CUfunc_cache cyconfig = config.value
+    cdef cydriver.CUfunc_cache cyconfig = int(config)
     with nogil:
         err = cydriver.cuFuncSetCacheConfig(cyhfunc, cyconfig)
     return (_dict_CUresult[err],)
@@ -42118,7 +42118,7 @@ def cuFuncSetSharedMemConfig(hfunc, config not None : CUsharedconfig):
     else:
         phfunc = int(CUfunction(hfunc))
     cyhfunc = <cydriver.CUfunction><void_ptr>phfunc
-    cdef cydriver.CUsharedconfig cyconfig = config.value
+    cdef cydriver.CUsharedconfig cyconfig = int(config)
     with nogil:
         err = cydriver.cuFuncSetSharedMemConfig(cyhfunc, cyconfig)
     return (_dict_CUresult[err],)
@@ -44292,7 +44292,7 @@ def cuDeviceGetGraphMemAttribute(device, attr not None : CUgraphMem_attribute):
     else:
         pdevice = int(CUdevice(device))
     cydevice = <cydriver.CUdevice>pdevice
-    cdef cydriver.CUgraphMem_attribute cyattr = attr.value
+    cdef cydriver.CUgraphMem_attribute cyattr = int(attr)
     cdef _HelperCUgraphMem_attribute cyvalue = _HelperCUgraphMem_attribute(attr, 0, is_getter=True)
     cdef void* cyvalue_ptr = <void*><void_ptr>cyvalue.cptr
     with nogil:
@@ -44344,7 +44344,7 @@ def cuDeviceSetGraphMemAttribute(device, attr not None : CUgraphMem_attribute, v
     else:
         pdevice = int(CUdevice(device))
     cydevice = <cydriver.CUdevice>pdevice
-    cdef cydriver.CUgraphMem_attribute cyattr = attr.value
+    cdef cydriver.CUgraphMem_attribute cyattr = int(attr)
     cdef _HelperCUgraphMem_attribute cyvalue = _HelperCUgraphMem_attribute(attr, value, is_getter=False)
     cdef void* cyvalue_ptr = <void*><void_ptr>cyvalue.cptr
     with nogil:
@@ -46763,7 +46763,7 @@ def cuGraphKernelNodeGetAttribute(hNode, attr not None : CUkernelNodeAttrID):
     else:
         phNode = int(CUgraphNode(hNode))
     cyhNode = <cydriver.CUgraphNode><void_ptr>phNode
-    cdef cydriver.CUkernelNodeAttrID cyattr = attr.value
+    cdef cydriver.CUkernelNodeAttrID cyattr = int(attr)
     cdef CUkernelNodeAttrValue value_out = CUkernelNodeAttrValue()
     with nogil:
         err = cydriver.cuGraphKernelNodeGetAttribute(cyhNode, cyattr, <cydriver.CUkernelNodeAttrValue*>value_out._pvt_ptr)
@@ -46807,7 +46807,7 @@ def cuGraphKernelNodeSetAttribute(hNode, attr not None : CUkernelNodeAttrID, val
     else:
         phNode = int(CUgraphNode(hNode))
     cyhNode = <cydriver.CUgraphNode><void_ptr>phNode
-    cdef cydriver.CUkernelNodeAttrID cyattr = attr.value
+    cdef cydriver.CUkernelNodeAttrID cyattr = int(attr)
     cdef cydriver.CUkernelNodeAttrValue* cyvalue_ptr = value._pvt_ptr if value is not None else NULL
     with nogil:
         err = cydriver.cuGraphKernelNodeSetAttribute(cyhNode, cyattr, cyvalue_ptr)
@@ -48137,7 +48137,7 @@ def cuTexRefSetFormat(hTexRef, fmt not None : CUarray_format, int NumPackedCompo
     else:
         phTexRef = int(CUtexref(hTexRef))
     cyhTexRef = <cydriver.CUtexref><void_ptr>phTexRef
-    cdef cydriver.CUarray_format cyfmt = fmt.value
+    cdef cydriver.CUarray_format cyfmt = int(fmt)
     with nogil:
         err = cydriver.cuTexRefSetFormat(cyhTexRef, cyfmt, NumPackedComponents)
     return (_dict_CUresult[err],)
@@ -48190,7 +48190,7 @@ def cuTexRefSetAddressMode(hTexRef, int dim, am not None : CUaddress_mode):
     else:
         phTexRef = int(CUtexref(hTexRef))
     cyhTexRef = <cydriver.CUtexref><void_ptr>phTexRef
-    cdef cydriver.CUaddress_mode cyam = am.value
+    cdef cydriver.CUaddress_mode cyam = int(am)
     with nogil:
         err = cydriver.cuTexRefSetAddressMode(cyhTexRef, dim, cyam)
     return (_dict_CUresult[err],)
@@ -48237,7 +48237,7 @@ def cuTexRefSetFilterMode(hTexRef, fm not None : CUfilter_mode):
     else:
         phTexRef = int(CUtexref(hTexRef))
     cyhTexRef = <cydriver.CUtexref><void_ptr>phTexRef
-    cdef cydriver.CUfilter_mode cyfm = fm.value
+    cdef cydriver.CUfilter_mode cyfm = int(fm)
     with nogil:
         err = cydriver.cuTexRefSetFilterMode(cyhTexRef, cyfm)
     return (_dict_CUresult[err],)
@@ -48284,7 +48284,7 @@ def cuTexRefSetMipmapFilterMode(hTexRef, fm not None : CUfilter_mode):
     else:
         phTexRef = int(CUtexref(hTexRef))
     cyhTexRef = <cydriver.CUtexref><void_ptr>phTexRef
-    cdef cydriver.CUfilter_mode cyfm = fm.value
+    cdef cydriver.CUfilter_mode cyfm = int(fm)
     with nogil:
         err = cydriver.cuTexRefSetMipmapFilterMode(cyhTexRef, cyfm)
     return (_dict_CUresult[err],)
@@ -49999,7 +49999,7 @@ def cuTensorMapEncodeTiled(tensorDataType not None : CUtensorMapDataType, tensor
         ptensorRank = int(cuuint32_t(tensorRank))
     cytensorRank = <cydriver.cuuint32_t><void_ptr>ptensorRank
     cdef CUtensorMap tensorMap = CUtensorMap()
-    cdef cydriver.CUtensorMapDataType cytensorDataType = tensorDataType.value
+    cdef cydriver.CUtensorMapDataType cytensorDataType = int(tensorDataType)
     cyglobalAddress = _HelperInputVoidPtr(globalAddress)
     cdef void* cyglobalAddress_ptr = <void*><void_ptr>cyglobalAddress.cptr
     cdef cydriver.cuuint64_t* cyglobalDim = NULL
@@ -50042,10 +50042,10 @@ def cuTensorMapEncodeTiled(tensorDataType not None : CUtensorMapDataType, tensor
                 cyelementStrides[idx] = <cydriver.cuuint32_t>(<cuuint32_t>elementStrides[idx])._pvt_ptr[0]
     elif len(elementStrides) == 1:
         cyelementStrides = <cydriver.cuuint32_t*>(<cuuint32_t>elementStrides[0])._pvt_ptr
-    cdef cydriver.CUtensorMapInterleave cyinterleave = interleave.value
-    cdef cydriver.CUtensorMapSwizzle cyswizzle = swizzle.value
-    cdef cydriver.CUtensorMapL2promotion cyl2Promotion = l2Promotion.value
-    cdef cydriver.CUtensorMapFloatOOBfill cyoobFill = oobFill.value
+    cdef cydriver.CUtensorMapInterleave cyinterleave = int(interleave)
+    cdef cydriver.CUtensorMapSwizzle cyswizzle = int(swizzle)
+    cdef cydriver.CUtensorMapL2promotion cyl2Promotion = int(l2Promotion)
+    cdef cydriver.CUtensorMapFloatOOBfill cyoobFill = int(oobFill)
     with nogil:
         err = cydriver.cuTensorMapEncodeTiled(<cydriver.CUtensorMap*>tensorMap._pvt_ptr, cytensorDataType, cytensorRank, cyglobalAddress_ptr, cyglobalDim, cyglobalStrides, cyboxDim, cyelementStrides, cyinterleave, cyswizzle, cyl2Promotion, cyoobFill)
     if len(globalDim) > 1 and cyglobalDim is not NULL:
@@ -50356,7 +50356,7 @@ def cuTensorMapEncodeIm2col(tensorDataType not None : CUtensorMapDataType, tenso
         ptensorRank = int(cuuint32_t(tensorRank))
     cytensorRank = <cydriver.cuuint32_t><void_ptr>ptensorRank
     cdef CUtensorMap tensorMap = CUtensorMap()
-    cdef cydriver.CUtensorMapDataType cytensorDataType = tensorDataType.value
+    cdef cydriver.CUtensorMapDataType cytensorDataType = int(tensorDataType)
     cyglobalAddress = _HelperInputVoidPtr(globalAddress)
     cdef void* cyglobalAddress_ptr = <void*><void_ptr>cyglobalAddress.cptr
     cdef cydriver.cuuint64_t* cyglobalDim = NULL
@@ -50391,10 +50391,10 @@ def cuTensorMapEncodeIm2col(tensorDataType not None : CUtensorMapDataType, tenso
                 cyelementStrides[idx] = <cydriver.cuuint32_t>(<cuuint32_t>elementStrides[idx])._pvt_ptr[0]
     elif len(elementStrides) == 1:
         cyelementStrides = <cydriver.cuuint32_t*>(<cuuint32_t>elementStrides[0])._pvt_ptr
-    cdef cydriver.CUtensorMapInterleave cyinterleave = interleave.value
-    cdef cydriver.CUtensorMapSwizzle cyswizzle = swizzle.value
-    cdef cydriver.CUtensorMapL2promotion cyl2Promotion = l2Promotion.value
-    cdef cydriver.CUtensorMapFloatOOBfill cyoobFill = oobFill.value
+    cdef cydriver.CUtensorMapInterleave cyinterleave = int(interleave)
+    cdef cydriver.CUtensorMapSwizzle cyswizzle = int(swizzle)
+    cdef cydriver.CUtensorMapL2promotion cyl2Promotion = int(l2Promotion)
+    cdef cydriver.CUtensorMapFloatOOBfill cyoobFill = int(oobFill)
     with nogil:
         err = cydriver.cuTensorMapEncodeIm2col(<cydriver.CUtensorMap*>tensorMap._pvt_ptr, cytensorDataType, cytensorRank, cyglobalAddress_ptr, cyglobalDim, cyglobalStrides, cypixelBoxLowerCorner.data(), cypixelBoxUpperCorner.data(), cychannelsPerPixel, cypixelsPerColumn, cyelementStrides, cyinterleave, cyswizzle, cyl2Promotion, cyoobFill)
     if len(globalDim) > 1 and cyglobalDim is not NULL:
@@ -50684,7 +50684,7 @@ def cuTensorMapEncodeIm2colWide(tensorDataType not None : CUtensorMapDataType, t
         ptensorRank = int(cuuint32_t(tensorRank))
     cytensorRank = <cydriver.cuuint32_t><void_ptr>ptensorRank
     cdef CUtensorMap tensorMap = CUtensorMap()
-    cdef cydriver.CUtensorMapDataType cytensorDataType = tensorDataType.value
+    cdef cydriver.CUtensorMapDataType cytensorDataType = int(tensorDataType)
     cyglobalAddress = _HelperInputVoidPtr(globalAddress)
     cdef void* cyglobalAddress_ptr = <void*><void_ptr>cyglobalAddress.cptr
     cdef cydriver.cuuint64_t* cyglobalDim = NULL
@@ -50717,11 +50717,11 @@ def cuTensorMapEncodeIm2colWide(tensorDataType not None : CUtensorMapDataType, t
                 cyelementStrides[idx] = <cydriver.cuuint32_t>(<cuuint32_t>elementStrides[idx])._pvt_ptr[0]
     elif len(elementStrides) == 1:
         cyelementStrides = <cydriver.cuuint32_t*>(<cuuint32_t>elementStrides[0])._pvt_ptr
-    cdef cydriver.CUtensorMapInterleave cyinterleave = interleave.value
-    cdef cydriver.CUtensorMapIm2ColWideMode cymode = mode.value
-    cdef cydriver.CUtensorMapSwizzle cyswizzle = swizzle.value
-    cdef cydriver.CUtensorMapL2promotion cyl2Promotion = l2Promotion.value
-    cdef cydriver.CUtensorMapFloatOOBfill cyoobFill = oobFill.value
+    cdef cydriver.CUtensorMapInterleave cyinterleave = int(interleave)
+    cdef cydriver.CUtensorMapIm2ColWideMode cymode = int(mode)
+    cdef cydriver.CUtensorMapSwizzle cyswizzle = int(swizzle)
+    cdef cydriver.CUtensorMapL2promotion cyl2Promotion = int(l2Promotion)
+    cdef cydriver.CUtensorMapFloatOOBfill cyoobFill = int(oobFill)
     with nogil:
         err = cydriver.cuTensorMapEncodeIm2colWide(<cydriver.CUtensorMap*>tensorMap._pvt_ptr, cytensorDataType, cytensorRank, cyglobalAddress_ptr, cyglobalDim, cyglobalStrides, pixelBoxLowerCornerWidth, pixelBoxUpperCornerWidth, cychannelsPerPixel, cypixelsPerColumn, cyelementStrides, cyinterleave, cymode, cyswizzle, cyl2Promotion, cyoobFill)
     if len(globalDim) > 1 and cyglobalDim is not NULL:
@@ -51010,7 +51010,7 @@ def cuDeviceGetP2PAttribute(attrib not None : CUdevice_P2PAttribute, srcDevice, 
         psrcDevice = int(CUdevice(srcDevice))
     cysrcDevice = <cydriver.CUdevice>psrcDevice
     cdef int value = 0
-    cdef cydriver.CUdevice_P2PAttribute cyattrib = attrib.value
+    cdef cydriver.CUdevice_P2PAttribute cyattrib = int(attrib)
     with nogil:
         err = cydriver.cuDeviceGetP2PAttribute(&value, cyattrib, cysrcDevice, cydstDevice)
     if err != cydriver.CUDA_SUCCESS:
@@ -51088,7 +51088,7 @@ def cuDeviceGetP2PAtomicCapabilities(operations : Optional[tuple[CUatomicOperati
         cycapabilities = <unsigned int*>calloc(count, sizeof(unsigned int))
         if cycapabilities is NULL:
             raise MemoryError('Failed to allocate length x size memory: ' + str(count) + 'x' + str(sizeof(unsigned int)))
-    cdef vector[cydriver.CUatomicOperation] cyoperations = [pyoperations.value for pyoperations in (operations)]
+    cdef vector[cydriver.CUatomicOperation] cyoperations = [int(pyoperations) for pyoperations in (operations)]
     if count > len(operations): raise RuntimeError("List is too small: " + str(len(operations)) + " < " + str(count))
     with nogil:
         err = cydriver.cuDeviceGetP2PAtomicCapabilities(cycapabilities, cyoperations.data(), count, cysrcDevice, cydstDevice)
@@ -51690,7 +51690,7 @@ def cuCoredumpGetAttribute(attrib not None : CUcoredumpSettings):
     --------
     :py:obj:`~.cuCoredumpGetAttributeGlobal`, :py:obj:`~.cuCoredumpSetAttribute`, :py:obj:`~.cuCoredumpSetAttributeGlobal`
     """
-    cdef cydriver.CUcoredumpSettings cyattrib = attrib.value
+    cdef cydriver.CUcoredumpSettings cyattrib = int(attrib)
     cdef _HelperCUcoredumpSettings cyvalue = _HelperCUcoredumpSettings(attrib, 0, is_getter=True)
     cdef void* cyvalue_ptr = <void*><void_ptr>cyvalue.cptr
     cdef size_t size = cyvalue.size()
@@ -51806,7 +51806,7 @@ def cuCoredumpGetAttributeGlobal(attrib not None : CUcoredumpSettings):
     --------
     :py:obj:`~.cuCoredumpGetAttribute`, :py:obj:`~.cuCoredumpSetAttribute`, :py:obj:`~.cuCoredumpSetAttributeGlobal`
     """
-    cdef cydriver.CUcoredumpSettings cyattrib = attrib.value
+    cdef cydriver.CUcoredumpSettings cyattrib = int(attrib)
     cdef _HelperCUcoredumpSettings cyvalue = _HelperCUcoredumpSettings(attrib, 0, is_getter=True)
     cdef void* cyvalue_ptr = <void*><void_ptr>cyvalue.cptr
     cdef size_t size = cyvalue.size()
@@ -51929,7 +51929,7 @@ def cuCoredumpSetAttribute(attrib not None : CUcoredumpSettings, value):
     --------
     :py:obj:`~.cuCoredumpGetAttributeGlobal`, :py:obj:`~.cuCoredumpGetAttribute`, :py:obj:`~.cuCoredumpSetAttributeGlobal`
     """
-    cdef cydriver.CUcoredumpSettings cyattrib = attrib.value
+    cdef cydriver.CUcoredumpSettings cyattrib = int(attrib)
     cdef _HelperCUcoredumpSettings cyvalue = _HelperCUcoredumpSettings(attrib, value, is_getter=False)
     cdef void* cyvalue_ptr = <void*><void_ptr>cyvalue.cptr
     cdef size_t size = cyvalue.size()
@@ -52055,7 +52055,7 @@ def cuCoredumpSetAttributeGlobal(attrib not None : CUcoredumpSettings, value):
     --------
     :py:obj:`~.cuCoredumpGetAttribute`, :py:obj:`~.cuCoredumpGetAttributeGlobal`, :py:obj:`~.cuCoredumpSetAttribute`
     """
-    cdef cydriver.CUcoredumpSettings cyattrib = attrib.value
+    cdef cydriver.CUcoredumpSettings cyattrib = int(attrib)
     cdef _HelperCUcoredumpSettings cyvalue = _HelperCUcoredumpSettings(attrib, value, is_getter=False)
     cdef void* cyvalue_ptr = <void*><void_ptr>cyvalue.cptr
     cdef size_t size = cyvalue.size()
@@ -52305,7 +52305,7 @@ def cuDeviceGetDevResource(device, typename not None : CUdevResourceType):
         pdevice = int(CUdevice(device))
     cydevice = <cydriver.CUdevice>pdevice
     cdef CUdevResource resource = CUdevResource()
-    cdef cydriver.CUdevResourceType cytypename = typename.value
+    cdef cydriver.CUdevResourceType cytypename = int(typename)
     with nogil:
         err = cydriver.cuDeviceGetDevResource(cydevice, <cydriver.CUdevResource*>resource._pvt_ptr, cytypename)
     if err != cydriver.CUDA_SUCCESS:
@@ -52349,7 +52349,7 @@ def cuCtxGetDevResource(hCtx, typename not None : CUdevResourceType):
         phCtx = int(CUcontext(hCtx))
     cyhCtx = <cydriver.CUcontext><void_ptr>phCtx
     cdef CUdevResource resource = CUdevResource()
-    cdef cydriver.CUdevResourceType cytypename = typename.value
+    cdef cydriver.CUdevResourceType cytypename = int(typename)
     with nogil:
         err = cydriver.cuCtxGetDevResource(cyhCtx, <cydriver.CUdevResource*>resource._pvt_ptr, cytypename)
     if err != cydriver.CUDA_SUCCESS:
@@ -52393,7 +52393,7 @@ def cuGreenCtxGetDevResource(hCtx, typename not None : CUdevResourceType):
         phCtx = int(CUgreenCtx(hCtx))
     cyhCtx = <cydriver.CUgreenCtx><void_ptr>phCtx
     cdef CUdevResource resource = CUdevResource()
-    cdef cydriver.CUdevResourceType cytypename = typename.value
+    cdef cydriver.CUdevResourceType cytypename = int(typename)
     with nogil:
         err = cydriver.cuGreenCtxGetDevResource(cyhCtx, <cydriver.CUdevResource*>resource._pvt_ptr, cytypename)
     if err != cydriver.CUDA_SUCCESS:
@@ -53083,7 +53083,7 @@ def cuStreamGetDevResource(hStream, typename not None : CUdevResourceType):
         phStream = int(CUstream(hStream))
     cyhStream = <cydriver.CUstream><void_ptr>phStream
     cdef CUdevResource resource = CUdevResource()
-    cdef cydriver.CUdevResourceType cytypename = typename.value
+    cdef cydriver.CUdevResourceType cytypename = int(typename)
     with nogil:
         err = cydriver.cuStreamGetDevResource(cyhStream, <cydriver.CUdevResource*>resource._pvt_ptr, cytypename)
     if err != cydriver.CUDA_SUCCESS:
@@ -54447,7 +54447,7 @@ def cuGLGetDevices(unsigned int cudaDeviceCount, deviceList not None : CUGLDevic
         cypCudaDevices = <cydriver.CUdevice*>calloc(cudaDeviceCount, sizeof(cydriver.CUdevice))
         if cypCudaDevices is NULL:
             raise MemoryError('Failed to allocate length x size memory: ' + str(cudaDeviceCount) + 'x' + str(sizeof(cydriver.CUdevice)))
-    cdef cydriver.CUGLDeviceList cydeviceList = deviceList.value
+    cdef cydriver.CUGLDeviceList cydeviceList = int(deviceList)
     with nogil:
         err = cydriver.cuGLGetDevices(&pCudaDeviceCount, cypCudaDevices, cudaDeviceCount, cydeviceList)
     if CUresult(err) == CUresult(0):

--- a/cuda_bindings/cuda/bindings/nvrtc.pyx.in
+++ b/cuda_bindings/cuda/bindings/nvrtc.pyx.in
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 # This code was automatically generated with version 13.1.0. Do not modify it directly.
@@ -145,7 +145,7 @@ def nvrtcGetErrorString(result not None : nvrtcResult):
     bytes
         Message string for the given :py:obj:`~.nvrtcResult` code.
     """
-    cdef cynvrtc.nvrtcResult cyresult = result.value
+    cdef cynvrtc.nvrtcResult cyresult = int(result)
     with nogil:
         err = cynvrtc.nvrtcGetErrorString(cyresult)
     return (nvrtcResult.NVRTC_SUCCESS, err)

--- a/cuda_bindings/cuda/bindings/runtime.pyx.in
+++ b/cuda_bindings/cuda/bindings/runtime.pyx.in
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 # This code was automatically generated with version 13.1.0. Do not modify it directly.
@@ -6384,7 +6384,7 @@ cdef class cudaChannelFormatDesc:
         return _dict_cudaChannelFormatKind[self._pvt_ptr[0].f]
     @f.setter
     def f(self, f not None : cudaChannelFormatKind):
-        self._pvt_ptr[0].f = f.value
+        self._pvt_ptr[0].f = int(f)
     {{endif}}
 {{endif}}
 {{if 'cudaArraySparseProperties.tileExtent' in found_struct}}
@@ -7172,7 +7172,7 @@ cdef class cudaMemcpy3DParms:
         return _dict_cudaMemcpyKind[self._pvt_ptr[0].kind]
     @kind.setter
     def kind(self, kind not None : cudaMemcpyKind):
-        self._pvt_ptr[0].kind = kind.value
+        self._pvt_ptr[0].kind = int(kind)
     {{endif}}
 {{endif}}
 {{if 'cudaMemcpyNodeParams' in found_struct}}
@@ -7966,7 +7966,7 @@ cdef class cudaAccessPolicyWindow:
         return _dict_cudaAccessProperty[self._pvt_ptr[0].hitProp]
     @hitProp.setter
     def hitProp(self, hitProp not None : cudaAccessProperty):
-        self._pvt_ptr[0].hitProp = hitProp.value
+        self._pvt_ptr[0].hitProp = int(hitProp)
     {{endif}}
     {{if 'cudaAccessPolicyWindow.missProp' in found_struct}}
     @property
@@ -7976,7 +7976,7 @@ cdef class cudaAccessPolicyWindow:
         return _dict_cudaAccessProperty[self._pvt_ptr[0].missProp]
     @missProp.setter
     def missProp(self, missProp not None : cudaAccessProperty):
-        self._pvt_ptr[0].missProp = missProp.value
+        self._pvt_ptr[0].missProp = int(missProp)
     {{endif}}
 {{endif}}
 {{if 'cudaHostNodeParams' in found_struct}}
@@ -8718,7 +8718,7 @@ cdef class cudaResourceDesc:
         return _dict_cudaResourceType[self._pvt_ptr[0].resType]
     @resType.setter
     def resType(self, resType not None : cudaResourceType):
-        self._pvt_ptr[0].resType = resType.value
+        self._pvt_ptr[0].resType = int(resType)
     {{endif}}
     {{if 'cudaResourceDesc.res' in found_struct}}
     @property
@@ -8866,7 +8866,7 @@ cdef class cudaResourceViewDesc:
         return _dict_cudaResourceViewFormat[self._pvt_ptr[0].format]
     @format.setter
     def format(self, format not None : cudaResourceViewFormat):
-        self._pvt_ptr[0].format = format.value
+        self._pvt_ptr[0].format = int(format)
     {{endif}}
     {{if 'cudaResourceViewDesc.width' in found_struct}}
     @property
@@ -9033,7 +9033,7 @@ cdef class cudaPointerAttributes:
         return _dict_cudaMemoryType[self._pvt_ptr[0].type]
     @type.setter
     def type(self, type not None : cudaMemoryType):
-        self._pvt_ptr[0].type = type.value
+        self._pvt_ptr[0].type = int(type)
     {{endif}}
     {{if 'cudaPointerAttributes.device' in found_struct}}
     @property
@@ -9507,7 +9507,7 @@ cdef class cudaMemLocation:
         return _dict_cudaMemLocationType[self._pvt_ptr[0].type]
     @type.setter
     def type(self, type not None : cudaMemLocationType):
-        self._pvt_ptr[0].type = type.value
+        self._pvt_ptr[0].type = int(type)
     {{endif}}
     {{if 'cudaMemLocation.id' in found_struct}}
     @property
@@ -9588,7 +9588,7 @@ cdef class cudaMemAccessDesc:
         return _dict_cudaMemAccessFlags[self._pvt_ptr[0].flags]
     @flags.setter
     def flags(self, flags not None : cudaMemAccessFlags):
-        self._pvt_ptr[0].flags = flags.value
+        self._pvt_ptr[0].flags = int(flags)
     {{endif}}
 {{endif}}
 {{if 'cudaMemPoolProps' in found_struct}}
@@ -9709,7 +9709,7 @@ cdef class cudaMemPoolProps:
         return _dict_cudaMemAllocationType[self._pvt_ptr[0].allocType]
     @allocType.setter
     def allocType(self, allocType not None : cudaMemAllocationType):
-        self._pvt_ptr[0].allocType = allocType.value
+        self._pvt_ptr[0].allocType = int(allocType)
     {{endif}}
     {{if 'cudaMemPoolProps.handleTypes' in found_struct}}
     @property
@@ -9719,7 +9719,7 @@ cdef class cudaMemPoolProps:
         return _dict_cudaMemAllocationHandleType[self._pvt_ptr[0].handleTypes]
     @handleTypes.setter
     def handleTypes(self, handleTypes not None : cudaMemAllocationHandleType):
-        self._pvt_ptr[0].handleTypes = handleTypes.value
+        self._pvt_ptr[0].handleTypes = int(handleTypes)
     {{endif}}
     {{if 'cudaMemPoolProps.location' in found_struct}}
     @property
@@ -10258,7 +10258,7 @@ cdef class cudaMemcpyAttributes:
         return _dict_cudaMemcpySrcAccessOrder[self._pvt_ptr[0].srcAccessOrder]
     @srcAccessOrder.setter
     def srcAccessOrder(self, srcAccessOrder not None : cudaMemcpySrcAccessOrder):
-        self._pvt_ptr[0].srcAccessOrder = srcAccessOrder.value
+        self._pvt_ptr[0].srcAccessOrder = int(srcAccessOrder)
     {{endif}}
     {{if 'cudaMemcpyAttributes.srcLocHint' in found_struct}}
     @property
@@ -10688,7 +10688,7 @@ cdef class cudaMemcpy3DOperand:
         return _dict_cudaMemcpy3DOperandType[self._pvt_ptr[0].type]
     @type.setter
     def type(self, type not None : cudaMemcpy3DOperandType):
-        self._pvt_ptr[0].type = type.value
+        self._pvt_ptr[0].type = int(type)
     {{endif}}
     {{if 'cudaMemcpy3DOperand.op' in found_struct}}
     @property
@@ -10820,7 +10820,7 @@ cdef class cudaMemcpy3DBatchOp:
         return _dict_cudaMemcpySrcAccessOrder[self._pvt_ptr[0].srcAccessOrder]
     @srcAccessOrder.setter
     def srcAccessOrder(self, srcAccessOrder not None : cudaMemcpySrcAccessOrder):
-        self._pvt_ptr[0].srcAccessOrder = srcAccessOrder.value
+        self._pvt_ptr[0].srcAccessOrder = int(srcAccessOrder)
     {{endif}}
     {{if 'cudaMemcpy3DBatchOp.flags' in found_struct}}
     @property
@@ -13047,7 +13047,7 @@ cdef class cudaExternalMemoryHandleDesc:
         return _dict_cudaExternalMemoryHandleType[self._pvt_ptr[0].type]
     @type.setter
     def type(self, type not None : cudaExternalMemoryHandleType):
-        self._pvt_ptr[0].type = type.value
+        self._pvt_ptr[0].type = int(type)
     {{endif}}
     {{if 'cudaExternalMemoryHandleDesc.handle' in found_struct}}
     @property
@@ -13570,7 +13570,7 @@ cdef class cudaExternalSemaphoreHandleDesc:
         return _dict_cudaExternalSemaphoreHandleType[self._pvt_ptr[0].type]
     @type.setter
     def type(self, type not None : cudaExternalSemaphoreHandleType):
-        self._pvt_ptr[0].type = type.value
+        self._pvt_ptr[0].type = int(type)
     {{endif}}
     {{if 'cudaExternalSemaphoreHandleDesc.handle' in found_struct}}
     @property
@@ -14534,7 +14534,7 @@ cdef class cudaDevWorkqueueConfigResource:
         return _dict_cudaDevWorkqueueConfigScope[self._pvt_ptr[0].sharingScope]
     @sharingScope.setter
     def sharingScope(self, sharingScope not None : cudaDevWorkqueueConfigScope):
-        self._pvt_ptr[0].sharingScope = sharingScope.value
+        self._pvt_ptr[0].sharingScope = int(sharingScope)
     {{endif}}
 {{endif}}
 {{if 'cudaDevWorkqueueResource' in found_struct}}
@@ -14854,7 +14854,7 @@ cdef class cudaDevResource_st:
         return _dict_cudaDevResourceType[self._pvt_ptr[0].type]
     @type.setter
     def type(self, type not None : cudaDevResourceType):
-        self._pvt_ptr[0].type = type.value
+        self._pvt_ptr[0].type = int(type)
     {{endif}}
     {{if 'cudaDevResource_st._internal_padding' in found_struct}}
     @property
@@ -15988,7 +15988,7 @@ cdef class cudaConditionalNodeParams:
         return _dict_cudaGraphConditionalNodeType[self._pvt_ptr[0].type]
     @type.setter
     def type(self, type not None : cudaGraphConditionalNodeType):
-        self._pvt_ptr[0].type = type.value
+        self._pvt_ptr[0].type = int(type)
     {{endif}}
     {{if 'cudaConditionalNodeParams.size' in found_struct}}
     @property
@@ -16105,7 +16105,7 @@ cdef class cudaChildGraphNodeParams:
         return _dict_cudaGraphChildGraphNodeOwnership[self._pvt_ptr[0].ownership]
     @ownership.setter
     def ownership(self, ownership not None : cudaGraphChildGraphNodeOwnership):
-        self._pvt_ptr[0].ownership = ownership.value
+        self._pvt_ptr[0].ownership = int(ownership)
     {{endif}}
 {{endif}}
 {{if 'cudaEventRecordNodeParams' in found_struct}}
@@ -16469,7 +16469,7 @@ cdef class cudaGraphNodeParams:
         return _dict_cudaGraphNodeType[self._pvt_ptr[0].type]
     @type.setter
     def type(self, type not None : cudaGraphNodeType):
-        self._pvt_ptr[0].type = type.value
+        self._pvt_ptr[0].type = int(type)
     {{endif}}
     {{if 'cudaGraphNodeParams.reserved0' in found_struct}}
     @property
@@ -16845,7 +16845,7 @@ cdef class cudaGraphInstantiateParams_st:
         return _dict_cudaGraphInstantiateResult[self._pvt_ptr[0].result_out]
     @result_out.setter
     def result_out(self, result_out not None : cudaGraphInstantiateResult):
-        self._pvt_ptr[0].result_out = result_out.value
+        self._pvt_ptr[0].result_out = int(result_out)
     {{endif}}
 {{endif}}
 {{if 'cudaGraphExecUpdateResultInfo_st' in found_struct}}
@@ -16926,7 +16926,7 @@ cdef class cudaGraphExecUpdateResultInfo_st:
         return _dict_cudaGraphExecUpdateResult[self._pvt_ptr[0].result]
     @result.setter
     def result(self, result not None : cudaGraphExecUpdateResult):
-        self._pvt_ptr[0].result = result.value
+        self._pvt_ptr[0].result = int(result)
     {{endif}}
     {{if 'cudaGraphExecUpdateResultInfo_st.errorNode' in found_struct}}
     @property
@@ -17230,7 +17230,7 @@ cdef class cudaGraphKernelNodeUpdate:
         return _dict_cudaGraphKernelNodeField[self._pvt_ptr[0].field]
     @field.setter
     def field(self, field not None : cudaGraphKernelNodeField):
-        self._pvt_ptr[0].field = field.value
+        self._pvt_ptr[0].field = int(field)
     {{endif}}
     {{if 'cudaGraphKernelNodeUpdate.updateData' in found_struct}}
     @property
@@ -18022,7 +18022,7 @@ cdef class cudaLaunchAttributeValue:
         return _dict_cudaSynchronizationPolicy[self._pvt_ptr[0].syncPolicy]
     @syncPolicy.setter
     def syncPolicy(self, syncPolicy not None : cudaSynchronizationPolicy):
-        self._pvt_ptr[0].syncPolicy = syncPolicy.value
+        self._pvt_ptr[0].syncPolicy = int(syncPolicy)
     {{endif}}
     {{if 'cudaLaunchAttributeValue.clusterDim' in found_struct}}
     @property
@@ -18040,7 +18040,7 @@ cdef class cudaLaunchAttributeValue:
         return _dict_cudaClusterSchedulingPolicy[self._pvt_ptr[0].clusterSchedulingPolicyPreference]
     @clusterSchedulingPolicyPreference.setter
     def clusterSchedulingPolicyPreference(self, clusterSchedulingPolicyPreference not None : cudaClusterSchedulingPolicy):
-        self._pvt_ptr[0].clusterSchedulingPolicyPreference = clusterSchedulingPolicyPreference.value
+        self._pvt_ptr[0].clusterSchedulingPolicyPreference = int(clusterSchedulingPolicyPreference)
     {{endif}}
     {{if 'cudaLaunchAttributeValue.programmaticStreamSerializationAllowed' in found_struct}}
     @property
@@ -18082,7 +18082,7 @@ cdef class cudaLaunchAttributeValue:
         return _dict_cudaLaunchMemSyncDomain[self._pvt_ptr[0].memSyncDomain]
     @memSyncDomain.setter
     def memSyncDomain(self, memSyncDomain not None : cudaLaunchMemSyncDomain):
-        self._pvt_ptr[0].memSyncDomain = memSyncDomain.value
+        self._pvt_ptr[0].memSyncDomain = int(memSyncDomain)
     {{endif}}
     {{if 'cudaLaunchAttributeValue.preferredClusterDim' in found_struct}}
     @property
@@ -18187,7 +18187,7 @@ cdef class cudaLaunchAttribute_st:
         return _dict_cudaLaunchAttributeID[self._pvt_ptr[0].id]
     @id.setter
     def id(self, id not None : cudaLaunchAttributeID):
-        self._pvt_ptr[0].id = id.value
+        self._pvt_ptr[0].id = int(id)
     {{endif}}
     {{if 'cudaLaunchAttribute_st.val' in found_struct}}
     @property
@@ -18358,7 +18358,7 @@ cdef class cudaAsyncNotificationInfo:
         return _dict_cudaAsyncNotificationType[self._pvt_ptr[0].type]
     @type.setter
     def type(self, type not None : cudaAsyncNotificationType):
-        self._pvt_ptr[0].type = type.value
+        self._pvt_ptr[0].type = int(type)
     {{endif}}
     {{if 'cudaAsyncNotificationInfo.info' in found_struct}}
     @property
@@ -18536,7 +18536,7 @@ cdef class cudaTextureDesc:
         return [_dict_cudaTextureAddressMode[_x] if _x in _dict_cudaTextureAddressMode else None for _x in list(self._pvt_ptr[0].addressMode)]
     @addressMode.setter
     def addressMode(self, addressMode):
-        self._pvt_ptr[0].addressMode = [_x.value for _x in addressMode]
+        self._pvt_ptr[0].addressMode = [int(_x) for _x in addressMode]
     {{endif}}
     {{if 'cudaTextureDesc.filterMode' in found_struct}}
     @property
@@ -18546,7 +18546,7 @@ cdef class cudaTextureDesc:
         return _dict_cudaTextureFilterMode[self._pvt_ptr[0].filterMode]
     @filterMode.setter
     def filterMode(self, filterMode not None : cudaTextureFilterMode):
-        self._pvt_ptr[0].filterMode = filterMode.value
+        self._pvt_ptr[0].filterMode = int(filterMode)
     {{endif}}
     {{if 'cudaTextureDesc.readMode' in found_struct}}
     @property
@@ -18556,7 +18556,7 @@ cdef class cudaTextureDesc:
         return _dict_cudaTextureReadMode[self._pvt_ptr[0].readMode]
     @readMode.setter
     def readMode(self, readMode not None : cudaTextureReadMode):
-        self._pvt_ptr[0].readMode = readMode.value
+        self._pvt_ptr[0].readMode = int(readMode)
     {{endif}}
     {{if 'cudaTextureDesc.sRGB' in found_struct}}
     @property
@@ -18598,7 +18598,7 @@ cdef class cudaTextureDesc:
         return _dict_cudaTextureFilterMode[self._pvt_ptr[0].mipmapFilterMode]
     @mipmapFilterMode.setter
     def mipmapFilterMode(self, mipmapFilterMode not None : cudaTextureFilterMode):
-        self._pvt_ptr[0].mipmapFilterMode = mipmapFilterMode.value
+        self._pvt_ptr[0].mipmapFilterMode = int(mipmapFilterMode)
     {{endif}}
     {{if 'cudaTextureDesc.mipmapLevelBias' in found_struct}}
     @property
@@ -19011,7 +19011,7 @@ cdef class cudaEglFrame_st:
         return _dict_cudaEglFrameType[self._pvt_ptr[0].frameType]
     @frameType.setter
     def frameType(self, frameType not None : cudaEglFrameType):
-        self._pvt_ptr[0].frameType = frameType.value
+        self._pvt_ptr[0].frameType = int(frameType)
     {{endif}}
     {{if True}}
     @property
@@ -19021,7 +19021,7 @@ cdef class cudaEglFrame_st:
         return _dict_cudaEglColorFormat[self._pvt_ptr[0].eglColorFormat]
     @eglColorFormat.setter
     def eglColorFormat(self, eglColorFormat not None : cudaEglColorFormat):
-        self._pvt_ptr[0].eglColorFormat = eglColorFormat.value
+        self._pvt_ptr[0].eglColorFormat = int(eglColorFormat)
     {{endif}}
 {{endif}}
 {{if 'cudaGraphConditionalHandle' in found_types}}
@@ -19509,7 +19509,7 @@ def cudaDeviceSetLimit(limit not None : cudaLimit, size_t value):
     --------
     :py:obj:`~.cudaDeviceGetLimit`, :py:obj:`~.cuCtxSetLimit`
     """
-    cdef cyruntime.cudaLimit cylimit = limit.value
+    cdef cyruntime.cudaLimit cylimit = int(limit)
     with nogil:
         err = cyruntime.cudaDeviceSetLimit(cylimit, value)
     return (_dict_cudaError_t[err],)
@@ -19567,7 +19567,7 @@ def cudaDeviceGetLimit(limit not None : cudaLimit):
     :py:obj:`~.cudaDeviceSetLimit`, :py:obj:`~.cuCtxGetLimit`
     """
     cdef size_t pValue = 0
-    cdef cyruntime.cudaLimit cylimit = limit.value
+    cdef cyruntime.cudaLimit cylimit = int(limit)
     with nogil:
         err = cyruntime.cudaDeviceGetLimit(&pValue, cylimit)
     if err != cyruntime.cudaSuccess:
@@ -19762,7 +19762,7 @@ def cudaDeviceSetCacheConfig(cacheConfig not None : cudaFuncCache):
     --------
     :py:obj:`~.cudaDeviceGetCacheConfig`, :py:obj:`~.cudaFuncSetCacheConfig (C API)`, cudaFuncSetCacheConfig (C++ API), :py:obj:`~.cuCtxSetCacheConfig`
     """
-    cdef cyruntime.cudaFuncCache cycacheConfig = cacheConfig.value
+    cdef cyruntime.cudaFuncCache cycacheConfig = int(cacheConfig)
     with nogil:
         err = cyruntime.cudaDeviceSetCacheConfig(cycacheConfig)
     return (_dict_cudaError_t[err],)
@@ -20154,8 +20154,8 @@ def cudaDeviceFlushGPUDirectRDMAWrites(target not None : cudaFlushGPUDirectRDMAW
     --------
     :py:obj:`~.cuFlushGPUDirectRDMAWrites`
     """
-    cdef cyruntime.cudaFlushGPUDirectRDMAWritesTarget cytarget = target.value
-    cdef cyruntime.cudaFlushGPUDirectRDMAWritesScope cyscope = scope.value
+    cdef cyruntime.cudaFlushGPUDirectRDMAWritesTarget cytarget = int(target)
+    cdef cyruntime.cudaFlushGPUDirectRDMAWritesScope cyscope = int(scope)
     with nogil:
         err = cyruntime.cudaDeviceFlushGPUDirectRDMAWrites(cytarget, cyscope)
     return (_dict_cudaError_t[err],)
@@ -20385,7 +20385,7 @@ def cudaDeviceSetSharedMemConfig(config not None : cudaSharedMemConfig):
     --------
     :py:obj:`~.cudaDeviceSetCacheConfig`, :py:obj:`~.cudaDeviceGetCacheConfig`, :py:obj:`~.cudaDeviceGetSharedMemConfig`, :py:obj:`~.cudaFuncSetCacheConfig`, :py:obj:`~.cuCtxSetSharedMemConfig`
     """
-    cdef cyruntime.cudaSharedMemConfig cyconfig = config.value
+    cdef cyruntime.cudaSharedMemConfig cyconfig = int(config)
     with nogil:
         err = cyruntime.cudaDeviceSetSharedMemConfig(cyconfig)
     return (_dict_cudaError_t[err],)
@@ -20474,7 +20474,7 @@ def cudaGetErrorName(error not None : cudaError_t):
     --------
     :py:obj:`~.cudaGetErrorString`, :py:obj:`~.cudaGetLastError`, :py:obj:`~.cudaPeekAtLastError`, :py:obj:`~.cudaError`, :py:obj:`~.cuGetErrorName`
     """
-    cdef cyruntime.cudaError_t cyerror = error.value
+    cdef cyruntime.cudaError_t cyerror = int(error)
     with nogil:
         err = cyruntime.cudaGetErrorName(cyerror)
     return (cudaError_t.cudaSuccess, err)
@@ -20505,7 +20505,7 @@ def cudaGetErrorString(error not None : cudaError_t):
     --------
     :py:obj:`~.cudaGetErrorName`, :py:obj:`~.cudaGetLastError`, :py:obj:`~.cudaPeekAtLastError`, :py:obj:`~.cudaError`, :py:obj:`~.cuGetErrorString`
     """
-    cdef cyruntime.cudaError_t cyerror = error.value
+    cdef cyruntime.cudaError_t cyerror = int(error)
     with nogil:
         err = cyruntime.cudaGetErrorString(cyerror)
     return (cudaError_t.cudaSuccess, err)
@@ -20600,7 +20600,7 @@ def cudaDeviceGetAttribute(attr not None : cudaDeviceAttr, int device):
     :py:obj:`~.cudaGetDeviceCount`, :py:obj:`~.cudaGetDevice`, :py:obj:`~.cudaSetDevice`, :py:obj:`~.cudaChooseDevice`, :py:obj:`~.cudaGetDeviceProperties`, :py:obj:`~.cudaInitDevice`, :py:obj:`~.cuDeviceGetAttribute`
     """
     cdef int value = 0
-    cdef cyruntime.cudaDeviceAttr cyattr = attr.value
+    cdef cyruntime.cudaDeviceAttr cyattr = int(attr)
     with nogil:
         err = cyruntime.cudaDeviceGetAttribute(&value, cyattr, device)
     if err != cyruntime.cudaSuccess:
@@ -20658,7 +20658,7 @@ def cudaDeviceGetHostAtomicCapabilities(operations : Optional[tuple[cudaAtomicOp
         cycapabilities = <unsigned int*>calloc(count, sizeof(unsigned int))
         if cycapabilities is NULL:
             raise MemoryError('Failed to allocate length x size memory: ' + str(count) + 'x' + str(sizeof(unsigned int)))
-    cdef vector[cyruntime.cudaAtomicOperation] cyoperations = [pyoperations.value for pyoperations in (operations)]
+    cdef vector[cyruntime.cudaAtomicOperation] cyoperations = [int(pyoperations) for pyoperations in (operations)]
     if count > len(operations): raise RuntimeError("List is too small: " + str(len(operations)) + " < " + str(count))
     with nogil:
         err = cyruntime.cudaDeviceGetHostAtomicCapabilities(cycapabilities, cyoperations.data(), count, device)
@@ -20929,7 +20929,7 @@ def cudaDeviceGetP2PAttribute(attr not None : cudaDeviceP2PAttr, int srcDevice, 
     :py:obj:`~.cudaDeviceEnablePeerAccess`, :py:obj:`~.cudaDeviceDisablePeerAccess`, :py:obj:`~.cudaDeviceCanAccessPeer`, :py:obj:`~.cuDeviceGetP2PAttribute` :py:obj:`~.cudaDeviceGetP2PAtomicCapabilities`
     """
     cdef int value = 0
-    cdef cyruntime.cudaDeviceP2PAttr cyattr = attr.value
+    cdef cyruntime.cudaDeviceP2PAttr cyattr = int(attr)
     with nogil:
         err = cyruntime.cudaDeviceGetP2PAttribute(&value, cyattr, srcDevice, dstDevice)
     if err != cyruntime.cudaSuccess:
@@ -20991,7 +20991,7 @@ def cudaDeviceGetP2PAtomicCapabilities(operations : Optional[tuple[cudaAtomicOpe
         cycapabilities = <unsigned int*>calloc(count, sizeof(unsigned int))
         if cycapabilities is NULL:
             raise MemoryError('Failed to allocate length x size memory: ' + str(count) + 'x' + str(sizeof(unsigned int)))
-    cdef vector[cyruntime.cudaAtomicOperation] cyoperations = [pyoperations.value for pyoperations in (operations)]
+    cdef vector[cyruntime.cudaAtomicOperation] cyoperations = [int(pyoperations) for pyoperations in (operations)]
     if count > len(operations): raise RuntimeError("List is too small: " + str(len(operations)) + " < " + str(count))
     with nogil:
         err = cyruntime.cudaDeviceGetP2PAtomicCapabilities(cycapabilities, cyoperations.data(), count, srcDevice, dstDevice)
@@ -21725,7 +21725,7 @@ def cudaStreamGetAttribute(hStream, attr not None : cudaStreamAttrID):
     else:
         phStream = int(cudaStream_t(hStream))
     cyhStream = <cyruntime.cudaStream_t><void_ptr>phStream
-    cdef cyruntime.cudaStreamAttrID cyattr = attr.value
+    cdef cyruntime.cudaStreamAttrID cyattr = int(attr)
     cdef cudaStreamAttrValue value_out = cudaStreamAttrValue()
     with nogil:
         err = cyruntime.cudaStreamGetAttribute(cyhStream, cyattr, <cyruntime.cudaStreamAttrValue*>value_out._pvt_ptr)
@@ -21770,7 +21770,7 @@ def cudaStreamSetAttribute(hStream, attr not None : cudaStreamAttrID, value : Op
     else:
         phStream = int(cudaStream_t(hStream))
     cyhStream = <cyruntime.cudaStream_t><void_ptr>phStream
-    cdef cyruntime.cudaStreamAttrID cyattr = attr.value
+    cdef cyruntime.cudaStreamAttrID cyattr = int(attr)
     cdef cyruntime.cudaStreamAttrValue* cyvalue_ptr = value._pvt_ptr if value is not None else NULL
     with nogil:
         err = cyruntime.cudaStreamSetAttribute(cyhStream, cyattr, cyvalue_ptr)
@@ -22232,7 +22232,7 @@ def cudaStreamBeginCapture(stream, mode not None : cudaStreamCaptureMode):
     else:
         pstream = int(cudaStream_t(stream))
     cystream = <cyruntime.cudaStream_t><void_ptr>pstream
-    cdef cyruntime.cudaStreamCaptureMode cymode = mode.value
+    cdef cyruntime.cudaStreamCaptureMode cymode = int(mode)
     with nogil:
         err = cyruntime.cudaStreamBeginCapture(cystream, cymode)
     return (_dict_cudaError_t[err],)
@@ -22333,7 +22333,7 @@ def cudaStreamBeginCaptureToGraph(stream, graph, dependencies : Optional[tuple[c
     elif len(dependencyData) == 1:
         cydependencyData = (<cudaGraphEdgeData>dependencyData[0])._pvt_ptr
     if numDependencies > <size_t>len(dependencies): raise RuntimeError("List is too small: " + str(len(dependencies)) + " < " + str(numDependencies))
-    cdef cyruntime.cudaStreamCaptureMode cymode = mode.value
+    cdef cyruntime.cudaStreamCaptureMode cymode = int(mode)
     with nogil:
         err = cyruntime.cudaStreamBeginCaptureToGraph(cystream, cygraph, cydependencies, cydependencyData, numDependencies, cymode)
     if len(dependencies) > 1 and cydependencies is not NULL:
@@ -22409,7 +22409,7 @@ def cudaThreadExchangeStreamCaptureMode(mode not None : cudaStreamCaptureMode):
     --------
     :py:obj:`~.cudaStreamBeginCapture`
     """
-    cdef cyruntime.cudaStreamCaptureMode cymode = mode.value
+    cdef cyruntime.cudaStreamCaptureMode cymode = int(mode)
     with nogil:
         err = cyruntime.cudaThreadExchangeStreamCaptureMode(&cymode)
     if err != cyruntime.cudaSuccess:
@@ -23988,7 +23988,7 @@ def cudaFuncSetCacheConfig(func, cacheConfig not None : cudaFuncCache):
     """
     cyfunc = _HelperInputVoidPtr(func)
     cdef void* cyfunc_ptr = <void*><void_ptr>cyfunc.cptr
-    cdef cyruntime.cudaFuncCache cycacheConfig = cacheConfig.value
+    cdef cyruntime.cudaFuncCache cycacheConfig = int(cacheConfig)
     with nogil:
         err = cyruntime.cudaFuncSetCacheConfig(cyfunc_ptr, cycacheConfig)
     return (_dict_cudaError_t[err],)
@@ -24118,7 +24118,7 @@ def cudaFuncSetAttribute(func, attr not None : cudaFuncAttribute, int value):
     """
     cyfunc = _HelperInputVoidPtr(func)
     cdef void* cyfunc_ptr = <void*><void_ptr>cyfunc.cptr
-    cdef cyruntime.cudaFuncAttribute cyattr = attr.value
+    cdef cyruntime.cudaFuncAttribute cyattr = int(attr)
     with nogil:
         err = cyruntime.cudaFuncSetAttribute(cyfunc_ptr, cyattr, value)
     return (_dict_cudaError_t[err],)
@@ -24296,7 +24296,7 @@ def cudaFuncSetSharedMemConfig(func, config not None : cudaSharedMemConfig):
     """
     cyfunc = _HelperInputVoidPtr(func)
     cdef void* cyfunc_ptr = <void*><void_ptr>cyfunc.cptr
-    cdef cyruntime.cudaSharedMemConfig cyconfig = config.value
+    cdef cyruntime.cudaSharedMemConfig cyconfig = int(config)
     with nogil:
         err = cyruntime.cudaFuncSetSharedMemConfig(cyfunc_ptr, cyconfig)
     return (_dict_cudaError_t[err],)
@@ -26296,7 +26296,7 @@ def cudaMemcpy(dst, src, size_t count, kind not None : cudaMemcpyKind):
     cdef void* cydst_ptr = <void*><void_ptr>cydst.cptr
     cysrc = _HelperInputVoidPtr(src)
     cdef void* cysrc_ptr = <void*><void_ptr>cysrc.cptr
-    cdef cyruntime.cudaMemcpyKind cykind = kind.value
+    cdef cyruntime.cudaMemcpyKind cykind = int(kind)
     with nogil:
         err = cyruntime.cudaMemcpy(cydst_ptr, cysrc_ptr, count, cykind)
     return (_dict_cudaError_t[err],)
@@ -26404,7 +26404,7 @@ def cudaMemcpy2D(dst, size_t dpitch, src, size_t spitch, size_t width, size_t he
     cdef void* cydst_ptr = <void*><void_ptr>cydst.cptr
     cysrc = _HelperInputVoidPtr(src)
     cdef void* cysrc_ptr = <void*><void_ptr>cysrc.cptr
-    cdef cyruntime.cudaMemcpyKind cykind = kind.value
+    cdef cyruntime.cudaMemcpyKind cykind = int(kind)
     with nogil:
         err = cyruntime.cudaMemcpy2D(cydst_ptr, dpitch, cysrc_ptr, spitch, width, height, cykind)
     return (_dict_cudaError_t[err],)
@@ -26471,7 +26471,7 @@ def cudaMemcpy2DToArray(dst, size_t wOffset, size_t hOffset, src, size_t spitch,
     cydst = <cyruntime.cudaArray_t><void_ptr>pdst
     cysrc = _HelperInputVoidPtr(src)
     cdef void* cysrc_ptr = <void*><void_ptr>cysrc.cptr
-    cdef cyruntime.cudaMemcpyKind cykind = kind.value
+    cdef cyruntime.cudaMemcpyKind cykind = int(kind)
     with nogil:
         err = cyruntime.cudaMemcpy2DToArray(cydst, wOffset, hOffset, cysrc_ptr, spitch, width, height, cykind)
     return (_dict_cudaError_t[err],)
@@ -26538,7 +26538,7 @@ def cudaMemcpy2DFromArray(dst, size_t dpitch, src, size_t wOffset, size_t hOffse
     cysrc = <cyruntime.cudaArray_const_t><void_ptr>psrc
     cydst = _HelperInputVoidPtr(dst)
     cdef void* cydst_ptr = <void*><void_ptr>cydst.cptr
-    cdef cyruntime.cudaMemcpyKind cykind = kind.value
+    cdef cyruntime.cudaMemcpyKind cykind = int(kind)
     with nogil:
         err = cyruntime.cudaMemcpy2DFromArray(cydst_ptr, dpitch, cysrc, wOffset, hOffset, width, height, cykind)
     return (_dict_cudaError_t[err],)
@@ -26611,7 +26611,7 @@ def cudaMemcpy2DArrayToArray(dst, size_t wOffsetDst, size_t hOffsetDst, src, siz
     else:
         pdst = int(cudaArray_t(dst))
     cydst = <cyruntime.cudaArray_t><void_ptr>pdst
-    cdef cyruntime.cudaMemcpyKind cykind = kind.value
+    cdef cyruntime.cudaMemcpyKind cykind = int(kind)
     with nogil:
         err = cyruntime.cudaMemcpy2DArrayToArray(cydst, wOffsetDst, hOffsetDst, cysrc, wOffsetSrc, hOffsetSrc, width, height, cykind)
     return (_dict_cudaError_t[err],)
@@ -26681,7 +26681,7 @@ def cudaMemcpyAsync(dst, src, size_t count, kind not None : cudaMemcpyKind, stre
     cdef void* cydst_ptr = <void*><void_ptr>cydst.cptr
     cysrc = _HelperInputVoidPtr(src)
     cdef void* cysrc_ptr = <void*><void_ptr>cysrc.cptr
-    cdef cyruntime.cudaMemcpyKind cykind = kind.value
+    cdef cyruntime.cudaMemcpyKind cykind = int(kind)
     with nogil:
         err = cyruntime.cudaMemcpyAsync(cydst_ptr, cysrc_ptr, count, cykind, cystream)
     return (_dict_cudaError_t[err],)
@@ -27098,7 +27098,7 @@ def cudaMemcpy2DAsync(dst, size_t dpitch, src, size_t spitch, size_t width, size
     cdef void* cydst_ptr = <void*><void_ptr>cydst.cptr
     cysrc = _HelperInputVoidPtr(src)
     cdef void* cysrc_ptr = <void*><void_ptr>cysrc.cptr
-    cdef cyruntime.cudaMemcpyKind cykind = kind.value
+    cdef cyruntime.cudaMemcpyKind cykind = int(kind)
     with nogil:
         err = cyruntime.cudaMemcpy2DAsync(cydst_ptr, dpitch, cysrc_ptr, spitch, width, height, cykind, cystream)
     return (_dict_cudaError_t[err],)
@@ -27186,7 +27186,7 @@ def cudaMemcpy2DToArrayAsync(dst, size_t wOffset, size_t hOffset, src, size_t sp
     cydst = <cyruntime.cudaArray_t><void_ptr>pdst
     cysrc = _HelperInputVoidPtr(src)
     cdef void* cysrc_ptr = <void*><void_ptr>cysrc.cptr
-    cdef cyruntime.cudaMemcpyKind cykind = kind.value
+    cdef cyruntime.cudaMemcpyKind cykind = int(kind)
     with nogil:
         err = cyruntime.cudaMemcpy2DToArrayAsync(cydst, wOffset, hOffset, cysrc_ptr, spitch, width, height, cykind, cystream)
     return (_dict_cudaError_t[err],)
@@ -27273,7 +27273,7 @@ def cudaMemcpy2DFromArrayAsync(dst, size_t dpitch, src, size_t wOffset, size_t h
     cysrc = <cyruntime.cudaArray_const_t><void_ptr>psrc
     cydst = _HelperInputVoidPtr(dst)
     cdef void* cydst_ptr = <void*><void_ptr>cydst.cptr
-    cdef cyruntime.cudaMemcpyKind cykind = kind.value
+    cdef cyruntime.cudaMemcpyKind cykind = int(kind)
     with nogil:
         err = cyruntime.cudaMemcpy2DFromArrayAsync(cydst_ptr, dpitch, cysrc, wOffset, hOffset, width, height, cykind, cystream)
     return (_dict_cudaError_t[err],)
@@ -28206,7 +28206,7 @@ def cudaMemAdvise(devPtr, size_t count, advice not None : cudaMemoryAdvise, loca
     """
     cydevPtr = _HelperInputVoidPtr(devPtr)
     cdef void* cydevPtr_ptr = <void*><void_ptr>cydevPtr.cptr
-    cdef cyruntime.cudaMemoryAdvise cyadvice = advice.value
+    cdef cyruntime.cudaMemoryAdvise cyadvice = int(advice)
     with nogil:
         err = cyruntime.cudaMemAdvise(cydevPtr_ptr, count, cyadvice, location._pvt_ptr[0])
     return (_dict_cudaError_t[err],)
@@ -28352,7 +28352,7 @@ def cudaMemRangeGetAttribute(size_t dataSize, attribute not None : cudaMemRangeA
     """
     cdef _HelperCUmem_range_attribute cydata = _HelperCUmem_range_attribute(attribute, dataSize)
     cdef void* cydata_ptr = <void*><void_ptr>cydata.cptr
-    cdef cyruntime.cudaMemRangeAttribute cyattribute = attribute.value
+    cdef cyruntime.cudaMemRangeAttribute cyattribute = int(attribute)
     cydevPtr = _HelperInputVoidPtr(devPtr)
     cdef void* cydevPtr_ptr = <void*><void_ptr>cydevPtr.cptr
     with nogil:
@@ -28431,7 +28431,7 @@ def cudaMemRangeGetAttributes(dataSizes : tuple[int] | list[int], attributes : O
     cdef _InputVoidPtrPtrHelper voidStarHelperdata = _InputVoidPtrPtrHelper(pylist)
     cdef void** cyvoidStarHelper_ptr = <void**><void_ptr>voidStarHelperdata.cptr
     cdef vector[size_t] cydataSizes = dataSizes
-    cdef vector[cyruntime.cudaMemRangeAttribute] cyattributes = [pyattributes.value for pyattributes in (attributes)]
+    cdef vector[cyruntime.cudaMemRangeAttribute] cyattributes = [int(pyattributes) for pyattributes in (attributes)]
     if numAttributes > <size_t>len(dataSizes): raise RuntimeError("List is too small: " + str(len(dataSizes)) + " < " + str(numAttributes))
     if numAttributes > <size_t>len(attributes): raise RuntimeError("List is too small: " + str(len(attributes)) + " < " + str(numAttributes))
     cydevPtr = _HelperInputVoidPtr(devPtr)
@@ -28496,7 +28496,7 @@ def cudaMemcpyToArray(dst, size_t wOffset, size_t hOffset, src, size_t count, ki
     cydst = <cyruntime.cudaArray_t><void_ptr>pdst
     cysrc = _HelperInputVoidPtr(src)
     cdef void* cysrc_ptr = <void*><void_ptr>cysrc.cptr
-    cdef cyruntime.cudaMemcpyKind cykind = kind.value
+    cdef cyruntime.cudaMemcpyKind cykind = int(kind)
     with nogil:
         err = cyruntime.cudaMemcpyToArray(cydst, wOffset, hOffset, cysrc_ptr, count, cykind)
     return (_dict_cudaError_t[err],)
@@ -28555,7 +28555,7 @@ def cudaMemcpyFromArray(dst, src, size_t wOffset, size_t hOffset, size_t count, 
     cysrc = <cyruntime.cudaArray_const_t><void_ptr>psrc
     cydst = _HelperInputVoidPtr(dst)
     cdef void* cydst_ptr = <void*><void_ptr>cydst.cptr
-    cdef cyruntime.cudaMemcpyKind cykind = kind.value
+    cdef cyruntime.cudaMemcpyKind cykind = int(kind)
     with nogil:
         err = cyruntime.cudaMemcpyFromArray(cydst_ptr, cysrc, wOffset, hOffset, count, cykind)
     return (_dict_cudaError_t[err],)
@@ -28625,7 +28625,7 @@ def cudaMemcpyArrayToArray(dst, size_t wOffsetDst, size_t hOffsetDst, src, size_
     else:
         pdst = int(cudaArray_t(dst))
     cydst = <cyruntime.cudaArray_t><void_ptr>pdst
-    cdef cyruntime.cudaMemcpyKind cykind = kind.value
+    cdef cyruntime.cudaMemcpyKind cykind = int(kind)
     with nogil:
         err = cyruntime.cudaMemcpyArrayToArray(cydst, wOffsetDst, hOffsetDst, cysrc, wOffsetSrc, hOffsetSrc, count, cykind)
     return (_dict_cudaError_t[err],)
@@ -28701,7 +28701,7 @@ def cudaMemcpyToArrayAsync(dst, size_t wOffset, size_t hOffset, src, size_t coun
     cydst = <cyruntime.cudaArray_t><void_ptr>pdst
     cysrc = _HelperInputVoidPtr(src)
     cdef void* cysrc_ptr = <void*><void_ptr>cysrc.cptr
-    cdef cyruntime.cudaMemcpyKind cykind = kind.value
+    cdef cyruntime.cudaMemcpyKind cykind = int(kind)
     with nogil:
         err = cyruntime.cudaMemcpyToArrayAsync(cydst, wOffset, hOffset, cysrc_ptr, count, cykind, cystream)
     return (_dict_cudaError_t[err],)
@@ -28777,7 +28777,7 @@ def cudaMemcpyFromArrayAsync(dst, src, size_t wOffset, size_t hOffset, size_t co
     cysrc = <cyruntime.cudaArray_const_t><void_ptr>psrc
     cydst = _HelperInputVoidPtr(dst)
     cdef void* cydst_ptr = <void*><void_ptr>cydst.cptr
-    cdef cyruntime.cudaMemcpyKind cykind = kind.value
+    cdef cyruntime.cudaMemcpyKind cykind = int(kind)
     with nogil:
         err = cyruntime.cudaMemcpyFromArrayAsync(cydst_ptr, cysrc, wOffset, hOffset, count, cykind, cystream)
     return (_dict_cudaError_t[err],)
@@ -29002,7 +29002,7 @@ def cudaMemPoolSetAttribute(memPool, attr not None : cudaMemPoolAttr, value):
     else:
         pmemPool = int(cudaMemPool_t(memPool))
     cymemPool = <cyruntime.cudaMemPool_t><void_ptr>pmemPool
-    cdef cyruntime.cudaMemPoolAttr cyattr = attr.value
+    cdef cyruntime.cudaMemPoolAttr cyattr = int(attr)
     cdef _HelperCUmemPool_attribute cyvalue = _HelperCUmemPool_attribute(attr, value, is_getter=False)
     cdef void* cyvalue_ptr = <void*><void_ptr>cyvalue.cptr
     with nogil:
@@ -29084,7 +29084,7 @@ def cudaMemPoolGetAttribute(memPool, attr not None : cudaMemPoolAttr):
     else:
         pmemPool = int(cudaMemPool_t(memPool))
     cymemPool = <cyruntime.cudaMemPool_t><void_ptr>pmemPool
-    cdef cyruntime.cudaMemPoolAttr cyattr = attr.value
+    cdef cyruntime.cudaMemPoolAttr cyattr = int(attr)
     cdef _HelperCUmemPool_attribute cyvalue = _HelperCUmemPool_attribute(attr, 0, is_getter=True)
     cdef void* cyvalue_ptr = <void*><void_ptr>cyvalue.cptr
     with nogil:
@@ -29374,7 +29374,7 @@ def cudaMemGetDefaultMemPool(location : Optional[cudaMemLocation], typename not 
     """
     cdef cudaMemPool_t memPool = cudaMemPool_t()
     cdef cyruntime.cudaMemLocation* cylocation_ptr = location._pvt_ptr if location is not None else NULL
-    cdef cyruntime.cudaMemAllocationType cytypename = typename.value
+    cdef cyruntime.cudaMemAllocationType cytypename = int(typename)
     with nogil:
         err = cyruntime.cudaMemGetDefaultMemPool(<cyruntime.cudaMemPool_t*>memPool._pvt_ptr, cylocation_ptr, cytypename)
     if err != cyruntime.cudaSuccess:
@@ -29428,7 +29428,7 @@ def cudaMemGetMemPool(location : Optional[cudaMemLocation], typename not None : 
     """
     cdef cudaMemPool_t memPool = cudaMemPool_t()
     cdef cyruntime.cudaMemLocation* cylocation_ptr = location._pvt_ptr if location is not None else NULL
-    cdef cyruntime.cudaMemAllocationType cytypename = typename.value
+    cdef cyruntime.cudaMemAllocationType cytypename = int(typename)
     with nogil:
         err = cyruntime.cudaMemGetMemPool(<cyruntime.cudaMemPool_t*>memPool._pvt_ptr, cylocation_ptr, cytypename)
     if err != cyruntime.cudaSuccess:
@@ -29497,7 +29497,7 @@ def cudaMemSetMemPool(location : Optional[cudaMemLocation], typename not None : 
         pmemPool = int(cudaMemPool_t(memPool))
     cymemPool = <cyruntime.cudaMemPool_t><void_ptr>pmemPool
     cdef cyruntime.cudaMemLocation* cylocation_ptr = location._pvt_ptr if location is not None else NULL
-    cdef cyruntime.cudaMemAllocationType cytypename = typename.value
+    cdef cyruntime.cudaMemAllocationType cytypename = int(typename)
     with nogil:
         err = cyruntime.cudaMemSetMemPool(cylocation_ptr, cytypename, cymemPool)
     return (_dict_cudaError_t[err],)
@@ -29611,7 +29611,7 @@ def cudaMemPoolExportToShareableHandle(memPool, handleType not None : cudaMemAll
     cymemPool = <cyruntime.cudaMemPool_t><void_ptr>pmemPool
     cdef _HelperCUmemAllocationHandleType cyshareableHandle = _HelperCUmemAllocationHandleType(handleType)
     cdef void* cyshareableHandle_ptr = <void*><void_ptr>cyshareableHandle.cptr
-    cdef cyruntime.cudaMemAllocationHandleType cyhandleType = handleType.value
+    cdef cyruntime.cudaMemAllocationHandleType cyhandleType = int(handleType)
     with nogil:
         err = cyruntime.cudaMemPoolExportToShareableHandle(cyshareableHandle_ptr, cymemPool, cyhandleType, flags)
     if err != cyruntime.cudaSuccess:
@@ -29655,7 +29655,7 @@ def cudaMemPoolImportFromShareableHandle(shareableHandle, handleType not None : 
     cdef cudaMemPool_t memPool = cudaMemPool_t()
     cyshareableHandle = _HelperInputVoidPtr(shareableHandle)
     cdef void* cyshareableHandle_ptr = <void*><void_ptr>cyshareableHandle.cptr
-    cdef cyruntime.cudaMemAllocationHandleType cyhandleType = handleType.value
+    cdef cyruntime.cudaMemAllocationHandleType cyhandleType = int(handleType)
     with nogil:
         err = cyruntime.cudaMemPoolImportFromShareableHandle(<cyruntime.cudaMemPool_t*>memPool._pvt_ptr, cyshareableHandle_ptr, cyhandleType, flags)
     if err != cyruntime.cudaSuccess:
@@ -30393,7 +30393,7 @@ def cudaCreateChannelDesc(int x, int y, int z, int w, f not None : cudaChannelFo
     --------
     cudaCreateChannelDesc (C++ API), :py:obj:`~.cudaGetChannelDesc`, :py:obj:`~.cudaCreateTextureObject`, :py:obj:`~.cudaCreateSurfaceObject`
     """
-    cdef cyruntime.cudaChannelFormatKind cyf = f.value
+    cdef cyruntime.cudaChannelFormatKind cyf = int(f)
     with nogil:
         err = cyruntime.cudaCreateChannelDesc(x, y, z, w, cyf)
     cdef cudaChannelFormatDesc wrapper = cudaChannelFormatDesc()
@@ -31509,7 +31509,7 @@ def cudaGraphKernelNodeGetAttribute(hNode, attr not None : cudaKernelNodeAttrID)
     else:
         phNode = int(cudaGraphNode_t(hNode))
     cyhNode = <cyruntime.cudaGraphNode_t><void_ptr>phNode
-    cdef cyruntime.cudaKernelNodeAttrID cyattr = attr.value
+    cdef cyruntime.cudaKernelNodeAttrID cyattr = int(attr)
     cdef cudaKernelNodeAttrValue value_out = cudaKernelNodeAttrValue()
     with nogil:
         err = cyruntime.cudaGraphKernelNodeGetAttribute(cyhNode, cyattr, <cyruntime.cudaKernelNodeAttrValue*>value_out._pvt_ptr)
@@ -31553,7 +31553,7 @@ def cudaGraphKernelNodeSetAttribute(hNode, attr not None : cudaKernelNodeAttrID,
     else:
         phNode = int(cudaGraphNode_t(hNode))
     cyhNode = <cyruntime.cudaGraphNode_t><void_ptr>phNode
-    cdef cyruntime.cudaKernelNodeAttrID cyattr = attr.value
+    cdef cyruntime.cudaKernelNodeAttrID cyattr = int(attr)
     cdef cyruntime.cudaKernelNodeAttrValue* cyvalue_ptr = value._pvt_ptr if value is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphKernelNodeSetAttribute(cyhNode, cyattr, cyvalue_ptr)
@@ -31721,7 +31721,7 @@ def cudaGraphAddMemcpyNode1D(graph, pDependencies : Optional[tuple[cudaGraphNode
     cdef void* cydst_ptr = <void*><void_ptr>cydst.cptr
     cysrc = _HelperInputVoidPtr(src)
     cdef void* cysrc_ptr = <void*><void_ptr>cysrc.cptr
-    cdef cyruntime.cudaMemcpyKind cykind = kind.value
+    cdef cyruntime.cudaMemcpyKind cykind = int(kind)
     with nogil:
         err = cyruntime.cudaGraphAddMemcpyNode1D(<cyruntime.cudaGraphNode_t*>pGraphNode._pvt_ptr, cygraph, cypDependencies, numDependencies, cydst_ptr, cysrc_ptr, count, cykind)
     if len(pDependencies) > 1 and cypDependencies is not NULL:
@@ -31865,7 +31865,7 @@ def cudaGraphMemcpyNodeSetParams1D(node, dst, src, size_t count, kind not None :
     cdef void* cydst_ptr = <void*><void_ptr>cydst.cptr
     cysrc = _HelperInputVoidPtr(src)
     cdef void* cysrc_ptr = <void*><void_ptr>cysrc.cptr
-    cdef cyruntime.cudaMemcpyKind cykind = kind.value
+    cdef cyruntime.cudaMemcpyKind cykind = int(kind)
     with nogil:
         err = cyruntime.cudaGraphMemcpyNodeSetParams1D(cynode, cydst_ptr, cysrc_ptr, count, cykind)
     return (_dict_cudaError_t[err],)
@@ -33367,7 +33367,7 @@ def cudaDeviceGetGraphMemAttribute(int device, attr not None : cudaGraphMemAttri
     --------
     :py:obj:`~.cudaDeviceSetGraphMemAttribute`, :py:obj:`~.cudaGraphAddMemAllocNode`, :py:obj:`~.cudaGraphAddMemFreeNode`, :py:obj:`~.cudaDeviceGraphMemTrim`, :py:obj:`~.cudaMallocAsync`, :py:obj:`~.cudaFreeAsync`
     """
-    cdef cyruntime.cudaGraphMemAttributeType cyattr = attr.value
+    cdef cyruntime.cudaGraphMemAttributeType cyattr = int(attr)
     cdef _HelperCUgraphMem_attribute cyvalue = _HelperCUgraphMem_attribute(attr, 0, is_getter=True)
     cdef void* cyvalue_ptr = <void*><void_ptr>cyvalue.cptr
     with nogil:
@@ -33411,7 +33411,7 @@ def cudaDeviceSetGraphMemAttribute(int device, attr not None : cudaGraphMemAttri
     --------
     :py:obj:`~.cudaDeviceGetGraphMemAttribute`, :py:obj:`~.cudaGraphAddMemAllocNode`, :py:obj:`~.cudaGraphAddMemFreeNode`, :py:obj:`~.cudaDeviceGraphMemTrim`, :py:obj:`~.cudaMallocAsync`, :py:obj:`~.cudaFreeAsync`
     """
-    cdef cyruntime.cudaGraphMemAttributeType cyattr = attr.value
+    cdef cyruntime.cudaGraphMemAttributeType cyattr = int(attr)
     cdef _HelperCUgraphMem_attribute cyvalue = _HelperCUgraphMem_attribute(attr, value, is_getter=False)
     cdef void* cyvalue_ptr = <void*><void_ptr>cyvalue.cptr
     with nogil:
@@ -34973,7 +34973,7 @@ def cudaGraphExecMemcpyNodeSetParams1D(hGraphExec, node, dst, src, size_t count,
     cdef void* cydst_ptr = <void*><void_ptr>cydst.cptr
     cysrc = _HelperInputVoidPtr(src)
     cdef void* cysrc_ptr = <void*><void_ptr>cysrc.cptr
-    cdef cyruntime.cudaMemcpyKind cykind = kind.value
+    cdef cyruntime.cudaMemcpyKind cykind = int(kind)
     with nogil:
         err = cyruntime.cudaGraphExecMemcpyNodeSetParams1D(cyhGraphExec, cynode, cydst_ptr, cysrc_ptr, count, cykind)
     return (_dict_cudaError_t[err],)
@@ -36794,13 +36794,13 @@ def cudaLibraryLoadData(code, jitOptions : Optional[tuple[cudaJitOption] | list[
     cdef cudaLibrary_t library = cudaLibrary_t()
     cycode = _HelperInputVoidPtr(code)
     cdef void* cycode_ptr = <void*><void_ptr>cycode.cptr
-    cdef vector[cyruntime.cudaJitOption] cyjitOptions = [pyjitOptions.value for pyjitOptions in (jitOptions)]
+    cdef vector[cyruntime.cudaJitOption] cyjitOptions = [int(pyjitOptions) for pyjitOptions in (jitOptions)]
     pylist = [_HelperCudaJitOption(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(jitOptions, jitOptionsValues)]
     cdef _InputVoidPtrPtrHelper voidStarHelperjitOptionsValues = _InputVoidPtrPtrHelper(pylist)
     cdef void** cyjitOptionsValues_ptr = <void**><void_ptr>voidStarHelperjitOptionsValues.cptr
     if numJitOptions > len(jitOptions): raise RuntimeError("List is too small: " + str(len(jitOptions)) + " < " + str(numJitOptions))
     if numJitOptions > len(jitOptionsValues): raise RuntimeError("List is too small: " + str(len(jitOptionsValues)) + " < " + str(numJitOptions))
-    cdef vector[cyruntime.cudaLibraryOption] cylibraryOptions = [pylibraryOptions.value for pylibraryOptions in (libraryOptions)]
+    cdef vector[cyruntime.cudaLibraryOption] cylibraryOptions = [int(pylibraryOptions) for pylibraryOptions in (libraryOptions)]
     pylist = [_HelperCudaLibraryOption(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(libraryOptions, libraryOptionValues)]
     cdef _InputVoidPtrPtrHelper voidStarHelperlibraryOptionValues = _InputVoidPtrPtrHelper(pylist)
     cdef void** cylibraryOptionValues_ptr = <void**><void_ptr>voidStarHelperlibraryOptionValues.cptr
@@ -36892,13 +36892,13 @@ def cudaLibraryLoadFromFile(char* fileName, jitOptions : Optional[tuple[cudaJitO
     if not all(isinstance(_x, (cudaJitOption)) for _x in jitOptions):
         raise TypeError("Argument 'jitOptions' is not instance of type (expected tuple[cyruntime.cudaJitOption] or list[cyruntime.cudaJitOption]")
     cdef cudaLibrary_t library = cudaLibrary_t()
-    cdef vector[cyruntime.cudaJitOption] cyjitOptions = [pyjitOptions.value for pyjitOptions in (jitOptions)]
+    cdef vector[cyruntime.cudaJitOption] cyjitOptions = [int(pyjitOptions) for pyjitOptions in (jitOptions)]
     pylist = [_HelperCudaJitOption(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(jitOptions, jitOptionsValues)]
     cdef _InputVoidPtrPtrHelper voidStarHelperjitOptionsValues = _InputVoidPtrPtrHelper(pylist)
     cdef void** cyjitOptionsValues_ptr = <void**><void_ptr>voidStarHelperjitOptionsValues.cptr
     if numJitOptions > len(jitOptions): raise RuntimeError("List is too small: " + str(len(jitOptions)) + " < " + str(numJitOptions))
     if numJitOptions > len(jitOptionsValues): raise RuntimeError("List is too small: " + str(len(jitOptionsValues)) + " < " + str(numJitOptions))
-    cdef vector[cyruntime.cudaLibraryOption] cylibraryOptions = [pylibraryOptions.value for pylibraryOptions in (libraryOptions)]
+    cdef vector[cyruntime.cudaLibraryOption] cylibraryOptions = [int(pylibraryOptions) for pylibraryOptions in (libraryOptions)]
     pylist = [_HelperCudaLibraryOption(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(libraryOptions, libraryOptionValues)]
     cdef _InputVoidPtrPtrHelper voidStarHelperlibraryOptionValues = _InputVoidPtrPtrHelper(pylist)
     cdef void** cylibraryOptionValues_ptr = <void**><void_ptr>voidStarHelperlibraryOptionValues.cptr
@@ -37335,7 +37335,7 @@ def cudaKernelSetAttributeForDevice(kernel, attr not None : cudaFuncAttribute, i
     else:
         pkernel = int(cudaKernel_t(kernel))
     cykernel = <cyruntime.cudaKernel_t><void_ptr>pkernel
-    cdef cyruntime.cudaFuncAttribute cyattr = attr.value
+    cdef cyruntime.cudaFuncAttribute cyattr = int(attr)
     with nogil:
         err = cyruntime.cudaKernelSetAttributeForDevice(cykernel, cyattr, value, device)
     return (_dict_cudaError_t[err],)
@@ -37372,7 +37372,7 @@ def cudaDeviceGetDevResource(int device, typename not None : cudaDevResourceType
     :py:obj:`~.cuDeviceGetDevResource`, :py:obj:`~.cudaExecutionCtxGetDevResource`, :py:obj:`~.cudaDevSmResourceSplit`, :py:obj:`~.cudaDevResourceGenerateDesc`
     """
     cdef cudaDevResource resource = cudaDevResource()
-    cdef cyruntime.cudaDevResourceType cytypename = typename.value
+    cdef cyruntime.cudaDevResourceType cytypename = int(typename)
     with nogil:
         err = cyruntime.cudaDeviceGetDevResource(device, <cyruntime.cudaDevResource*>resource._pvt_ptr, cytypename)
     if err != cyruntime.cudaSuccess:
@@ -37887,7 +37887,7 @@ def cudaExecutionCtxGetDevResource(ctx, typename not None : cudaDevResourceType)
         pctx = int(cudaExecutionContext_t(ctx))
     cyctx = <cyruntime.cudaExecutionContext_t><void_ptr>pctx
     cdef cudaDevResource resource = cudaDevResource()
-    cdef cyruntime.cudaDevResourceType cytypename = typename.value
+    cdef cyruntime.cudaDevResourceType cytypename = int(typename)
     with nogil:
         err = cyruntime.cudaExecutionCtxGetDevResource(cyctx, <cyruntime.cudaDevResource*>resource._pvt_ptr, cytypename)
     if err != cyruntime.cudaSuccess:
@@ -38137,7 +38137,7 @@ def cudaStreamGetDevResource(hStream, typename not None : cudaDevResourceType):
         phStream = int(cudaStream_t(hStream))
     cyhStream = <cyruntime.cudaStream_t><void_ptr>phStream
     cdef cudaDevResource resource = cudaDevResource()
-    cdef cyruntime.cudaDevResourceType cytypename = typename.value
+    cdef cyruntime.cudaDevResourceType cytypename = int(typename)
     with nogil:
         err = cyruntime.cudaStreamGetDevResource(cyhStream, <cyruntime.cudaDevResource*>resource._pvt_ptr, cytypename)
     if err != cyruntime.cudaSuccess:
@@ -39238,7 +39238,7 @@ def cudaGLGetDevices(unsigned int cudaDeviceCount, deviceList not None : cudaGLD
         cypCudaDevices = <int*>calloc(cudaDeviceCount, sizeof(int))
         if cypCudaDevices is NULL:
             raise MemoryError('Failed to allocate length x size memory: ' + str(cudaDeviceCount) + 'x' + str(sizeof(int)))
-    cdef cyruntime.cudaGLDeviceList cydeviceList = deviceList.value
+    cdef cyruntime.cudaGLDeviceList cydeviceList = int(deviceList)
     with nogil:
         err = cyruntime.cudaGLGetDevices(&pCudaDeviceCount, cypCudaDevices, cudaDeviceCount, cydeviceList)
     if cudaError_t(err) == cudaError_t(0):
@@ -40050,10 +40050,10 @@ def sizeof(objType):
     {{if True}}
     if objType == VdpOutputSurface:
         return sizeof(cyruntime.VdpOutputSurface){{endif}}
-    {{if True}}
+    {{if 'cudaStreamAttrValue' in found_types}}
     if objType == cudaStreamAttrValue:
         return sizeof(cyruntime.cudaStreamAttrValue){{endif}}
-    {{if True}}
+    {{if 'cudaKernelNodeAttrValue' in found_types}}
     if objType == cudaKernelNodeAttrValue:
         return sizeof(cyruntime.cudaKernelNodeAttrValue){{endif}}
     {{if True}}


### PR DESCRIPTION
See [background discussion here](https://github.com/NVIDIA/cuda-python/issues/659#issuecomment-3820026706).

It turns out that instead of

```
cdef cydriver.CUtensorMapInterleave cyinterleave = interleave.value
```

doing this:

```
cdef cydriver.CUtensorMapInterleave cyinterleave = int(interleave)
```

reduces the function call overhead of `cuTensorMapEncodeTiled` by about 25%.  Not all API functions have that many enum arguments (5), so I wouldn't expect such a huge win across the board, but seems very worth doing nonetheless.

The reason this works is because `IntEnum` inherits from `int`, so there is a good fast path in C to grab its value quickly. `enum.value` has to do both a dictionary lookup for `value` and run the Python-written value property code.