### PR TITLE
Update docs following CTK 13.2 release

### DIFF
--- a/cuda_bindings/cuda/bindings/runtime.pyx.in
+++ b/cuda_bindings/cuda/bindings/runtime.pyx.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version 8797618. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 0.3.1.dev1422+gf4812259e.d20260318. Do not modify it directly.
 from typing import Any, Optional
 import cython
 import ctypes
@@ -1858,7 +1858,9 @@ class cudaLogLevel(_FastEnum):
 {{if 'cudaDataType_t' in found_types}}
 
 class cudaDataType(_FastEnum):
-    """"""
+    """
+
+    """
     {{if 'CUDA_R_32F' in found_values}}
     CUDA_R_32F = cyruntime.cudaDataType_t.CUDA_R_32F{{endif}}
     {{if 'CUDA_R_64F' in found_values}}
@@ -1934,43 +1936,98 @@ class cudaDataType(_FastEnum):
 {{if 'cudaEmulationStrategy_t' in found_types}}
 
 class cudaEmulationStrategy(_FastEnum):
-    """"""
+    """
+    Enum for specifying how to leverage floating-point emulation
+    algorithms
+    """
     {{if 'CUDA_EMULATION_STRATEGY_DEFAULT' in found_values}}
-    CUDA_EMULATION_STRATEGY_DEFAULT = cyruntime.cudaEmulationStrategy_t.CUDA_EMULATION_STRATEGY_DEFAULT{{endif}}
+
+    CUDA_EMULATION_STRATEGY_DEFAULT = (
+        cyruntime.cudaEmulationStrategy_t.CUDA_EMULATION_STRATEGY_DEFAULT,
+        'The default emulation strategy. For emulated computations, this is\n'
+        'equivalent to CUDA_EMULATION_STRATEGY_PERFORMANT, unless a library\n'
+        'dependent environment variable is set\n'
+    ){{endif}}
     {{if 'CUDA_EMULATION_STRATEGY_PERFORMANT' in found_values}}
-    CUDA_EMULATION_STRATEGY_PERFORMANT = cyruntime.cudaEmulationStrategy_t.CUDA_EMULATION_STRATEGY_PERFORMANT{{endif}}
+
+    CUDA_EMULATION_STRATEGY_PERFORMANT = (
+        cyruntime.cudaEmulationStrategy_t.CUDA_EMULATION_STRATEGY_PERFORMANT,
+        'An emulation strategy which configures libraries to use emulation when it\n'
+        'provides a performance benefit\n'
+    ){{endif}}
     {{if 'CUDA_EMULATION_STRATEGY_EAGER' in found_values}}
-    CUDA_EMULATION_STRATEGY_EAGER = cyruntime.cudaEmulationStrategy_t.CUDA_EMULATION_STRATEGY_EAGER{{endif}}
+
+    CUDA_EMULATION_STRATEGY_EAGER = (
+        cyruntime.cudaEmulationStrategy_t.CUDA_EMULATION_STRATEGY_EAGER,
+        'An emulation strategy which configures libraries to use emulation whenever\n'
+        'possible\n'
+    ){{endif}}
 
 {{endif}}
 {{if 'cudaEmulationMantissaControl_t' in found_types}}
 
 class cudaEmulationMantissaControl(_FastEnum):
-    """"""
+    """
+    Enum to configure the mantissa related parameters for floating-
+    point emulation algorithms
+    """
     {{if 'CUDA_EMULATION_MANTISSA_CONTROL_DYNAMIC' in found_values}}
-    CUDA_EMULATION_MANTISSA_CONTROL_DYNAMIC = cyruntime.cudaEmulationMantissaControl_t.CUDA_EMULATION_MANTISSA_CONTROL_DYNAMIC{{endif}}
+
+    CUDA_EMULATION_MANTISSA_CONTROL_DYNAMIC = (
+        cyruntime.cudaEmulationMantissaControl_t.CUDA_EMULATION_MANTISSA_CONTROL_DYNAMIC,
+        'The number of retained mantissa bits are computed at runtime to ensure the\n'
+        'same or better accuracy than the floating point representation being\n'
+        'emulated\n'
+    ){{endif}}
     {{if 'CUDA_EMULATION_MANTISSA_CONTROL_FIXED' in found_values}}
