### PR TITLE
NVML: Change Inforom-related APIs from str to bytes

### DIFF
--- a/cuda_bindings/cuda/bindings/nvml.pxd
+++ b/cuda_bindings/cuda/bindings/nvml.pxd
@@ -182,9 +182,9 @@ cpdef int device_get_topology_common_ancestor(intptr_t device1, intptr_t device2
 cpdef int device_get_p2p_status(intptr_t device1, intptr_t device2, int p2p_ind_ex) except? -1
 cpdef str device_get_uuid(intptr_t device)
 cpdef unsigned int device_get_minor_number(intptr_t device) except? 0
-cpdef str device_get_board_part_number(intptr_t device)
-cpdef str device_get_inforom_version(intptr_t device, int object)
-cpdef str device_get_inforom_image_version(intptr_t device)
+cpdef bytes device_get_board_part_number(intptr_t device)
+cpdef bytes device_get_inforom_version(intptr_t device, int object)
+cpdef bytes device_get_inforom_image_version(intptr_t device)
 cpdef unsigned int device_get_inforom_configuration_checksum(intptr_t device) except? 0
 cpdef device_validate_inforom(intptr_t device)
 cpdef tuple device_get_last_bbx_flush_time(intptr_t device)

--- a/cuda_bindings/cuda/bindings/nvml.pyx
+++ b/cuda_bindings/cuda/bindings/nvml.pyx
@@ -20035,7 +20035,7 @@ cpdef unsigned int device_get_minor_number(intptr_t device) except? 0:
     return minor_number
 
 
-cpdef str device_get_board_part_number(intptr_t device):
+cpdef bytes device_get_board_part_number(intptr_t device):
     """Retrieves the the device board part number which is programmed into the board's InfoROM.
 
     Args:
@@ -20048,10 +20048,10 @@ cpdef str device_get_board_part_number(intptr_t device):
     with nogil:
         __status__ = nvmlDeviceGetBoardPartNumber(<Device>device, part_number, length)
     check_status(__status__)
-    return cpython.PyUnicode_FromString(part_number)
+    return cpython.PyBytes_FromStringAndSize(part_number, 80)
 
 
-cpdef str device_get_inforom_version(intptr_t device, int object):
+cpdef bytes device_get_inforom_version(intptr_t device, int object):
     """Retrieves the version information for the device's infoROM object.
 
     Args:
@@ -20065,10 +20065,10 @@ cpdef str device_get_inforom_version(intptr_t device, int object):
     with nogil:
         __status__ = nvmlDeviceGetInforomVersion(<Device>device, <_InforomObject>object, version, length)
     check_status(__status__)
-    return cpython.PyUnicode_FromString(version)
+    return cpython.PyBytes_FromStringAndSize(version, 16)
 
 
-cpdef str device_get_inforom_image_version(intptr_t device):
+cpdef bytes device_get_inforom_image_version(intptr_t device):
     """Retrieves the global infoROM image version.
 
     Args:
@@ -20081,7 +20081,7 @@ cpdef str device_get_inforom_image_version(intptr_t device):
     with nogil:
         __status__ = nvmlDeviceGetInforomImageVersion(<Device>device, version, length)
     check_status(__status__)
-    return cpython.PyUnicode_FromString(version)
+    return cpython.PyBytes_FromStringAndSize(version, 16)
 
 
 cpdef unsigned int device_get_inforom_configuration_checksum(intptr_t device) except? 0:

--- a/cuda_core/cuda/core/system/_inforom.pxi
+++ b/cuda_core/cuda/core/system/_inforom.pxi
@@ -12,7 +12,7 @@ cdef class InforomInfo:
     def __init__(self, device: Device):
         self._device = device
 
-    def get_version(self, inforom: InforomObject) -> str:
+    def get_version(self, inforom: InforomObject) -> bytes:
         """
         Retrieves the InfoROM version for a given InfoROM object.
 
@@ -34,7 +34,7 @@ cdef class InforomInfo:
         return nvml.device_get_inforom_version(self._device._handle, inforom)
 
     @property
-    def image_version(self) -> str:
+    def image_version(self) -> bytes:
         """
         Retrieves the global InfoROM image version.
 
@@ -100,7 +100,7 @@ cdef class InforomInfo:
         return nvml.device_get_last_bbx_flush_time(self._device._handle)
 
     @property
-    def board_part_number(self) -> str:
+    def board_part_number(self) -> bytes:
         """
         The device board part number which is programmed into the board's InfoROM.
         """

--- a/cuda_core/tests/system/test_system_device.py
+++ b/cuda_core/tests/system/test_system_device.py
@@ -514,11 +514,11 @@ def test_get_inforom_version():
 
         with unsupported_before(device, "HAS_INFOROM"):
             inforom_image_version = inforom.image_version
-        assert isinstance(inforom_image_version, str)
+        assert isinstance(inforom_image_version, bytes)
         assert len(inforom_image_version) > 0
 
         inforom_version = inforom.get_version(system.InforomObject.INFOROM_OEM)
-        assert isinstance(inforom_version, str)
+        assert isinstance(inforom_version, bytes)
         assert len(inforom_version) > 0
 
         checksum = inforom.configuration_checksum
@@ -537,7 +537,7 @@ def test_get_inforom_version():
 
         with unsupported_before(device, "HAS_INFOROM"):
             board_part_number = inforom.board_part_number
-        assert isinstance(board_part_number, str)
+        assert isinstance(board_part_number, bytes)
         assert len(board_part_number) > 0
 
         inforom.validate()


### PR DESCRIPTION
Based on a discussion elsewhere with the NVML team, it seems that these APIs should really be `bytes` (containing embedded NULL characters), not `str`.
