### PR TITLE
[Backport] Fix CI checks job to detect test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
 
   checks:
     name: Check job status
+    if: always()
     runs-on: ubuntu-latest
     needs:
       - test-linux-64
@@ -181,4 +182,14 @@ jobs:
       # we don't build docs on the backport branch, see #809
     steps:
       - name: Exit
-        run: exit 0
+        run: |
+          # if any dependencies were cancelled or failed, that's a failure
+          if ${{ needs.test-linux-64.result == 'cancelled' ||
+                 needs.test-linux-64.result == 'failure' ||
+                 needs.test-linux-aarch64.result == 'cancelled' ||
+                 needs.test-linux-aarch64.result == 'failure' ||
+                 needs.test-windows.result == 'cancelled' ||
+                 needs.test-windows.result == 'failure' }}; then
+            exit 1
+          fi
+          exit 0


### PR DESCRIPTION
## Summary

- Fix the `checks` job to detect test failures, not just exit 0 unconditionally
- Add `if: always()` to ensure the checks job runs even when test jobs fail
- Add proper failure and cancellation checks for all test jobs

## Test plan

- [ ] Verify CI runs and the checks job correctly fails when tests fail