-    CUDA_EMULATION_MANTISSA_CONTROL_FIXED = cyruntime.cudaEmulationMantissaControl_t.CUDA_EMULATION_MANTISSA_CONTROL_FIXED{{endif}}
+
+    CUDA_EMULATION_MANTISSA_CONTROL_FIXED = (
+        cyruntime.cudaEmulationMantissaControl_t.CUDA_EMULATION_MANTISSA_CONTROL_FIXED,
+        'The number of retained mantissa bits are known at runtime\n'
+    ){{endif}}
 
 {{endif}}
 {{if 'cudaEmulationSpecialValuesSupport_t' in found_types}}
 
 class cudaEmulationSpecialValuesSupport(_FastEnum):
-    """"""
+    """
+    Enum to configure how special floating-point values will be handled
+    by emulation algorithms
+    """
     {{if 'CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_NONE' in found_values}}
-    CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_NONE = cyruntime.cudaEmulationSpecialValuesSupport_t.CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_NONE{{endif}}
+
+    CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_NONE = (
+        cyruntime.cudaEmulationSpecialValuesSupport_t.CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_NONE,
+        'There are no requirements for emulation algorithms to support special\n'
+        'values\n'
+    ){{endif}}
     {{if 'CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_INFINITY' in found_values}}
-    CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_INFINITY = cyruntime.cudaEmulationSpecialValuesSupport_t.CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_INFINITY{{endif}}
+
+    CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_INFINITY = (
+        cyruntime.cudaEmulationSpecialValuesSupport_t.CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_INFINITY,
+        'Require emulation algorithms to handle signed infinity inputs and outputs\n'
+    ){{endif}}
     {{if 'CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_NAN' in found_values}}
-    CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_NAN = cyruntime.cudaEmulationSpecialValuesSupport_t.CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_NAN{{endif}}
+
+    CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_NAN = (
+        cyruntime.cudaEmulationSpecialValuesSupport_t.CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_NAN,
+        'Require emulation algorithms to handle NaN inputs and outputs\n'
+    ){{endif}}
     {{if 'CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_DEFAULT' in found_values}}
-    CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_DEFAULT = cyruntime.cudaEmulationSpecialValuesSupport_t.CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_DEFAULT{{endif}}
+
+    CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_DEFAULT = (
+        cyruntime.cudaEmulationSpecialValuesSupport_t.CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_DEFAULT,
+        'The default special value support mask which contains support for signed\n'
+        'infinities and NaN values\n'
+    ){{endif}}
 
 {{endif}}
 {{if 'libraryPropertyType_t' in found_types}}
 
 class libraryPropertyType(_FastEnum):
-    """"""
+    """
+
+    """
     {{if 'MAJOR_VERSION' in found_values}}
     MAJOR_VERSION = cyruntime.libraryPropertyType_t.MAJOR_VERSION{{endif}}
     {{if 'MINOR_VERSION' in found_values}}
@@ -6394,7 +6451,9 @@ class cudaTextureReadMode(_FastEnum):
 {{if 'cudaRoundMode' in found_types}}
 
 class cudaRoundMode(_FastEnum):
-    """"""
+    """
+
+    """
     {{if 'cudaRoundNearest' in found_values}}
     cudaRoundNearest = cyruntime.cudaRoundMode.cudaRoundNearest{{endif}}
     {{if 'cudaRoundZero' in found_values}}

--- a/cuda_bindings/docs/source/module/driver.rst
+++ b/cuda_bindings/docs/source/module/driver.rst
@@ -1,9 +1,27 @@
-.. SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 .. SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 ------
 driver
 ------
