### PR TITLE
Update pathfinder descriptor catalogs for cusparseLt release 0.9.0

### DIFF
--- a/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/descriptor_catalog.py
+++ b/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/descriptor_catalog.py
@@ -331,8 +331,8 @@ DESCRIPTOR_CATALOG: tuple[DescriptorSpec, ...] = (
         packaged_with="other",
         linux_sonames=("libcusparseLt.so.0",),
         windows_dlls=("cusparseLt.dll",),
-        site_packages_linux=("nvidia/cusparselt/lib",),
-        site_packages_windows=("nvidia/cusparselt/bin",),
+        site_packages_linux=("nvidia/cu13/lib", "nvidia/cusparselt/lib"),
+        site_packages_windows=("nvidia/cu13/bin/x64", "nvidia/cusparselt/bin"),
     ),
     DescriptorSpec(
         name="cutensor",

--- a/cuda_pathfinder/cuda/pathfinder/_headers/header_descriptor_catalog.py
+++ b/cuda_pathfinder/cuda/pathfinder/_headers/header_descriptor_catalog.py
@@ -141,7 +141,7 @@ HEADER_DESCRIPTOR_CATALOG: tuple[HeaderDescriptorSpec, ...] = (
         name="cusparseLt",
         packaged_with="other",
         header_basename="cusparseLt.h",
-        site_packages_dirs=("nvidia/cusparselt/include",),
+        site_packages_dirs=("nvidia/cu13/include", "nvidia/cusparselt/include"),
         conda_targets_layout=False,
         use_ctk_root_canary=False,
     ),


### PR DESCRIPTION
**NOTE: MERGED via #1653**

https://pypi.org/project/nvidia-cusparselt-cu13/0.9.0/ (Released: Mar 21, 2026) changed the directory structure.

NOTE: I folded the commit from here into #1653 and set it to auto-merge, so that we get our CI green again asap.