### PR TITLE
[no-ci] fix(ci): prevent `printf` from treating error message as option

### DIFF
--- a/.github/workflows/pr-metadata-check.yml
+++ b/.github/workflows/pr-metadata-check.yml
@@ -38,10 +38,12 @@ jobs:
           ERRORS=""
 
           # Module labels identify which package the PR touches.
+          # Cross-cutting labels exempt PRs from needing a module label.
           MODULE_LABELS="cuda.bindings cuda.core cuda.pathfinder"
+          MODULE_EXEMPT_LABELS="CI/CD"
           HAS_MODULE=false
           for label in $LABEL_NAMES; do
-            for mod in $MODULE_LABELS; do
+            for mod in $MODULE_LABELS $MODULE_EXEMPT_LABELS; do
               if [ "$label" = "$mod" ]; then
                 HAS_MODULE=true
                 break 2
@@ -50,7 +52,7 @@ jobs:
           done
 
           if [ "$HAS_MODULE" = "false" ]; then
-            ERRORS="${ERRORS}- **Missing module label**: add at least one of: \`cuda.bindings\`, \`cuda.core\`, \`cuda.pathfinder\`.\n"
+            ERRORS="${ERRORS}- **Missing module label**: add at least one of: \`cuda.bindings\`, \`cuda.core\`, \`cuda.pathfinder\` (or a cross-cutting label such as \`CI/CD\`).\n"
           fi
 
           # Type labels categorize the kind of change.


### PR DESCRIPTION
Fixes `printf: - : invalid option` error in the PR metadata check workflow.

Error seen here:

* https://github.com/NVIDIA/cuda-python/actions/runs/23523856642/job/68472723391?pr=1817

Two fixes for the PR metadata check workflow.

**Fix `printf` crash** — `printf "$ERRORS"` fails when `$ERRORS` starts with a dash (e.g. `- **Missing module label**...`), because bash's `printf` interprets the leading `-` as an option flag. Fix: `printf '%b' "$ERRORS"` passes the variable as an argument rather than the format string, while `%b` still interprets `\n` escape sequences.

**Allow `CI/CD` to bypass module label requirement** — PRs that only touch CI/infrastructure don't belong to `cuda.bindings`, `cuda.core`, or `cuda.pathfinder`. The module label check now accepts `CI/CD` as a cross-cutting alternative, via a `MODULE_EXEMPT_LABELS` list that can be extended later if needed.
