### PR TITLE
ci: add pytest-randomly to cuda-bindings

### DIFF
--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -46,6 +46,7 @@ test = [
     "pytest>=6.2.4",
     "pytest-benchmark>=3.4.1",
     "pytest-repeat",
+    "pytest-randomly",
     "pyglet>=2.1.9",
 ]
 


### PR DESCRIPTION
Add pytest-randomly to `cuda_bindings/pyproject.toml`