### PR TITLE
Fix bindings & update tests for `cuDevSmResourceSplit` and `cudaDevSmResourceSplit`

### DIFF
--- a/cuda_bindings/cuda/bindings/_bindings/cydriver.pxd.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cydriver.pxd.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 from cuda.bindings.cydriver cimport *
 
 {{if 'cuGetErrorString' in found_functions}}

--- a/cuda_bindings/cuda/bindings/_bindings/cydriver.pyx.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cydriver.pyx.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 {{if 'Windows' == platform.system()}}
 import os
 cimport cuda.bindings._lib.windll as windll

--- a/cuda_bindings/cuda/bindings/_bindings/cynvrtc.pxd.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cynvrtc.pxd.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 from cuda.bindings.cynvrtc cimport *
 
 {{if 'nvrtcGetErrorString' in found_functions}}

--- a/cuda_bindings/cuda/bindings/_bindings/cynvrtc.pyx.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cynvrtc.pyx.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 {{if 'Windows' == platform.system()}}
 import os
 cimport cuda.bindings._lib.windll as windll

--- a/cuda_bindings/cuda/bindings/_bindings/cyruntime.pxd.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cyruntime.pxd.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 include "../cyruntime_types.pxi"
 
 include "../_lib/cyruntime/cyruntime.pxd"

--- a/cuda_bindings/cuda/bindings/_bindings/cyruntime.pyx.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cyruntime.pyx.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 include "../cyruntime_functions.pxi"
 
 import os

--- a/cuda_bindings/cuda/bindings/_bindings/cyruntime_ptds.pxd.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cyruntime_ptds.pxd.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 cdef extern from "":
     """
     #define CUDA_API_PER_THREAD_DEFAULT_STREAM

--- a/cuda_bindings/cuda/bindings/_bindings/cyruntime_ptds.pyx.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cyruntime_ptds.pyx.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 cdef extern from "":
     """
     #define CUDA_API_PER_THREAD_DEFAULT_STREAM

--- a/cuda_bindings/cuda/bindings/cydriver.pxd.in
+++ b/cuda_bindings/cuda/bindings/cydriver.pxd.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 
 from libc.stdint cimport uint32_t, uint64_t
 

--- a/cuda_bindings/cuda/bindings/cydriver.pyx.in
+++ b/cuda_bindings/cuda/bindings/cydriver.pyx.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 cimport cuda.bindings._bindings.cydriver as cydriver
 
 {{if 'cuGetErrorString' in found_functions}}

--- a/cuda_bindings/cuda/bindings/cynvrtc.pxd.in
+++ b/cuda_bindings/cuda/bindings/cynvrtc.pxd.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 
 from libc.stdint cimport uint32_t, uint64_t
 

--- a/cuda_bindings/cuda/bindings/cynvrtc.pyx.in
+++ b/cuda_bindings/cuda/bindings/cynvrtc.pyx.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 cimport cuda.bindings._bindings.cynvrtc as cynvrtc
 
 {{if 'nvrtcGetErrorString' in found_functions}}

--- a/cuda_bindings/cuda/bindings/cyruntime.pxd.in
+++ b/cuda_bindings/cuda/bindings/cyruntime.pxd.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 
 from libc.stdint cimport uint32_t, uint64_t
 

--- a/cuda_bindings/cuda/bindings/cyruntime.pyx.in
+++ b/cuda_bindings/cuda/bindings/cyruntime.pyx.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 cimport cuda.bindings._bindings.cyruntime as cyruntime
 cimport cython
 

--- a/cuda_bindings/cuda/bindings/cyruntime_functions.pxi.in
+++ b/cuda_bindings/cuda/bindings/cyruntime_functions.pxi.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 cdef extern from "cuda_runtime_api.h":
 
     {{if 'cudaDeviceReset' in found_functions}}

