### PR TITLE
[no-ci] Fix race condition in PR metadata check workflow

### DIFF
--- a/.github/workflows/pr-metadata-check.yml
+++ b/.github/workflows/pr-metadata-check.yml
@@ -39,7 +39,8 @@ jobs:
 
           # Fetch live PR data to avoid stale event payload (race condition
           # when labels/milestone are added shortly after PR creation).
-          PR_JSON=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" \
+          PR_JSON=$(gh pr view "${PR_NUMBER}" --repo "${GH_REPO}" \
+            --json assignees,labels,milestone \
             --jq '{assignees: .assignees, labels: .labels, milestone: (.milestone.title // empty)}')
           ASSIGNEES=$(echo "$PR_JSON" | jq '.assignees')
           LABELS=$(echo "$PR_JSON" | jq '.labels')


### PR DESCRIPTION
## Summary

The `pr-metadata-check` workflow reads assignees, labels, and milestone from `github.event.pull_request`, which is a snapshot taken at event trigger time. When a PR is opened, the `opened` event fires before labels/milestone/assignee are fully applied (e.g. by automation or rapid manual edits), causing the check to fail with stale data. Re-running the job doesn't help because it re-uses the same stale event payload.

This PR fixes the race by fetching live PR data via `gh api` instead of relying on the event payload. The downstream validation logic is unchanged.

## What changed

- Replaced `github.event.pull_request.{assignees,labels,milestone}` env vars with a single `gh api` call that fetches current PR state
- Uses `--jq` to filter the API response to only the 3 fields needed (assignees, labels, milestone)
- Added `PR_NUMBER`, `GH_REPO`, and `GH_TOKEN` env vars to support the API call
- All existing validation logic (module labels, type labels, blocked labels, milestone, assignee) remains identical

## Test plan

- Open a test PR and verify the check passes even if labels/milestone are added a few seconds after creation
- Verify the check still fails correctly when metadata is genuinely missing
- Verify bot/draft PRs are still skipped

-- Leo's bot