### PR TITLE
Declare uv conflicts for mutually exclusive CUDA version extras/groups

### DIFF
--- a/cuda_core/pyproject.toml
+++ b/cuda_core/pyproject.toml
@@ -65,6 +65,20 @@ test-cu13 = [ {include-group = "ml-dtypes" }, {include-group = "test" }, "cupy-c
 test-cu12-ft = [ {include-group = "ml-dtypes" }, {include-group = "test" }, "cuda-toolkit[cudart]==12.*"]
 test-cu13-ft = [ {include-group = "ml-dtypes" }, {include-group = "test" }, "cuda-toolkit[cudart]==13.*"]
 
+[tool.uv]
+conflicts = [
+    [
+        { extra = "cu12" },
+        { extra = "cu13" },
+    ],
+    [
+        { group = "test-cu12" },
+        { group = "test-cu13" },
+        { group = "test-cu12-ft" },
+        { group = "test-cu13-ft" },
+    ],
+]
+
 [project.urls]
 homepage = "https://nvidia.github.io/cuda-python/"
 documentation = "https://nvidia.github.io/cuda-python/cuda-core/"

--- a/cuda_pathfinder/pyproject.toml
+++ b/cuda_pathfinder/pyproject.toml
@@ -57,6 +57,18 @@ test-cu13 = [
     { include-group = "host" },
 ]
 
+[tool.uv]
+conflicts = [
+    [
+        { group = "cu12" },
+        { group = "cu13" },
+    ],
+    [
+        { group = "test-cu12" },
+        { group = "test-cu13" },
+    ],
+]
+
 [project.urls]
 Repository = "https://github.com/NVIDIA/cuda-python"
 Documentation = "https://nvidia.github.io/cuda-python/"


### PR DESCRIPTION
## Summary

- Adds `[tool.uv] conflicts` to `cuda_core/pyproject.toml` and `cuda_pathfinder/pyproject.toml` so `uv` knows that `cu12`/`cu13` extras and dependency groups are mutually exclusive alternatives, not co-installable
- Without this, `uv sync` and `uv lock` fail with unsatisfiable dependency errors because `uv` tries to resolve all extras simultaneously
- The `[tool.uv]` section is only read by `uv` — pip, setuptools, and pixi ignore it, so existing workflows are unaffected

Closes #1247

## Test plan

- [x] Both `pyproject.toml` files validated with `tomllib.load()`
- [x] `uv lock` succeeds on `cuda_pathfinder` (63 packages resolved)
- [x] `uv lock` succeeds on `cuda_core` with `CUDA_HOME` set (41 packages resolved)
- [x] Reproduced the exact error from the issue (nccl4py-style downstream package) without the fix, confirmed it resolves with the fix