### PR TITLE
Enable automatic CI for ready pull requests

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -5,6 +5,6 @@
 # https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/
 
 enabled: true
-# always require manual CI triggering, ignoring signed commits
+# auto-sync ready PRs so CI starts immediately; keep draft PRs manual
 auto_sync_draft: false
-auto_sync_ready: false
+auto_sync_ready: true


### PR DESCRIPTION
## Description

Ready pull requests should not require an `ok to test` comment before the required CI/CD runs begin for verified Nvidian accounts.

This updates `copy-pr-bot` so ready PRs auto-sync to the internal `pull-request/<n>` branch and start CI immediately. Draft PRs remain manual because `auto_sync_draft` stays `false`.