### PR TITLE
[no-ci] CI: Add restricted-paths-guard.yml

### DIFF
--- a/.github/workflows/restricted-paths-guard.yml
+++ b/.github/workflows/restricted-paths-guard.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 name: "CI: Restricted Paths Guard"


### PR DESCRIPTION
Supersedes (and reuses work from) #1871

Closes #1139

## Summary

This PR adds a separate workflow, `restricted-paths-guard.yml`, for pull requests that touch restricted paths under `cuda_bindings/` or `cuda_python/`.

The new `restricted-paths-guard.yml` workflow does **not** implement strict enforcement. Instead, if a PR touches one of the restricted paths and we do not have a trusted signal for the PR author, the workflow assigns the `Needs-Restricted-Paths-Review` label for manual follow-up. The job summary shows the author login, the author association, the matched restricted paths, the trusted signal, if any, that was used, and whether the label was needed.

## Trusted Signals

The current implementation treats the following as trusted signals (these are tightly controlled at the org level):

- `github.event.pull_request.author_association` is `MEMBER`, `OWNER`, or `COLLABORATOR`

**Note:** This workflow currently **trusts the PR author**; it does not check the full provenance of every commit on the PR branch. In practice, that means a trusted signal also carries the expectation that the `cuda-python` maintainer who merges the PR is careful not to merge external-user commits touching `cuda_bindings/` or `cuda_python/`.

## Intended Workflow Beyond This PR

The intended direction, in a follow-on PR, is for `Needs-Restricted-Paths-Review` to become a merge-blocking mechanism for inconclusive cases.

The flow would then be:

- the workflow detects that a PR touches `cuda_bindings/` or `cuda_python/`
- if no trusted signal is available, the workflow applies `Needs-Restricted-Paths-Review`
- that label blocks merge, together with a clear message explaining that restricted-path review by the maintainer is required before merging
- the maintainer who merges the PR reviews the restricted-path changes specifically for the policy
- if the PR is acceptable, they remove the `Needs-Restricted-Paths-Review` label manually and merge

In other words, the workflow should automatically clear the easy, common cases and route the remaining ones into an explicit manual review step.

## Testing

See commit 02edff4cb58c5b537be340dca97b61d76dc9f2bf: the `pull_request` trigger and a dummy change under `cuda_bindings/` were used for testing. This was undone in the commit.

See below: **[Example Summary view of a workflow run (screenshot)](https://github.com/NVIDIA/cuda-python/pull/1878#issuecomment-4220603439)**