### PR TITLE
Coverage: Extract cuda version dynamically from ci versions file when running code coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,14 +11,27 @@ on:
 
 env:
   PY_VER: "3.14"
-  CUDA_VER: "13.1.0"
   LOCAL_CTK: "1"
   GPU: "a100"
   DRIVER: "latest"
 
 jobs:
+  coverage-vars:
+    runs-on: ubuntu-latest
+    outputs:
+      CUDA_VER: ${{ steps.get-vars.outputs.cuda_ver }}
+    steps:
+      - name: Checkout ${{ github.event.repository.name }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Get CUDA version
+        id: get-vars
+        run: |
+          cuda_ver=$(yq '.cuda.build.version' ci/versions.yml)
+          echo "cuda_ver=$cuda_ver" >> $GITHUB_OUTPUT
+
   coverage-linux:
     name: Coverage (Linux)
+    needs: [coverage-vars]
     runs-on: "linux-amd64-gpu-a100-latest-1"
     permissions:
       id-token: write
@@ -29,6 +42,7 @@ jobs:
     env:
       HOST_PLATFORM: "linux-64"
       ARCH: "x86_64"
+      CUDA_VER: ${{ needs.coverage-vars.outputs.CUDA_VER }}
     # Our self-hosted runners require a container
     # TODO: use a different (nvidia?) container
     container:
@@ -164,6 +178,7 @@ jobs:
   # Build Windows wheels on GitHub-hosted runner (has VS, no GPU)
   build-wheel-windows:
     name: Build Wheels (Windows)
+    needs: [coverage-vars]
     runs-on: windows-2022
     permissions:
       contents: read
@@ -173,6 +188,7 @@ jobs:
     env:
       HOST_PLATFORM: "win-64"
       CUDA_PYTHON_COVERAGE: "1"
+      CUDA_VER: ${{ needs.coverage-vars.outputs.CUDA_VER }}
     steps:
       - name: Checkout ${{ github.event.repository.name }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -231,7 +247,7 @@ jobs:
   # Run coverage tests on self-hosted GPU runner (no VS needed, installs pre-built wheels)
   coverage-windows:
     name: Coverage (Windows)
-    needs: [build-wheel-windows]
+    needs: [coverage-vars, build-wheel-windows]
     runs-on: "windows-amd64-gpu-a100-latest-1"
     permissions:
       id-token: write
@@ -240,6 +256,7 @@ jobs:
       HOST_PLATFORM: "win-64"
       ARCH: "amd64"
       CUDA_PYTHON_COVERAGE: "1"
+      CUDA_VER: ${{ needs.coverage-vars.outputs.CUDA_VER }}
     defaults:
       run:
         shell: bash --noprofile --norc -xeuo pipefail {0}


### PR DESCRIPTION
Enhance the code coverage workflow to use the cuda version dynamically fetched from ci/versions.yml instead of hardcoded version.