### PR TITLE
[doc-only] Sync pathfinder api.rst with public APIs in __init__.py

### DIFF
--- a/cuda_pathfinder/cuda/pathfinder/__init__.py
+++ b/cuda_pathfinder/cuda/pathfinder/__init__.py
@@ -3,6 +3,10 @@
 
 """cuda.pathfinder public APIs"""
 
+# NOTE: When adding or removing public APIs from this file, remember to update
+#     cuda_pathfinder/docs/source/api.rst
+# to keep the documentation in sync.
+
 from cuda.pathfinder._binaries.find_nvidia_binary_utility import (
     find_nvidia_binary_utility as find_nvidia_binary_utility,
 )

--- a/cuda_pathfinder/docs/source/api.rst
+++ b/cuda_pathfinder/docs/source/api.rst
@@ -7,7 +7,11 @@
 =================================
 
 The ``cuda.pathfinder`` module provides utilities for loading NVIDIA dynamic libraries,
-locating NVIDIA C/C++ header directories, and finding CUDA binary utilities.
+locating NVIDIA C/C++ header directories, finding CUDA binary utilities, and locating
+CUDA bitcode and static libraries.
+
+.. NOTE: The source of truth for public APIs is cuda_pathfinder/cuda/pathfinder/__init__.py.
+.. Keep this documentation in sync when adding or removing exports.
 
 .. autosummary::
    :toctree: generated/
@@ -20,8 +24,21 @@ locating NVIDIA C/C++ header directories, and finding CUDA binary utilities.
    DynamicLibNotAvailableError
 
    SUPPORTED_HEADERS_CTK
-   SUPPORTED_HEADERS_NON_CTK
    find_nvidia_header_directory
+   locate_nvidia_header_directory
+   LocatedHeaderDir
 
    SUPPORTED_BINARY_UTILITIES
    find_nvidia_binary_utility
+
+   SUPPORTED_BITCODE_LIBS
+   find_bitcode_lib
+   locate_bitcode_lib
+   LocatedBitcodeLib
+   BitcodeLibNotFoundError
+
+   SUPPORTED_STATIC_LIBS
+   find_static_lib
+   locate_static_lib
+   LocatedStaticLib
+   StaticLibNotFoundError


### PR DESCRIPTION
The `cuda_pathfinder/docs/source/api.rst` file had diverged from the actual public APIs exported in `cuda_pathfinder/cuda/pathfinder/__init__.py`. This was discovered when a user reported that `locate_nvidia_header_directory` was missing from the documentation.

This PR brings `api.rst` in sync with `__init__.py` (which is the source of truth).

Other Changes:
* Updated module description to mention bitcode and static libraries
* Added developer reminder notes in both `__init__.py` and `api.rst` to help prevent future drift