--- a/cuda_bindings/cuda/bindings/cyruntime_types.pxi.in
+++ b/cuda_bindings/cuda/bindings/cyruntime_types.pxi.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 
 cdef extern from "vector_types.h":
 

--- a/cuda_bindings/cuda/bindings/driver.pxd.in
+++ b/cuda_bindings/cuda/bindings/driver.pxd.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 cimport cuda.bindings.cydriver as cydriver
 
 include "_lib/utils.pxd"

--- a/cuda_bindings/cuda/bindings/driver.pyx.in
+++ b/cuda_bindings/cuda/bindings/driver.pyx.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 from typing import Any, Optional
 import cython
 import ctypes
@@ -55223,7 +55223,7 @@ def cuDevSmResourceSplitByCount(unsigned int nbGroups, input_ : Optional[CUdevRe
 {{if 'cuDevSmResourceSplit' in found_functions}}
 
 @cython.embedsignature(True)
-def cuDevSmResourceSplit(unsigned int nbGroups, input_ : Optional[CUdevResource], unsigned int flags, groupParams : Optional[CU_DEV_SM_RESOURCE_GROUP_PARAMS]):
+def cuDevSmResourceSplit(unsigned int nbGroups, input_ : Optional[CUdevResource], unsigned int flags, groupParams : Optional[tuple[CU_DEV_SM_RESOURCE_GROUP_PARAMS] | list[CU_DEV_SM_RESOURCE_GROUP_PARAMS]]):
     """ Splits a `CU_DEV_RESOURCE_TYPE_SM` resource into structured groups.
 
     This API will split a resource of :py:obj:`~.CU_DEV_RESOURCE_TYPE_SM`
@@ -55341,7 +55341,7 @@ def cuDevSmResourceSplit(unsigned int nbGroups, input_ : Optional[CUdevResource]
     flags : unsigned int
         Flags specifying how the API should behave. The value should be 0
         for now.
-    groupParams : :py:obj:`~.CU_DEV_SM_RESOURCE_GROUP_PARAMS`
+    groupParams : list[:py:obj:`~.CU_DEV_SM_RESOURCE_GROUP_PARAMS`]
         Description of how the SMs should be split and assigned to the
         corresponding result entry.
 
@@ -55360,6 +55360,9 @@ def cuDevSmResourceSplit(unsigned int nbGroups, input_ : Optional[CUdevResource]
     --------
     :py:obj:`~.cuGreenCtxGetDevResource`, :py:obj:`~.cuCtxGetDevResource`, :py:obj:`~.cuDeviceGetDevResource`
     """
+    groupParams = [] if groupParams is None else groupParams
+    if not all(isinstance(_x, (CU_DEV_SM_RESOURCE_GROUP_PARAMS,)) for _x in groupParams):
+        raise TypeError("Argument 'groupParams' is not instance of type (expected tuple[cydriver.CU_DEV_SM_RESOURCE_GROUP_PARAMS,] or list[cydriver.CU_DEV_SM_RESOURCE_GROUP_PARAMS,]")
     cdef cydriver.CUdevResource* cyresult = NULL
     pyresult = [CUdevResource() for idx in range(nbGroups)]
     if nbGroups != 0:
@@ -55368,14 +55371,24 @@ def cuDevSmResourceSplit(unsigned int nbGroups, input_ : Optional[CUdevResource]
             raise MemoryError('Failed to allocate length x size memory: ' + str(nbGroups) + 'x' + str(sizeof(cydriver.CUdevResource)))
     cdef cydriver.CUdevResource* cyinput__ptr = input_._pvt_ptr if input_ is not None else NULL
     cdef CUdevResource remainder = CUdevResource()
-    cdef cydriver.CU_DEV_SM_RESOURCE_GROUP_PARAMS* cygroupParams_ptr = groupParams._pvt_ptr if groupParams is not None else NULL
+    cdef cydriver.CU_DEV_SM_RESOURCE_GROUP_PARAMS* cygroupParams = NULL
+    if len(groupParams) > 1:
+        cygroupParams = <cydriver.CU_DEV_SM_RESOURCE_GROUP_PARAMS*> calloc(len(groupParams), sizeof(cydriver.CU_DEV_SM_RESOURCE_GROUP_PARAMS))
+        if cygroupParams is NULL:
+            raise MemoryError('Failed to allocate length x size memory: ' + str(len(groupParams)) + 'x' + str(sizeof(cydriver.CU_DEV_SM_RESOURCE_GROUP_PARAMS)))
+        for idx in range(len(groupParams)):
+            string.memcpy(&cygroupParams[idx], (<CU_DEV_SM_RESOURCE_GROUP_PARAMS>groupParams[idx])._pvt_ptr, sizeof(cydriver.CU_DEV_SM_RESOURCE_GROUP_PARAMS))
+    elif len(groupParams) == 1:
+        cygroupParams = (<CU_DEV_SM_RESOURCE_GROUP_PARAMS>groupParams[0])._pvt_ptr
     with nogil:
-        err = cydriver.cuDevSmResourceSplit(cyresult, nbGroups, cyinput__ptr, <cydriver.CUdevResource*>remainder._pvt_ptr, flags, cygroupParams_ptr)
+        err = cydriver.cuDevSmResourceSplit(cyresult, nbGroups, cyinput__ptr, <cydriver.CUdevResource*>remainder._pvt_ptr, flags, cygroupParams)
     if CUresult(err) == CUresult(0):
         for idx in range(nbGroups):
             string.memcpy((<CUdevResource>pyresult[idx])._pvt_ptr, &cyresult[idx], sizeof(cydriver.CUdevResource))
     if cyresult is not NULL:
         free(cyresult)
+    if len(groupParams) > 1 and cygroupParams is not NULL:
+        free(cygroupParams)
     if err != cydriver.CUDA_SUCCESS:
         return (_CUresult(err), None, None)
     return (_CUresult_SUCCESS, pyresult, remainder)

--- a/cuda_bindings/cuda/bindings/nvrtc.pxd.in
+++ b/cuda_bindings/cuda/bindings/nvrtc.pxd.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 cimport cuda.bindings.cynvrtc as cynvrtc
 
 include "_lib/utils.pxd"

--- a/cuda_bindings/cuda/bindings/nvrtc.pyx.in
+++ b/cuda_bindings/cuda/bindings/nvrtc.pyx.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 from typing import Any, Optional
 import cython
 import ctypes

--- a/cuda_bindings/cuda/bindings/runtime.pxd.in
+++ b/cuda_bindings/cuda/bindings/runtime.pxd.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 cimport cuda.bindings.cyruntime as cyruntime
 
 include "_lib/utils.pxd"

--- a/cuda_bindings/cuda/bindings/runtime.pyx.in
+++ b/cuda_bindings/cuda/bindings/runtime.pyx.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version fa58871. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
 from typing import Any, Optional
 import cython
 import ctypes
@@ -39487,7 +39487,7 @@ def cudaDevSmResourceSplitByCount(unsigned int nbGroups, input_ : Optional[cudaD
 {{if 'cudaDevSmResourceSplit' in found_functions}}
 
 @cython.embedsignature(True)
-def cudaDevSmResourceSplit(unsigned int nbGroups, input_ : Optional[cudaDevResource], unsigned int flags, groupParams : Optional[cudaDevSmResourceGroupParams]):
+def cudaDevSmResourceSplit(unsigned int nbGroups, input_ : Optional[cudaDevResource], unsigned int flags, groupParams : Optional[tuple[cudaDevSmResourceGroupParams] | list[cudaDevSmResourceGroupParams]]):
     """ Splits a `cudaDevResourceTypeSm` resource into structured groups.
 
     This API will split a resource of :py:obj:`~.cudaDevResourceTypeSm`
@@ -39604,7 +39604,7 @@ def cudaDevSmResourceSplit(unsigned int nbGroups, input_ : Optional[cudaDevResou
     flags : unsigned int
         Flags specifying how the API should behave. The value should be 0
         for now.
-    groupParams : :py:obj:`~.cudaDevSmResourceGroupParams`
+    groupParams : list[:py:obj:`~.cudaDevSmResourceGroupParams`]
         Description of how the SMs should be split and assigned to the
         corresponding result entry.
 
@@ -39623,6 +39623,9 @@ def cudaDevSmResourceSplit(unsigned int nbGroups, input_ : Optional[cudaDevResou
     --------
     :py:obj:`~.cuDevSmResourceSplit`, :py:obj:`~.cudaDeviceGetDevResource`, :py:obj:`~.cudaExecutionCtxGetDevResource`, :py:obj:`~.cudaDevResourceGenerateDesc`
     """
+    groupParams = [] if groupParams is None else groupParams
+    if not all(isinstance(_x, (cudaDevSmResourceGroupParams,)) for _x in groupParams):
+        raise TypeError("Argument 'groupParams' is not instance of type (expected tuple[cyruntime.cudaDevSmResourceGroupParams,] or list[cyruntime.cudaDevSmResourceGroupParams,]")
     cdef cyruntime.cudaDevResource* cyresult = NULL
     pyresult = [cudaDevResource() for idx in range(nbGroups)]
     if nbGroups != 0:
@@ -39631,14 +39634,24 @@ def cudaDevSmResourceSplit(unsigned int nbGroups, input_ : Optional[cudaDevResou
             raise MemoryError('Failed to allocate length x size memory: ' + str(nbGroups) + 'x' + str(sizeof(cyruntime.cudaDevResource)))
     cdef cyruntime.cudaDevResource* cyinput__ptr = input_._pvt_ptr if input_ is not None else NULL
     cdef cudaDevResource remainder = cudaDevResource()
-    cdef cyruntime.cudaDevSmResourceGroupParams* cygroupParams_ptr = groupParams._pvt_ptr if groupParams is not None else NULL
+    cdef cyruntime.cudaDevSmResourceGroupParams* cygroupParams = NULL
+    if len(groupParams) > 1:
+        cygroupParams = <cyruntime.cudaDevSmResourceGroupParams*> calloc(len(groupParams), sizeof(cyruntime.cudaDevSmResourceGroupParams))
+        if cygroupParams is NULL:
+            raise MemoryError('Failed to allocate length x size memory: ' + str(len(groupParams)) + 'x' + str(sizeof(cyruntime.cudaDevSmResourceGroupParams)))
+        for idx in range(len(groupParams)):
+            string.memcpy(&cygroupParams[idx], (<cudaDevSmResourceGroupParams>groupParams[idx])._pvt_ptr, sizeof(cyruntime.cudaDevSmResourceGroupParams))
+    elif len(groupParams) == 1:
+        cygroupParams = (<cudaDevSmResourceGroupParams>groupParams[0])._pvt_ptr
     with nogil:
-        err = cyruntime.cudaDevSmResourceSplit(cyresult, nbGroups, cyinput__ptr, <cyruntime.cudaDevResource*>remainder._pvt_ptr, flags, cygroupParams_ptr)
+        err = cyruntime.cudaDevSmResourceSplit(cyresult, nbGroups, cyinput__ptr, <cyruntime.cudaDevResource*>remainder._pvt_ptr, flags, cygroupParams)
     if cudaError_t(err) == cudaError_t(0):
         for idx in range(nbGroups):
             string.memcpy((<cudaDevResource>pyresult[idx])._pvt_ptr, &cyresult[idx], sizeof(cyruntime.cudaDevResource))
     if cyresult is not NULL:
         free(cyresult)
+    if len(groupParams) > 1 and cygroupParams is not NULL:
+        free(cygroupParams)
     if err != cyruntime.cudaSuccess:
         return (_cudaError_t(err), None, None)
     return (_cudaError_t_SUCCESS, pyresult, remainder)

--- a/cuda_bindings/tests/test_cuda.py
+++ b/cuda_bindings/tests/test_cuda.py
@@ -1126,20 +1126,63 @@ def test_cuDevSmResourceSplit(device, ctx):
     err, resource_in = cuda.cuDeviceGetDevResource(device, cuda.CUdevResourceType.CU_DEV_RESOURCE_TYPE_SM)
     assert err == cuda.CUresult.CUDA_SUCCESS
 
-    # Create group params for splitting into 1 group (simpler test)
+    # Test case 1: Split into 1 group
     nb_groups = 1
-    group_params = cuda.CU_DEV_SM_RESOURCE_GROUP_PARAMS()
+    group_params = [cuda.CU_DEV_SM_RESOURCE_GROUP_PARAMS()]
     # Set up group: request 4 SMs with coscheduled count of 2
-    group_params.smCount = 4
-    group_params.coscheduledSmCount = 2
+    group_params[0].smCount = 4
+    group_params[0].coscheduledSmCount = 2
 
-    # Split the resource
     err, res, rem = cuda.cuDevSmResourceSplit(nb_groups, resource_in, 0, group_params)
     assert err == cuda.CUresult.CUDA_SUCCESS
-    # Verify we got results
     assert len(res) == nb_groups
-    # Verify remainder is valid (may be None if no remainder)
     assert rem is not None or len(res) > 0
+
+    # Test case 2: Split into 2 groups (if device has enough SMs)
+    # First, get the device resource again for a fresh split
+    err, resource_in = cuda.cuDeviceGetDevResource(device, cuda.CUdevResourceType.CU_DEV_RESOURCE_TYPE_SM)
+    assert err == cuda.CUresult.CUDA_SUCCESS
+
+    nb_groups = 2
+    group_params = [
+        cuda.CU_DEV_SM_RESOURCE_GROUP_PARAMS(),
+        cuda.CU_DEV_SM_RESOURCE_GROUP_PARAMS(),
+    ]
+    # First group: request 4 SMs with coscheduled count of 2
+    group_params[0].smCount = 4
+    group_params[0].coscheduledSmCount = 2
+    # Second group: request 4 SMs with coscheduled count of 2
+    group_params[1].smCount = 4
+    group_params[1].coscheduledSmCount = 2
+
+    err, res, rem = cuda.cuDevSmResourceSplit(nb_groups, resource_in, 0, group_params)
+    # This may succeed or fail depending on device SM count, but should handle gracefully
+    if err == cuda.CUresult.CUDA_SUCCESS:
+        assert len(res) == nb_groups
+        assert rem is not None or len(res) > 0
+    else:
+        # If it fails, it should be due to insufficient resources, not a binding error
+        assert err in (
+            cuda.CUresult.CUDA_ERROR_INVALID_RESOURCE_CONFIGURATION,
+            cuda.CUresult.CUDA_ERROR_INVALID_VALUE,
+        )
+
+    # Test case 3: Empty list (0 groups) - should handle gracefully
+    # Note: According to CUDA docs, nbGroups specifies number of groups, so 0 might not be valid
+    # But we test that the binding accepts an empty list without crashing
+    nb_groups = 0
+    group_params = []
+
+    err, res, rem = cuda.cuDevSmResourceSplit(nb_groups, resource_in, 0, group_params)
+    # With 0 groups, result should be empty
+    if err == cuda.CUresult.CUDA_SUCCESS:
+        assert len(res) == 0
+    else:
+        # If it fails, it should be a valid CUDA error, not a Python binding error
+        assert err in (
+            cuda.CUresult.CUDA_ERROR_INVALID_VALUE,
+            cuda.CUresult.CUDA_ERROR_INVALID_RESOURCE_CONFIGURATION,
+        )
 
 
 def test_buffer_reference():

--- a/cuda_bindings/tests/test_cudart.py
+++ b/cuda_bindings/tests/test_cudart.py
@@ -1721,20 +1721,63 @@ def test_cudaDevSmResourceSplit():
     err, resource_in = cudart.cudaDeviceGetDevResource(device, cudart.cudaDevResourceType.cudaDevResourceTypeSm)
     assertSuccess(err)
 
-    # Create group params for splitting into 1 group (simpler test)
+    # Test case 1: Split into 1 group
     nb_groups = 1
-    group_params = cudart.cudaDevSmResourceGroupParams()
+    group_params = [cudart.cudaDevSmResourceGroupParams()]
     # Set up group: request 4 SMs with coscheduled count of 2
-    group_params.smCount = 4
-    group_params.coscheduledSmCount = 2
+    group_params[0].smCount = 4
+    group_params[0].coscheduledSmCount = 2
 
-    # Split the resource
     err, res, rem = cudart.cudaDevSmResourceSplit(nb_groups, resource_in, 0, group_params)
     assertSuccess(err)
-    # Verify we got results
     assert len(res) == nb_groups
-    # Verify remainder is valid (may be None if no remainder)
     assert rem is not None or len(res) > 0
+
+    # Test case 2: Split into 2 groups (if device has enough SMs)
+    # First, get the device resource again for a fresh split
+    err, resource_in = cudart.cudaDeviceGetDevResource(device, cudart.cudaDevResourceType.cudaDevResourceTypeSm)
+    assertSuccess(err)
+
+    nb_groups = 2
+    group_params = [
+        cudart.cudaDevSmResourceGroupParams(),
+        cudart.cudaDevSmResourceGroupParams(),
+    ]
+    # First group: request 4 SMs with coscheduled count of 2
+    group_params[0].smCount = 4
+    group_params[0].coscheduledSmCount = 2
+    # Second group: request 4 SMs with coscheduled count of 2
+    group_params[1].smCount = 4
+    group_params[1].coscheduledSmCount = 2
+
+    err, res, rem = cudart.cudaDevSmResourceSplit(nb_groups, resource_in, 0, group_params)
+    # This may succeed or fail depending on device SM count, but should handle gracefully
+    if err == cudart.cudaError_t.cudaSuccess:
+        assert len(res) == nb_groups
+        assert rem is not None or len(res) > 0
+    else:
+        # If it fails, it should be due to insufficient resources, not a binding error
+        assert err in (
+            cudart.cudaError_t.cudaErrorInvalidResourceConfiguration,
+            cudart.cudaError_t.cudaErrorInvalidValue,
+        )
+
+    # Test case 3: Empty list (0 groups) - should handle gracefully
+    # Note: According to CUDA docs, nbGroups specifies number of groups, so 0 might not be valid
+    # But we test that the binding accepts an empty list without crashing
+    nb_groups = 0
+    group_params = []
+
+    err, res, rem = cudart.cudaDevSmResourceSplit(nb_groups, resource_in, 0, group_params)
+    # With 0 groups, result should be empty
+    if err == cudart.cudaError_t.cudaSuccess:
+        assert len(res) == 0
+    else:
+        # If it fails, it should be a valid CUDA error, not a Python binding error
+        assert err in (
+            cudart.cudaError_t.cudaErrorInvalidValue,
+            cudart.cudaError_t.cudaErrorInvalidResourceConfiguration,
+        )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Fixes: #1764

cython-gen PR: 282

The incorrect bindings were added with #1337 shortly after the CTK 13.1.0 release.

Update `test_cuDevSmResourceSplit` and `test_cudaDevSmResourceSplit` to:
- Pass `groupParams` as a list instead of a single object (matching the corrected signature mapping)
- Add test cases for 0, 1, and 2 group parameters to ensure proper edge case coverage
- Handle cases where the API may fail due to insufficient device resources gracefully

The binding signature was corrected in cython-gen to match the CUDA API documentation which specifies `groupParams` as an array of size `nbGroups`.