### PR TITLE
fix: add /usr/local/cuda fallback for CTK header discovery

### DIFF
--- a/cuda_pathfinder/cuda/pathfinder/_headers/find_nvidia_headers.py
+++ b/cuda_pathfinder/cuda/pathfinder/_headers/find_nvidia_headers.py
@@ -108,9 +108,12 @@ def _find_ctk_header_directory(libname: str) -> LocatedHeaderDir | None:
             return LocatedHeaderDir(abs_path=result, found_via="CUDA_HOME")
 
     # Fallback: typical system install path (matches CuPy's get_cuda_path())
-    if not IS_WINDOWS and os.path.exists('/usr/local/cuda'):
-        if result := _locate_based_on_ctk_layout(libname, h_basename, '/usr/local/cuda'):
-            return LocatedHeaderDir(abs_path=result, found_via="system_default")
+    if (
+        not IS_WINDOWS
+        and os.path.exists("/usr/local/cuda")
+        and (result := _locate_based_on_ctk_layout(libname, h_basename, "/usr/local/cuda"))
+    ):
+        return LocatedHeaderDir(abs_path=result, found_via="system_default")
 
     return None
 


### PR DESCRIPTION
When `CUDA_PATH`/`CUDA_HOME` are unset, fall back to `/usr/local/cuda` on non-Windows platforms. Aligns with CuPy's `get_cuda_path()` behavior and fixes CuPy header detection in containers (e.g. Holoscan).

Follow-up of PR:
* #956

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cuda-python/issues/1707

Add a `/usr/local/cuda` fallback in `find_nvidia_header_directory` (used by CuPy's `_get_include_dir_from_conda_or_wheel`) when `CUDA_PATH` and `CUDA_HOME` are unset. This matches the behavior of CuPy's `_get_cuda_path()` in `cupy/_environment.py`, which already falls back to `/usr/local/cuda` for the typical Linux container layout.

**Problem:** CuPy fails with "Failed to auto-detect CUDA root directory" when running `RawKernel` in containers where CUDA is at `/usr/local/cuda` but env vars are not set. The header detection path (via cuda-pathfinder) only checked site-packages, conda, and env vars—not the default install path.

**Solution:** On non-Windows platforms, if headers are not found via existing checks, try `/usr/local/cuda/include` when the directory exists.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.