### PR TITLE
ci: consolidate release publishing flow

### DIFF
--- a/.github/RELEASE-core.md
+++ b/.github/RELEASE-core.md
@@ -131,8 +131,7 @@ publish to TestPyPI, then publish the same wheel set to PyPI.
    - **The release git tag**: `cuda-core-v0.6.0`
 
    The workflow automatically looks up the successful tag-triggered CI run
-   for the selected release tag. If needed, you can also provide the
-   optional run ID input explicitly.
+   for the selected release tag.
 
 2. Wait for the workflow to complete. It will:
    - publish the selected wheels to TestPyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,15 +52,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [[ -n "${{ inputs.run-id }}" ]]; then
-            echo "Using provided run ID: ${{ inputs.run-id }}"
-            echo "run-id=${{ inputs.run-id }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "Auto-detecting successful tag-triggered run ID for tag: ${{ inputs.git-tag }}"
-            RUN_ID=$(./ci/tools/lookup-run-id "${{ inputs.git-tag }}" "${{ github.repository }}")
-            echo "Auto-detected run ID: $RUN_ID"
-            echo "run-id=$RUN_ID" >> "$GITHUB_OUTPUT"
-          fi
+          echo "Auto-detecting successful tag-triggered run ID for tag: ${{ inputs.git-tag }}"
+          RUN_ID=$(./ci/tools/lookup-run-id "${{ inputs.git-tag }}" "${{ github.repository }}")
+          echo "Auto-detected run ID: $RUN_ID"
+          echo "run-id=$RUN_ID" >> "$GITHUB_OUTPUT"
 
   check-tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- remove the manual wheel-index selector from `CI: Release`
- publish the selected wheels to TestPyPI and then PyPI in a single workflow run
- update the release docs to match the streamlined release flow and clean up shell quoting in `release.yml`