+
+Profiler Control
+----------------
+
+This section describes the profiler control functions of the low-level CUDA driver application programming interface.
+
+.. autofunction:: cuda.bindings.driver.cuProfilerStart
+.. autofunction:: cuda.bindings.driver.cuProfilerStop
+
+VDPAU Interoperability
+----------------------
+
+This section describes the VDPAU interoperability functions of the low-level CUDA driver application programming interface.
+
+.. autofunction:: cuda.bindings.driver.cuVDPAUGetDevice
+.. autofunction:: cuda.bindings.driver.cuVDPAUCtxCreate
+.. autofunction:: cuda.bindings.driver.cuGraphicsVDPAURegisterVideoSurface
+.. autofunction:: cuda.bindings.driver.cuGraphicsVDPAURegisterOutputSurface
 
 Data types used by CUDA driver
 ------------------------------
@@ -7752,24 +7770,6 @@ Checkpoint and restore capabilities are currently restricted to Linux.
 .. autofunction:: cuda.bindings.driver.cuCheckpointProcessRestore
 .. autofunction:: cuda.bindings.driver.cuCheckpointProcessUnlock
 
-EGL Interoperability
---------------------
-
-This section describes the EGL interoperability functions of the low-level CUDA driver application programming interface.
-
-.. autofunction:: cuda.bindings.driver.cuGraphicsEGLRegisterImage
-.. autofunction:: cuda.bindings.driver.cuEGLStreamConsumerConnect
-.. autofunction:: cuda.bindings.driver.cuEGLStreamConsumerConnectWithFlags
-.. autofunction:: cuda.bindings.driver.cuEGLStreamConsumerDisconnect
-.. autofunction:: cuda.bindings.driver.cuEGLStreamConsumerAcquireFrame
-.. autofunction:: cuda.bindings.driver.cuEGLStreamConsumerReleaseFrame
-.. autofunction:: cuda.bindings.driver.cuEGLStreamProducerConnect
-.. autofunction:: cuda.bindings.driver.cuEGLStreamProducerDisconnect
-.. autofunction:: cuda.bindings.driver.cuEGLStreamProducerPresentFrame
-.. autofunction:: cuda.bindings.driver.cuEGLStreamProducerReturnFrame
-.. autofunction:: cuda.bindings.driver.cuGraphicsResourceGetMappedEglFrame
-.. autofunction:: cuda.bindings.driver.cuEventCreateFromEGLSync
-
 OpenGL Interoperability
 -----------------------
 
@@ -7798,20 +7798,20 @@ This section describes the OpenGL interoperability functions of the low-level CU
 .. autofunction:: cuda.bindings.driver.cuGraphicsGLRegisterImage
 .. autofunction:: cuda.bindings.driver.cuGLGetDevices
 
-Profiler Control
-----------------
+EGL Interoperability
+--------------------
 
-This section describes the profiler control functions of the low-level CUDA driver application programming interface.
+This section describes the EGL interoperability functions of the low-level CUDA driver application programming interface.
 
-.. autofunction:: cuda.bindings.driver.cuProfilerStart
-.. autofunction:: cuda.bindings.driver.cuProfilerStop
-
-VDPAU Interoperability
-----------------------
-
-This section describes the VDPAU interoperability functions of the low-level CUDA driver application programming interface.
-
-.. autofunction:: cuda.bindings.driver.cuVDPAUGetDevice
-.. autofunction:: cuda.bindings.driver.cuVDPAUCtxCreate
-.. autofunction:: cuda.bindings.driver.cuGraphicsVDPAURegisterVideoSurface
-.. autofunction:: cuda.bindings.driver.cuGraphicsVDPAURegisterOutputSurface
+.. autofunction:: cuda.bindings.driver.cuGraphicsEGLRegisterImage
+.. autofunction:: cuda.bindings.driver.cuEGLStreamConsumerConnect
+.. autofunction:: cuda.bindings.driver.cuEGLStreamConsumerConnectWithFlags
+.. autofunction:: cuda.bindings.driver.cuEGLStreamConsumerDisconnect
+.. autofunction:: cuda.bindings.driver.cuEGLStreamConsumerAcquireFrame
+.. autofunction:: cuda.bindings.driver.cuEGLStreamConsumerReleaseFrame
+.. autofunction:: cuda.bindings.driver.cuEGLStreamProducerConnect
+.. autofunction:: cuda.bindings.driver.cuEGLStreamProducerDisconnect
+.. autofunction:: cuda.bindings.driver.cuEGLStreamProducerPresentFrame
+.. autofunction:: cuda.bindings.driver.cuEGLStreamProducerReturnFrame
+.. autofunction:: cuda.bindings.driver.cuGraphicsResourceGetMappedEglFrame
+.. autofunction:: cuda.bindings.driver.cuEventCreateFromEGLSync

