### PR TITLE
Add tests for ObjectCode.from_fatbin() using nvfatbin bindings

### DIFF
--- a/cuda_core/tests/test_module.py
+++ b/cuda_core/tests/test_module.py
@@ -44,9 +44,7 @@ def _is_nvfatbin_available():
         return False
 
 
-nvfatbin_available = pytest.mark.skipif(
-    not _is_nvfatbin_available(), reason="nvfatbin bindings not available"
-)
+nvfatbin_available = pytest.mark.skipif(not _is_nvfatbin_available(), reason="nvfatbin bindings not available")
 
 
 @pytest.fixture(scope="module")
@@ -126,9 +124,7 @@ def get_saxpy_fatbin(init_cuda):
     sym_map = mod.symbol_mapping
 
     # Compile to PTX targeting the second arch
-    ptx_mod = Program(
-        SAXPY_KERNEL, code_type="c++", options=ProgramOptions(arch=f"sm_{second_arch}")
-    ).compile(
+    ptx_mod = Program(SAXPY_KERNEL, code_type="c++", options=ProgramOptions(arch=f"sm_{second_arch}")).compile(
         "ptx",
         name_expressions=("saxpy<float>", "saxpy<double>"),
     )


### PR DESCRIPTION
## Summary
- Add `_is_nvfatbin_available()` detection + `nvfatbin_available` skip marker (follows the same pattern as `nvvm_available` in `test_program.py`)
- Add `get_saxpy_fatbin` fixture that creates a multi-arch fatbin (cubin for current device + PTX for a second arch) using the `nvfatbin` bindings API
- Add `test_object_code_load_fatbin` — loads fatbin bytes via `ObjectCode.from_fatbin()`, verifies `.code`, `.code_type`, and `get_kernel()`
- Add `test_object_code_load_fatbin_from_file` — writes fatbin to disk, loads via file path string, verifies `.code` is the path and `get_kernel()` works

Partially addresses #663 (fatbin coverage).

## Test plan
- [ ] CI passes with nvfatbin bindings available (tests run and pass)
- [ ] CI passes without nvfatbin bindings (tests are skipped gracefully)
- [ ] Both in-memory (bytes) and on-disk (file path) loading paths are covered

-- Leo's bot