### PR TITLE
ci: remove manual run-id from release workflow

### DIFF
--- a/.github/RELEASE-core.md
+++ b/.github/RELEASE-core.md
@@ -131,14 +131,11 @@ publish to PyPI.
 1. Go to **Actions > CI: Release** and run the workflow with:
    - **Component**: `cuda-core`
    - **The release git tag**: `cuda-core-v0.6.0`
-   - **The GHA run ID that generated validated artifacts**: This is the
-     run ID of the successful tag-triggered CI run from the previous step.
-     You can find it in the URL when viewing the run in the Actions tab
-     (e.g. `https://github.com/NVIDIA/cuda-python/actions/runs/123456789`
-     — the run ID is `123456789`).
    - **build-ctk-ver**: the `cuda.build.version` from
      [`ci/versions.yml`](../ci/versions.yml) (e.g. `13.1.1`)
    - **Which wheel index to publish to**: `testpypi`
+   The workflow automatically looks up the successful tag-triggered CI run
+   for the selected release tag.
 
 2. Wait for the workflow to complete.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,6 @@ on:
         description: "The release git tag"
         required: true
         type: string
-      run-id:
-        description: "The GHA run ID that generated validated artifacts (optional - auto-detects successful tag-triggered CI run for git-tag)"
-        required: false
-        type: string
-        default: ""
       build-ctk-ver:
         type: string
         required: true
@@ -60,15 +55,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [[ -n "${{ inputs.run-id }}" ]]; then
-            echo "Using provided run ID: ${{ inputs.run-id }}"
-            echo "run-id=${{ inputs.run-id }}" >> $GITHUB_OUTPUT
-          else
-            echo "Auto-detecting successful tag-triggered run ID for tag: ${{ inputs.git-tag }}"
-            RUN_ID=$(./ci/tools/lookup-run-id "${{ inputs.git-tag }}" "${{ github.repository }}")
-            echo "Auto-detected run ID: $RUN_ID"
-            echo "run-id=$RUN_ID" >> $GITHUB_OUTPUT
-          fi
+          echo "Auto-detecting successful tag-triggered run ID for tag: ${{ inputs.git-tag }}"
+          RUN_ID=$(./ci/tools/lookup-run-id "${{ inputs.git-tag }}" "${{ github.repository }}")
+          echo "Auto-detected run ID: $RUN_ID"
+          echo "run-id=$RUN_ID" >> $GITHUB_OUTPUT
 
   check-tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- remove the manual `run-id` input from `CI: Release`
- always auto-detect the validated tag-triggered run from the selected release tag
- update the release instructions to match the simplified workflow

Made with [Cursor](https://cursor.com)