### PR TITLE
[doc-only] Add cuda-pathfinder 1.3.5 release notes

### DIFF
--- a/cuda_pathfinder/docs/nv-versions.json
+++ b/cuda_pathfinder/docs/nv-versions.json
@@ -4,6 +4,10 @@
         "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/latest/"
     },
     {
+        "version": "1.3.5",
+        "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/1.3.5/"
+    },
+    {
         "version": "1.3.4",
         "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/1.3.4/"
     },

--- a/cuda_pathfinder/docs/source/release/1.3.5-notes.rst
+++ b/cuda_pathfinder/docs/source/release/1.3.5-notes.rst
@@ -1,0 +1,21 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+.. py:currentmodule:: cuda.pathfinder
+
+``cuda-pathfinder`` 1.3.5 Release notes
+=======================================
+
+Released on Feb 19, 2026
+
+Highlights
+----------
+
+* Add support for loading NVIDIA driver libraries (``"cuda"``, ``"nvml"``)
+  via ``load_nvidia_dynamic_lib()``, and reject unsupported library names
+  with ``ValueError``.
+  (`PR #1602 <https://github.com/NVIDIA/cuda-python/pull/1602>`_)
+
+* Add bitcode library discovery helpers and public API support, including
+  ``find_bitcode_lib()``, ``locate_bitcode_lib()``, and ``SUPPORTED_BITCODE_LIBS``.
+  (`PR #1218 <https://github.com/NVIDIA/cuda-python/pull/1218>`_)


### PR DESCRIPTION
## Description
Document the 1.3.5 highlights and add the docs version entry so published docs can link to this release.
