### PR TITLE
Use 'not success' checks instead of specific failure conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,16 +243,16 @@ jobs:
           # Note: When [doc-only] is in PR title, test jobs are intentionally
           # skipped and should not cause failure.
           doc_only=${{ needs.should-skip.outputs.doc-only }}
-          if ${{ needs.doc.result == 'cancelled' || needs.doc.result == 'failure' }}; then
+          # Fail if doc job didn't succeed (covers cancelled, failure, skipped, or any unexpected state)
+          if ${{ needs.doc.result != 'success' }}; then
             exit 1
           fi
           if [[ "${doc_only}" != "true" ]]; then
-            if ${{ needs.test-linux-64.result == 'cancelled' ||
-                   needs.test-linux-64.result == 'failure' ||
-                   needs.test-linux-aarch64.result == 'cancelled' ||
-                   needs.test-linux-aarch64.result == 'failure' ||
-                   needs.test-windows.result == 'cancelled' ||
-                   needs.test-windows.result == 'failure' }}; then
+            # Fail if any test job didn't succeed (covers cancelled, failure, skipped, or any unexpected state)
+            # When doc_only != "true", test jobs should have run, so any non-success state is a failure
+            if ${{ needs.test-linux-64.result != 'success' ||
+                   needs.test-linux-aarch64.result != 'success' ||
+                   needs.test-windows.result != 'success' }}; then
               exit 1
             fi
           fi


### PR DESCRIPTION
@kkraus14 this is a mix of suggestion & question. It boils down to: How do we want to handle the `skipped` condition?

___

Change the checks job to test for `result != 'success'` instead of explicitly checking for `'cancelled'` or `'failure'` states. This is safer because:

1. **It catches all non-success states** - cancelled, failure, skipped, or any unexpected future states that GitHub might introduce

2. **It follows a 'fail closed' approach** - if we don't know the state is success, we fail

3. **It's simpler and more maintainable** - no need to list specific failure conditions

The possible values for `needs.<job>.result` are: `success`, `failure`, `cancelled`, or `skipped`. By checking for 'not success', we ensure we catch any unexpected states and err on the safer side.

## Changes

- Updated doc job check: `result == 'cancelled' || result == 'failure'` → `result != 'success'`
- Updated test job checks: `result == 'cancelled' || result == 'failure'` → `result != 'success'`
