### PR TITLE
[Example] Fix reversed P2P direction logging

### DIFF
--- a/cuda_bindings/examples/0_Introduction/simpleP2P_test.py
+++ b/cuda_bindings/examples/0_Introduction/simpleP2P_test.py
@@ -73,7 +73,7 @@ def main():
             )
             print(
                 "> Peer access from {} (GPU{}) -> {} (GPU{}) : {}\n".format(
-                    prop[j].name, j, prop[i].name, i, "Yes" if i_access_j else "No"
+                    prop[j].name, j, prop[i].name, i, "Yes" if j_access_i else "No"
                 )
             )
             if i_access_j and j_access_i:

--- a/cuda_bindings/examples/extra/isoFDModelling_test.py
+++ b/cuda_bindings/examples/extra/isoFDModelling_test.py
@@ -649,7 +649,7 @@ def main():
             )
             print(
                 "> Peer access from {} (GPU{}) -> {} (GPU{}) : {}\n".format(
-                    prop[j].name, j, prop[i].name, i, "Yes" if i_access_j else "No"
+                    prop[j].name, j, prop[i].name, i, "Yes" if j_access_i else "No"
                 )
             )
             if i_access_j and j_access_i:


### PR DESCRIPTION
## Summary
- Correct the reverse-direction peer access log in the `cuda_bindings` P2P examples.
- Use `j_access_i` for `GPU[j] -> GPU[i]` so asymmetric peer access is reported accurately.

## Test plan
- [x] `cd cuda_bindings && pixi run pytest -q -s examples/0_Introduction/simpleP2P_test.py examples/extra/isoFDModelling_test.py`
- [x] Validate the asymmetric direction logging path with a focused simulated 2-GPU run.

Closes #1763

Made with [Cursor](https://cursor.com)