### PR TITLE
[no-ci] Add assignee check to PR metadata check workflow

### DIFF
--- a/.github/workflows/pr-metadata-check.yml
+++ b/.github/workflows/pr-metadata-check.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: "CI: Enforce label/milestone on PRs"
+name: "CI: Enforce assignee/label/milestone on PRs"
 
 on:
   pull_request_target:
@@ -10,6 +10,8 @@ on:
       - opened
       - edited
       - synchronize
+      - assigned
+      - unassigned
       - labeled
       - unlabeled
       - reopened
@@ -17,12 +19,13 @@ on:
 
 jobs:
   check-metadata:
-    name: PR has labels and milestone
+    name: PR has assignee, labels, and milestone
     if: github.repository_owner == 'NVIDIA'
     runs-on: ubuntu-latest
     steps:
-      - name: Check for labels and milestone
+      - name: Check for assignee, labels, and milestone
         env:
+          ASSIGNEES: ${{ toJson(github.event.pull_request.assignees) }}
           LABELS: ${{ toJson(github.event.pull_request.labels) }}
           MILESTONE: ${{ github.event.pull_request.milestone && github.event.pull_request.milestone.title || '' }}
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -34,11 +37,16 @@ jobs:
             exit 0
           fi
 
-          LABEL_NAMES=$(echo "$LABELS" | jq -r '.[].name')
           ERRORS=""
+
+          ASSIGNEE_COUNT=$(echo "$ASSIGNEES" | jq 'length')
+          if [ "$ASSIGNEE_COUNT" -eq 0 ]; then
+            ERRORS="${ERRORS}- **Missing assignee**: assign at least one person to this PR.\n"
+          fi
 
           # Module labels identify which package the PR touches.
           # Cross-cutting labels exempt PRs from needing a module label.
+          LABEL_NAMES=$(echo "$LABELS" | jq -r '.[].name')
           MODULE_LABELS="cuda.bindings cuda.core cuda.pathfinder"
           MODULE_EXEMPT_LABELS="CI/CD"
           HAS_MODULE=false
@@ -98,10 +106,12 @@ jobs:
             exit 1
           fi
 
+          ASSIGNEE_LIST=$(echo "$ASSIGNEES" | jq -r '.[].login' | paste -sd ', ' -)
           LABEL_LIST=$(echo "$LABEL_NAMES" | paste -sd ', ' -)
           {
             echo "## PR Metadata Check Passed"
             echo ""
+            echo "- **Assignees**: $ASSIGNEE_LIST"
             echo "- **Labels**: $LABEL_LIST"
             echo "- **Milestone**: $MILESTONE"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Extends the PR metadata check (#1815) to also require at least one assignee.

## Changes

- Add assignee check: fail with "Missing assignee" if no one is assigned
- Trigger on `assigned` / `unassigned` events so the check re-runs when assignees change
- Order all references (workflow name, env vars, check logic, summary output) to match the GitHub UI sidebar order: Assignees, Labels, Milestone