### PR TITLE
Try running without root

### DIFF
--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -81,7 +81,6 @@ jobs:
     # Our self-hosted runners require a container
     # TODO: use a different (nvidia?) container
     container:
-      options: -u root --security-opt seccomp=unconfined --shm-size 16g
       image: ubuntu:22.04
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}


### PR DESCRIPTION
The discussion around #1829 got some of us to wondering /why/ the Linux container runs as root with wide-open security.

This line seems to have existed from the first time CI was added to this repo, and was brought over from config in the legate project.  I didn't trace it beyond the boundaries of this repo.

It seems that removing it, all the tests still pass.

Additionally, it doesn't result in any more tests being skipped by looking at the logs.

```
 grep -c SKIPPED ~/Downloads/upstream.txt
364

 grep -c SKIPPED ~/Downloads/pr.txt
364
```

I'm not sure I'm comfortable merging this without confirmation from a project "old timer", but I do feel like this is a better solution to the issue in #1829 than turning off a git security feature.
