### PR TITLE
refactor(workflows): remove release build-ctk-ver input

### DIFF
--- a/.github/RELEASE-core.md
+++ b/.github/RELEASE-core.md
@@ -131,8 +131,11 @@ publish to PyPI.
 1. Go to **Actions > CI: Release** and run the workflow with:
    - **Component**: `cuda-core`
    - **The release git tag**: `cuda-core-v0.6.0`
-   - **build-ctk-ver**: the `cuda.build.version` from
-     [`ci/versions.yml`](../ci/versions.yml) (e.g. `13.1.1`)
+   - **The GHA run ID that generated validated artifacts**: This is the
+     run ID of the successful tag-triggered CI run from the previous step.
+     You can find it in the URL when viewing the run in the Actions tab
+     (e.g. `https://github.com/NVIDIA/cuda-python/actions/runs/123456789`
+     — the run ID is `123456789`).
    - **Which wheel index to publish to**: `testpypi`
    The workflow automatically looks up the successful tag-triggered CI run
    for the selected release tag.

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -7,9 +7,6 @@ name: "CI: Build and update docs"
 on:
   workflow_call:
     inputs:
-      build-ctk-ver:
-        type: string
-        required: true
       component:
         description: "Component(s) to build docs for"
         required: false
@@ -47,17 +44,20 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
-      - name: validate build-ctk
-        run: |
-          if [ ! "${{ inputs.build-ctk-ver }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]; then
-            echo "error: `build-ctk-ver` ${{ inputs.build-ctk-ver }} version does not match MAJOR.MINOR.MICRO" >&2
-            exit 1
-          fi
       - name: Checkout ${{ github.event.repository.name }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           ref: ${{ inputs.git-tag }}
+
+      - name: Read build CTK version
+        run: |
+          BUILD_CTK_VER=$(yq '.cuda.build.version' ci/versions.yml)
+          if [[ ! "${BUILD_CTK_VER}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "error: derived CTK build version ${BUILD_CTK_VER} does not match MAJOR.MINOR.MICRO" >&2
+            exit 1
+          fi
+          echo "BUILD_CTK_VER=${BUILD_CTK_VER}" >> "$GITHUB_ENV"
 
       # TODO: This workflow runs on GH-hosted runner and cannot use the proxy cache
 
@@ -82,7 +82,7 @@ jobs:
         uses: ./.github/actions/fetch_ctk
         with:
           host-platform: linux-64
-          cuda-version: ${{ inputs.build-ctk-ver }}
+          cuda-version: ${{ env.BUILD_CTK_VER }}
 
       - name: Set environment variables
         run: |
@@ -103,7 +103,7 @@ jobs:
           echo "CUDA_CORE_ARTIFACT_BASENAME=${CUDA_CORE_ARTIFACT_BASENAME}" >> $GITHUB_ENV
           echo "CUDA_CORE_ARTIFACT_NAME=${CUDA_CORE_ARTIFACT_BASENAME}-${FILE_HASH}" >> $GITHUB_ENV
           echo "CUDA_CORE_ARTIFACTS_DIR=$(realpath "$REPO_DIR/cuda_core/dist")" >> $GITHUB_ENV
-          CUDA_BINDINGS_ARTIFACT_BASENAME="cuda-bindings-python${PYTHON_VERSION_FORMATTED}-cuda${{ inputs.build-ctk-ver }}-linux-64"
+          CUDA_BINDINGS_ARTIFACT_BASENAME="cuda-bindings-python${PYTHON_VERSION_FORMATTED}-cuda${BUILD_CTK_VER}-linux-64"
           echo "CUDA_BINDINGS_ARTIFACT_BASENAME=${CUDA_BINDINGS_ARTIFACT_BASENAME}" >> $GITHUB_ENV
           echo "CUDA_BINDINGS_ARTIFACT_NAME=${CUDA_BINDINGS_ARTIFACT_BASENAME}-${FILE_HASH}" >> $GITHUB_ENV
           echo "CUDA_BINDINGS_ARTIFACTS_DIR=$(realpath "$REPO_DIR/cuda_bindings/dist")" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/build-docs.yml
     with:
-      build-ctk-ver: ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
       is-release: ${{ github.ref_type == 'tag' }}
 
   checks:

--- a/.github/workflows/release-cuda-pathfinder.yml
+++ b/.github/workflows/release-cuda-pathfinder.yml
@@ -40,7 +40,6 @@ jobs:
       tag: ${{ steps.vars.outputs.tag }}
       version: ${{ steps.vars.outputs.version }}
       run-id: ${{ steps.detect-run.outputs.run-id }}
-      ctk-ver: ${{ steps.ctk.outputs.ctk-ver }}
     steps:
       - name: Verify running on default branch
         run: |
@@ -76,12 +75,6 @@ jobs:
             echo "Create the release notes file before running this workflow."
             exit 1
           fi
-
-      - name: Read CTK build version
-        id: ctk
-        run: |
-          ctk_ver=$(yq '.cuda.build.version' ci/versions.yml)
-          echo "ctk-ver=${ctk_ver}" >> "$GITHUB_OUTPUT"
 
       - name: Detect CI run ID
         id: detect-run
@@ -146,7 +139,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/build-docs.yml
     with:
-      build-ctk-ver: ${{ needs.prepare.outputs.ctk-ver }}
       component: cuda-pathfinder
       git-tag: ${{ needs.prepare.outputs.tag }}
       run-id: ${{ needs.prepare.outputs.run-id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,11 @@ on:
         description: "The release git tag"
         required: true
         type: string
-      build-ctk-ver:
+      run-id:
+        description: "The GHA run ID that generated validated artifacts (optional - auto-detects successful tag-triggered CI run for git-tag)"
+        required: false
         type: string
-        required: true
+        default: ""
       wheel-dst:
         description: "Which wheel index to publish to?"
         required: true
@@ -112,7 +114,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/build-docs.yml
     with:
-      build-ctk-ver: ${{ inputs.build-ctk-ver }}
       component: ${{ inputs.component }}
       git-tag: ${{ inputs.git-tag }}
       run-id: ${{ needs.determine-run-id.outputs.run-id }}


### PR DESCRIPTION
## Summary
- derive the docs CTK build version from `ci/versions.yml` in the checked-out ref instead of requiring a manual `build-ctk-ver` input
- remove redundant `build-ctk-ver` plumbing from the shared docs callers in `release.yml`, `release-cuda-pathfinder.yml`, and `ci.yml`
- update the core release instructions to match the simplified release workflow inputs

Made with [Cursor](https://cursor.com)