### PR TITLE
Exclude Cython-generated .cpp files from wheels

### DIFF
--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -56,6 +56,9 @@ Documentation = "https://nvidia.github.io/cuda-python/"
 [tool.setuptools.packages.find]
 include = ["cuda*"]
 
+[tool.setuptools.exclude-package-data]
+"*" = ["*.cpp"]
+
 [tool.setuptools.dynamic]
 readme = { file = ["DESCRIPTION.rst"], content-type = "text/x-rst" }
 

--- a/cuda_bindings/setup.py
+++ b/cuda_bindings/setup.py
@@ -356,6 +356,7 @@ def do_cythonize(extensions):
     return cythonize(
         extensions,
         nthreads=nthreads,
+        build_dir="build/cython",
         compiler_directives=compiler_directives,
         **extra_cythonize_kwargs,
     )

--- a/cuda_core/build_hooks.py
+++ b/cuda_core/build_hooks.py
@@ -163,6 +163,7 @@ def _build_cuda_core():
         ext_modules,
         verbose=True,
         language_level=3,
+        build_dir="build/cython",
         nthreads=nthreads,
         compiler_directives=compiler_directives,
         compile_time_env=compile_time_env,


### PR DESCRIPTION
## Summary

Cython-generated `.cpp` files were being included in the wheels, consuming significant space without providing value to users (they have the compiled binaries already).

This PR:
- Uses cythonize `build_dir` parameter to place generated `.cpp` files in `build/cython/` instead of the source tree
- Adds `exclude-package-data` for `*.cpp` in cuda-bindings to exclude any remaining `.cpp` files

## Size Reduction

### Installed Package Size (uncompressed)

| Package | Before | After | Reduction |
|---------|--------|-------|-----------|
| cuda-bindings | 141MB (24 .cpp files) | 37MB (0 .cpp files) | **74%** |
| cuda-core | 28MB (24 .cpp files) | 5.4MB (0 .cpp files) | **81%** |
| **Total** | **169MB** | **42.4MB** | **75%** |

### Wheel Size (compressed)

| Package | Before | After | Reduction |
|---------|--------|-------|-----------|
| cuda-bindings | 16MB | 7.3MB | **54%** |
| cuda-core | 17MB | 1.7MB | **90%** |
| **Total** | **33MB** | **9MB** | **73%** |

## Test Plan

- [x] CI passes
- [x] Verify wheels do not contain `.cpp` files
- [x] Verify packages install and function correctly