### PR TITLE
BUG: Minor fix to fast enum support

### DIFF
--- a/cuda_bindings/cuda/bindings/driver.pyx.in
+++ b/cuda_bindings/cuda/bindings/driver.pyx.in
@@ -7952,7 +7952,7 @@ cdef class CUgraphConditionalHandle:
 
 {{if 'CUlaunchAttributeID_enum' in found_types}}
 
-class CUlaunchAttributeID(_FastEnum):
+class CUkernelNodeAttrID(_FastEnum):
     """
     Launch attributes enum; used as id field of
     :py:obj:`~.CUlaunchAttribute`
@@ -8184,7 +8184,7 @@ class CUlaunchAttributeID(_FastEnum):
 {{endif}}
 {{if 'CUlaunchAttributeID_enum' in found_types}}
 
-class CUlaunchAttributeID(_FastEnum):
+class CUstreamAttrID(_FastEnum):
     """
     Launch attributes enum; used as id field of
     :py:obj:`~.CUlaunchAttribute`

--- a/cuda_bindings/cuda/bindings/runtime.pyx.in
+++ b/cuda_bindings/cuda/bindings/runtime.pyx.in
@@ -6260,7 +6260,7 @@ class cudaGLMapFlags(_FastEnum):
 {{endif}}
 {{if 'cudaLaunchAttributeID' in found_types}}
 
-class cudaLaunchAttributeID(_FastEnum):
+class cudaStreamAttrID(_FastEnum):
     """
     Launch attributes enum; used as id field of
     :py:obj:`~.cudaLaunchAttribute`
@@ -6491,7 +6491,7 @@ class cudaLaunchAttributeID(_FastEnum):
 {{endif}}
 {{if 'cudaLaunchAttributeID' in found_types}}
 
-class cudaLaunchAttributeID(_FastEnum):
+class cudaKernelNodeAttrID(_FastEnum):
     """
     Launch attributes enum; used as id field of
     :py:obj:`~.cudaLaunchAttribute`


### PR DESCRIPTION
This fixes a bug introduced in #1581.  There was a bug in the generator that when an enum is typedef'd under multiple names, it was emitting the first name twice, rather than each of them.