### PR TITLE
Display C compiler version in logs

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -106,6 +106,16 @@ jobs:
         run: |
           env
 
+      - name: Display compiler version
+        if: ${{ !startsWith(inputs.host-platform, 'win') }}
+        run: |
+          cc --version
+
+      - name: Display compiler version
+        if: ${{ startsWith(inputs.host-platform, 'win') }}
+        run: |
+          cl.exe
+
       - name: Install twine
         run: |
           pip install twine


### PR DESCRIPTION
It is sometimes useful to know the C compiler that was used to build our wheels.  This just adds it to the build logs.