### PR TITLE
[no-ci] Fix: Claim context7 repo

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,5 +1,4 @@
 {
-  "description": "Python access to NVIDIA's CUDA platform, including cuda.bindings (low-level CUDA C API bindings), cuda.core (Pythonic CUDA runtime), and cuda.pathfinder (component discovery)",
   "url": "https://context7.com/nvidia/cuda-python",
   "public_key": "pk_gupaHhsdvsuT1j3BZpb7i"
 }


### PR DESCRIPTION
Follow up:

https://github.com/NVIDIA/cuda-python/pull/1757

Fixing the context7.json

Apparently it cant contain any other fields even if they are part of their spec :)

```
context7.json format is incorrect for claiming

For claiming, context7.json must ONLY contain "url" and "public_key". Remove other fields (folders, excludeFolders, etc.) to claim. After claiming, you can configure these settings via the admin panel at https://context7.com/nvidia/cuda-python/admin
```