### PR TITLE
Remove workaround related to `LongPathsEnabled` on Windows

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -28,12 +28,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          # TEMPORARY: only building 3.14t to verify LongPathsEnabled
-          # - "3.10"
-          # - "3.11"
-          # - "3.12"
-          # - "3.13"
-          # - "3.14"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
           - "3.14t"
     name: py${{ matrix.python-version }}
     runs-on: ${{ (inputs.host-platform == 'linux-64' && 'linux-amd64-cpu8') ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         host-platform:
           - linux-aarch64
     name: Build ${{ matrix.host-platform }}, CUDA ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
-    if: github.event_name == 'TEMPORARY_DISABLED'  # TEMPORARY: only testing Windows 3.14t
+    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.skip) && !fromJSON(needs.should-skip.outputs.doc-only) }}
     secrets: inherit
     uses: ./.github/workflows/build-wheel.yml
     with:
@@ -145,7 +145,7 @@ jobs:
         host-platform:
           - linux-64
     name: Test ${{ matrix.host-platform }}
-    if: github.event_name == 'TEMPORARY_DISABLED'  # TEMPORARY: only testing Windows 3.14t
+    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.doc-only) }}
     permissions:
       contents: read  # This is required for actions/checkout
     needs:
@@ -168,7 +168,7 @@ jobs:
         host-platform:
           - linux-aarch64
     name: Test ${{ matrix.host-platform }}
-    if: github.event_name == 'TEMPORARY_DISABLED'  # TEMPORARY: only testing Windows 3.14t
+    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.doc-only) }}
     permissions:
       contents: read  # This is required for actions/checkout
     needs:
@@ -204,12 +204,11 @@ jobs:
       build-type: pull-request
       host-platform: ${{ matrix.host-platform }}
       build-ctk-ver: ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
-      matrix_filter: 'map(select(.PY_VER == "3.14t"))'  # TEMPORARY: only testing Windows 3.14t
       nruns: ${{ (github.event_name == 'schedule' && 100) || 1}}
 
   doc:
     name: Docs
-    if: github.event_name == 'TEMPORARY_DISABLED'  # TEMPORARY: only testing Windows 3.14t
+    if: ${{ github.repository_owner == 'nvidia' }}
     # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
     permissions:
       id-token: write


### PR DESCRIPTION
Closes #1820

The CI runner images now have `LongPathsEnabled=1` (nv-gha-runners/vm-images#241), so the `nvidia-cutlass` wheel installs successfully under free-threaded Python on Windows even though the longest path (266 characters) exceeds the default MAX_PATH limit.

## Changes

- Remove the `if: !endsWith(matrix.PY_VER, 't')` guards that skipped `pip install --group` and the `all_must_work` pathfinder test for free-threaded Python on Windows
- Add a `Verify LongPathsEnabled` step that fails early with a clear error referencing #1820 if a runner lacks the registry setting
