### PR TITLE
[doc-only] docs(pathfinder): prepare 1.5.1 release notes

### DIFF
--- a/cuda_pathfinder/docs/nv-versions.json
+++ b/cuda_pathfinder/docs/nv-versions.json
@@ -4,6 +4,10 @@
         "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/latest/"
     },
     {
+        "version": "1.5.1",
+        "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/1.5.1/"
+    },
+    {
         "version": "1.5.0",
         "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/1.5.0/"
     },

--- a/cuda_pathfinder/docs/source/release/1.5.1-notes.rst
+++ b/cuda_pathfinder/docs/source/release/1.5.1-notes.rst
@@ -1,0 +1,23 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+.. py:currentmodule:: cuda.pathfinder
+
+``cuda-pathfinder`` 1.5.1 Release notes
+=======================================
+
+Highlights
+----------
+
+* Add ``locate_nvidia_header_directory()`` support for ``mathdx``, ``cutlass``,
+  and ``cute``.
+  (`PR #1816 <https://github.com/NVIDIA/cuda-python/pull/1816>`_)
+
+* Add ``cusolverMp`` support for dynamic loading and header discovery.
+  (`PR #1845 <https://github.com/NVIDIA/cuda-python/pull/1845>`_)
+
+* Extend NVIDIA binary search paths with ``nvidia/cu13/bin``.
+  (`PR #1846 <https://github.com/NVIDIA/cuda-python/pull/1846>`_)
+
+* Add ``find_bitcode_lib("nvshmem_device")`` support.
+  (`PR #1828 <https://github.com/NVIDIA/cuda-python/pull/1828>`_)


### PR DESCRIPTION
Add cuda-pathfinder 1.5.1 release notes and register 1.5.1 in nv-versions so the published docs include the new version entry.

Made-with: Cursor