### PR TITLE
Fix peer access test synchronization issue

### DIFF
--- a/cuda_core/tests/memory_ipc/test_peer_access.py
+++ b/cuda_core/tests/memory_ipc/test_peer_access.py
@@ -94,6 +94,8 @@ class TestBufferPeerAccessAfterImport:
         # Test 1: Buffer accessible from resident device (dev1) - should always work
         dev1 = Device(1)
         dev1.set_current()
+        # Sync dev1 to ensure IPC import operations are complete
+        dev1.sync()
         PatternGen(dev1, NBYTES).verify_buffer(buffer, seed=False)
 
         # Test 2: Buffer NOT accessible from dev0 initially (peer access not preserved)
@@ -106,6 +108,9 @@ class TestBufferPeerAccessAfterImport:
         dev1.set_current()
         mr.peer_accessible_by = [0]
         assert mr.peer_accessible_by == (0,)
+        # Sync dev1 to ensure peer access setup and any pending operations are complete
+        # before dev0 accesses the peer memory
+        dev1.sync()
         dev0.set_current()
         PatternGen(dev0, NBYTES).verify_buffer(buffer, seed=False)
 


### PR DESCRIPTION
This Cursor-generated change is expected to resolve failures in QA environments (nvbug 5821337).

___

## Problem

The test `TestBufferPeerAccessAfterImport::test_main` was failing with assertion errors indicating memory comparison failures. The root cause is most likely a synchronization issue when accessing peer memory.

When `dev0` accesses peer memory from `dev1`, `PatternGen.verify_buffer()` only synchronizes `dev0` (the accessing device) but not `dev1` (the resident device). This can cause synchronization issues where `dev0` reads peer memory before `dev1` has completed all operations, leading to incorrect data being read.

## Changes

- Added `dev1.sync()` call after IPC import (Test 1)
- Added `dev1.sync()` call after granting peer access (Test 3) before `dev0` accesses peer memory

This follows CUDA best practices: when accessing peer memory, sync the resident device to ensure its operations are complete before the peer device reads the memory.