### PR TITLE
Make pathfinder `INFO` line counting non-failing unconditionally.

### DIFF
--- a/ci/tools/run-tests
+++ b/ci/tools/run-tests
@@ -33,8 +33,9 @@ if [[ "${test_module}" == "pathfinder" ]]; then
       "LD:${CUDA_PATHFINDER_TEST_LOAD_NVIDIA_DYNAMIC_LIB_STRICTNESS} " \
       "FH:${CUDA_PATHFINDER_TEST_FIND_NVIDIA_HEADERS_STRICTNESS}"
   pytest -ra -s -v --durations=0 tests/ |& tee /tmp/pathfinder_test_log.txt
-  # Fail if no "INFO test_" lines are found; capture line count otherwise
-  line_count=$(grep '^INFO test_' /tmp/pathfinder_test_log.txt | wc -l)
+  # Report the number of "INFO test_" lines (including zero)
+  # to support quick validations based on GHA log archives.
+  line_count=$(awk '/^INFO test_/ {count++} END {print count+0}' /tmp/pathfinder_test_log.txt)
   echo "Number of \"INFO test_\" lines: $line_count"
   popd
 elif [[ "${test_module}" == "bindings" ]]; then


### PR DESCRIPTION
This resolves failures in the nightly testing.

Super-simple alternative to to #1592 and #1593

The `INFO` lines are very valuable in the unique situation that pathfinder is in: the behavior is by design highly dependent on the environment setup. Without the `INFO` lines, we have no way of validating what the behavior is in the GHA jobs.

The fraction of `INFO` lines in a typical CI log file is around 2.5%:

```
rwgk-win11.localdomain:~/wrk/logs_21965469504 $ wc -l Test_linux-aarch64___py3.11__12.9.1__wheels__a100.txt
5596 Test_linux-aarch64___py3.11__12.9.1__wheels__a100.txt
rwgk-win11.localdomain:~/wrk/logs_21965469504 $ grep 'Z INFO' Test_linux-aarch64___py3.11__12.9.1__wheels__a100.txt | wc -l
140
```

In interactive use, the `INFO` lines are shown only if the `pytest -v` option is specified. In that case, the fraction of `INFO` lines in the combined pathfinder, bindings, core test outputs is also around 2%, e.g.:

```
smc120-0009.ipp2a2.colossus.nvidia.com:/wrk/logs $ wc -l cuda-python_qa_bindings_linux_2026-01-07+142305_tests_log.txt
3199 cuda-python_qa_bindings_linux_2026-01-07+142305_tests_log.txt
smc120-0009.ipp2a2.colossus.nvidia.com:/wrk/logs $ grep -a '^INFO ' cuda-python_qa_bindings_linux_2026-01-07+142305_tests_log.txt | wc -l
55
```

(The exact fraction here is 1.7%, but the log file includes some other things, like `nvidia-smi`, `pip list`.)