### PR TITLE
Fix race condition in PR metadata check workflow

### DIFF
--- a/.github/workflows/pr-metadata-check.yml
+++ b/.github/workflows/pr-metadata-check.yml
@@ -25,10 +25,10 @@ jobs:
     steps:
       - name: Check for assignee, labels, and milestone
         env:
-          ASSIGNEES: ${{ toJson(github.event.pull_request.assignees) }}
-          LABELS: ${{ toJson(github.event.pull_request.labels) }}
-          MILESTONE: ${{ github.event.pull_request.milestone && github.event.pull_request.milestone.title || '' }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IS_BOT: ${{ github.actor == 'dependabot[bot]' || github.actor == 'pre-commit-ci[bot]' || github.actor == 'copy-pr-bot[bot]' }}
           IS_DRAFT: ${{ github.event.pull_request.draft }}
         run: |
@@ -36,6 +36,13 @@ jobs:
             echo "Skipping check for bot or draft PR."
             exit 0
           fi
+
+          # Fetch live PR data to avoid stale event payload (race condition
+          # when labels/milestone are added shortly after PR creation).
+          PR_JSON=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}")
+          ASSIGNEES=$(echo "$PR_JSON" | jq '.assignees')
+          LABELS=$(echo "$PR_JSON" | jq '.labels')
+          MILESTONE=$(echo "$PR_JSON" | jq -r '.milestone.title // empty')
 
           ERRORS=""
 


### PR DESCRIPTION
## Summary

The `pr-metadata-check` workflow reads assignees, labels, and milestone from `github.event.pull_request`, which is a snapshot taken at event trigger time. When a PR is opened, the `opened` event fires before labels/milestone/assignee are fully applied (e.g. by automation or rapid manual edits), causing the check to fail with stale data. Re-running the job doesn't help because it re-uses the same stale event payload.

This PR fixes the race by fetching live PR data via `gh api` instead of relying on the event payload. The downstream validation logic is unchanged.

## What changed

- Replaced `github.event.pull_request.{assignees,labels,milestone}` env vars with a single `gh api` call that fetches current PR state
- Added `PR_NUMBER`, `GH_REPO`, and `GH_TOKEN` env vars to support the API call
- All existing validation logic (module labels, type labels, blocked labels, milestone, assignee) remains identical

## Test plan

- Open a test PR and verify the check passes even if labels/milestone are added a few seconds after creation
- Verify the check still fails correctly when metadata is genuinely missing
- Verify bot/draft PRs are still skipped

-- Leo's bot