### PR TITLE
Fix race condition in PR metadata check workflow

### DIFF
--- a/.github/workflows/pr-metadata-check.yml
+++ b/.github/workflows/pr-metadata-check.yml
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: "CI: Enforce assignee/label/milestone on PRs"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - assigned
+      - unassigned
+      - labeled
+      - unlabeled
+      - reopened
+      - ready_for_review
+
+jobs:
+  check-metadata:
+    name: PR has assignee, labels, and milestone
+    if: github.repository_owner == 'NVIDIA'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for assignee, labels, and milestone
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IS_BOT: ${{ github.actor == 'dependabot[bot]' || github.actor == 'pre-commit-ci[bot]' || github.actor == 'copy-pr-bot[bot]' }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+        run: |
+          if [ "$IS_BOT" = "true" ] || [ "$IS_DRAFT" = "true" ]; then
+            echo "Skipping check for bot or draft PR."
+            exit 0
+          fi
+
+          # Fetch live PR data to avoid stale event payload (race condition
+          # when labels/milestone are added shortly after PR creation).
+          PR_JSON=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}")
+          ASSIGNEES=$(echo "$PR_JSON" | jq '.assignees')
+          LABELS=$(echo "$PR_JSON" | jq '.labels')
+          MILESTONE=$(echo "$PR_JSON" | jq -r '.milestone.title // empty')
+
+          ERRORS=""
+
+          ASSIGNEE_COUNT=$(echo "$ASSIGNEES" | jq 'length')
+          if [ "$ASSIGNEE_COUNT" -eq 0 ]; then
+            ERRORS="${ERRORS}- **Missing assignee**: assign at least one person to this PR.\n"
+          fi
+
+          # Module labels identify which package the PR touches.
+          # Cross-cutting labels exempt PRs from needing a module label.
+          # Read label names line-by-line (jq outputs one per line) so
+          # multi-word GitHub labels are not split by shell word-splitting.
+          MODULE_LABELS="cuda.bindings cuda.core cuda.pathfinder"
+          MODULE_EXEMPT_LABELS="CI/CD"
+          HAS_MODULE=false
+          while IFS= read -r label; do
+            [ -n "$label" ] || continue
+            for mod in $MODULE_LABELS $MODULE_EXEMPT_LABELS; do
+              if [ "$label" = "$mod" ]; then
+                HAS_MODULE=true
+                break 2
+              fi
+            done
+          done < <(echo "$LABELS" | jq -r '.[].name')
+
+          if [ "$HAS_MODULE" = "false" ]; then
+            ERRORS="${ERRORS}- **Missing module label**: add at least one of: \`cuda.bindings\`, \`cuda.core\`, \`cuda.pathfinder\` (or a cross-cutting label such as \`CI/CD\`).\n"
+          fi
+
+          # Type labels categorize the kind of change.
+          TYPE_LABELS="bug enhancement feature documentation test example CI/CD packaging dependencies performance experiment RFC support P0 P1 P2"
+          HAS_TYPE=false
+          while IFS= read -r label; do
+            [ -n "$label" ] || continue
+            for typ in $TYPE_LABELS; do
+              if [ "$label" = "$typ" ]; then
+                HAS_TYPE=true
+                break 2
+              fi
+            done
+          done < <(echo "$LABELS" | jq -r '.[].name')
+
+          if [ "$HAS_TYPE" = "false" ]; then
+            ERRORS="${ERRORS}- **Missing type label**: add at least one of: \`bug\`, \`enhancement\`, \`feature\`, \`documentation\`, \`test\`, \`example\`, \`CI/CD\`, \`packaging\`, \`dependencies\`, \`performance\`, \`experiment\`, \`RFC\`, \`support\`, \`P0\`, \`P1\`, \`P2\`.\n"
+          fi
+
+          if [ -z "$MILESTONE" ]; then
+            ERRORS="${ERRORS}- **Missing milestone**: assign a milestone to this PR.\n"
+          fi
+
+          # Block PRs with labels that indicate they are not ready to merge.
+          # Match blocked label names exactly (case-insensitively); emit the
+          # original spelling from the payload so error text matches GitHub.
+          BLOCKED_LABELS=$(jq -r '
+            (["blocked", "do not merge"]) as $blocking
+            | .[]
+            | .name as $n
+            | if ($blocking | index($n | ascii_downcase)) != null
+              then $n
+              else empty
+              end
+          ' <<<"$LABELS")
+          while IFS= read -r label; do
+            [ -n "$label" ] || continue
+            ERRORS="${ERRORS}- **Blocked label detected**: label \`$label\` prevents merging. Remove it when the PR is ready.\n"
+          done <<<"$BLOCKED_LABELS"
+
+          if [ -n "$ERRORS" ]; then
+            echo "::error::This PR is missing required metadata. See the job summary for details."
+            {
+              echo "## PR Metadata Check Failed"
+              echo ""
+              printf '%b' "$ERRORS"
+              echo ""
+              echo "Please update the PR at: $PR_URL"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          ASSIGNEE_LIST=$(echo "$ASSIGNEES" | jq -r '.[].login' | paste -sd ', ' -)
+          LABEL_LIST=$(echo "$LABELS" | jq -r '.[].name' | paste -sd ', ' -)
+          {
+            echo "## PR Metadata Check Passed"
+            echo ""
+            echo "- **Assignees**: $ASSIGNEE_LIST"
+            echo "- **Labels**: $LABEL_LIST"
+            echo "- **Milestone**: $MILESTONE"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

The `pr-metadata-check` workflow reads assignees, labels, and milestone from `github.event.pull_request`, which is a snapshot taken at event trigger time. When a PR is opened, the `opened` event fires before labels/milestone/assignee are fully applied (e.g. by automation or rapid manual edits), causing the check to fail with stale data. Re-running the job doesn't help because it re-uses the same stale event payload.

This PR fixes the race by fetching live PR data via `gh api` instead of relying on the event payload. The downstream validation logic is unchanged.

## What changed

- Replaced `github.event.pull_request.{assignees,labels,milestone}` env vars with a single `gh api` call that fetches current PR state
- Added `PR_NUMBER`, `GH_REPO`, and `GH_TOKEN` env vars to support the API call
- All existing validation logic (module labels, type labels, blocked labels, milestone, assignee) remains identical

## Test plan

- Open a test PR and verify the check passes even if labels/milestone are added a few seconds after creation
- Verify the check still fails correctly when metadata is genuinely missing
- Verify bot/draft PRs are still skipped

-- Leo's bot