### PR TITLE
Fix documented enums in cuda_core

### DIFF
--- a/cuda_core/docs/source/api.rst
+++ b/cuda_core/docs/source/api.rst
@@ -82,6 +82,9 @@ CUDA compilation toolchain
 CUDA system information and NVIDIA Management Library (NVML)
 ------------------------------------------------------------
 
+Basic functions
+```````````````
+
 .. autosummary::
    :toctree: generated/
 
@@ -94,35 +97,61 @@ CUDA system information and NVIDIA Management Library (NVML)
    system.get_topology_common_ancestor
    system.get_p2p_status
 
+Events
+``````
+
+.. autosummary::
+   :toctree: generated/
+
    system.register_events
    system.RegisteredSystemEvents
    system.SystemEvent
    system.SystemEvents
    system.SystemEventType
 
+Enums
+`````
+
+.. autosummary::
+   :toctree: generated/
+
+   system.AddressingMode
+   system.AffinityScope
+   system.BrandType
+   system.ClockId
+   system.ClocksEventReasons
+   system.CoolerControl
+   system.CoolerTarget
+   system.DeviceArch
+   system.EventType
+   system.FanControlPolicy
+   system.FieldId
+   system.InforomObject
+   system.PcieUtilCounter
+   system.Pstates
+   system.TemperatureSensors
+   system.TemperatureThresholds
+   system.ThermalController
+   system.ThermalTarget
+
+Types
+`````
+
+.. autosummary::
+   :toctree: generated/
+
    :template: autosummary/cyclass.rst
 
    system.Device
-   system.AddressingMode
-   system.AffinityScope
    system.BAR1MemoryInfo
-   system.BrandType
-   system.ClockId
    system.ClockInfo
    system.ClockOffsets
-   system.ClocksEventReasons
    system.ClockType
-   system.CoolerControl
    system.CoolerInfo
-   system.CoolerTarget
-   system.DeviceArch
    system.DeviceAttributes
    system.DeviceEvents
    system.EventData
-   system.EventType
-   system.FanControlPolicy
    system.FanInfo
-   system.FieldId
    system.FieldValue
    system.FieldValues
    system.GpuDynamicPstatesInfo
@@ -131,19 +160,12 @@ CUDA system information and NVIDIA Management Library (NVML)
    system.GpuP2PStatus
    system.GpuTopologyLevel
    system.InforomInfo
-   system.InforomObject
    system.MemoryInfo
-   system.PcieUtilCounter
    system.PciInfo
-   system.Pstates
    system.RepairStatus
    system.Temperature
-   system.TemperatureSensors
-   system.TemperatureThresholds
-   system.ThermalController
    system.ThermalSensor
    system.ThermalSettings
-   system.ThermalTarget
 
 .. module:: cuda.core.utils
 

--- a/cuda_core/docs/source/conf.py
+++ b/cuda_core/docs/source/conf.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Configuration file for the Sphinx documentation builder.
@@ -37,11 +37,11 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
     "myst_nb",
-    "enum_tools.autoenum",
     "sphinx_copybutton",
     "sphinx_toolbox.more_autodoc.autoprotocol",
     "release_toc",
     "release_date",
+    "enum_documenter",
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Applies the same fixes to enums from #1778 in cuda_bindings to cuda_core.