### PR TITLE
[doc-only] docs(pathfinder): prepare 1.5.2 release notes

### DIFF
--- a/cuda_pathfinder/docs/nv-versions.json
+++ b/cuda_pathfinder/docs/nv-versions.json
@@ -4,6 +4,10 @@
         "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/latest/"
     },
     {
+        "version": "1.5.2",
+        "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/1.5.2/"
+    },
+    {
         "version": "1.5.1",
         "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/1.5.1/"
     },

--- a/cuda_pathfinder/docs/source/release/1.5.2-notes.rst
+++ b/cuda_pathfinder/docs/source/release/1.5.2-notes.rst
@@ -1,0 +1,18 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+.. py:currentmodule:: cuda.pathfinder
+
+``cuda-pathfinder`` 1.5.2 Release notes
+=======================================
+
+Highlights
+----------
+
+* Add ``load_nvidia_dynamic_lib()`` support for ``cudla`` and ``nvcudla``, and
+  add header discovery support for ``cudla``.
+  (`PR #1855 <https://github.com/NVIDIA/cuda-python/pull/1855>`_)
+
+* Add header discovery support for ``profiler`` via
+  ``find_nvidia_header_directory()`` and ``locate_nvidia_header_directory()``.
+  (`PR #1862 <https://github.com/NVIDIA/cuda-python/pull/1862>`_)


### PR DESCRIPTION
Add cuda-pathfinder 1.5.2 release notes and register 1.5.2 in nv-versions so the published docs include the new version entry.

Made-with: Cursor