### PR TITLE
Add dlpack as a pixi host dependency for cuda_core

### DIFF
--- a/cuda_core/pixi.toml
+++ b/cuda_core/pixi.toml
@@ -135,6 +135,7 @@ setuptools-scm = ">=8"
 cython = ">=3.2,<3.3"
 cuda-nvrtc-dev = "*"
 cuda-bindings = "*"
+dlpack = "*"
 
 [package.target.linux-64.host-dependencies]
 cuda-cudart-dev_linux-64 = "*"


### PR DESCRIPTION
## Summary

Adds `dlpack` as a host dependency in `cuda_core/pixi.toml` so that DLPack headers are available at build time for Cython/C++ compilation. This was introduced as a build requirement by #1687 (TMA TensorMapDescriptor support), which includes `<dlpack/dlpack.h>` from `_cpp/tensor_map.cpp`.

## Changes

- `cuda_core/pixi.toml`: Added `dlpack = "*"` to `[package.host-dependencies]`

## Test Coverage

Build-only change — verified that `pixi install` and `pip install -v .` succeed with the new dependency.