### PR TITLE
Expose type aliases and protocols via cuda.core.typing

### DIFF
--- a/cuda_core/cuda/core/typing.py
+++ b/cuda_core/cuda/core/typing.py
@@ -5,21 +5,9 @@
 """Public type aliases and protocols used in cuda.core API signatures."""
 
 from cuda.core._memory._buffer import DevicePointerT
-from cuda.core._memory._virtual_memory_resource import (
-    VirtualMemoryAccessTypeT,
-    VirtualMemoryAllocationTypeT,
-    VirtualMemoryGranularityT,
-    VirtualMemoryHandleTypeT,
-    VirtualMemoryLocationTypeT,
-)
 from cuda.core._stream import IsStreamT
 
 __all__ = [
     "DevicePointerT",
     "IsStreamT",
-    "VirtualMemoryAccessTypeT",
-    "VirtualMemoryAllocationTypeT",
-    "VirtualMemoryGranularityT",
-    "VirtualMemoryHandleTypeT",
-    "VirtualMemoryLocationTypeT",
 ]

--- a/cuda_core/docs/source/api_private.rst
+++ b/cuda_core/docs/source/api_private.rst
@@ -17,11 +17,11 @@ CUDA runtime
    :toctree: generated/
 
    typing.DevicePointerT
-   typing.VirtualMemoryAllocationTypeT
-   typing.VirtualMemoryLocationTypeT
-   typing.VirtualMemoryGranularityT
-   typing.VirtualMemoryAccessTypeT
-   typing.VirtualMemoryHandleTypeT
+   _memory._virtual_memory_resource.VirtualMemoryAllocationTypeT
+   _memory._virtual_memory_resource.VirtualMemoryLocationTypeT
+   _memory._virtual_memory_resource.VirtualMemoryGranularityT
+   _memory._virtual_memory_resource.VirtualMemoryAccessTypeT
+   _memory._virtual_memory_resource.VirtualMemoryHandleTypeT
    _module.KernelAttributes
    _module.KernelOccupancy
    _module.ParamInfo

--- a/cuda_core/tests/test_typing_imports.py
+++ b/cuda_core/tests/test_typing_imports.py
@@ -10,51 +10,20 @@ def test_typing_module_imports():
     from cuda.core.typing import (
         DevicePointerT,
         IsStreamT,
-        VirtualMemoryAccessTypeT,
-        VirtualMemoryAllocationTypeT,
-        VirtualMemoryGranularityT,
-        VirtualMemoryHandleTypeT,
-        VirtualMemoryLocationTypeT,
     )
 
-    # Verify they are not None (sanity check)
-    for name, obj in (
-        ("DevicePointerT", DevicePointerT),
-        ("IsStreamT", IsStreamT),
-        ("VirtualMemoryAccessTypeT", VirtualMemoryAccessTypeT),
-        ("VirtualMemoryAllocationTypeT", VirtualMemoryAllocationTypeT),
-        ("VirtualMemoryGranularityT", VirtualMemoryGranularityT),
-        ("VirtualMemoryHandleTypeT", VirtualMemoryHandleTypeT),
-        ("VirtualMemoryLocationTypeT", VirtualMemoryLocationTypeT),
-    ):
-        assert obj is not None, f"{name} should not be None"
+    assert DevicePointerT is not None
+    assert IsStreamT is not None
 
 
 def test_typing_matches_private_definitions():
     """cuda.core.typing re-exports match the original private definitions."""
     from cuda.core._memory._buffer import DevicePointerT as _DevicePointerT
-    from cuda.core._memory._virtual_memory_resource import (
-        VirtualMemoryAccessTypeT as _VirtualMemoryAccessTypeT,
-        VirtualMemoryAllocationTypeT as _VirtualMemoryAllocationTypeT,
-        VirtualMemoryGranularityT as _VirtualMemoryGranularityT,
-        VirtualMemoryHandleTypeT as _VirtualMemoryHandleTypeT,
-        VirtualMemoryLocationTypeT as _VirtualMemoryLocationTypeT,
-    )
     from cuda.core._stream import IsStreamT as _IsStreamT
     from cuda.core.typing import (
         DevicePointerT,
         IsStreamT,
-        VirtualMemoryAccessTypeT,
-        VirtualMemoryAllocationTypeT,
-        VirtualMemoryGranularityT,
-        VirtualMemoryHandleTypeT,
-        VirtualMemoryLocationTypeT,
     )
 
     assert DevicePointerT is _DevicePointerT
     assert IsStreamT is _IsStreamT
-    assert VirtualMemoryAccessTypeT is _VirtualMemoryAccessTypeT
-    assert VirtualMemoryAllocationTypeT is _VirtualMemoryAllocationTypeT
-    assert VirtualMemoryGranularityT is _VirtualMemoryGranularityT
-    assert VirtualMemoryHandleTypeT is _VirtualMemoryHandleTypeT
-    assert VirtualMemoryLocationTypeT is _VirtualMemoryLocationTypeT


### PR DESCRIPTION
## Summary
- Add a public `cuda.core.typing` module that re-exports `IsStreamT` and `DevicePointerT` — type annotations that appear in `cuda.core` public API signatures but were previously only accessible via private module paths
- Update `api_private.rst` docs to reference `cuda.core.typing.IsStreamT` and `cuda.core.typing.DevicePointerT`
- Add tests verifying imports and identity with the original definitions

Closes #1419

## Test plan
- [x] `test_typing_module_imports` — `IsStreamT` and `DevicePointerT` importable from `cuda.core.typing`
- [x] `test_typing_matches_private_definitions` — re-exports are identical objects to the private definitions

-- Leo's bot