### PR TITLE
Improve error message for ManagedMemoryResource() on unsupported platforms

### DIFF
--- a/cuda_core/cuda/core/_memory/_managed_memory_resource.pyx
+++ b/cuda_core/cuda/core/_memory/_managed_memory_resource.pyx
@@ -11,6 +11,7 @@ from cuda.core._utils.cuda_utils cimport (
     HANDLE_RETURN,
     check_or_create_options,
 )
+from cuda.core._utils.cuda_utils import CUDAError
 
 from dataclasses import dataclass
 import threading
@@ -226,12 +227,25 @@ cdef inline _MMR_init(ManagedMemoryResource self, options):
         )
 
         if opts is None:
-            MP_init_current_pool(
-                self,
-                loc_type,
-                loc_id,
-                cydriver.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_MANAGED,
-            )
+            try:
+                MP_init_current_pool(
+                    self,
+                    loc_type,
+                    loc_id,
+                    cydriver.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_MANAGED,
+                )
+            except CUDAError as e:
+                if "CUDA_ERROR_NOT_SUPPORTED" in str(e):
+                    from .._device import Device
+                    if not Device().properties.concurrent_managed_access:
+                        raise RuntimeError(
+                            "The default memory pool on this device does not support "
+                            "managed allocations (concurrent managed access is not "
+                            "available). Use "
+                            "ManagedMemoryResource(options=ManagedMemoryResourceOptions(...)) "
+                            "to create a dedicated managed pool."
+                        ) from e
+                raise
         else:
             MP_init_create_pool(
                 self,

--- a/cuda_core/cuda/core/_memory/_memory_pool.pyx
+++ b/cuda_core/cuda/core/_memory/_memory_pool.pyx
@@ -257,7 +257,9 @@ cdef int MP_init_current_pool(
         self._h_pool = create_mempool_handle_ref(pool)
         self._mempool_owned = False
     ELSE:
-        raise RuntimeError("not supported")
+        raise RuntimeError(
+            "Getting the current memory pool requires CUDA 13.0 or later"
+        )
     return 0
 
 

--- a/cuda_core/tests/test_managed_memory_warning.py
+++ b/cuda_core/tests/test_managed_memory_warning.py
@@ -45,6 +45,13 @@ def device_without_concurrent_managed_access(init_cuda):
 
 
 @requires_cuda_13
+def test_default_pool_error_without_concurrent_access(device_without_concurrent_managed_access):
+    """ManagedMemoryResource() raises RuntimeError when the default pool doesn't support managed."""
+    with pytest.raises(RuntimeError, match="does not support managed allocations"):
+        ManagedMemoryResource()
+
+
+@requires_cuda_13
 def test_warning_emitted(device_without_concurrent_managed_access):
     """ManagedMemoryResource emits a warning when concurrent managed access is unsupported."""
     dev_id = device_without_concurrent_managed_access.device_id


### PR DESCRIPTION
Closes #1617

## Summary

`ManagedMemoryResource()` (no options) calls `cuMemGetMemPool` to retrieve the default managed memory pool, but on platforms without concurrent managed access (e.g. WSL2), this fails with a cryptic `CUDA_ERROR_NOT_SUPPORTED`. Meanwhile, explicitly creating a pool via `ManagedMemoryResource(options=ManagedMemoryResourceOptions(...))` works fine on the same platform.

This PR catches the error and re-raises it as a `RuntimeError` with an actionable message pointing users to the explicit options path. The improved message is only emitted when concurrent managed access is confirmed to be unavailable; otherwise the original `CUDAError` propagates unchanged.

The error is identified via string match on the `CUDAError` message rather than inspecting a structured error code because (1) we prefer not to change the `CUDAError` class or the `MP_init_current_pool` API for this, and (2) this is not a hot path.

## Changes
- `_managed_memory_resource.pyx` — catch `CUDAError` from `MP_init_current_pool` in the `opts is None` path; check `concurrent_managed_access` via device properties and raise a clear `RuntimeError` when applicable
- `_memory_pool.pyx` — improve the CUDA < 13 fallback error message in `MP_init_current_pool` to describe the unsupported operation
- `test_managed_memory_warning.py` — add `test_default_pool_error_without_concurrent_access` using the existing `device_without_concurrent_managed_access` fixture

## Test Plan
- [x] Reproduced on WSL2 (RTX 3500 Ada, `concurrent_managed_access=False`)
- [x] Verified fix produces the improved error message
- [x] CI

Made with [Cursor](https://cursor.com)