### PR TITLE
Sync test dependencies between pyproject.toml and pixi.toml

### DIFF
--- a/cuda_core/pixi.toml
+++ b/cuda_core/pixi.toml
@@ -19,6 +19,9 @@ pytest = "*"
 pytest-benchmark = "*"
 pytest-randomly = "*"
 pytest-repeat = "*"
+pytest-rerunfailures = "*"
+cloudpickle = "*"
+psutil = "*"
 pyglet = "*"
 
 [feature.examples.dependencies]

--- a/cuda_core/pyproject.toml
+++ b/cuda_core/pyproject.toml
@@ -56,7 +56,7 @@ cu12 = ["cuda-bindings[all]==12.*"]
 cu13 = ["cuda-bindings[all]==13.*"]
 
 [dependency-groups]
-test = ["cython>=3.2,<3.3", "setuptools", "pytest>=6.2.4", "pytest-randomly", "pytest-repeat", "pytest-rerunfailures"]
+test = ["cython>=3.2,<3.3", "setuptools", "pytest>=6.2.4", "pytest-benchmark", "pytest-randomly", "pytest-repeat", "pytest-rerunfailures", "cloudpickle", "psutil"]
 ml-dtypes = ["ml-dtypes>=0.5.4,<0.6.0"]
 test-cu12 = [ {include-group = "ml-dtypes" }, {include-group = "test" }, "cupy-cuda12x; python_version < '3.14'", "cuda-toolkit[cudart]==12.*"]  # runtime headers needed by CuPy
 test-cu13 = [ {include-group = "ml-dtypes" }, {include-group = "test" }, "cupy-cuda13x; python_version < '3.14'", "cuda-toolkit[cudart]==13.*"]  # runtime headers needed by CuPy


### PR DESCRIPTION
## Summary

Synchronizes test dependencies between `pyproject.toml` `[dependency-groups]` and `pixi.toml` `[feature.test.dependencies]` so both surfaces install the same test tooling. Adds `cloudpickle` and `psutil` to ensure CI actually runs the cloudpickle regression tests (#1810) and fd-leak tests rather than silently skipping them via `importorskip`.

## Changes

- `cuda_core/pyproject.toml`: Added `pytest-benchmark`, `cloudpickle`, `psutil` to `[dependency-groups] test`
- `cuda_core/pixi.toml`: Added `pytest-rerunfailures`, `cloudpickle`, `psutil` to `[feature.test.dependencies]`

## Test Coverage

No new tests — this ensures existing tests with `importorskip` guards run in CI.

Companion to #1810.

Made with [Cursor](https://cursor.com)