### PR TITLE
Add Device context manager for temporary device switching

### DIFF
--- a/cuda_core/tests/conftest.py
+++ b/cuda_core/tests/conftest.py
@@ -192,13 +192,15 @@ def _mempool_device_impl(num):
 @pytest.fixture
 def mempool_device_x2():
     """Fixture that provides two devices if available, otherwise skips test."""
-    return _mempool_device_impl(2)
+    yield _mempool_device_impl(2)
+    _device_unset_current()
 
 
 @pytest.fixture
 def mempool_device_x3():
     """Fixture that provides three devices if available, otherwise skips test."""
-    return _mempool_device_impl(3)
+    yield _mempool_device_impl(3)
+    _device_unset_current()
 
 
 @pytest.fixture(


### PR DESCRIPTION
## Summary

Closes #1586. Adds `__enter__`/`__exit__` to `Device` so it can be used as a context manager that temporarily activates a device and restores the previous CUDA context on exit.

```python
from cuda.core import Device

dev0 = Device(0)
dev0.set_current()
# ... do work on device 0 ...

with Device(1) as dev1:
    # device 1 is now current
    buf = dev1.allocate(1024)

# device 0 is automatically restored here
```

## Changes

- **`cuda/core/_device.pyx`**: Added `__enter__` and `__exit__` methods to `Device`. On enter, queries the current context via `cuCtxGetCurrent` and saves it on a per-thread stack (`_tls._ctx_stack`), then calls `set_current()`. On exit, restores the saved context via `cuCtxSetCurrent`. Uses peek-then-pop ordering so the stack is not corrupted if `cuCtxSetCurrent` raises.
- **`tests/test_device.py`**: Added 12 tests covering basic usage, context restoration, exception safety, same-device nesting, deep nesting, multi-GPU nesting, `set_current()` inside a `with` block, device usability after exit, device initialization, and thread safety (3 threads on 3 GPUs).
- **`tests/conftest.py`**: Added teardown to `mempool_device_x2` and `mempool_device_x3` fixtures to clean up residual contexts between tests.

## Design

- **Stateless restoration**: Each `__enter__` queries the actual CUDA driver state rather than maintaining a Python-side device cache. This ensures correct interoperability with other libraries (PyTorch, CuPy) that use `cudaSetDevice`/`cuCtxSetCurrent`.
- **Reentrant**: Saved contexts are stored on a per-thread stack (not on the `Device` singleton), so nested and reentrant usage works correctly.
- **Uses `cuCtxGetCurrent`/`cuCtxSetCurrent`**: Consistent with `set_current()` and the runtime API model. Does not use `cuCtxPushCurrent`/`cuCtxPopCurrent`.

## Test Coverage

All tests pass locally on single-GPU (L40) and multi-GPU (3x RTX PRO 6000 Blackwell) machines. Stress-tested with 20 randomized iterations via `pytest-repeat` + `pytest-randomly` with no ordering issues.


Made with [Cursor](https://cursor.com)