### PR TITLE
Fix #1641: Handle cleanup when exceptions are thrown

### DIFF
--- a/cuda_bindings/cuda/bindings/driver.pyx.in
+++ b/cuda_bindings/cuda/bindings/driver.pyx.in
@@ -26102,7 +26102,9 @@ def cuDeviceGetHostAtomicCapabilities(operations : Optional[tuple[CUatomicOperat
     :py:obj:`~.cuDeviceGetAttribute`, :py:obj:`~.cuDeviceGetP2PAtomicCapabilities`, :py:obj:`~.cudaDeviceGeHostAtomicCapabilities`
     """
     cdef cydriver.CUdevice cydev
+
     cdef vector[cydriver.CUatomicOperation] cyoperations
+    operations = [] if operations is None else operations
     cdef unsigned int* cycapabilities = NULL
     pycapabilities = []
     try:
@@ -26110,7 +26112,6 @@ def cuDeviceGetHostAtomicCapabilities(operations : Optional[tuple[CUatomicOperat
             cycapabilities = <unsigned int*>calloc(count, sizeof(unsigned int))
             if cycapabilities is NULL:
                 raise MemoryError('Failed to allocate length x size memory: ' + str(count) + 'x' + str(sizeof(unsigned int)))
-        operations = [] if operations is None else operations
         if not all(isinstance(_x, (CUatomicOperation)) for _x in operations):
             raise TypeError("Argument 'operations' is not instance of type (expected tuple[cydriver.CUatomicOperation] or list[cydriver.CUatomicOperation]")
         cyoperations = operations
@@ -28405,7 +28406,10 @@ def cuModuleLoadDataEx(image, unsigned int numOptions, options : Optional[tuple[
     """
     cdef _InputVoidPtrPtrHelper voidStarHelperoptionValues
     cdef void ** cyoptionValues_ptr
+    optionValues = [] if optionValues is None else optionValues
+
     cdef vector[cydriver.CUjit_option] cyoptions
+    options = [] if options is None else options
     cdef _HelperInputVoidPtrStruct cyimageHelper
     cdef void* cyimage
     cdef CUmodule module
@@ -28414,11 +28418,9 @@ def cuModuleLoadDataEx(image, unsigned int numOptions, options : Optional[tuple[
         cyimage = _helper_input_void_ptr(image, &cyimageHelper)
         if numOptions > len(options): raise RuntimeError("List is too small: " + str(len(options)) + " < " + str(numOptions))
         if numOptions > len(optionValues): raise RuntimeError("List is too small: " + str(len(optionValues)) + " < " + str(numOptions))
-        options = [] if options is None else options
         if not all(isinstance(_x, (CUjit_option)) for _x in options):
             raise TypeError("Argument 'options' is not instance of type (expected tuple[cydriver.CUjit_option] or list[cydriver.CUjit_option]")
         cyoptions = options
-        optionValues = [] if optionValues is None else optionValues  
         pylist = [_HelperCUjit_option(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(options, optionValues)] 
         voidStarHelperoptionValues = _InputVoidPtrPtrHelper(pylist)
         cyoptionValues_ptr = <void**><void_ptr>voidStarHelperoptionValues.cptr
@@ -28794,15 +28796,16 @@ def cuLinkCreate(unsigned int numOptions, options : Optional[tuple[CUjit_option]
     cdef CUlinkState stateOut
     cdef _InputVoidPtrPtrHelper voidStarHelperoptionValues
     cdef void ** cyoptionValues_ptr
+    optionValues = [] if optionValues is None else optionValues
+
     cdef vector[cydriver.CUjit_option] cyoptions
+    options = [] if options is None else options
     try:
         if numOptions > len(options): raise RuntimeError("List is too small: " + str(len(options)) + " < " + str(numOptions))
         if numOptions > len(optionValues): raise RuntimeError("List is too small: " + str(len(optionValues)) + " < " + str(numOptions))
-        options = [] if options is None else options
         if not all(isinstance(_x, (CUjit_option)) for _x in options):
             raise TypeError("Argument 'options' is not instance of type (expected tuple[cydriver.CUjit_option] or list[cydriver.CUjit_option]")
         cyoptions = options
-        optionValues = [] if optionValues is None else optionValues  
         pylist = [_HelperCUjit_option(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(options, optionValues)] 
         voidStarHelperoptionValues = _InputVoidPtrPtrHelper(pylist)
         cyoptionValues_ptr = <void**><void_ptr>voidStarHelperoptionValues.cptr
@@ -28868,7 +28871,10 @@ def cuLinkAddData(state, typename not None : CUjitInputType, data, size_t size, 
     """
     cdef _InputVoidPtrPtrHelper voidStarHelperoptionValues
     cdef void ** cyoptionValues_ptr
+    optionValues = [] if optionValues is None else optionValues
+
     cdef vector[cydriver.CUjit_option] cyoptions
+    options = [] if options is None else options
     cdef _HelperInputVoidPtrStruct cydataHelper
     cdef void* cydata
     cdef cydriver.CUjitInputType cytypename
@@ -28885,11 +28891,9 @@ def cuLinkAddData(state, typename not None : CUjitInputType, data, size_t size, 
         cydata = _helper_input_void_ptr(data, &cydataHelper)
         if numOptions > len(options): raise RuntimeError("List is too small: " + str(len(options)) + " < " + str(numOptions))
         if numOptions > len(optionValues): raise RuntimeError("List is too small: " + str(len(optionValues)) + " < " + str(numOptions))
-        options = [] if options is None else options
         if not all(isinstance(_x, (CUjit_option)) for _x in options):
             raise TypeError("Argument 'options' is not instance of type (expected tuple[cydriver.CUjit_option] or list[cydriver.CUjit_option]")
         cyoptions = options
-        optionValues = [] if optionValues is None else optionValues  
         pylist = [_HelperCUjit_option(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(options, optionValues)] 
         voidStarHelperoptionValues = _InputVoidPtrPtrHelper(pylist)
         cyoptionValues_ptr = <void**><void_ptr>voidStarHelperoptionValues.cptr
@@ -28948,7 +28952,10 @@ def cuLinkAddFile(state, typename not None : CUjitInputType, char* path, unsigne
     """
     cdef _InputVoidPtrPtrHelper voidStarHelperoptionValues
     cdef void ** cyoptionValues_ptr
+    optionValues = [] if optionValues is None else optionValues
+
     cdef vector[cydriver.CUjit_option] cyoptions
+    options = [] if options is None else options
     cdef cydriver.CUjitInputType cytypename
     cdef cydriver.CUlinkState cystate
     if state is None:
@@ -28961,11 +28968,9 @@ def cuLinkAddFile(state, typename not None : CUjitInputType, char* path, unsigne
     cytypename = int(typename)
     if numOptions > len(options): raise RuntimeError("List is too small: " + str(len(options)) + " < " + str(numOptions))
     if numOptions > len(optionValues): raise RuntimeError("List is too small: " + str(len(optionValues)) + " < " + str(numOptions))
-    options = [] if options is None else options
     if not all(isinstance(_x, (CUjit_option)) for _x in options):
         raise TypeError("Argument 'options' is not instance of type (expected tuple[cydriver.CUjit_option] or list[cydriver.CUjit_option]")
     cyoptions = options
-    optionValues = [] if optionValues is None else optionValues  
     pylist = [_HelperCUjit_option(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(options, optionValues)] 
     voidStarHelperoptionValues = _InputVoidPtrPtrHelper(pylist)
     cyoptionValues_ptr = <void**><void_ptr>voidStarHelperoptionValues.cptr
@@ -29223,31 +29228,33 @@ def cuLibraryLoadData(code, jitOptions : Optional[tuple[CUjit_option] | list[CUj
     """
     cdef _InputVoidPtrPtrHelper voidStarHelperlibraryOptionValues
     cdef void** cylibraryOptionValues_ptr
+    libraryOptionValues = [] if libraryOptionValues is None else libraryOptionValues
+
     cdef vector[cydriver.CUlibraryOption] cylibraryOptions
+    libraryOptions = [] if libraryOptions is None else libraryOptions
     cdef _InputVoidPtrPtrHelper voidStarHelperjitOptionsValues
     cdef void** cyjitOptionsValues_ptr
+    jitOptionsValues = [] if jitOptionsValues is None else jitOptionsValues
+
     cdef vector[cydriver.CUjit_option] cyjitOptions
+    jitOptions = [] if jitOptions is None else jitOptions
     cdef _HelperInputVoidPtrStruct cycodeHelper
     cdef void* cycode
     cdef CUlibrary library
     try:
         library = CUlibrary()
         cycode = _helper_input_void_ptr(code, &cycodeHelper)
-        jitOptions = [] if jitOptions is None else jitOptions
         if not all(isinstance(_x, (CUjit_option)) for _x in jitOptions):
             raise TypeError("Argument 'jitOptions' is not instance of type (expected tuple[cydriver.CUjit_option] or list[cydriver.CUjit_option]")
         cyjitOptions = jitOptions
-        jitOptionsValues = [] if jitOptionsValues is None else jitOptionsValues
         pylist = [_HelperCUjit_option(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(jitOptions, jitOptionsValues)]
         voidStarHelperjitOptionsValues = _InputVoidPtrPtrHelper(pylist)
         cyjitOptionsValues_ptr = <void**><void_ptr>voidStarHelperjitOptionsValues.cptr
         if numJitOptions > len(jitOptions): raise RuntimeError("List is too small: " + str(len(jitOptions)) + " < " + str(numJitOptions))
         if numJitOptions > len(jitOptionsValues): raise RuntimeError("List is too small: " + str(len(jitOptionsValues)) + " < " + str(numJitOptions))
-        libraryOptions = [] if libraryOptions is None else libraryOptions
         if not all(isinstance(_x, (CUlibraryOption)) for _x in libraryOptions):
             raise TypeError("Argument 'libraryOptions' is not instance of type (expected tuple[cydriver.CUlibraryOption] or list[cydriver.CUlibraryOption]")
         cylibraryOptions = libraryOptions
-        libraryOptionValues = [] if libraryOptionValues is None else libraryOptionValues
         pylist = [_HelperCUlibraryOption(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(libraryOptions, libraryOptionValues)]
         voidStarHelperlibraryOptionValues = _InputVoidPtrPtrHelper(pylist)
         cylibraryOptionValues_ptr = <void**><void_ptr>voidStarHelperlibraryOptionValues.cptr
@@ -29333,27 +29340,29 @@ def cuLibraryLoadFromFile(char* fileName, jitOptions : Optional[tuple[CUjit_opti
     """
     cdef _InputVoidPtrPtrHelper voidStarHelperlibraryOptionValues
     cdef void** cylibraryOptionValues_ptr
+    libraryOptionValues = [] if libraryOptionValues is None else libraryOptionValues
+
     cdef vector[cydriver.CUlibraryOption] cylibraryOptions
+    libraryOptions = [] if libraryOptions is None else libraryOptions
     cdef _InputVoidPtrPtrHelper voidStarHelperjitOptionsValues
     cdef void** cyjitOptionsValues_ptr
+    jitOptionsValues = [] if jitOptionsValues is None else jitOptionsValues
+
     cdef vector[cydriver.CUjit_option] cyjitOptions
+    jitOptions = [] if jitOptions is None else jitOptions
     cdef CUlibrary library
     library = CUlibrary()
-    jitOptions = [] if jitOptions is None else jitOptions
     if not all(isinstance(_x, (CUjit_option)) for _x in jitOptions):
         raise TypeError("Argument 'jitOptions' is not instance of type (expected tuple[cydriver.CUjit_option] or list[cydriver.CUjit_option]")
     cyjitOptions = jitOptions
-    jitOptionsValues = [] if jitOptionsValues is None else jitOptionsValues
     pylist = [_HelperCUjit_option(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(jitOptions, jitOptionsValues)]
     voidStarHelperjitOptionsValues = _InputVoidPtrPtrHelper(pylist)
     cyjitOptionsValues_ptr = <void**><void_ptr>voidStarHelperjitOptionsValues.cptr
     if numJitOptions > len(jitOptions): raise RuntimeError("List is too small: " + str(len(jitOptions)) + " < " + str(numJitOptions))
     if numJitOptions > len(jitOptionsValues): raise RuntimeError("List is too small: " + str(len(jitOptionsValues)) + " < " + str(numJitOptions))
-    libraryOptions = [] if libraryOptions is None else libraryOptions
     if not all(isinstance(_x, (CUlibraryOption)) for _x in libraryOptions):
         raise TypeError("Argument 'libraryOptions' is not instance of type (expected tuple[cydriver.CUlibraryOption] or list[cydriver.CUlibraryOption]")
     cylibraryOptions = libraryOptions
-    libraryOptionValues = [] if libraryOptionValues is None else libraryOptionValues
     pylist = [_HelperCUlibraryOption(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(libraryOptions, libraryOptionValues)]
     voidStarHelperlibraryOptionValues = _InputVoidPtrPtrHelper(pylist)
     cylibraryOptionValues_ptr = <void**><void_ptr>voidStarHelperlibraryOptionValues.cptr
@@ -33414,11 +33423,13 @@ def cuMemcpyBatchAsync(dsts : Optional[tuple[CUdeviceptr] | list[CUdeviceptr]], 
     cdef cydriver.CUstream cyhStream
     cdef vector[size_t] cyattrsIdxs
     cdef cydriver.CUmemcpyAttributes* cyattrs = NULL
+    attrs = [] if attrs is None else attrs
     cdef vector[size_t] cysizes
     cdef cydriver.CUdeviceptr* cysrcs = NULL
+    srcs = [] if srcs is None else srcs
     cdef cydriver.CUdeviceptr* cydsts = NULL
+    dsts = [] if dsts is None else dsts
     try:
-        dsts = [] if dsts is None else dsts
         if not all(isinstance(_x, (CUdeviceptr,)) for _x in dsts):
             raise TypeError("Argument 'dsts' is not instance of type (expected tuple[cydriver.CUdeviceptr,] or list[cydriver.CUdeviceptr,]")
         if len(dsts) > 1:
@@ -33430,7 +33441,6 @@ def cuMemcpyBatchAsync(dsts : Optional[tuple[CUdeviceptr] | list[CUdeviceptr]], 
                     cydsts[idx] = <cydriver.CUdeviceptr>(<CUdeviceptr>dsts[idx])._pvt_ptr[0]
         elif len(dsts) == 1:
             cydsts = <cydriver.CUdeviceptr*>(<CUdeviceptr>dsts[0])._pvt_ptr
-        srcs = [] if srcs is None else srcs
         if not all(isinstance(_x, (CUdeviceptr,)) for _x in srcs):
             raise TypeError("Argument 'srcs' is not instance of type (expected tuple[cydriver.CUdeviceptr,] or list[cydriver.CUdeviceptr,]")
         if len(srcs) > 1:
@@ -33448,7 +33458,6 @@ def cuMemcpyBatchAsync(dsts : Optional[tuple[CUdeviceptr] | list[CUdeviceptr]], 
         if count > <size_t>len(dsts): raise RuntimeError("List is too small: " + str(len(dsts)) + " < " + str(count))
         if count > <size_t>len(srcs): raise RuntimeError("List is too small: " + str(len(srcs)) + " < " + str(count))
         if count > <size_t>len(sizes): raise RuntimeError("List is too small: " + str(len(sizes)) + " < " + str(count))
-        attrs = [] if attrs is None else attrs
         if not all(isinstance(_x, (CUmemcpyAttributes,)) for _x in attrs):
             raise TypeError("Argument 'attrs' is not instance of type (expected tuple[cydriver.CUmemcpyAttributes,] or list[cydriver.CUmemcpyAttributes,]")
         if len(attrs) > 1:
@@ -33588,9 +33597,9 @@ def cuMemcpy3DBatchAsync(size_t numOps, opList : Optional[tuple[CUDA_MEMCPY3D_BA
     """
     cdef cydriver.CUstream cyhStream
     cdef cydriver.CUDA_MEMCPY3D_BATCH_OP* cyopList = NULL
+    opList = [] if opList is None else opList
     try:
         if numOps > <size_t>len(opList): raise RuntimeError("List is too small: " + str(len(opList)) + " < " + str(numOps))
-        opList = [] if opList is None else opList
         if not all(isinstance(_x, (CUDA_MEMCPY3D_BATCH_OP,)) for _x in opList):
             raise TypeError("Argument 'opList' is not instance of type (expected tuple[cydriver.CUDA_MEMCPY3D_BATCH_OP,] or list[cydriver.CUDA_MEMCPY3D_BATCH_OP,]")
         if len(opList) > 1:
@@ -35668,8 +35677,8 @@ def cuMemMapArrayAsync(mapInfoList : Optional[tuple[CUarrayMapInfo] | list[CUarr
     """
     cdef cydriver.CUstream cyhStream
     cdef cydriver.CUarrayMapInfo* cymapInfoList = NULL
+    mapInfoList = [] if mapInfoList is None else mapInfoList
     try:
-        mapInfoList = [] if mapInfoList is None else mapInfoList
         if not all(isinstance(_x, (CUarrayMapInfo,)) for _x in mapInfoList):
             raise TypeError("Argument 'mapInfoList' is not instance of type (expected tuple[cydriver.CUarrayMapInfo,] or list[cydriver.CUarrayMapInfo,]")
         if len(mapInfoList) > 1:
@@ -35790,6 +35799,7 @@ def cuMemSetAccess(ptr, size_t size, desc : Optional[tuple[CUmemAccessDesc] | li
     :py:obj:`~.cuMemSetAccess`, :py:obj:`~.cuMemCreate`, :py:obj:`~.py`:obj:`~.cuMemMap`
     """
     cdef cydriver.CUmemAccessDesc* cydesc = NULL
+    desc = [] if desc is None else desc
     cdef cydriver.CUdeviceptr cyptr
     try:
         if ptr is None:
@@ -35799,7 +35809,6 @@ def cuMemSetAccess(ptr, size_t size, desc : Optional[tuple[CUmemAccessDesc] | li
         else:
             pptr = int(CUdeviceptr(ptr))
         cyptr = <cydriver.CUdeviceptr><void_ptr>pptr
-        desc = [] if desc is None else desc
         if not all(isinstance(_x, (CUmemAccessDesc,)) for _x in desc):
             raise TypeError("Argument 'desc' is not instance of type (expected tuple[cydriver.CUmemAccessDesc,] or list[cydriver.CUmemAccessDesc,]")
         if len(desc) > 1:
@@ -36451,6 +36460,7 @@ def cuMemPoolSetAccess(pool, map : Optional[tuple[CUmemAccessDesc] | list[CUmemA
     :py:obj:`~.cuMemAllocAsync`, :py:obj:`~.cuMemFreeAsync`, :py:obj:`~.cuDeviceGetDefaultMemPool`, :py:obj:`~.cuDeviceGetMemPool`, :py:obj:`~.cuMemPoolCreate`
     """
     cdef cydriver.CUmemAccessDesc* cymap = NULL
+    map = [] if map is None else map
     cdef cydriver.CUmemoryPool cypool
     try:
         if pool is None:
@@ -36460,7 +36470,6 @@ def cuMemPoolSetAccess(pool, map : Optional[tuple[CUmemAccessDesc] | list[CUmemA
         else:
             ppool = int(CUmemoryPool(pool))
         cypool = <cydriver.CUmemoryPool><void_ptr>ppool
-        map = [] if map is None else map
         if not all(isinstance(_x, (CUmemAccessDesc,)) for _x in map):
             raise TypeError("Argument 'map' is not instance of type (expected tuple[cydriver.CUmemAccessDesc,] or list[cydriver.CUmemAccessDesc,]")
         if len(map) > 1:
@@ -38316,10 +38325,11 @@ def cuMemPrefetchBatchAsync(dptrs : Optional[tuple[CUdeviceptr] | list[CUdevicep
     cdef cydriver.CUstream cyhStream
     cdef vector[size_t] cyprefetchLocIdxs
     cdef cydriver.CUmemLocation* cyprefetchLocs = NULL
+    prefetchLocs = [] if prefetchLocs is None else prefetchLocs
     cdef vector[size_t] cysizes
     cdef cydriver.CUdeviceptr* cydptrs = NULL
+    dptrs = [] if dptrs is None else dptrs
     try:
-        dptrs = [] if dptrs is None else dptrs
         if not all(isinstance(_x, (CUdeviceptr,)) for _x in dptrs):
             raise TypeError("Argument 'dptrs' is not instance of type (expected tuple[cydriver.CUdeviceptr,] or list[cydriver.CUdeviceptr,]")
         if len(dptrs) > 1:
@@ -38336,7 +38346,6 @@ def cuMemPrefetchBatchAsync(dptrs : Optional[tuple[CUdeviceptr] | list[CUdevicep
         cysizes = sizes
         if count > <size_t>len(dptrs): raise RuntimeError("List is too small: " + str(len(dptrs)) + " < " + str(count))
         if count > <size_t>len(sizes): raise RuntimeError("List is too small: " + str(len(sizes)) + " < " + str(count))
-        prefetchLocs = [] if prefetchLocs is None else prefetchLocs
         if not all(isinstance(_x, (CUmemLocation,)) for _x in prefetchLocs):
             raise TypeError("Argument 'prefetchLocs' is not instance of type (expected tuple[cydriver.CUmemLocation,] or list[cydriver.CUmemLocation,]")
         if len(prefetchLocs) > 1:
@@ -38424,8 +38433,8 @@ def cuMemDiscardBatchAsync(dptrs : Optional[tuple[CUdeviceptr] | list[CUdevicept
     cdef cydriver.CUstream cyhStream
     cdef vector[size_t] cysizes
     cdef cydriver.CUdeviceptr* cydptrs = NULL
+    dptrs = [] if dptrs is None else dptrs
     try:
-        dptrs = [] if dptrs is None else dptrs
         if not all(isinstance(_x, (CUdeviceptr,)) for _x in dptrs):
             raise TypeError("Argument 'dptrs' is not instance of type (expected tuple[cydriver.CUdeviceptr,] or list[cydriver.CUdeviceptr,]")
         if len(dptrs) > 1:
@@ -38536,10 +38545,11 @@ def cuMemDiscardAndPrefetchBatchAsync(dptrs : Optional[tuple[CUdeviceptr] | list
     cdef cydriver.CUstream cyhStream
     cdef vector[size_t] cyprefetchLocIdxs
     cdef cydriver.CUmemLocation* cyprefetchLocs = NULL
+    prefetchLocs = [] if prefetchLocs is None else prefetchLocs
     cdef vector[size_t] cysizes
     cdef cydriver.CUdeviceptr* cydptrs = NULL
+    dptrs = [] if dptrs is None else dptrs
     try:
-        dptrs = [] if dptrs is None else dptrs
         if not all(isinstance(_x, (CUdeviceptr,)) for _x in dptrs):
             raise TypeError("Argument 'dptrs' is not instance of type (expected tuple[cydriver.CUdeviceptr,] or list[cydriver.CUdeviceptr,]")
         if len(dptrs) > 1:
@@ -38556,7 +38566,6 @@ def cuMemDiscardAndPrefetchBatchAsync(dptrs : Optional[tuple[CUdeviceptr] | list
         cysizes = sizes
         if count > <size_t>len(dptrs): raise RuntimeError("List is too small: " + str(len(dptrs)) + " < " + str(count))
         if count > <size_t>len(sizes): raise RuntimeError("List is too small: " + str(len(sizes)) + " < " + str(count))
-        prefetchLocs = [] if prefetchLocs is None else prefetchLocs
         if not all(isinstance(_x, (CUmemLocation,)) for _x in prefetchLocs):
             raise TypeError("Argument 'prefetchLocs' is not instance of type (expected tuple[cydriver.CUmemLocation,] or list[cydriver.CUmemLocation,]")
         if len(prefetchLocs) > 1:
@@ -38811,7 +38820,9 @@ def cuMemRangeGetAttributes(dataSizes : tuple[int] | list[int], attributes : Opt
     :py:obj:`~.cuMemRangeGetAttribute`, :py:obj:`~.cuMemAdvise`, :py:obj:`~.cuMemPrefetchAsync`, :py:obj:`~.cudaMemRangeGetAttributes`
     """
     cdef cydriver.CUdeviceptr cydevPtr
+
     cdef vector[cydriver.CUmem_range_attribute] cyattributes
+    attributes = [] if attributes is None else attributes
     cdef vector[size_t] cydataSizes
     cdef _InputVoidPtrPtrHelper voidStarHelperdata
     cdef void** cyvoidStarHelper_ptr
@@ -38821,7 +38832,6 @@ def cuMemRangeGetAttributes(dataSizes : tuple[int] | list[int], attributes : Opt
     if not all(isinstance(_x, (int)) for _x in dataSizes):
         raise TypeError("Argument 'dataSizes' is not instance of type (expected tuple[int] or list[int]")
     cydataSizes = dataSizes
-    attributes = [] if attributes is None else attributes
     if not all(isinstance(_x, (CUmem_range_attribute)) for _x in attributes):
         raise TypeError("Argument 'attributes' is not instance of type (expected tuple[cydriver.CUmem_range_attribute] or list[cydriver.CUmem_range_attribute]")
     cyattributes = attributes
@@ -38974,9 +38984,10 @@ def cuPointerGetAttributes(unsigned int numAttributes, attributes : Optional[tup
     cdef cydriver.CUdeviceptr cyptr
     cdef _InputVoidPtrPtrHelper voidStarHelperdata
     cdef void** cyvoidStarHelper_ptr
+
     cdef vector[cydriver.CUpointer_attribute] cyattributes
-    if numAttributes > len(attributes): raise RuntimeError("List is too small: " + str(len(attributes)) + " < " + str(numAttributes))
     attributes = [] if attributes is None else attributes
+    if numAttributes > len(attributes): raise RuntimeError("List is too small: " + str(len(attributes)) + " < " + str(numAttributes))
     if not all(isinstance(_x, (CUpointer_attribute)) for _x in attributes):
         raise TypeError("Argument 'attributes' is not instance of type (expected tuple[cydriver.CUpointer_attribute] or list[cydriver.CUpointer_attribute]")
     cyattributes = attributes
@@ -39725,7 +39736,9 @@ def cuStreamBeginCaptureToGraph(hStream, hGraph, dependencies : Optional[tuple[C
     """
     cdef cydriver.CUstreamCaptureMode cymode
     cdef cydriver.CUgraphEdgeData* cydependencyData = NULL
+    dependencyData = [] if dependencyData is None else dependencyData
     cdef cydriver.CUgraphNode* cydependencies = NULL
+    dependencies = [] if dependencies is None else dependencies
     cdef cydriver.CUgraph cyhGraph
     cdef cydriver.CUstream cyhStream
     try:
@@ -39743,7 +39756,6 @@ def cuStreamBeginCaptureToGraph(hStream, hGraph, dependencies : Optional[tuple[C
         else:
             phGraph = int(CUgraph(hGraph))
         cyhGraph = <cydriver.CUgraph><void_ptr>phGraph
-        dependencies = [] if dependencies is None else dependencies
         if not all(isinstance(_x, (CUgraphNode,)) for _x in dependencies):
             raise TypeError("Argument 'dependencies' is not instance of type (expected tuple[cydriver.CUgraphNode,] or list[cydriver.CUgraphNode,]")
         if len(dependencies) > 1:
@@ -39755,7 +39767,6 @@ def cuStreamBeginCaptureToGraph(hStream, hGraph, dependencies : Optional[tuple[C
                     cydependencies[idx] = <cydriver.CUgraphNode>(<CUgraphNode>dependencies[idx])._pvt_ptr[0]
         elif len(dependencies) == 1:
             cydependencies = <cydriver.CUgraphNode*>(<CUgraphNode>dependencies[0])._pvt_ptr
-        dependencyData = [] if dependencyData is None else dependencyData
         if not all(isinstance(_x, (CUgraphEdgeData,)) for _x in dependencyData):
             raise TypeError("Argument 'dependencyData' is not instance of type (expected tuple[cydriver.CUgraphEdgeData,] or list[cydriver.CUgraphEdgeData,]")
         if len(dependencyData) > 1:
@@ -40115,7 +40126,9 @@ def cuStreamUpdateCaptureDependencies(hStream, dependencies : Optional[tuple[CUg
     :py:obj:`~.cuStreamBeginCapture`, :py:obj:`~.cuStreamGetCaptureInfo`
     """
     cdef cydriver.CUgraphEdgeData* cydependencyData = NULL
+    dependencyData = [] if dependencyData is None else dependencyData
     cdef cydriver.CUgraphNode* cydependencies = NULL
+    dependencies = [] if dependencies is None else dependencies
     cdef cydriver.CUstream cyhStream
     try:
         if hStream is None:
@@ -40125,7 +40138,6 @@ def cuStreamUpdateCaptureDependencies(hStream, dependencies : Optional[tuple[CUg
         else:
             phStream = int(CUstream(hStream))
         cyhStream = <cydriver.CUstream><void_ptr>phStream
-        dependencies = [] if dependencies is None else dependencies
         if not all(isinstance(_x, (CUgraphNode,)) for _x in dependencies):
             raise TypeError("Argument 'dependencies' is not instance of type (expected tuple[cydriver.CUgraphNode,] or list[cydriver.CUgraphNode,]")
         if len(dependencies) > 1:
@@ -40137,7 +40149,6 @@ def cuStreamUpdateCaptureDependencies(hStream, dependencies : Optional[tuple[CUg
                     cydependencies[idx] = <cydriver.CUgraphNode>(<CUgraphNode>dependencies[idx])._pvt_ptr[0]
         elif len(dependencies) == 1:
             cydependencies = <cydriver.CUgraphNode*>(<CUgraphNode>dependencies[0])._pvt_ptr
-        dependencyData = [] if dependencyData is None else dependencyData
         if not all(isinstance(_x, (CUgraphEdgeData,)) for _x in dependencyData):
             raise TypeError("Argument 'dependencyData' is not instance of type (expected tuple[cydriver.CUgraphEdgeData,] or list[cydriver.CUgraphEdgeData,]")
         if len(dependencyData) > 1:
@@ -41535,9 +41546,10 @@ def cuSignalExternalSemaphoresAsync(extSemArray : Optional[tuple[CUexternalSemap
     """
     cdef cydriver.CUstream cystream
     cdef cydriver.CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS* cyparamsArray = NULL
+    paramsArray = [] if paramsArray is None else paramsArray
     cdef cydriver.CUexternalSemaphore* cyextSemArray = NULL
+    extSemArray = [] if extSemArray is None else extSemArray
     try:
-        extSemArray = [] if extSemArray is None else extSemArray
         if not all(isinstance(_x, (CUexternalSemaphore,)) for _x in extSemArray):
             raise TypeError("Argument 'extSemArray' is not instance of type (expected tuple[cydriver.CUexternalSemaphore,] or list[cydriver.CUexternalSemaphore,]")
         if len(extSemArray) > 1:
@@ -41549,7 +41561,6 @@ def cuSignalExternalSemaphoresAsync(extSemArray : Optional[tuple[CUexternalSemap
                     cyextSemArray[idx] = <cydriver.CUexternalSemaphore>(<CUexternalSemaphore>extSemArray[idx])._pvt_ptr[0]
         elif len(extSemArray) == 1:
             cyextSemArray = <cydriver.CUexternalSemaphore*>(<CUexternalSemaphore>extSemArray[0])._pvt_ptr
-        paramsArray = [] if paramsArray is None else paramsArray
         if not all(isinstance(_x, (CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS,)) for _x in paramsArray):
             raise TypeError("Argument 'paramsArray' is not instance of type (expected tuple[cydriver.CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS,] or list[cydriver.CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS,]")
         if len(paramsArray) > 1:
@@ -41667,9 +41678,10 @@ def cuWaitExternalSemaphoresAsync(extSemArray : Optional[tuple[CUexternalSemapho
     """
     cdef cydriver.CUstream cystream
     cdef cydriver.CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS* cyparamsArray = NULL
+    paramsArray = [] if paramsArray is None else paramsArray
     cdef cydriver.CUexternalSemaphore* cyextSemArray = NULL
+    extSemArray = [] if extSemArray is None else extSemArray
     try:
-        extSemArray = [] if extSemArray is None else extSemArray
         if not all(isinstance(_x, (CUexternalSemaphore,)) for _x in extSemArray):
             raise TypeError("Argument 'extSemArray' is not instance of type (expected tuple[cydriver.CUexternalSemaphore,] or list[cydriver.CUexternalSemaphore,]")
         if len(extSemArray) > 1:
@@ -41681,7 +41693,6 @@ def cuWaitExternalSemaphoresAsync(extSemArray : Optional[tuple[CUexternalSemapho
                     cyextSemArray[idx] = <cydriver.CUexternalSemaphore>(<CUexternalSemaphore>extSemArray[idx])._pvt_ptr[0]
         elif len(extSemArray) == 1:
             cyextSemArray = <cydriver.CUexternalSemaphore*>(<CUexternalSemaphore>extSemArray[0])._pvt_ptr
-        paramsArray = [] if paramsArray is None else paramsArray
         if not all(isinstance(_x, (CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS,)) for _x in paramsArray):
             raise TypeError("Argument 'paramsArray' is not instance of type (expected tuple[cydriver.CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS,] or list[cydriver.CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS,]")
         if len(paramsArray) > 1:
@@ -42066,6 +42077,7 @@ def cuStreamBatchMemOp(stream, unsigned int count, paramArray : Optional[tuple[C
     Warning: Improper use of this API may deadlock the application. Synchronization ordering established through this API is not visible to CUDA. CUDA tasks that are (even indirectly) ordered by this API should also have that order expressed with CUDA-visible dependencies such as events. This ensures that the scheduler does not serialize them in an improper order.
     """
     cdef cydriver.CUstreamBatchMemOpParams* cyparamArray = NULL
+    paramArray = [] if paramArray is None else paramArray
     cdef cydriver.CUstream cystream
     try:
         if stream is None:
@@ -42076,7 +42088,6 @@ def cuStreamBatchMemOp(stream, unsigned int count, paramArray : Optional[tuple[C
             pstream = int(CUstream(stream))
         cystream = <cydriver.CUstream><void_ptr>pstream
         if count > len(paramArray): raise RuntimeError("List is too small: " + str(len(paramArray)) + " < " + str(count))
-        paramArray = [] if paramArray is None else paramArray
         if not all(isinstance(_x, (CUstreamBatchMemOpParams,)) for _x in paramArray):
             raise TypeError("Argument 'paramArray' is not instance of type (expected tuple[cydriver.CUstreamBatchMemOpParams,] or list[cydriver.CUstreamBatchMemOpParams,]")
         if len(paramArray) > 1:
@@ -43258,8 +43269,8 @@ def cuLaunchCooperativeKernelMultiDevice(launchParamsList : Optional[tuple[CUDA_
     :py:obj:`~.cuCtxGetCacheConfig`, :py:obj:`~.cuCtxSetCacheConfig`, :py:obj:`~.cuFuncSetCacheConfig`, :py:obj:`~.cuFuncGetAttribute`, :py:obj:`~.cuLaunchCooperativeKernel`, :py:obj:`~.cudaLaunchCooperativeKernelMultiDevice`
     """
     cdef cydriver.CUDA_LAUNCH_PARAMS* cylaunchParamsList = NULL
+    launchParamsList = [] if launchParamsList is None else launchParamsList
     try:
-        launchParamsList = [] if launchParamsList is None else launchParamsList
         if not all(isinstance(_x, (CUDA_LAUNCH_PARAMS,)) for _x in launchParamsList):
             raise TypeError("Argument 'launchParamsList' is not instance of type (expected tuple[cydriver.CUDA_LAUNCH_PARAMS,] or list[cydriver.CUDA_LAUNCH_PARAMS,]")
         if len(launchParamsList) > 1:
@@ -44079,6 +44090,7 @@ def cuGraphAddKernelNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | li
     """
     cdef cydriver.CUDA_KERNEL_NODE_PARAMS* cynodeParams_ptr
     cdef cydriver.CUgraphNode* cydependencies = NULL
+    dependencies = [] if dependencies is None else dependencies
     cdef cydriver.CUgraph cyhGraph
     cdef CUgraphNode phGraphNode
     try:
@@ -44090,7 +44102,6 @@ def cuGraphAddKernelNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | li
         else:
             phGraph = int(CUgraph(hGraph))
         cyhGraph = <cydriver.CUgraph><void_ptr>phGraph
-        dependencies = [] if dependencies is None else dependencies
         if not all(isinstance(_x, (CUgraphNode,)) for _x in dependencies):
             raise TypeError("Argument 'dependencies' is not instance of type (expected tuple[cydriver.CUgraphNode,] or list[cydriver.CUgraphNode,]")
         if len(dependencies) > 1:
@@ -44256,6 +44267,7 @@ def cuGraphAddMemcpyNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | li
     cdef cydriver.CUcontext cyctx
     cdef cydriver.CUDA_MEMCPY3D* cycopyParams_ptr
     cdef cydriver.CUgraphNode* cydependencies = NULL
+    dependencies = [] if dependencies is None else dependencies
     cdef cydriver.CUgraph cyhGraph
     cdef CUgraphNode phGraphNode
     try:
@@ -44267,7 +44279,6 @@ def cuGraphAddMemcpyNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | li
         else:
             phGraph = int(CUgraph(hGraph))
         cyhGraph = <cydriver.CUgraph><void_ptr>phGraph
-        dependencies = [] if dependencies is None else dependencies
         if not all(isinstance(_x, (CUgraphNode,)) for _x in dependencies):
             raise TypeError("Argument 'dependencies' is not instance of type (expected tuple[cydriver.CUgraphNode,] or list[cydriver.CUgraphNode,]")
         if len(dependencies) > 1:
@@ -44421,6 +44432,7 @@ def cuGraphAddMemsetNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | li
     cdef cydriver.CUcontext cyctx
     cdef cydriver.CUDA_MEMSET_NODE_PARAMS* cymemsetParams_ptr
     cdef cydriver.CUgraphNode* cydependencies = NULL
+    dependencies = [] if dependencies is None else dependencies
     cdef cydriver.CUgraph cyhGraph
     cdef CUgraphNode phGraphNode
     try:
@@ -44432,7 +44444,6 @@ def cuGraphAddMemsetNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | li
         else:
             phGraph = int(CUgraph(hGraph))
         cyhGraph = <cydriver.CUgraph><void_ptr>phGraph
-        dependencies = [] if dependencies is None else dependencies
         if not all(isinstance(_x, (CUgraphNode,)) for _x in dependencies):
             raise TypeError("Argument 'dependencies' is not instance of type (expected tuple[cydriver.CUgraphNode,] or list[cydriver.CUgraphNode,]")
         if len(dependencies) > 1:
@@ -44583,6 +44594,7 @@ def cuGraphAddHostNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | list
     """
     cdef cydriver.CUDA_HOST_NODE_PARAMS* cynodeParams_ptr
     cdef cydriver.CUgraphNode* cydependencies = NULL
+    dependencies = [] if dependencies is None else dependencies
     cdef cydriver.CUgraph cyhGraph
     cdef CUgraphNode phGraphNode
     try:
@@ -44594,7 +44606,6 @@ def cuGraphAddHostNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | list
         else:
             phGraph = int(CUgraph(hGraph))
         cyhGraph = <cydriver.CUgraph><void_ptr>phGraph
-        dependencies = [] if dependencies is None else dependencies
         if not all(isinstance(_x, (CUgraphNode,)) for _x in dependencies):
             raise TypeError("Argument 'dependencies' is not instance of type (expected tuple[cydriver.CUgraphNode,] or list[cydriver.CUgraphNode,]")
         if len(dependencies) > 1:
@@ -44741,6 +44752,7 @@ def cuGraphAddChildGraphNode(hGraph, dependencies : Optional[tuple[CUgraphNode] 
     """
     cdef cydriver.CUgraph cychildGraph
     cdef cydriver.CUgraphNode* cydependencies = NULL
+    dependencies = [] if dependencies is None else dependencies
     cdef cydriver.CUgraph cyhGraph
     cdef CUgraphNode phGraphNode
     try:
@@ -44752,7 +44764,6 @@ def cuGraphAddChildGraphNode(hGraph, dependencies : Optional[tuple[CUgraphNode] 
         else:
             phGraph = int(CUgraph(hGraph))
         cyhGraph = <cydriver.CUgraph><void_ptr>phGraph
-        dependencies = [] if dependencies is None else dependencies
         if not all(isinstance(_x, (CUgraphNode,)) for _x in dependencies):
             raise TypeError("Argument 'dependencies' is not instance of type (expected tuple[cydriver.CUgraphNode,] or list[cydriver.CUgraphNode,]")
         if len(dependencies) > 1:
@@ -44868,6 +44879,7 @@ def cuGraphAddEmptyNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | lis
     :py:obj:`~.cuGraphAddNode`, :py:obj:`~.cuGraphCreate`, :py:obj:`~.cuGraphDestroyNode`, :py:obj:`~.cuGraphAddChildGraphNode`, :py:obj:`~.cuGraphAddKernelNode`, :py:obj:`~.cuGraphAddHostNode`, :py:obj:`~.cuGraphAddMemcpyNode`, :py:obj:`~.cuGraphAddMemsetNode`
     """
     cdef cydriver.CUgraphNode* cydependencies = NULL
+    dependencies = [] if dependencies is None else dependencies
     cdef cydriver.CUgraph cyhGraph
     cdef CUgraphNode phGraphNode
     try:
@@ -44879,7 +44891,6 @@ def cuGraphAddEmptyNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | lis
         else:
             phGraph = int(CUgraph(hGraph))
         cyhGraph = <cydriver.CUgraph><void_ptr>phGraph
-        dependencies = [] if dependencies is None else dependencies
         if not all(isinstance(_x, (CUgraphNode,)) for _x in dependencies):
             raise TypeError("Argument 'dependencies' is not instance of type (expected tuple[cydriver.CUgraphNode,] or list[cydriver.CUgraphNode,]")
         if len(dependencies) > 1:
@@ -44942,6 +44953,7 @@ def cuGraphAddEventRecordNode(hGraph, dependencies : Optional[tuple[CUgraphNode]
     """
     cdef cydriver.CUevent cyevent
     cdef cydriver.CUgraphNode* cydependencies = NULL
+    dependencies = [] if dependencies is None else dependencies
     cdef cydriver.CUgraph cyhGraph
     cdef CUgraphNode phGraphNode
     try:
@@ -44953,7 +44965,6 @@ def cuGraphAddEventRecordNode(hGraph, dependencies : Optional[tuple[CUgraphNode]
         else:
             phGraph = int(CUgraph(hGraph))
         cyhGraph = <cydriver.CUgraph><void_ptr>phGraph
-        dependencies = [] if dependencies is None else dependencies
         if not all(isinstance(_x, (CUgraphNode,)) for _x in dependencies):
             raise TypeError("Argument 'dependencies' is not instance of type (expected tuple[cydriver.CUgraphNode,] or list[cydriver.CUgraphNode,]")
         if len(dependencies) > 1:
@@ -45111,6 +45122,7 @@ def cuGraphAddEventWaitNode(hGraph, dependencies : Optional[tuple[CUgraphNode] |
     """
     cdef cydriver.CUevent cyevent
     cdef cydriver.CUgraphNode* cydependencies = NULL
+    dependencies = [] if dependencies is None else dependencies
     cdef cydriver.CUgraph cyhGraph
     cdef CUgraphNode phGraphNode
     try:
@@ -45122,7 +45134,6 @@ def cuGraphAddEventWaitNode(hGraph, dependencies : Optional[tuple[CUgraphNode] |
         else:
             phGraph = int(CUgraph(hGraph))
         cyhGraph = <cydriver.CUgraph><void_ptr>phGraph
-        dependencies = [] if dependencies is None else dependencies
         if not all(isinstance(_x, (CUgraphNode,)) for _x in dependencies):
             raise TypeError("Argument 'dependencies' is not instance of type (expected tuple[cydriver.CUgraphNode,] or list[cydriver.CUgraphNode,]")
         if len(dependencies) > 1:
@@ -45279,6 +45290,7 @@ def cuGraphAddExternalSemaphoresSignalNode(hGraph, dependencies : Optional[tuple
     """
     cdef cydriver.CUDA_EXT_SEM_SIGNAL_NODE_PARAMS* cynodeParams_ptr
     cdef cydriver.CUgraphNode* cydependencies = NULL
+    dependencies = [] if dependencies is None else dependencies
     cdef cydriver.CUgraph cyhGraph
     cdef CUgraphNode phGraphNode
     try:
@@ -45290,7 +45302,6 @@ def cuGraphAddExternalSemaphoresSignalNode(hGraph, dependencies : Optional[tuple
         else:
             phGraph = int(CUgraph(hGraph))
         cyhGraph = <cydriver.CUgraph><void_ptr>phGraph
-        dependencies = [] if dependencies is None else dependencies
         if not all(isinstance(_x, (CUgraphNode,)) for _x in dependencies):
             raise TypeError("Argument 'dependencies' is not instance of type (expected tuple[cydriver.CUgraphNode,] or list[cydriver.CUgraphNode,]")
         if len(dependencies) > 1:
@@ -45442,6 +45453,7 @@ def cuGraphAddExternalSemaphoresWaitNode(hGraph, dependencies : Optional[tuple[C
     """
     cdef cydriver.CUDA_EXT_SEM_WAIT_NODE_PARAMS* cynodeParams_ptr
     cdef cydriver.CUgraphNode* cydependencies = NULL
+    dependencies = [] if dependencies is None else dependencies
     cdef cydriver.CUgraph cyhGraph
     cdef CUgraphNode phGraphNode
     try:
@@ -45453,7 +45465,6 @@ def cuGraphAddExternalSemaphoresWaitNode(hGraph, dependencies : Optional[tuple[C
         else:
             phGraph = int(CUgraph(hGraph))
         cyhGraph = <cydriver.CUgraph><void_ptr>phGraph
-        dependencies = [] if dependencies is None else dependencies
         if not all(isinstance(_x, (CUgraphNode,)) for _x in dependencies):
             raise TypeError("Argument 'dependencies' is not instance of type (expected tuple[cydriver.CUgraphNode,] or list[cydriver.CUgraphNode,]")
         if len(dependencies) > 1:
@@ -45608,6 +45619,7 @@ def cuGraphAddBatchMemOpNode(hGraph, dependencies : Optional[tuple[CUgraphNode] 
     """
     cdef cydriver.CUDA_BATCH_MEM_OP_NODE_PARAMS* cynodeParams_ptr
     cdef cydriver.CUgraphNode* cydependencies = NULL
+    dependencies = [] if dependencies is None else dependencies
     cdef cydriver.CUgraph cyhGraph
     cdef CUgraphNode phGraphNode
     try:
@@ -45619,7 +45631,6 @@ def cuGraphAddBatchMemOpNode(hGraph, dependencies : Optional[tuple[CUgraphNode] 
         else:
             phGraph = int(CUgraph(hGraph))
         cyhGraph = <cydriver.CUgraph><void_ptr>phGraph
-        dependencies = [] if dependencies is None else dependencies
         if not all(isinstance(_x, (CUgraphNode,)) for _x in dependencies):
             raise TypeError("Argument 'dependencies' is not instance of type (expected tuple[cydriver.CUgraphNode,] or list[cydriver.CUgraphNode,]")
         if len(dependencies) > 1:
@@ -45884,6 +45895,7 @@ def cuGraphAddMemAllocNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | 
     """
     cdef cydriver.CUDA_MEM_ALLOC_NODE_PARAMS* cynodeParams_ptr
     cdef cydriver.CUgraphNode* cydependencies = NULL
+    dependencies = [] if dependencies is None else dependencies
     cdef cydriver.CUgraph cyhGraph
     cdef CUgraphNode phGraphNode
     try:
@@ -45895,7 +45907,6 @@ def cuGraphAddMemAllocNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | 
         else:
             phGraph = int(CUgraph(hGraph))
         cyhGraph = <cydriver.CUgraph><void_ptr>phGraph
-        dependencies = [] if dependencies is None else dependencies
         if not all(isinstance(_x, (CUgraphNode,)) for _x in dependencies):
             raise TypeError("Argument 'dependencies' is not instance of type (expected tuple[cydriver.CUgraphNode,] or list[cydriver.CUgraphNode,]")
         if len(dependencies) > 1:
@@ -46021,6 +46032,7 @@ def cuGraphAddMemFreeNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | l
     """
     cdef cydriver.CUdeviceptr cydptr
     cdef cydriver.CUgraphNode* cydependencies = NULL
+    dependencies = [] if dependencies is None else dependencies
     cdef cydriver.CUgraph cyhGraph
     cdef CUgraphNode phGraphNode
     try:
@@ -46032,7 +46044,6 @@ def cuGraphAddMemFreeNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | l
         else:
             phGraph = int(CUgraph(hGraph))
         cyhGraph = <cydriver.CUgraph><void_ptr>phGraph
-        dependencies = [] if dependencies is None else dependencies
         if not all(isinstance(_x, (CUgraphNode,)) for _x in dependencies):
             raise TypeError("Argument 'dependencies' is not instance of type (expected tuple[cydriver.CUgraphNode,] or list[cydriver.CUgraphNode,]")
         if len(dependencies) > 1:
@@ -47017,8 +47028,11 @@ def cuGraphAddDependencies(hGraph, from_ : Optional[tuple[CUgraphNode] | list[CU
     :py:obj:`~.cuGraphRemoveDependencies`, :py:obj:`~.cuGraphGetEdges`, :py:obj:`~.cuGraphNodeGetDependencies`, :py:obj:`~.cuGraphNodeGetDependentNodes`
     """
     cdef cydriver.CUgraphEdgeData* cyedgeData = NULL
+    edgeData = [] if edgeData is None else edgeData
     cdef cydriver.CUgraphNode* cyto = NULL
+    to = [] if to is None else to
     cdef cydriver.CUgraphNode* cyfrom_ = NULL
+    from_ = [] if from_ is None else from_
     cdef cydriver.CUgraph cyhGraph
     try:
         if hGraph is None:
@@ -47028,7 +47042,6 @@ def cuGraphAddDependencies(hGraph, from_ : Optional[tuple[CUgraphNode] | list[CU
         else:
             phGraph = int(CUgraph(hGraph))
         cyhGraph = <cydriver.CUgraph><void_ptr>phGraph
-        from_ = [] if from_ is None else from_
         if not all(isinstance(_x, (CUgraphNode,)) for _x in from_):
             raise TypeError("Argument 'from_' is not instance of type (expected tuple[cydriver.CUgraphNode,] or list[cydriver.CUgraphNode,]")
         if len(from_) > 1:
@@ -47040,7 +47053,6 @@ def cuGraphAddDependencies(hGraph, from_ : Optional[tuple[CUgraphNode] | list[CU
                     cyfrom_[idx] = <cydriver.CUgraphNode>(<CUgraphNode>from_[idx])._pvt_ptr[0]
         elif len(from_) == 1:
             cyfrom_ = <cydriver.CUgraphNode*>(<CUgraphNode>from_[0])._pvt_ptr
-        to = [] if to is None else to
         if not all(isinstance(_x, (CUgraphNode,)) for _x in to):
             raise TypeError("Argument 'to' is not instance of type (expected tuple[cydriver.CUgraphNode,] or list[cydriver.CUgraphNode,]")
         if len(to) > 1:
@@ -47052,7 +47064,6 @@ def cuGraphAddDependencies(hGraph, from_ : Optional[tuple[CUgraphNode] | list[CU
                     cyto[idx] = <cydriver.CUgraphNode>(<CUgraphNode>to[idx])._pvt_ptr[0]
         elif len(to) == 1:
             cyto = <cydriver.CUgraphNode*>(<CUgraphNode>to[0])._pvt_ptr
-        edgeData = [] if edgeData is None else edgeData
         if not all(isinstance(_x, (CUgraphEdgeData,)) for _x in edgeData):
             raise TypeError("Argument 'edgeData' is not instance of type (expected tuple[cydriver.CUgraphEdgeData,] or list[cydriver.CUgraphEdgeData,]")
         if len(edgeData) > 1:
@@ -47118,8 +47129,11 @@ def cuGraphRemoveDependencies(hGraph, from_ : Optional[tuple[CUgraphNode] | list
     :py:obj:`~.cuGraphAddDependencies`, :py:obj:`~.cuGraphGetEdges`, :py:obj:`~.cuGraphNodeGetDependencies`, :py:obj:`~.cuGraphNodeGetDependentNodes`
     """
     cdef cydriver.CUgraphEdgeData* cyedgeData = NULL
+    edgeData = [] if edgeData is None else edgeData
     cdef cydriver.CUgraphNode* cyto = NULL
+    to = [] if to is None else to
     cdef cydriver.CUgraphNode* cyfrom_ = NULL
+    from_ = [] if from_ is None else from_
     cdef cydriver.CUgraph cyhGraph
     try:
         if hGraph is None:
@@ -47129,7 +47143,6 @@ def cuGraphRemoveDependencies(hGraph, from_ : Optional[tuple[CUgraphNode] | list
         else:
             phGraph = int(CUgraph(hGraph))
         cyhGraph = <cydriver.CUgraph><void_ptr>phGraph
-        from_ = [] if from_ is None else from_
         if not all(isinstance(_x, (CUgraphNode,)) for _x in from_):
             raise TypeError("Argument 'from_' is not instance of type (expected tuple[cydriver.CUgraphNode,] or list[cydriver.CUgraphNode,]")
         if len(from_) > 1:
@@ -47141,7 +47154,6 @@ def cuGraphRemoveDependencies(hGraph, from_ : Optional[tuple[CUgraphNode] | list
                     cyfrom_[idx] = <cydriver.CUgraphNode>(<CUgraphNode>from_[idx])._pvt_ptr[0]
         elif len(from_) == 1:
             cyfrom_ = <cydriver.CUgraphNode*>(<CUgraphNode>from_[0])._pvt_ptr
-        to = [] if to is None else to
         if not all(isinstance(_x, (CUgraphNode,)) for _x in to):
             raise TypeError("Argument 'to' is not instance of type (expected tuple[cydriver.CUgraphNode,] or list[cydriver.CUgraphNode,]")
         if len(to) > 1:
@@ -47153,7 +47165,6 @@ def cuGraphRemoveDependencies(hGraph, from_ : Optional[tuple[CUgraphNode] | list
                     cyto[idx] = <cydriver.CUgraphNode>(<CUgraphNode>to[idx])._pvt_ptr[0]
         elif len(to) == 1:
             cyto = <cydriver.CUgraphNode*>(<CUgraphNode>to[0])._pvt_ptr
-        edgeData = [] if edgeData is None else edgeData
         if not all(isinstance(_x, (CUgraphEdgeData,)) for _x in edgeData):
             raise TypeError("Argument 'edgeData' is not instance of type (expected tuple[cydriver.CUgraphEdgeData,] or list[cydriver.CUgraphEdgeData,]")
         if len(edgeData) > 1:
@@ -49102,7 +49113,9 @@ def cuGraphAddNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | list[CUg
     """
     cdef cydriver.CUgraphNodeParams* cynodeParams_ptr
     cdef cydriver.CUgraphEdgeData* cydependencyData = NULL
+    dependencyData = [] if dependencyData is None else dependencyData
     cdef cydriver.CUgraphNode* cydependencies = NULL
+    dependencies = [] if dependencies is None else dependencies
     cdef cydriver.CUgraph cyhGraph
     cdef CUgraphNode phGraphNode
     try:
@@ -49114,7 +49127,6 @@ def cuGraphAddNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | list[CUg
         else:
             phGraph = int(CUgraph(hGraph))
         cyhGraph = <cydriver.CUgraph><void_ptr>phGraph
-        dependencies = [] if dependencies is None else dependencies
         if not all(isinstance(_x, (CUgraphNode,)) for _x in dependencies):
             raise TypeError("Argument 'dependencies' is not instance of type (expected tuple[cydriver.CUgraphNode,] or list[cydriver.CUgraphNode,]")
         if len(dependencies) > 1:
@@ -49126,7 +49138,6 @@ def cuGraphAddNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | list[CUg
                     cydependencies[idx] = <cydriver.CUgraphNode>(<CUgraphNode>dependencies[idx])._pvt_ptr[0]
         elif len(dependencies) == 1:
             cydependencies = <cydriver.CUgraphNode*>(<CUgraphNode>dependencies[0])._pvt_ptr
-        dependencyData = [] if dependencyData is None else dependencyData
         if not all(isinstance(_x, (CUgraphEdgeData,)) for _x in dependencyData):
             raise TypeError("Argument 'dependencyData' is not instance of type (expected tuple[cydriver.CUgraphEdgeData,] or list[cydriver.CUgraphEdgeData,]")
         if len(dependencyData) > 1:
@@ -52301,7 +52312,9 @@ def cuTensorMapEncodeIm2col(tensorDataType not None : CUtensorMapDataType, tenso
     cdef cydriver.cuuint32_t cypixelsPerColumn
     cdef cydriver.cuuint32_t cychannelsPerPixel
     cdef vector[int] cypixelBoxUpperCorner
+    pixelBoxUpperCorner = [] if pixelBoxUpperCorner is None else pixelBoxUpperCorner
     cdef vector[int] cypixelBoxLowerCorner
+    pixelBoxLowerCorner = [] if pixelBoxLowerCorner is None else pixelBoxLowerCorner
     cdef cydriver.cuuint64_t* cyglobalStrides
     cdef size_t globalStridesLen
     cdef cydriver.cuuint64_t[5] globalStridesStatic
@@ -52346,11 +52359,9 @@ def cuTensorMapEncodeIm2col(tensorDataType not None : CUtensorMapDataType, tenso
             cyglobalStrides = globalStridesStatic
         else:
             raise ValueError("Argument 'globalStrides' too long, must be <= 5")
-        pixelBoxLowerCorner = [] if pixelBoxLowerCorner is None else pixelBoxLowerCorner
         if not all(isinstance(_x, (int)) for _x in pixelBoxLowerCorner):
             raise TypeError("Argument 'pixelBoxLowerCorner' is not instance of type (expected tuple[int] or list[int]")
         cypixelBoxLowerCorner = pixelBoxLowerCorner
-        pixelBoxUpperCorner = [] if pixelBoxUpperCorner is None else pixelBoxUpperCorner
         if not all(isinstance(_x, (int)) for _x in pixelBoxUpperCorner):
             raise TypeError("Argument 'pixelBoxUpperCorner' is not instance of type (expected tuple[int] or list[int]")
         cypixelBoxUpperCorner = pixelBoxUpperCorner
@@ -53063,7 +53074,9 @@ def cuDeviceGetP2PAtomicCapabilities(operations : Optional[tuple[CUatomicOperati
     """
     cdef cydriver.CUdevice cydstDevice
     cdef cydriver.CUdevice cysrcDevice
+
     cdef vector[cydriver.CUatomicOperation] cyoperations
+    operations = [] if operations is None else operations
     cdef unsigned int* cycapabilities = NULL
     pycapabilities = []
     try:
@@ -53071,7 +53084,6 @@ def cuDeviceGetP2PAtomicCapabilities(operations : Optional[tuple[CUatomicOperati
             cycapabilities = <unsigned int*>calloc(count, sizeof(unsigned int))
             if cycapabilities is NULL:
                 raise MemoryError('Failed to allocate length x size memory: ' + str(count) + 'x' + str(sizeof(unsigned int)))
-        operations = [] if operations is None else operations
         if not all(isinstance(_x, (CUatomicOperation)) for _x in operations):
             raise TypeError("Argument 'operations' is not instance of type (expected tuple[cydriver.CUatomicOperation] or list[cydriver.CUatomicOperation]")
         cyoperations = operations
@@ -54771,10 +54783,10 @@ def cuDevResourceGenerateDesc(resources : Optional[tuple[CUdevResource] | list[C
     :py:obj:`~.cuDevSmResourceSplitByCount`
     """
     cdef cydriver.CUdevResource* cyresources = NULL
+    resources = [] if resources is None else resources
     cdef CUdevResourceDesc phDesc
     try:
         phDesc = CUdevResourceDesc()
-        resources = [] if resources is None else resources
         if not all(isinstance(_x, (CUdevResource,)) for _x in resources):
             raise TypeError("Argument 'resources' is not instance of type (expected tuple[cydriver.CUdevResource,] or list[cydriver.CUdevResource,]")
         if len(resources) > 1:

--- a/cuda_bindings/cuda/bindings/nvrtc.pyx.in
+++ b/cuda_bindings/cuda/bindings/nvrtc.pyx.in
@@ -274,16 +274,16 @@ def nvrtcCreateProgram(char* src, char* name, int numHeaders, headers : Optional
     :py:obj:`~.nvrtcDestroyProgram`
     """
     cdef vector[const char*] cyincludeNames
+    includeNames = [] if includeNames is None else includeNames
     cdef vector[const char*] cyheaders
+    headers = [] if headers is None else headers
     cdef nvrtcProgram prog
     prog = nvrtcProgram()
     if numHeaders > len(headers): raise RuntimeError("List is too small: " + str(len(headers)) + " < " + str(numHeaders))
     if numHeaders > len(includeNames): raise RuntimeError("List is too small: " + str(len(includeNames)) + " < " + str(numHeaders))
-    headers = [] if headers is None else headers
     if not all(isinstance(_x, (bytes)) for _x in headers):
         raise TypeError("Argument 'headers' is not instance of type (expected tuple[bytes] or list[bytes]")
     cyheaders = headers
-    includeNames = [] if includeNames is None else includeNames
     if not all(isinstance(_x, (bytes)) for _x in includeNames):
         raise TypeError("Argument 'includeNames' is not instance of type (expected tuple[bytes] or list[bytes]")
     cyincludeNames = includeNames
@@ -363,6 +363,7 @@ def nvrtcCompileProgram(prog, int numOptions, options : Optional[tuple[bytes] | 
         - :py:obj:`~.NVRTC_ERROR_CANCELLED`
     """
     cdef vector[const char*] cyoptions
+    options = [] if options is None else options
     cdef cynvrtc.nvrtcProgram cyprog
     if prog is None:
         pprog = 0
@@ -372,7 +373,6 @@ def nvrtcCompileProgram(prog, int numOptions, options : Optional[tuple[bytes] | 
         pprog = int(nvrtcProgram(prog))
     cyprog = <cynvrtc.nvrtcProgram><void_ptr>pprog
     if numOptions > len(options): raise RuntimeError("List is too small: " + str(len(options)) + " < " + str(numOptions))
-    options = [] if options is None else options
     if not all(isinstance(_x, (bytes)) for _x in options):
         raise TypeError("Argument 'options' is not instance of type (expected tuple[bytes] or list[bytes]")
     cyoptions = options

--- a/cuda_bindings/cuda/bindings/runtime.pyx.in
+++ b/cuda_bindings/cuda/bindings/runtime.pyx.in
@@ -21895,7 +21895,9 @@ def cudaDeviceGetHostAtomicCapabilities(operations : Optional[tuple[cudaAtomicOp
     --------
     :py:obj:`~.cudaDeviceGetAttribute`, :py:obj:`~.cudaDeviceGetP2PAtomicCapabilities`, :py:obj:`~.cuDeviceGeHostAtomicCapabilities`
     """
+
     cdef vector[cyruntime.cudaAtomicOperation] cyoperations
+    operations = [] if operations is None else operations
     cdef unsigned int* cycapabilities = NULL
     pycapabilities = []
     try:
@@ -21903,7 +21905,6 @@ def cudaDeviceGetHostAtomicCapabilities(operations : Optional[tuple[cudaAtomicOp
             cycapabilities = <unsigned int*>calloc(count, sizeof(unsigned int))
             if cycapabilities is NULL:
                 raise MemoryError('Failed to allocate length x size memory: ' + str(count) + 'x' + str(sizeof(unsigned int)))
-        operations = [] if operations is None else operations
         if not all(isinstance(_x, (cudaAtomicOperation)) for _x in operations):
             raise TypeError("Argument 'operations' is not instance of type (expected tuple[cyruntime.cudaAtomicOperation] or list[cyruntime.cudaAtomicOperation]")
         cyoperations = operations
@@ -22238,7 +22239,9 @@ def cudaDeviceGetP2PAtomicCapabilities(operations : Optional[tuple[cudaAtomicOpe
     --------
     :py:obj:`~.cudaDeviceGetP2PAttribute`, :py:obj:`~.cuDeviceGetP2PAttribute`, :py:obj:`~.cuDeviceGetP2PAtomicCapabilities`
     """
+
     cdef vector[cyruntime.cudaAtomicOperation] cyoperations
+    operations = [] if operations is None else operations
     cdef unsigned int* cycapabilities = NULL
     pycapabilities = []
     try:
@@ -22246,7 +22249,6 @@ def cudaDeviceGetP2PAtomicCapabilities(operations : Optional[tuple[cudaAtomicOpe
             cycapabilities = <unsigned int*>calloc(count, sizeof(unsigned int))
             if cycapabilities is NULL:
                 raise MemoryError('Failed to allocate length x size memory: ' + str(count) + 'x' + str(sizeof(unsigned int)))
-        operations = [] if operations is None else operations
         if not all(isinstance(_x, (cudaAtomicOperation)) for _x in operations):
             raise TypeError("Argument 'operations' is not instance of type (expected tuple[cyruntime.cudaAtomicOperation] or list[cyruntime.cudaAtomicOperation]")
         cyoperations = operations
@@ -23569,7 +23571,9 @@ def cudaStreamBeginCaptureToGraph(stream, graph, dependencies : Optional[tuple[c
     """
     cdef cyruntime.cudaStreamCaptureMode cymode
     cdef cyruntime.cudaGraphEdgeData* cydependencyData = NULL
+    dependencyData = [] if dependencyData is None else dependencyData
     cdef cyruntime.cudaGraphNode_t* cydependencies = NULL
+    dependencies = [] if dependencies is None else dependencies
     cdef cyruntime.cudaGraph_t cygraph
     cdef cyruntime.cudaStream_t cystream
     try:
@@ -23587,7 +23591,6 @@ def cudaStreamBeginCaptureToGraph(stream, graph, dependencies : Optional[tuple[c
         else:
             pgraph = int(cudaGraph_t(graph))
         cygraph = <cyruntime.cudaGraph_t><void_ptr>pgraph
-        dependencies = [] if dependencies is None else dependencies
         if not all(isinstance(_x, (cudaGraphNode_t,driver.CUgraphNode)) for _x in dependencies):
             raise TypeError("Argument 'dependencies' is not instance of type (expected tuple[cyruntime.cudaGraphNode_t,driver.CUgraphNode] or list[cyruntime.cudaGraphNode_t,driver.CUgraphNode]")
         if len(dependencies) > 1:
@@ -23599,7 +23602,6 @@ def cudaStreamBeginCaptureToGraph(stream, graph, dependencies : Optional[tuple[c
                     cydependencies[idx] = <cyruntime.cudaGraphNode_t>(<cudaGraphNode_t>dependencies[idx])._pvt_ptr[0]
         elif len(dependencies) == 1:
             cydependencies = <cyruntime.cudaGraphNode_t*>(<cudaGraphNode_t>dependencies[0])._pvt_ptr
-        dependencyData = [] if dependencyData is None else dependencyData
         if not all(isinstance(_x, (cudaGraphEdgeData,)) for _x in dependencyData):
             raise TypeError("Argument 'dependencyData' is not instance of type (expected tuple[cyruntime.cudaGraphEdgeData,] or list[cyruntime.cudaGraphEdgeData,]")
         if len(dependencyData) > 1:
@@ -23957,7 +23959,9 @@ def cudaStreamUpdateCaptureDependencies(stream, dependencies : Optional[tuple[cu
     :py:obj:`~.cudaStreamBeginCapture`, :py:obj:`~.cudaStreamGetCaptureInfo`,
     """
     cdef cyruntime.cudaGraphEdgeData* cydependencyData = NULL
+    dependencyData = [] if dependencyData is None else dependencyData
     cdef cyruntime.cudaGraphNode_t* cydependencies = NULL
+    dependencies = [] if dependencies is None else dependencies
     cdef cyruntime.cudaStream_t cystream
     try:
         if stream is None:
@@ -23967,7 +23971,6 @@ def cudaStreamUpdateCaptureDependencies(stream, dependencies : Optional[tuple[cu
         else:
             pstream = int(cudaStream_t(stream))
         cystream = <cyruntime.cudaStream_t><void_ptr>pstream
-        dependencies = [] if dependencies is None else dependencies
         if not all(isinstance(_x, (cudaGraphNode_t,driver.CUgraphNode)) for _x in dependencies):
             raise TypeError("Argument 'dependencies' is not instance of type (expected tuple[cyruntime.cudaGraphNode_t,driver.CUgraphNode] or list[cyruntime.cudaGraphNode_t,driver.CUgraphNode]")
         if len(dependencies) > 1:
@@ -23979,7 +23982,6 @@ def cudaStreamUpdateCaptureDependencies(stream, dependencies : Optional[tuple[cu
                     cydependencies[idx] = <cyruntime.cudaGraphNode_t>(<cudaGraphNode_t>dependencies[idx])._pvt_ptr[0]
         elif len(dependencies) == 1:
             cydependencies = <cyruntime.cudaGraphNode_t*>(<cudaGraphNode_t>dependencies[0])._pvt_ptr
-        dependencyData = [] if dependencyData is None else dependencyData
         if not all(isinstance(_x, (cudaGraphEdgeData,)) for _x in dependencyData):
             raise TypeError("Argument 'dependencyData' is not instance of type (expected tuple[cyruntime.cudaGraphEdgeData,] or list[cyruntime.cudaGraphEdgeData,]")
         if len(dependencyData) > 1:
@@ -25014,9 +25016,10 @@ def cudaSignalExternalSemaphoresAsync(extSemArray : Optional[tuple[cudaExternalS
     """
     cdef cyruntime.cudaStream_t cystream
     cdef cyruntime.cudaExternalSemaphoreSignalParams* cyparamsArray = NULL
+    paramsArray = [] if paramsArray is None else paramsArray
     cdef cyruntime.cudaExternalSemaphore_t* cyextSemArray = NULL
+    extSemArray = [] if extSemArray is None else extSemArray
     try:
-        extSemArray = [] if extSemArray is None else extSemArray
         if not all(isinstance(_x, (cudaExternalSemaphore_t,)) for _x in extSemArray):
             raise TypeError("Argument 'extSemArray' is not instance of type (expected tuple[cyruntime.cudaExternalSemaphore_t,] or list[cyruntime.cudaExternalSemaphore_t,]")
         if len(extSemArray) > 1:
@@ -25028,7 +25031,6 @@ def cudaSignalExternalSemaphoresAsync(extSemArray : Optional[tuple[cudaExternalS
                     cyextSemArray[idx] = <cyruntime.cudaExternalSemaphore_t>(<cudaExternalSemaphore_t>extSemArray[idx])._pvt_ptr[0]
         elif len(extSemArray) == 1:
             cyextSemArray = <cyruntime.cudaExternalSemaphore_t*>(<cudaExternalSemaphore_t>extSemArray[0])._pvt_ptr
-        paramsArray = [] if paramsArray is None else paramsArray
         if not all(isinstance(_x, (cudaExternalSemaphoreSignalParams,)) for _x in paramsArray):
             raise TypeError("Argument 'paramsArray' is not instance of type (expected tuple[cyruntime.cudaExternalSemaphoreSignalParams,] or list[cyruntime.cudaExternalSemaphoreSignalParams,]")
         if len(paramsArray) > 1:
@@ -25145,9 +25147,10 @@ def cudaWaitExternalSemaphoresAsync(extSemArray : Optional[tuple[cudaExternalSem
     """
     cdef cyruntime.cudaStream_t cystream
     cdef cyruntime.cudaExternalSemaphoreWaitParams* cyparamsArray = NULL
+    paramsArray = [] if paramsArray is None else paramsArray
     cdef cyruntime.cudaExternalSemaphore_t* cyextSemArray = NULL
+    extSemArray = [] if extSemArray is None else extSemArray
     try:
-        extSemArray = [] if extSemArray is None else extSemArray
         if not all(isinstance(_x, (cudaExternalSemaphore_t,)) for _x in extSemArray):
             raise TypeError("Argument 'extSemArray' is not instance of type (expected tuple[cyruntime.cudaExternalSemaphore_t,] or list[cyruntime.cudaExternalSemaphore_t,]")
         if len(extSemArray) > 1:
@@ -25159,7 +25162,6 @@ def cudaWaitExternalSemaphoresAsync(extSemArray : Optional[tuple[cudaExternalSem
                     cyextSemArray[idx] = <cyruntime.cudaExternalSemaphore_t>(<cudaExternalSemaphore_t>extSemArray[idx])._pvt_ptr[0]
         elif len(extSemArray) == 1:
             cyextSemArray = <cyruntime.cudaExternalSemaphore_t*>(<cudaExternalSemaphore_t>extSemArray[0])._pvt_ptr
-        paramsArray = [] if paramsArray is None else paramsArray
         if not all(isinstance(_x, (cudaExternalSemaphoreWaitParams,)) for _x in paramsArray):
             raise TypeError("Argument 'paramsArray' is not instance of type (expected tuple[cyruntime.cudaExternalSemaphoreWaitParams,] or list[cyruntime.cudaExternalSemaphoreWaitParams,]")
         if len(paramsArray) > 1:
@@ -28272,17 +28274,18 @@ def cudaMemcpyBatchAsync(dsts : Optional[tuple[Any] | list[Any]], srcs : Optiona
     cdef cyruntime.cudaStream_t cystream
     cdef vector[size_t] cyattrsIdxs
     cdef cyruntime.cudaMemcpyAttributes* cyattrs = NULL
+    attrs = [] if attrs is None else attrs
     cdef vector[size_t] cysizes
     cdef _InputVoidPtrPtrHelper voidStarHelpersrcs
     cdef const void** cysrcs_ptr
+    srcs = [] if srcs is None else srcs
     cdef _InputVoidPtrPtrHelper voidStarHelperdsts
     cdef const void** cydsts_ptr
+    dsts = [] if dsts is None else dsts
     try:
-        dsts = [] if dsts is None else dsts
         pylist = [_HelperInputVoidPtr(pydsts) for pydsts in dsts]
         voidStarHelperdsts = _InputVoidPtrPtrHelper(pylist)
         cydsts_ptr = <const void**><void_ptr>voidStarHelperdsts.cptr
-        srcs = [] if srcs is None else srcs
         pylist = [_HelperInputVoidPtr(pysrcs) for pysrcs in srcs]
         voidStarHelpersrcs = _InputVoidPtrPtrHelper(pylist)
         cysrcs_ptr = <const void**><void_ptr>voidStarHelpersrcs.cptr
@@ -28292,7 +28295,6 @@ def cudaMemcpyBatchAsync(dsts : Optional[tuple[Any] | list[Any]], srcs : Optiona
         if count > <size_t>len(dsts): raise RuntimeError("List is too small: " + str(len(dsts)) + " < " + str(count))
         if count > <size_t>len(srcs): raise RuntimeError("List is too small: " + str(len(srcs)) + " < " + str(count))
         if count > <size_t>len(sizes): raise RuntimeError("List is too small: " + str(len(sizes)) + " < " + str(count))
-        attrs = [] if attrs is None else attrs
         if not all(isinstance(_x, (cudaMemcpyAttributes,)) for _x in attrs):
             raise TypeError("Argument 'attrs' is not instance of type (expected tuple[cyruntime.cudaMemcpyAttributes,] or list[cyruntime.cudaMemcpyAttributes,]")
         if len(attrs) > 1:
@@ -28427,9 +28429,9 @@ def cudaMemcpy3DBatchAsync(size_t numOps, opList : Optional[tuple[cudaMemcpy3DBa
     """
     cdef cyruntime.cudaStream_t cystream
     cdef cyruntime.cudaMemcpy3DBatchOp* cyopList = NULL
+    opList = [] if opList is None else opList
     try:
         if numOps > <size_t>len(opList): raise RuntimeError("List is too small: " + str(len(opList)) + " < " + str(numOps))
-        opList = [] if opList is None else opList
         if not all(isinstance(_x, (cudaMemcpy3DBatchOp,)) for _x in opList):
             raise TypeError("Argument 'opList' is not instance of type (expected tuple[cyruntime.cudaMemcpy3DBatchOp,] or list[cyruntime.cudaMemcpy3DBatchOp,]")
         if len(opList) > 1:
@@ -29255,11 +29257,12 @@ def cudaMemPrefetchBatchAsync(dptrs : Optional[tuple[Any] | list[Any]], sizes : 
     cdef cyruntime.cudaStream_t cystream
     cdef vector[size_t] cyprefetchLocIdxs
     cdef cyruntime.cudaMemLocation* cyprefetchLocs = NULL
+    prefetchLocs = [] if prefetchLocs is None else prefetchLocs
     cdef vector[size_t] cysizes
     cdef _InputVoidPtrPtrHelper voidStarHelperdptrs
     cdef void** cydptrs_ptr
+    dptrs = [] if dptrs is None else dptrs
     try:
-        dptrs = [] if dptrs is None else dptrs
         pylist = [_HelperInputVoidPtr(pydptrs) for pydptrs in dptrs]
         voidStarHelperdptrs = _InputVoidPtrPtrHelper(pylist)
         cydptrs_ptr = <void**><void_ptr>voidStarHelperdptrs.cptr
@@ -29268,7 +29271,6 @@ def cudaMemPrefetchBatchAsync(dptrs : Optional[tuple[Any] | list[Any]], sizes : 
         cysizes = sizes
         if count > <size_t>len(dptrs): raise RuntimeError("List is too small: " + str(len(dptrs)) + " < " + str(count))
         if count > <size_t>len(sizes): raise RuntimeError("List is too small: " + str(len(sizes)) + " < " + str(count))
-        prefetchLocs = [] if prefetchLocs is None else prefetchLocs
         if not all(isinstance(_x, (cudaMemLocation,)) for _x in prefetchLocs):
             raise TypeError("Argument 'prefetchLocs' is not instance of type (expected tuple[cyruntime.cudaMemLocation,] or list[cyruntime.cudaMemLocation,]")
         if len(prefetchLocs) > 1:
@@ -29455,11 +29457,12 @@ def cudaMemDiscardAndPrefetchBatchAsync(dptrs : Optional[tuple[Any] | list[Any]]
     cdef cyruntime.cudaStream_t cystream
     cdef vector[size_t] cyprefetchLocIdxs
     cdef cyruntime.cudaMemLocation* cyprefetchLocs = NULL
+    prefetchLocs = [] if prefetchLocs is None else prefetchLocs
     cdef vector[size_t] cysizes
     cdef _InputVoidPtrPtrHelper voidStarHelperdptrs
     cdef void** cydptrs_ptr
+    dptrs = [] if dptrs is None else dptrs
     try:
-        dptrs = [] if dptrs is None else dptrs
         pylist = [_HelperInputVoidPtr(pydptrs) for pydptrs in dptrs]
         voidStarHelperdptrs = _InputVoidPtrPtrHelper(pylist)
         cydptrs_ptr = <void**><void_ptr>voidStarHelperdptrs.cptr
@@ -29468,7 +29471,6 @@ def cudaMemDiscardAndPrefetchBatchAsync(dptrs : Optional[tuple[Any] | list[Any]]
         cysizes = sizes
         if count > <size_t>len(dptrs): raise RuntimeError("List is too small: " + str(len(dptrs)) + " < " + str(count))
         if count > <size_t>len(sizes): raise RuntimeError("List is too small: " + str(len(sizes)) + " < " + str(count))
-        prefetchLocs = [] if prefetchLocs is None else prefetchLocs
         if not all(isinstance(_x, (cudaMemLocation,)) for _x in prefetchLocs):
             raise TypeError("Argument 'prefetchLocs' is not instance of type (expected tuple[cyruntime.cudaMemLocation,] or list[cyruntime.cudaMemLocation,]")
         if len(prefetchLocs) > 1:
@@ -29920,7 +29922,9 @@ def cudaMemRangeGetAttributes(dataSizes : tuple[int] | list[int], attributes : O
     """
     cdef _HelperInputVoidPtrStruct cydevPtrHelper
     cdef void* cydevPtr
+
     cdef vector[cyruntime.cudaMemRangeAttribute] cyattributes
+    attributes = [] if attributes is None else attributes
     cdef vector[size_t] cydataSizes
     cdef _InputVoidPtrPtrHelper voidStarHelperdata
     cdef void** cyvoidStarHelper_ptr
@@ -29931,7 +29935,6 @@ def cudaMemRangeGetAttributes(dataSizes : tuple[int] | list[int], attributes : O
         if not all(isinstance(_x, (int)) for _x in dataSizes):
             raise TypeError("Argument 'dataSizes' is not instance of type (expected tuple[int] or list[int]")
         cydataSizes = dataSizes
-        attributes = [] if attributes is None else attributes
         if not all(isinstance(_x, (cudaMemRangeAttribute)) for _x in attributes):
             raise TypeError("Argument 'attributes' is not instance of type (expected tuple[cyruntime.cudaMemRangeAttribute] or list[cyruntime.cudaMemRangeAttribute]")
         cyattributes = attributes
@@ -30655,6 +30658,7 @@ def cudaMemPoolSetAccess(memPool, descList : Optional[tuple[cudaMemAccessDesc] |
     :py:obj:`~.cuMemPoolSetAccess`, :py:obj:`~.cudaMemPoolGetAccess`, :py:obj:`~.cudaMallocAsync`, :py:obj:`~.cudaFreeAsync`
     """
     cdef cyruntime.cudaMemAccessDesc* cydescList = NULL
+    descList = [] if descList is None else descList
     cdef cyruntime.cudaMemPool_t cymemPool
     try:
         if memPool is None:
@@ -30664,7 +30668,6 @@ def cudaMemPoolSetAccess(memPool, descList : Optional[tuple[cudaMemAccessDesc] |
         else:
             pmemPool = int(cudaMemPool_t(memPool))
         cymemPool = <cyruntime.cudaMemPool_t><void_ptr>pmemPool
-        descList = [] if descList is None else descList
         if not all(isinstance(_x, (cudaMemAccessDesc,)) for _x in descList):
             raise TypeError("Argument 'descList' is not instance of type (expected tuple[cyruntime.cudaMemAccessDesc,] or list[cyruntime.cudaMemAccessDesc,]")
         if len(descList) > 1:
@@ -32901,6 +32904,7 @@ def cudaGraphAddKernelNode(graph, pDependencies : Optional[tuple[cudaGraphNode_t
     """
     cdef cyruntime.cudaKernelNodeParams* cypNodeParams_ptr
     cdef cyruntime.cudaGraphNode_t* cypDependencies = NULL
+    pDependencies = [] if pDependencies is None else pDependencies
     cdef cyruntime.cudaGraph_t cygraph
     cdef cudaGraphNode_t pGraphNode
     try:
@@ -32912,7 +32916,6 @@ def cudaGraphAddKernelNode(graph, pDependencies : Optional[tuple[cudaGraphNode_t
         else:
             pgraph = int(cudaGraph_t(graph))
         cygraph = <cyruntime.cudaGraph_t><void_ptr>pgraph
-        pDependencies = [] if pDependencies is None else pDependencies
         if not all(isinstance(_x, (cudaGraphNode_t,driver.CUgraphNode)) for _x in pDependencies):
             raise TypeError("Argument 'pDependencies' is not instance of type (expected tuple[cyruntime.cudaGraphNode_t,driver.CUgraphNode] or list[cyruntime.cudaGraphNode_t,driver.CUgraphNode]")
         if len(pDependencies) > 1:
@@ -33207,6 +33210,7 @@ def cudaGraphAddMemcpyNode(graph, pDependencies : Optional[tuple[cudaGraphNode_t
     """
     cdef cyruntime.cudaMemcpy3DParms* cypCopyParams_ptr
     cdef cyruntime.cudaGraphNode_t* cypDependencies = NULL
+    pDependencies = [] if pDependencies is None else pDependencies
     cdef cyruntime.cudaGraph_t cygraph
     cdef cudaGraphNode_t pGraphNode
     try:
@@ -33218,7 +33222,6 @@ def cudaGraphAddMemcpyNode(graph, pDependencies : Optional[tuple[cudaGraphNode_t
         else:
             pgraph = int(cudaGraph_t(graph))
         cygraph = <cyruntime.cudaGraph_t><void_ptr>pgraph
-        pDependencies = [] if pDependencies is None else pDependencies
         if not all(isinstance(_x, (cudaGraphNode_t,driver.CUgraphNode)) for _x in pDependencies):
             raise TypeError("Argument 'pDependencies' is not instance of type (expected tuple[cyruntime.cudaGraphNode_t,driver.CUgraphNode] or list[cyruntime.cudaGraphNode_t,driver.CUgraphNode]")
         if len(pDependencies) > 1:
@@ -33307,6 +33310,7 @@ def cudaGraphAddMemcpyNode1D(graph, pDependencies : Optional[tuple[cudaGraphNode
     cdef _HelperInputVoidPtrStruct cydstHelper
     cdef void* cydst
     cdef cyruntime.cudaGraphNode_t* cypDependencies = NULL
+    pDependencies = [] if pDependencies is None else pDependencies
     cdef cyruntime.cudaGraph_t cygraph
     cdef cudaGraphNode_t pGraphNode
     try:
@@ -33318,7 +33322,6 @@ def cudaGraphAddMemcpyNode1D(graph, pDependencies : Optional[tuple[cudaGraphNode
         else:
             pgraph = int(cudaGraph_t(graph))
         cygraph = <cyruntime.cudaGraph_t><void_ptr>pgraph
-        pDependencies = [] if pDependencies is None else pDependencies
         if not all(isinstance(_x, (cudaGraphNode_t,driver.CUgraphNode)) for _x in pDependencies):
             raise TypeError("Argument 'pDependencies' is not instance of type (expected tuple[cyruntime.cudaGraphNode_t,driver.CUgraphNode] or list[cyruntime.cudaGraphNode_t,driver.CUgraphNode]")
         if len(pDependencies) > 1:
@@ -33533,6 +33536,7 @@ def cudaGraphAddMemsetNode(graph, pDependencies : Optional[tuple[cudaGraphNode_t
     """
     cdef cyruntime.cudaMemsetParams* cypMemsetParams_ptr
     cdef cyruntime.cudaGraphNode_t* cypDependencies = NULL
+    pDependencies = [] if pDependencies is None else pDependencies
     cdef cyruntime.cudaGraph_t cygraph
     cdef cudaGraphNode_t pGraphNode
     try:
@@ -33544,7 +33548,6 @@ def cudaGraphAddMemsetNode(graph, pDependencies : Optional[tuple[cudaGraphNode_t
         else:
             pgraph = int(cudaGraph_t(graph))
         cygraph = <cyruntime.cudaGraph_t><void_ptr>pgraph
-        pDependencies = [] if pDependencies is None else pDependencies
         if not all(isinstance(_x, (cudaGraphNode_t,driver.CUgraphNode)) for _x in pDependencies):
             raise TypeError("Argument 'pDependencies' is not instance of type (expected tuple[cyruntime.cudaGraphNode_t,driver.CUgraphNode] or list[cyruntime.cudaGraphNode_t,driver.CUgraphNode]")
         if len(pDependencies) > 1:
@@ -33688,6 +33691,7 @@ def cudaGraphAddHostNode(graph, pDependencies : Optional[tuple[cudaGraphNode_t] 
     """
     cdef cyruntime.cudaHostNodeParams* cypNodeParams_ptr
     cdef cyruntime.cudaGraphNode_t* cypDependencies = NULL
+    pDependencies = [] if pDependencies is None else pDependencies
     cdef cyruntime.cudaGraph_t cygraph
     cdef cudaGraphNode_t pGraphNode
     try:
@@ -33699,7 +33703,6 @@ def cudaGraphAddHostNode(graph, pDependencies : Optional[tuple[cudaGraphNode_t] 
         else:
             pgraph = int(cudaGraph_t(graph))
         cygraph = <cyruntime.cudaGraph_t><void_ptr>pgraph
-        pDependencies = [] if pDependencies is None else pDependencies
         if not all(isinstance(_x, (cudaGraphNode_t,driver.CUgraphNode)) for _x in pDependencies):
             raise TypeError("Argument 'pDependencies' is not instance of type (expected tuple[cyruntime.cudaGraphNode_t,driver.CUgraphNode] or list[cyruntime.cudaGraphNode_t,driver.CUgraphNode]")
         if len(pDependencies) > 1:
@@ -33846,6 +33849,7 @@ def cudaGraphAddChildGraphNode(graph, pDependencies : Optional[tuple[cudaGraphNo
     """
     cdef cyruntime.cudaGraph_t cychildGraph
     cdef cyruntime.cudaGraphNode_t* cypDependencies = NULL
+    pDependencies = [] if pDependencies is None else pDependencies
     cdef cyruntime.cudaGraph_t cygraph
     cdef cudaGraphNode_t pGraphNode
     try:
@@ -33857,7 +33861,6 @@ def cudaGraphAddChildGraphNode(graph, pDependencies : Optional[tuple[cudaGraphNo
         else:
             pgraph = int(cudaGraph_t(graph))
         cygraph = <cyruntime.cudaGraph_t><void_ptr>pgraph
-        pDependencies = [] if pDependencies is None else pDependencies
         if not all(isinstance(_x, (cudaGraphNode_t,driver.CUgraphNode)) for _x in pDependencies):
             raise TypeError("Argument 'pDependencies' is not instance of type (expected tuple[cyruntime.cudaGraphNode_t,driver.CUgraphNode] or list[cyruntime.cudaGraphNode_t,driver.CUgraphNode]")
         if len(pDependencies) > 1:
@@ -33973,6 +33976,7 @@ def cudaGraphAddEmptyNode(graph, pDependencies : Optional[tuple[cudaGraphNode_t]
     :py:obj:`~.cudaGraphAddNode`, :py:obj:`~.cudaGraphCreate`, :py:obj:`~.cudaGraphDestroyNode`, :py:obj:`~.cudaGraphAddChildGraphNode`, :py:obj:`~.cudaGraphAddKernelNode`, :py:obj:`~.cudaGraphAddHostNode`, :py:obj:`~.cudaGraphAddMemcpyNode`, :py:obj:`~.cudaGraphAddMemsetNode`
     """
     cdef cyruntime.cudaGraphNode_t* cypDependencies = NULL
+    pDependencies = [] if pDependencies is None else pDependencies
     cdef cyruntime.cudaGraph_t cygraph
     cdef cudaGraphNode_t pGraphNode
     try:
@@ -33984,7 +33988,6 @@ def cudaGraphAddEmptyNode(graph, pDependencies : Optional[tuple[cudaGraphNode_t]
         else:
             pgraph = int(cudaGraph_t(graph))
         cygraph = <cyruntime.cudaGraph_t><void_ptr>pgraph
-        pDependencies = [] if pDependencies is None else pDependencies
         if not all(isinstance(_x, (cudaGraphNode_t,driver.CUgraphNode)) for _x in pDependencies):
             raise TypeError("Argument 'pDependencies' is not instance of type (expected tuple[cyruntime.cudaGraphNode_t,driver.CUgraphNode] or list[cyruntime.cudaGraphNode_t,driver.CUgraphNode]")
         if len(pDependencies) > 1:
@@ -34049,6 +34052,7 @@ def cudaGraphAddEventRecordNode(graph, pDependencies : Optional[tuple[cudaGraphN
     """
     cdef cyruntime.cudaEvent_t cyevent
     cdef cyruntime.cudaGraphNode_t* cypDependencies = NULL
+    pDependencies = [] if pDependencies is None else pDependencies
     cdef cyruntime.cudaGraph_t cygraph
     cdef cudaGraphNode_t pGraphNode
     try:
@@ -34060,7 +34064,6 @@ def cudaGraphAddEventRecordNode(graph, pDependencies : Optional[tuple[cudaGraphN
         else:
             pgraph = int(cudaGraph_t(graph))
         cygraph = <cyruntime.cudaGraph_t><void_ptr>pgraph
-        pDependencies = [] if pDependencies is None else pDependencies
         if not all(isinstance(_x, (cudaGraphNode_t,driver.CUgraphNode)) for _x in pDependencies):
             raise TypeError("Argument 'pDependencies' is not instance of type (expected tuple[cyruntime.cudaGraphNode_t,driver.CUgraphNode] or list[cyruntime.cudaGraphNode_t,driver.CUgraphNode]")
         if len(pDependencies) > 1:
@@ -34221,6 +34224,7 @@ def cudaGraphAddEventWaitNode(graph, pDependencies : Optional[tuple[cudaGraphNod
     """
     cdef cyruntime.cudaEvent_t cyevent
     cdef cyruntime.cudaGraphNode_t* cypDependencies = NULL
+    pDependencies = [] if pDependencies is None else pDependencies
     cdef cyruntime.cudaGraph_t cygraph
     cdef cudaGraphNode_t pGraphNode
     try:
@@ -34232,7 +34236,6 @@ def cudaGraphAddEventWaitNode(graph, pDependencies : Optional[tuple[cudaGraphNod
         else:
             pgraph = int(cudaGraph_t(graph))
         cygraph = <cyruntime.cudaGraph_t><void_ptr>pgraph
-        pDependencies = [] if pDependencies is None else pDependencies
         if not all(isinstance(_x, (cudaGraphNode_t,driver.CUgraphNode)) for _x in pDependencies):
             raise TypeError("Argument 'pDependencies' is not instance of type (expected tuple[cyruntime.cudaGraphNode_t,driver.CUgraphNode] or list[cyruntime.cudaGraphNode_t,driver.CUgraphNode]")
         if len(pDependencies) > 1:
@@ -34389,6 +34392,7 @@ def cudaGraphAddExternalSemaphoresSignalNode(graph, pDependencies : Optional[tup
     """
     cdef cyruntime.cudaExternalSemaphoreSignalNodeParams* cynodeParams_ptr
     cdef cyruntime.cudaGraphNode_t* cypDependencies = NULL
+    pDependencies = [] if pDependencies is None else pDependencies
     cdef cyruntime.cudaGraph_t cygraph
     cdef cudaGraphNode_t pGraphNode
     try:
@@ -34400,7 +34404,6 @@ def cudaGraphAddExternalSemaphoresSignalNode(graph, pDependencies : Optional[tup
         else:
             pgraph = int(cudaGraph_t(graph))
         cygraph = <cyruntime.cudaGraph_t><void_ptr>pgraph
-        pDependencies = [] if pDependencies is None else pDependencies
         if not all(isinstance(_x, (cudaGraphNode_t,driver.CUgraphNode)) for _x in pDependencies):
             raise TypeError("Argument 'pDependencies' is not instance of type (expected tuple[cyruntime.cudaGraphNode_t,driver.CUgraphNode] or list[cyruntime.cudaGraphNode_t,driver.CUgraphNode]")
         if len(pDependencies) > 1:
@@ -34552,6 +34555,7 @@ def cudaGraphAddExternalSemaphoresWaitNode(graph, pDependencies : Optional[tuple
     """
     cdef cyruntime.cudaExternalSemaphoreWaitNodeParams* cynodeParams_ptr
     cdef cyruntime.cudaGraphNode_t* cypDependencies = NULL
+    pDependencies = [] if pDependencies is None else pDependencies
     cdef cyruntime.cudaGraph_t cygraph
     cdef cudaGraphNode_t pGraphNode
     try:
@@ -34563,7 +34567,6 @@ def cudaGraphAddExternalSemaphoresWaitNode(graph, pDependencies : Optional[tuple
         else:
             pgraph = int(cudaGraph_t(graph))
         cygraph = <cyruntime.cudaGraph_t><void_ptr>pgraph
-        pDependencies = [] if pDependencies is None else pDependencies
         if not all(isinstance(_x, (cudaGraphNode_t,driver.CUgraphNode)) for _x in pDependencies):
             raise TypeError("Argument 'pDependencies' is not instance of type (expected tuple[cyruntime.cudaGraphNode_t,driver.CUgraphNode] or list[cyruntime.cudaGraphNode_t,driver.CUgraphNode]")
         if len(pDependencies) > 1:
@@ -34754,6 +34757,7 @@ def cudaGraphAddMemAllocNode(graph, pDependencies : Optional[tuple[cudaGraphNode
     """
     cdef cyruntime.cudaMemAllocNodeParams* cynodeParams_ptr
     cdef cyruntime.cudaGraphNode_t* cypDependencies = NULL
+    pDependencies = [] if pDependencies is None else pDependencies
     cdef cyruntime.cudaGraph_t cygraph
     cdef cudaGraphNode_t pGraphNode
     try:
@@ -34765,7 +34769,6 @@ def cudaGraphAddMemAllocNode(graph, pDependencies : Optional[tuple[cudaGraphNode
         else:
             pgraph = int(cudaGraph_t(graph))
         cygraph = <cyruntime.cudaGraph_t><void_ptr>pgraph
-        pDependencies = [] if pDependencies is None else pDependencies
         if not all(isinstance(_x, (cudaGraphNode_t,driver.CUgraphNode)) for _x in pDependencies):
             raise TypeError("Argument 'pDependencies' is not instance of type (expected tuple[cyruntime.cudaGraphNode_t,driver.CUgraphNode] or list[cyruntime.cudaGraphNode_t,driver.CUgraphNode]")
         if len(pDependencies) > 1:
@@ -34892,6 +34895,7 @@ def cudaGraphAddMemFreeNode(graph, pDependencies : Optional[tuple[cudaGraphNode_
     cdef _HelperInputVoidPtrStruct cydptrHelper
     cdef void* cydptr
     cdef cyruntime.cudaGraphNode_t* cypDependencies = NULL
+    pDependencies = [] if pDependencies is None else pDependencies
     cdef cyruntime.cudaGraph_t cygraph
     cdef cudaGraphNode_t pGraphNode
     try:
@@ -34903,7 +34907,6 @@ def cudaGraphAddMemFreeNode(graph, pDependencies : Optional[tuple[cudaGraphNode_
         else:
             pgraph = int(cudaGraph_t(graph))
         cygraph = <cyruntime.cudaGraph_t><void_ptr>pgraph
-        pDependencies = [] if pDependencies is None else pDependencies
         if not all(isinstance(_x, (cudaGraphNode_t,driver.CUgraphNode)) for _x in pDependencies):
             raise TypeError("Argument 'pDependencies' is not instance of type (expected tuple[cyruntime.cudaGraphNode_t,driver.CUgraphNode] or list[cyruntime.cudaGraphNode_t,driver.CUgraphNode]")
         if len(pDependencies) > 1:
@@ -35859,8 +35862,11 @@ def cudaGraphAddDependencies(graph, from_ : Optional[tuple[cudaGraphNode_t] | li
     :py:obj:`~.cudaGraphRemoveDependencies`, :py:obj:`~.cudaGraphGetEdges`, :py:obj:`~.cudaGraphNodeGetDependencies`, :py:obj:`~.cudaGraphNodeGetDependentNodes`
     """
     cdef cyruntime.cudaGraphEdgeData* cyedgeData = NULL
+    edgeData = [] if edgeData is None else edgeData
     cdef cyruntime.cudaGraphNode_t* cyto = NULL
+    to = [] if to is None else to
     cdef cyruntime.cudaGraphNode_t* cyfrom_ = NULL
+    from_ = [] if from_ is None else from_
     cdef cyruntime.cudaGraph_t cygraph
     try:
         if graph is None:
@@ -35870,7 +35876,6 @@ def cudaGraphAddDependencies(graph, from_ : Optional[tuple[cudaGraphNode_t] | li
         else:
             pgraph = int(cudaGraph_t(graph))
         cygraph = <cyruntime.cudaGraph_t><void_ptr>pgraph
-        from_ = [] if from_ is None else from_
         if not all(isinstance(_x, (cudaGraphNode_t,driver.CUgraphNode)) for _x in from_):
             raise TypeError("Argument 'from_' is not instance of type (expected tuple[cyruntime.cudaGraphNode_t,driver.CUgraphNode] or list[cyruntime.cudaGraphNode_t,driver.CUgraphNode]")
         if len(from_) > 1:
@@ -35882,7 +35887,6 @@ def cudaGraphAddDependencies(graph, from_ : Optional[tuple[cudaGraphNode_t] | li
                     cyfrom_[idx] = <cyruntime.cudaGraphNode_t>(<cudaGraphNode_t>from_[idx])._pvt_ptr[0]
         elif len(from_) == 1:
             cyfrom_ = <cyruntime.cudaGraphNode_t*>(<cudaGraphNode_t>from_[0])._pvt_ptr
-        to = [] if to is None else to
         if not all(isinstance(_x, (cudaGraphNode_t,driver.CUgraphNode)) for _x in to):
             raise TypeError("Argument 'to' is not instance of type (expected tuple[cyruntime.cudaGraphNode_t,driver.CUgraphNode] or list[cyruntime.cudaGraphNode_t,driver.CUgraphNode]")
         if len(to) > 1:
@@ -35894,7 +35898,6 @@ def cudaGraphAddDependencies(graph, from_ : Optional[tuple[cudaGraphNode_t] | li
                     cyto[idx] = <cyruntime.cudaGraphNode_t>(<cudaGraphNode_t>to[idx])._pvt_ptr[0]
         elif len(to) == 1:
             cyto = <cyruntime.cudaGraphNode_t*>(<cudaGraphNode_t>to[0])._pvt_ptr
-        edgeData = [] if edgeData is None else edgeData
         if not all(isinstance(_x, (cudaGraphEdgeData,)) for _x in edgeData):
             raise TypeError("Argument 'edgeData' is not instance of type (expected tuple[cyruntime.cudaGraphEdgeData,] or list[cyruntime.cudaGraphEdgeData,]")
         if len(edgeData) > 1:
@@ -35957,8 +35960,11 @@ def cudaGraphRemoveDependencies(graph, from_ : Optional[tuple[cudaGraphNode_t] |
     :py:obj:`~.cudaGraphAddDependencies`, :py:obj:`~.cudaGraphGetEdges`, :py:obj:`~.cudaGraphNodeGetDependencies`, :py:obj:`~.cudaGraphNodeGetDependentNodes`
     """
     cdef cyruntime.cudaGraphEdgeData* cyedgeData = NULL
+    edgeData = [] if edgeData is None else edgeData
     cdef cyruntime.cudaGraphNode_t* cyto = NULL
+    to = [] if to is None else to
     cdef cyruntime.cudaGraphNode_t* cyfrom_ = NULL
+    from_ = [] if from_ is None else from_
     cdef cyruntime.cudaGraph_t cygraph
     try:
         if graph is None:
@@ -35968,7 +35974,6 @@ def cudaGraphRemoveDependencies(graph, from_ : Optional[tuple[cudaGraphNode_t] |
         else:
             pgraph = int(cudaGraph_t(graph))
         cygraph = <cyruntime.cudaGraph_t><void_ptr>pgraph
-        from_ = [] if from_ is None else from_
         if not all(isinstance(_x, (cudaGraphNode_t,driver.CUgraphNode)) for _x in from_):
             raise TypeError("Argument 'from_' is not instance of type (expected tuple[cyruntime.cudaGraphNode_t,driver.CUgraphNode] or list[cyruntime.cudaGraphNode_t,driver.CUgraphNode]")
         if len(from_) > 1:
@@ -35980,7 +35985,6 @@ def cudaGraphRemoveDependencies(graph, from_ : Optional[tuple[cudaGraphNode_t] |
                     cyfrom_[idx] = <cyruntime.cudaGraphNode_t>(<cudaGraphNode_t>from_[idx])._pvt_ptr[0]
         elif len(from_) == 1:
             cyfrom_ = <cyruntime.cudaGraphNode_t*>(<cudaGraphNode_t>from_[0])._pvt_ptr
-        to = [] if to is None else to
         if not all(isinstance(_x, (cudaGraphNode_t,driver.CUgraphNode)) for _x in to):
             raise TypeError("Argument 'to' is not instance of type (expected tuple[cyruntime.cudaGraphNode_t,driver.CUgraphNode] or list[cyruntime.cudaGraphNode_t,driver.CUgraphNode]")
         if len(to) > 1:
@@ -35992,7 +35996,6 @@ def cudaGraphRemoveDependencies(graph, from_ : Optional[tuple[cudaGraphNode_t] |
                     cyto[idx] = <cyruntime.cudaGraphNode_t>(<cudaGraphNode_t>to[idx])._pvt_ptr[0]
         elif len(to) == 1:
             cyto = <cyruntime.cudaGraphNode_t*>(<cudaGraphNode_t>to[0])._pvt_ptr
-        edgeData = [] if edgeData is None else edgeData
         if not all(isinstance(_x, (cudaGraphEdgeData,)) for _x in edgeData):
             raise TypeError("Argument 'edgeData' is not instance of type (expected tuple[cyruntime.cudaGraphEdgeData,] or list[cyruntime.cudaGraphEdgeData,]")
         if len(edgeData) > 1:
@@ -37957,7 +37960,9 @@ def cudaGraphAddNode(graph, pDependencies : Optional[tuple[cudaGraphNode_t] | li
     """
     cdef cyruntime.cudaGraphNodeParams* cynodeParams_ptr
     cdef cyruntime.cudaGraphEdgeData* cydependencyData = NULL
+    dependencyData = [] if dependencyData is None else dependencyData
     cdef cyruntime.cudaGraphNode_t* cypDependencies = NULL
+    pDependencies = [] if pDependencies is None else pDependencies
     cdef cyruntime.cudaGraph_t cygraph
     cdef cudaGraphNode_t pGraphNode
     try:
@@ -37969,7 +37974,6 @@ def cudaGraphAddNode(graph, pDependencies : Optional[tuple[cudaGraphNode_t] | li
         else:
             pgraph = int(cudaGraph_t(graph))
         cygraph = <cyruntime.cudaGraph_t><void_ptr>pgraph
-        pDependencies = [] if pDependencies is None else pDependencies
         if not all(isinstance(_x, (cudaGraphNode_t,driver.CUgraphNode)) for _x in pDependencies):
             raise TypeError("Argument 'pDependencies' is not instance of type (expected tuple[cyruntime.cudaGraphNode_t,driver.CUgraphNode] or list[cyruntime.cudaGraphNode_t,driver.CUgraphNode]")
         if len(pDependencies) > 1:
@@ -37981,7 +37985,6 @@ def cudaGraphAddNode(graph, pDependencies : Optional[tuple[cudaGraphNode_t] | li
                     cypDependencies[idx] = <cyruntime.cudaGraphNode_t>(<cudaGraphNode_t>pDependencies[idx])._pvt_ptr[0]
         elif len(pDependencies) == 1:
             cypDependencies = <cyruntime.cudaGraphNode_t*>(<cudaGraphNode_t>pDependencies[0])._pvt_ptr
-        dependencyData = [] if dependencyData is None else dependencyData
         if not all(isinstance(_x, (cudaGraphEdgeData,)) for _x in dependencyData):
             raise TypeError("Argument 'dependencyData' is not instance of type (expected tuple[cyruntime.cudaGraphEdgeData,] or list[cyruntime.cudaGraphEdgeData,]")
         if len(dependencyData) > 1:
@@ -38511,31 +38514,33 @@ def cudaLibraryLoadData(code, jitOptions : Optional[tuple[cudaJitOption] | list[
     """
     cdef _InputVoidPtrPtrHelper voidStarHelperlibraryOptionValues
     cdef void** cylibraryOptionValues_ptr
+    libraryOptionValues = [] if libraryOptionValues is None else libraryOptionValues
+
     cdef vector[cyruntime.cudaLibraryOption] cylibraryOptions
+    libraryOptions = [] if libraryOptions is None else libraryOptions
     cdef _InputVoidPtrPtrHelper voidStarHelperjitOptionsValues
     cdef void** cyjitOptionsValues_ptr
+    jitOptionsValues = [] if jitOptionsValues is None else jitOptionsValues
+
     cdef vector[cyruntime.cudaJitOption] cyjitOptions
+    jitOptions = [] if jitOptions is None else jitOptions
     cdef _HelperInputVoidPtrStruct cycodeHelper
     cdef void* cycode
     cdef cudaLibrary_t library
     try:
         library = cudaLibrary_t()
         cycode = _helper_input_void_ptr(code, &cycodeHelper)
-        jitOptions = [] if jitOptions is None else jitOptions
         if not all(isinstance(_x, (cudaJitOption)) for _x in jitOptions):
             raise TypeError("Argument 'jitOptions' is not instance of type (expected tuple[cyruntime.cudaJitOption] or list[cyruntime.cudaJitOption]")
         cyjitOptions = jitOptions
-        jitOptionsValues = [] if jitOptionsValues is None else jitOptionsValues
         pylist = [_HelperCudaJitOption(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(jitOptions, jitOptionsValues)]
         voidStarHelperjitOptionsValues = _InputVoidPtrPtrHelper(pylist)
         cyjitOptionsValues_ptr = <void**><void_ptr>voidStarHelperjitOptionsValues.cptr
         if numJitOptions > len(jitOptions): raise RuntimeError("List is too small: " + str(len(jitOptions)) + " < " + str(numJitOptions))
         if numJitOptions > len(jitOptionsValues): raise RuntimeError("List is too small: " + str(len(jitOptionsValues)) + " < " + str(numJitOptions))
-        libraryOptions = [] if libraryOptions is None else libraryOptions
         if not all(isinstance(_x, (cudaLibraryOption)) for _x in libraryOptions):
             raise TypeError("Argument 'libraryOptions' is not instance of type (expected tuple[cyruntime.cudaLibraryOption] or list[cyruntime.cudaLibraryOption]")
         cylibraryOptions = libraryOptions
-        libraryOptionValues = [] if libraryOptionValues is None else libraryOptionValues
         pylist = [_HelperCudaLibraryOption(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(libraryOptions, libraryOptionValues)]
         voidStarHelperlibraryOptionValues = _InputVoidPtrPtrHelper(pylist)
         cylibraryOptionValues_ptr = <void**><void_ptr>voidStarHelperlibraryOptionValues.cptr
@@ -38622,27 +38627,29 @@ def cudaLibraryLoadFromFile(char* fileName, jitOptions : Optional[tuple[cudaJitO
     """
     cdef _InputVoidPtrPtrHelper voidStarHelperlibraryOptionValues
     cdef void** cylibraryOptionValues_ptr
+    libraryOptionValues = [] if libraryOptionValues is None else libraryOptionValues
+
     cdef vector[cyruntime.cudaLibraryOption] cylibraryOptions
+    libraryOptions = [] if libraryOptions is None else libraryOptions
     cdef _InputVoidPtrPtrHelper voidStarHelperjitOptionsValues
     cdef void** cyjitOptionsValues_ptr
+    jitOptionsValues = [] if jitOptionsValues is None else jitOptionsValues
+
     cdef vector[cyruntime.cudaJitOption] cyjitOptions
+    jitOptions = [] if jitOptions is None else jitOptions
     cdef cudaLibrary_t library
     library = cudaLibrary_t()
-    jitOptions = [] if jitOptions is None else jitOptions
     if not all(isinstance(_x, (cudaJitOption)) for _x in jitOptions):
         raise TypeError("Argument 'jitOptions' is not instance of type (expected tuple[cyruntime.cudaJitOption] or list[cyruntime.cudaJitOption]")
     cyjitOptions = jitOptions
-    jitOptionsValues = [] if jitOptionsValues is None else jitOptionsValues
     pylist = [_HelperCudaJitOption(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(jitOptions, jitOptionsValues)]
     voidStarHelperjitOptionsValues = _InputVoidPtrPtrHelper(pylist)
     cyjitOptionsValues_ptr = <void**><void_ptr>voidStarHelperjitOptionsValues.cptr
     if numJitOptions > len(jitOptions): raise RuntimeError("List is too small: " + str(len(jitOptions)) + " < " + str(numJitOptions))
     if numJitOptions > len(jitOptionsValues): raise RuntimeError("List is too small: " + str(len(jitOptionsValues)) + " < " + str(numJitOptions))
-    libraryOptions = [] if libraryOptions is None else libraryOptions
     if not all(isinstance(_x, (cudaLibraryOption)) for _x in libraryOptions):
         raise TypeError("Argument 'libraryOptions' is not instance of type (expected tuple[cyruntime.cudaLibraryOption] or list[cyruntime.cudaLibraryOption]")
     cylibraryOptions = libraryOptions
-    libraryOptionValues = [] if libraryOptionValues is None else libraryOptionValues
     pylist = [_HelperCudaLibraryOption(pyoptions, pyoptionValues) for pyoptions, pyoptionValues in zip(libraryOptions, libraryOptionValues)]
     voidStarHelperlibraryOptionValues = _InputVoidPtrPtrHelper(pylist)
     cylibraryOptionValues_ptr = <void**><void_ptr>voidStarHelperlibraryOptionValues.cptr
@@ -39466,10 +39473,10 @@ def cudaDevResourceGenerateDesc(resources : Optional[tuple[cudaDevResource] | li
     :py:obj:`~.cuDevResourceGenerateDesc`, :py:obj:`~.cudaDeviceGetDevResource`, :py:obj:`~.cudaExecutionCtxGetDevResource`, :py:obj:`~.cudaDevSmResourceSplit`, :py:obj:`~.cudaGreenCtxCreate`
     """
     cdef cyruntime.cudaDevResource* cyresources = NULL
+    resources = [] if resources is None else resources
     cdef cudaDevResourceDesc_t phDesc
     try:
         phDesc = cudaDevResourceDesc_t()
-        resources = [] if resources is None else resources
         if not all(isinstance(_x, (cudaDevResource,)) for _x in resources):
             raise TypeError("Argument 'resources' is not instance of type (expected tuple[cyruntime.cudaDevResource,] or list[cyruntime.cudaDevResource,]")
         if len(resources) > 1:


### PR DESCRIPTION
In driver, runtime and nvrtc, the generated code follows the following pattern:

```
def func(args):
    $init
    $precall
    $call
    $postcall
    $return
```

For certain argument types, $precall and $postcall are required to be pairs, such as `malloc`/`free`.  If an exception is thrown when parsing one of the other arguments in `$precall`, `$postcall` will not get called, leaking memory or other resources.

This reorganizes the code (whenever `$postcall` is non-empty) to:

```
def func(args):
    $init
    try:
        $precall
        $call
    finally:
        $postcall
    $return
```

This diff is larger than it otherwise might need to be since `Cython` only allows `cdef` declarations at the top level.  So all the `cdef`'s that used to be part of `$precall` need to be moved to `$init`.

## Performance impact

`try`/`finally` is implemented by Cython with `goto`s.  It generates two copies of the `finally` clause: one for success and one for failure, so there is a cost in overall code size.  (This is similar to CPython's bytecode implementation of `try`/`finally`).  However, the runtime performance penalty is below the noise threshold in the #659 benchmark.  There is a small performance penalty of around 200ns for the error case, but that's to be expected -- the old implementation leaked memory.

## Alternatives considered

We could use C++ RAII to automatically free memory.  In fact, some of our code in these files already does that in the use of `std::vector`.  However, this is not generally applicable as a solution, since it's not possible to implement a custom RAII struct Cython that is not also a PyObject.  This would make the `HelperVoidPtrStruct` optimization impossible.

We could require that $init does all validation (but not any resource allocation), and the $precall would never raise, so $postcall would always be guaranteed to run.  It seems like this may have been part of the original design, but then has not been strictly enforced everywhere over time.  Even if we could get to that, it has two problems.  (1) Some exceptions in $precall are unavoidable, even if the inputs are valid, such as `malloc` failing.  (2) Doing a separate validation and conversion pass on all the arguments is never going to be as performant as a single pass.