### PR TITLE
Fix Cython compilation warnings in cuda.core

### DIFF
--- a/cuda_core/cuda/core/_device.pyx
+++ b/cuda_core/cuda/core/_device.pyx
@@ -16,6 +16,7 @@ from cuda.core._context cimport Context
 from cuda.core._context import ContextOptions
 from cuda.core._event cimport Event as cyEvent
 from cuda.core._event import Event, EventOptions
+from cuda.core._memory._buffer cimport Buffer, MemoryResource
 from cuda.core._resource_handles cimport (
     ContextHandle,
     create_context_handle_ref,

--- a/cuda_core/cuda/core/_graph/_graph_builder.pyx
+++ b/cuda_core/cuda/core/_graph/_graph_builder.pyx
@@ -140,7 +140,7 @@ class GraphCompleteOptions:
     use_node_priority: bool = False
 
 
-def _instantiate_graph(h_graph, options: GraphCompleteOptions | None = None) -> Graph:
+def _instantiate_graph(h_graph, options: GraphCompleteOptions | None = None) -> "Graph":
     params = driver.CUDA_GRAPH_INSTANTIATE_PARAMS()
     if options:
         flags = 0
@@ -322,7 +322,7 @@ class GraphBuilder:
         self._building_ended = True
         return self
 
-    def complete(self, options: GraphCompleteOptions | None = None) -> Graph:
+    def complete(self, options: GraphCompleteOptions | None = None) -> "Graph":
         """Completes the graph builder and returns the built :obj:`~_graph.Graph` object.
 
         Parameters

--- a/cuda_core/cuda/core/_linker.pyx
+++ b/cuda_core/cuda/core/_linker.pyx
@@ -67,7 +67,7 @@ cdef class Linker:
         Options for the linker. If not provided, default options will be used.
     """
 
-    def __init__(self, *object_codes: ObjectCode, options: LinkerOptions = None):
+    def __init__(self, *object_codes: ObjectCode, options: "LinkerOptions" = None):
         Linker_init(self, object_codes, options)
 
     def link(self, target_type) -> ObjectCode:

--- a/cuda_core/cuda/core/_memory/_graph_memory_resource.pyx
+++ b/cuda_core/cuda/core/_memory/_graph_memory_resource.pyx
@@ -111,7 +111,7 @@ cdef class cyGraphMemoryResource(MemoryResource):
         stream = Stream_accept(stream) if stream is not None else default_stream()
         return GMR_allocate(self, size, <Stream> stream)
 
-    def deallocate(self, ptr: DevicePointerT, size_t size, stream: Stream | GraphBuilder | None = None):
+    def deallocate(self, ptr: "DevicePointerT", size_t size, stream: Stream | GraphBuilder | None = None):
         """
         Deallocate a buffer of the requested size. See documentation for :obj:`~_memory.MemoryResource`.
         """

--- a/cuda_core/cuda/core/_memory/_memory_pool.pyx
+++ b/cuda_core/cuda/core/_memory/_memory_pool.pyx
@@ -144,7 +144,7 @@ cdef class _MemPool(MemoryResource):
         stream = Stream_accept(stream) if stream is not None else default_stream()
         return _MP_allocate(self, size, <Stream> stream)
 
-    def deallocate(self, ptr: DevicePointerT, size_t size, stream: Stream | GraphBuilder | None = None):
+    def deallocate(self, ptr: "DevicePointerT", size_t size, stream: Stream | GraphBuilder | None = None):
         """Deallocate a buffer previously allocated by this resource.
 
         Parameters

--- a/cuda_core/cuda/core/_resource_handles.pyx
+++ b/cuda_core/cuda/core/_resource_handles.pyx
@@ -120,9 +120,6 @@ cdef extern from "_cpp/resource_handles.hpp" namespace "cuda_core":
         const StreamHandle& h_stream) except+ nogil
 
     # MR deallocation callback
-    ctypedef void (*MRDeallocCallback)(
-        object mr, cydriver.CUdeviceptr ptr, size_t size,
-        const StreamHandle& stream) noexcept
     void register_mr_dealloc_callback "cuda_core::register_mr_dealloc_callback" (
         MRDeallocCallback cb) noexcept
     DevicePtrHandle deviceptr_create_with_mr "cuda_core::deviceptr_create_with_mr" (


### PR DESCRIPTION
## Summary

Eliminates all 8 Cython-level compilation warnings emitted during the `cuda.core` build.

## Changes
- `_device.pyx` — `cimport Buffer, MemoryResource` from `_buffer.pxd` to resolve "Unknown type declaration" warnings (no circular dependency)
- `_graph_builder.pyx` — quote `"Graph"` in two return annotations (plain Python class, cannot be cimported)
- `_linker.pyx` — quote `"LinkerOptions"` in `__init__` annotation (dataclass defined in same file)
- `_memory_pool.pyx`, `_graph_memory_resource.pyx` — quote `"DevicePointerT"` in `deallocate` annotation (Python type alias, cannot be cimported)
- `_resource_handles.pyx` — remove duplicate `MRDeallocCallback` ctypedef (already declared in `.pxd`)

## Test Plan
- [x] Clean build with zero Cython warnings
- [x] CI

Made with [Cursor](https://cursor.com)