### PR TITLE
[doc-only] Add pathfinder 1.4.4 release notes

### DIFF
--- a/cuda_pathfinder/docs/nv-versions.json
+++ b/cuda_pathfinder/docs/nv-versions.json
@@ -4,6 +4,18 @@
         "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/latest/"
     },
     {
+        "version": "1.4.4",
+        "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/1.4.4/"
+    },
+    {
+        "version": "1.4.3",
+        "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/1.4.3/"
+    },
+    {
+        "version": "1.4.2",
+        "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/1.4.2/"
+    },
+    {
         "version": "1.4.1",
         "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/1.4.1/"
     },

--- a/cuda_pathfinder/docs/source/release/1.4.4-notes.rst
+++ b/cuda_pathfinder/docs/source/release/1.4.4-notes.rst
@@ -1,0 +1,18 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+.. py:currentmodule:: cuda.pathfinder
+
+``cuda-pathfinder`` 1.4.4 Release notes
+=======================================
+
+Highlights
+----------
+
+* Support cusparseLt release 0.9.0 (wheels have new directory structure).
+  (`PR #1806 <https://github.com/NVIDIA/cuda-python/pull/1806>`_)
+
+* Clarified that Python 3.8+ excludes ``PATH`` from the native Windows DLL
+  search used by ``load_nvidia_dynamic_lib()``, so CTK installs are typically
+  found via ``CUDA_PATH``/``CUDA_HOME`` or other explicit search steps instead.
+  (`PR #1795 <https://github.com/NVIDIA/cuda-python/pull/1795>`_)


### PR DESCRIPTION
Split out from #1801 to get the `cusparseLt` updates (#1806) released as soon as possible.

Also add missing entries in pathfinder `nv-versions.json`