### PR TITLE
fix(core): depend on released cuda-pathfinder >=1.4.1

### DIFF
--- a/cuda_core/pyproject.toml
+++ b/cuda_core/pyproject.toml
@@ -47,7 +47,8 @@ classifiers = [
     "Environment :: GPU :: NVIDIA CUDA :: 13",
 ]
 dependencies = [
-    "cuda-pathfinder >=1.4.2",
+    # TODO: bump to >=1.4.2 once cuda-pathfinder 1.4.2 is released.
+    "cuda-pathfinder >=1.4.1",
     "numpy",
 ]
 


### PR DESCRIPTION
Fixes #980

Supersedes #1733.

## Summary
- update `cuda-core` to depend on released `cuda-pathfinder >=1.4.1` instead of unreleased `>=1.4.2`
- add a TODO in `cuda_core/pyproject.toml` to bump to `>=1.4.2` once that release is available

## Test plan
- [x] `nix run 'nixpkgs#pre-commit' -- run check-toml --files cuda_core/pyproject.toml`