--- a/cuda_bindings/docs/source/module/runtime.rst
+++ b/cuda_bindings/docs/source/module/runtime.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 .. SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 -------
@@ -172,6 +172,9 @@ This section describes the memory management functions of the CUDA runtime appli
 
 Some functions have overloaded C++ API template versions documented separately in the C++ API Routines module.
 
+.. autofunction:: cuda.bindings.runtime.make_cudaPitchedPtr
+.. autofunction:: cuda.bindings.runtime.make_cudaPos
+.. autofunction:: cuda.bindings.runtime.make_cudaExtent
 .. autofunction:: cuda.bindings.runtime.cudaMallocManaged
 .. autofunction:: cuda.bindings.runtime.cudaMalloc
 .. autofunction:: cuda.bindings.runtime.cudaMallocHost
@@ -229,9 +232,6 @@ Some functions have overloaded C++ API template versions documented separately i
 .. autofunction:: cuda.bindings.runtime.cudaMemAdvise
 .. autofunction:: cuda.bindings.runtime.cudaMemRangeGetAttribute
 .. autofunction:: cuda.bindings.runtime.cudaMemRangeGetAttributes
-.. autofunction:: cuda.bindings.runtime.make_cudaPitchedPtr
-.. autofunction:: cuda.bindings.runtime.make_cudaPos
-.. autofunction:: cuda.bindings.runtime.make_cudaExtent
 
 Stream Ordered Memory Allocator
 -------------------------------
@@ -1110,6 +1110,7 @@ Data types used by CUDA Runtime
 
 
 
+.. autoclass:: cuda.bindings.runtime.cudaTextureDesc
 .. autoclass:: cuda.bindings.runtime.cudaEglPlaneDesc_st
 .. autoclass:: cuda.bindings.runtime.cudaEglFrame_st
 .. autoclass:: cuda.bindings.runtime.cudaChannelFormatDesc
@@ -1177,7 +1178,89 @@ Data types used by CUDA Runtime
 .. autoclass:: cuda.bindings.runtime.cudaLaunchAttributeValue
 .. autoclass:: cuda.bindings.runtime.cudaLaunchAttribute_st
 .. autoclass:: cuda.bindings.runtime.cudaAsyncNotificationInfo
-.. autoclass:: cuda.bindings.runtime.cudaTextureDesc
+.. autoclass:: cuda.bindings.runtime.cudaTextureAddressMode
+
+    .. autoattribute:: cuda.bindings.runtime.cudaTextureAddressMode.cudaAddressModeWrap
+
+
+        Wrapping address mode
+
+
+    .. autoattribute:: cuda.bindings.runtime.cudaTextureAddressMode.cudaAddressModeClamp
+
+
+        Clamp to edge address mode
+
+
+    .. autoattribute:: cuda.bindings.runtime.cudaTextureAddressMode.cudaAddressModeMirror
+
+
+        Mirror address mode
+
+
+    .. autoattribute:: cuda.bindings.runtime.cudaTextureAddressMode.cudaAddressModeBorder
+
+
+        Border address mode
+
+.. autoclass:: cuda.bindings.runtime.cudaTextureFilterMode
+
+    .. autoattribute:: cuda.bindings.runtime.cudaTextureFilterMode.cudaFilterModePoint
+
+
+        Point filter mode
+
+
+    .. autoattribute:: cuda.bindings.runtime.cudaTextureFilterMode.cudaFilterModeLinear
+
+
+        Linear filter mode
+
+.. autoclass:: cuda.bindings.runtime.cudaTextureReadMode
+
+    .. autoattribute:: cuda.bindings.runtime.cudaTextureReadMode.cudaReadModeElementType
+
+
+        Read texture as specified element type
+
+
+    .. autoattribute:: cuda.bindings.runtime.cudaTextureReadMode.cudaReadModeNormalizedFloat
+
+
+        Read texture as normalized float
+
+.. autoclass:: cuda.bindings.runtime.cudaSurfaceBoundaryMode
+
+    .. autoattribute:: cuda.bindings.runtime.cudaSurfaceBoundaryMode.cudaBoundaryModeZero
+
+
+        Zero boundary mode
+
+
+    .. autoattribute:: cuda.bindings.runtime.cudaSurfaceBoundaryMode.cudaBoundaryModeClamp
+
+
+        Clamp boundary mode
+
+
+    .. autoattribute:: cuda.bindings.runtime.cudaSurfaceBoundaryMode.cudaBoundaryModeTrap
+
+
+        Trap boundary mode
+
+.. autoclass:: cuda.bindings.runtime.cudaSurfaceFormatMode
+
+    .. autoattribute:: cuda.bindings.runtime.cudaSurfaceFormatMode.cudaFormatModeForced
+
+
+        Forced format mode
+
+
+    .. autoattribute:: cuda.bindings.runtime.cudaSurfaceFormatMode.cudaFormatModeAuto
+
+
+        Auto format mode
+
 .. autoclass:: cuda.bindings.runtime.cudaEglFrameType
 
     .. autoattribute:: cuda.bindings.runtime.cudaEglFrameType.cudaEglFrameTypeArray
@@ -5907,89 +5990,8 @@ Data types used by CUDA Runtime
 
     .. autoattribute:: cuda.bindings.runtime.cudaLogLevel.cudaLogLevelWarning
 
-.. autoclass:: cuda.bindings.runtime.cudaSurfaceBoundaryMode
-
-    .. autoattribute:: cuda.bindings.runtime.cudaSurfaceBoundaryMode.cudaBoundaryModeZero
-
-
-        Zero boundary mode
-
-
-    .. autoattribute:: cuda.bindings.runtime.cudaSurfaceBoundaryMode.cudaBoundaryModeClamp
-
-
-        Clamp boundary mode
-
-
-    .. autoattribute:: cuda.bindings.runtime.cudaSurfaceBoundaryMode.cudaBoundaryModeTrap
-
-
-        Trap boundary mode
-
-.. autoclass:: cuda.bindings.runtime.cudaSurfaceFormatMode
-
-    .. autoattribute:: cuda.bindings.runtime.cudaSurfaceFormatMode.cudaFormatModeForced
-
-
-        Forced format mode
-
-
-    .. autoattribute:: cuda.bindings.runtime.cudaSurfaceFormatMode.cudaFormatModeAuto
-
-
-        Auto format mode
-
-.. autoclass:: cuda.bindings.runtime.cudaTextureAddressMode
-
-    .. autoattribute:: cuda.bindings.runtime.cudaTextureAddressMode.cudaAddressModeWrap
-
-
-        Wrapping address mode
-
-
-    .. autoattribute:: cuda.bindings.runtime.cudaTextureAddressMode.cudaAddressModeClamp
-
-
-        Clamp to edge address mode
-
-
-    .. autoattribute:: cuda.bindings.runtime.cudaTextureAddressMode.cudaAddressModeMirror
-
-
-        Mirror address mode
-
-
-    .. autoattribute:: cuda.bindings.runtime.cudaTextureAddressMode.cudaAddressModeBorder
-
-
-        Border address mode
-
-.. autoclass:: cuda.bindings.runtime.cudaTextureFilterMode
-
-    .. autoattribute:: cuda.bindings.runtime.cudaTextureFilterMode.cudaFilterModePoint
-
-
-        Point filter mode
-
-
-    .. autoattribute:: cuda.bindings.runtime.cudaTextureFilterMode.cudaFilterModeLinear
-
-
-        Linear filter mode
-
-.. autoclass:: cuda.bindings.runtime.cudaTextureReadMode
-
-    .. autoattribute:: cuda.bindings.runtime.cudaTextureReadMode.cudaReadModeElementType
-
-
-        Read texture as specified element type
-
-
-    .. autoattribute:: cuda.bindings.runtime.cudaTextureReadMode.cudaReadModeNormalizedFloat
-
-
-        Read texture as normalized float
-
+.. autoclass:: cuda.bindings.runtime.cudaTextureObject_t
+.. autoclass:: cuda.bindings.runtime.cudaSurfaceObject_t
 .. autoclass:: cuda.bindings.runtime.cudaEglPlaneDesc
 .. autoclass:: cuda.bindings.runtime.cudaEglFrame
 .. autoclass:: cuda.bindings.runtime.cudaEglStreamConnection
@@ -6033,8 +6035,20 @@ Data types used by CUDA Runtime
 .. autoclass:: cuda.bindings.runtime.cudaAsyncCallback
 .. autoclass:: cuda.bindings.runtime.cudaLogsCallbackHandle
 .. autoclass:: cuda.bindings.runtime.cudaLogIterator
-.. autoclass:: cuda.bindings.runtime.cudaSurfaceObject_t
-.. autoclass:: cuda.bindings.runtime.cudaTextureObject_t
+.. autoattribute:: cuda.bindings.runtime.cudaTextureType1D
+.. autoattribute:: cuda.bindings.runtime.cudaTextureType2D
+.. autoattribute:: cuda.bindings.runtime.cudaTextureType3D
+.. autoattribute:: cuda.bindings.runtime.cudaTextureTypeCubemap
+.. autoattribute:: cuda.bindings.runtime.cudaTextureType1DLayered
+.. autoattribute:: cuda.bindings.runtime.cudaTextureType2DLayered
+.. autoattribute:: cuda.bindings.runtime.cudaTextureTypeCubemapLayered
+.. autoattribute:: cuda.bindings.runtime.cudaSurfaceType1D
+.. autoattribute:: cuda.bindings.runtime.cudaSurfaceType2D
+.. autoattribute:: cuda.bindings.runtime.cudaSurfaceType3D
+.. autoattribute:: cuda.bindings.runtime.cudaSurfaceTypeCubemap
+.. autoattribute:: cuda.bindings.runtime.cudaSurfaceType1DLayered
+.. autoattribute:: cuda.bindings.runtime.cudaSurfaceType2DLayered
+.. autoattribute:: cuda.bindings.runtime.cudaSurfaceTypeCubemapLayered
 .. autoattribute:: cuda.bindings.runtime.CUDA_EGL_MAX_PLANES
 
     Maximum number of planes per frame
@@ -6320,17 +6334,3 @@ Data types used by CUDA Runtime
 .. autoattribute:: cuda.bindings.runtime.cudaKernelNodeAttributeDeviceUpdatableKernelNode
 .. autoattribute:: cuda.bindings.runtime.cudaKernelNodeAttributeNvlinkUtilCentricScheduling
 .. autoattribute:: cuda.bindings.runtime.cudaKernelNodeAttrValue
-.. autoattribute:: cuda.bindings.runtime.cudaSurfaceType1D
-.. autoattribute:: cuda.bindings.runtime.cudaSurfaceType2D
-.. autoattribute:: cuda.bindings.runtime.cudaSurfaceType3D
-.. autoattribute:: cuda.bindings.runtime.cudaSurfaceTypeCubemap
-.. autoattribute:: cuda.bindings.runtime.cudaSurfaceType1DLayered
-.. autoattribute:: cuda.bindings.runtime.cudaSurfaceType2DLayered
-.. autoattribute:: cuda.bindings.runtime.cudaSurfaceTypeCubemapLayered
-.. autoattribute:: cuda.bindings.runtime.cudaTextureType1D
-.. autoattribute:: cuda.bindings.runtime.cudaTextureType2D
-.. autoattribute:: cuda.bindings.runtime.cudaTextureType3D
-.. autoattribute:: cuda.bindings.runtime.cudaTextureTypeCubemap
-.. autoattribute:: cuda.bindings.runtime.cudaTextureType1DLayered
-.. autoattribute:: cuda.bindings.runtime.cudaTextureType2DLayered
-.. autoattribute:: cuda.bindings.runtime.cudaTextureTypeCubemapLayered


### PR DESCRIPTION
During the last 13.2 release, the script to convert the docs from headers files to an intermediate format one of our generators was not run, so these new documentation elements were missed.

Now that our generators have merged, the documentation updates happen automatically as part of generation, so this step should not be missed in future.