### PR TITLE
Fix debug builds of cuda_bindings and cuda_core

### DIFF
--- a/cuda_bindings/README.md
+++ b/cuda_bindings/README.md
@@ -12,7 +12,8 @@ This subpackage adheres to the developing practices described in the parent meta
 
 ## Debugging
 
-Pass the `pip` / `uv` configuration option `-C="debug=True"` explicitly to build debuggable binaries.
+Pass the `pip` / `uv` configuration option `-C="debug=True"` or
+`--config-settings="debug=True"` to explicitly to build debuggable binaries.
 Debuggable binaries are built by default for editable builds.
 
 Debuggable builds are not supported on Windows.

--- a/cuda_bindings/README.md
+++ b/cuda_bindings/README.md
@@ -12,12 +12,8 @@ This subpackage adheres to the developing practices described in the parent meta
 
 ## Debugging
 
-Editable installs have debuggable binaries by default.  To build a non-editable
-debug build, pass the `debug=True` configuration option to `pip` or `uv`:
-
-```
-pip install -v ./cuda_bindings -C="debug=True"
-```
+Pass the `pip` / `uv` configuration option `-C="debug=True"` explicitly to build debuggable binaries.
+Debuggable binaries are built by default for editable builds.
 
 Debuggable builds are not supported on Windows.
 

--- a/cuda_bindings/README.md
+++ b/cuda_bindings/README.md
@@ -10,6 +10,15 @@ Please refer to the [Installation page](https://nvidia.github.io/cuda-python/cud
 
 This subpackage adheres to the developing practices described in the parent metapackage [CONTRIBUTING.md](https://github.com/NVIDIA/cuda-python/blob/main/CONTRIBUTING.md).
 
+## Debugging
+
+Editable installs have debuggable binaries by default.  To build a non-editable
+debug build, pass the `debug=True` configuration option to `pip` or `uv`:
+
+```
+pip install -v ./cuda_bindings -C="debug=True"
+```
+
 ## Testing
 
 Testing dependencies can be installed using the `[test]` optional dependency identifier. For example, `pip install -v -e .[test]`.

--- a/cuda_bindings/README.md
+++ b/cuda_bindings/README.md
@@ -19,6 +19,8 @@ debug build, pass the `debug=True` configuration option to `pip` or `uv`:
 pip install -v ./cuda_bindings -C="debug=True"
 ```
 
+Debuggable builds are not supported on Windows.
+
 ## Testing
 
 Testing dependencies can be installed using the `[test]` optional dependency identifier. For example, `pip install -v -e .[test]`.

--- a/cuda_bindings/build_hooks.py
+++ b/cuda_bindings/build_hooks.py
@@ -459,12 +459,13 @@ def _build_cuda_bindings(debug=False):
 
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
-    debug_default = sys.platform != "win32"  # Debug builds not supported on Windows
-    debug = config_settings.get("debug", debug_default) if config_settings else debug_default
+    debug = config_settings.get("debug", False) if config_settings else False
     _build_cuda_bindings(debug=debug)
     return _build_meta.build_wheel(wheel_directory, config_settings, metadata_directory)
 
 
 def build_editable(wheel_directory, config_settings=None, metadata_directory=None):
-    _build_cuda_bindings(debug=True)
+    debug_default = sys.platform != "win32"  # Debug builds not supported on Windows
+    debug = config_settings.get("debug", debug_default) if config_settings else debug_default
+    _build_cuda_bindings(debug=debug)
     return _build_meta.build_editable(wheel_directory, config_settings, metadata_directory)

--- a/cuda_bindings/build_hooks.py
+++ b/cuda_bindings/build_hooks.py
@@ -283,7 +283,7 @@ def _prep_extensions(sources, libraries, include_dirs, library_dirs, extra_compi
 # Main build function
 
 
-def _build_cuda_bindings(strip=False):
+def _build_cuda_bindings(debug=False):
     """Build all cuda-bindings extensions.
 
     All CUDA-dependent logic (header parsing, code generation, cythonization)
@@ -362,14 +362,13 @@ def _build_cuda_bindings(strip=False):
             "-Wno-deprecated-declarations",
             "-fno-var-tracking-assignments",
         ]
-        if "--debug" in sys.argv:
+        if debug:
             extra_cythonize_kwargs["gdb_debug"] = True
             extra_compile_args += ["-g", "-O0"]
             extra_compile_args += ["-D _GLIBCXX_ASSERTIONS"]
         else:
             extra_compile_args += ["-O3"]
-            if strip and sys.platform == "linux":
-                extra_link_args += ["-Wl,--strip-all"]
+            extra_link_args += ["-Wl,--strip-all"]
     if compile_for_coverage:
         # CYTHON_TRACE_NOGIL indicates to trace nogil functions.  It is not
         # related to free-threading builds.
@@ -429,10 +428,11 @@ def _build_cuda_bindings(strip=False):
 
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
-    _build_cuda_bindings(strip=True)
+    debug = config_settings.get("debug", False) if config_settings else False
+    _build_cuda_bindings(debug=debug)
     return _build_meta.build_wheel(wheel_directory, config_settings, metadata_directory)
 
 
 def build_editable(wheel_directory, config_settings=None, metadata_directory=None):
-    _build_cuda_bindings(strip=False)
+    _build_cuda_bindings(debug=True)
     return _build_meta.build_editable(wheel_directory, config_settings, metadata_directory)

--- a/cuda_bindings/build_hooks.py
+++ b/cuda_bindings/build_hooks.py
@@ -355,7 +355,10 @@ def _build_cuda_bindings(debug=False):
     extra_compile_args = []
     extra_link_args = []
     extra_cythonize_kwargs = {}
-    if sys.platform != "win32":
+    if sys.platform == "win32":
+        if debug:
+            raise RuntimeError("Debuggable builds are not supported on Windows.")
+    else:
         extra_compile_args += [
             "-std=c++14",
             "-fpermissive",
@@ -428,7 +431,8 @@ def _build_cuda_bindings(debug=False):
 
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
-    debug = config_settings.get("debug", False) if config_settings else False
+    debug_default = sys.platform != "win32"  # Debug builds not supported on Windows
+    debug = config_settings.get("debug", debug_default) if config_settings else debug_default
     _build_cuda_bindings(debug=debug)
     return _build_meta.build_wheel(wheel_directory, config_settings, metadata_directory)
 

--- a/cuda_core/README.md
+++ b/cuda_core/README.md
@@ -12,12 +12,8 @@ This subpackage adheres to the developing practices described in the parent meta
 
 ## Debugging
 
-Editable installs have debuggable binaries by default.  To build a non-editable
-build, pass the `debug=True` configuration option to `pip` or `uv`:
-
-```
-pip install -v ./cuda_bindings -C="debug=True"
-```
+Pass the `pip` / `uv` configuration option `-C="debug=True"` explicitly to build debuggable binaries.
+Debuggable binaries are built by default for editable builds.
 
 Debuggable builds are not supported on Windows.
 

--- a/cuda_core/README.md
+++ b/cuda_core/README.md
@@ -19,6 +19,8 @@ build, pass the `debug=True` configuration option to `pip` or `uv`:
 pip install -v ./cuda_bindings -C="debug=True"
 ```
 
+Debuggable builds are not supported on Windows.
+
 ## Testing
 
 To run these tests:

--- a/cuda_core/README.md
+++ b/cuda_core/README.md
@@ -12,7 +12,8 @@ This subpackage adheres to the developing practices described in the parent meta
 
 ## Debugging
 
-Pass the `pip` / `uv` configuration option `-C="debug=True"` explicitly to build debuggable binaries.
+Pass the `pip` / `uv` configuration option `-C="debug=True"` or
+`--config-settings="debug=True"` to explicitly to build debuggable binaries.
 Debuggable binaries are built by default for editable builds.
 
 Debuggable builds are not supported on Windows.

--- a/cuda_core/README.md
+++ b/cuda_core/README.md
@@ -10,6 +10,15 @@ Please refer to the [Installation page](https://nvidia.github.io/cuda-python/cud
 
 This subpackage adheres to the developing practices described in the parent metapackage [CONTRIBUTING.md](https://github.com/NVIDIA/cuda-python/blob/main/CONTRIBUTING.md).
 
+## Debugging
+
+Editable installs have debuggable binaries by default.  To build a non-editable
+build, pass the `debug=True` configuration option to `pip` or `uv`:
+
+```
+pip install -v ./cuda_bindings -C="debug=True"
+```
+
 ## Testing
 
 To run these tests:

--- a/cuda_core/build_hooks.py
+++ b/cuda_core/build_hooks.py
@@ -91,7 +91,7 @@ def _determine_cuda_major_version() -> str:
 _extensions = None
 
 
-def _build_cuda_core():
+def _build_cuda_core(strip=False):
     # Customizing the build hooks is needed because we must defer cythonization until cuda-bindings,
     # now a required build-time dependency that's dynamically installed via the other hook below,
     # is installed. Otherwise, cimport any cuda.bindings modules would fail!
@@ -136,6 +136,9 @@ def _build_cuda_core():
 
     all_include_dirs = [os.path.join(_get_cuda_path(), "include")]
     extra_compile_args = []
+    extra_link_args = []
+    if strip and sys.platform == "linux":
+        extra_link_args += ["-Wl,--strip-all"]
     if COMPILE_FOR_COVERAGE:
         # CYTHON_TRACE_NOGIL indicates to trace nogil functions.  It is not
         # related to free-threading builds.
@@ -152,6 +155,7 @@ def _build_cuda_core():
             + all_include_dirs,
             language="c++",
             extra_compile_args=extra_compile_args,
+            extra_link_args=extra_link_args,
         )
         for mod in module_names()
     )
@@ -254,7 +258,7 @@ def _add_cython_include_paths_to_pth(wheel_path: str) -> None:
 
 
 def build_editable(wheel_directory, config_settings=None, metadata_directory=None):
-    _build_cuda_core()
+    _build_cuda_core(strip=False)
     wheel_name = _build_meta.build_editable(wheel_directory, config_settings, metadata_directory)
 
     # Patch the .pth file to add Cython include paths
@@ -265,7 +269,7 @@ def build_editable(wheel_directory, config_settings=None, metadata_directory=Non
 
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
-    _build_cuda_core()
+    _build_cuda_core(strip=True)
     return _build_meta.build_wheel(wheel_directory, config_settings, metadata_directory)
 
 

--- a/cuda_core/build_hooks.py
+++ b/cuda_core/build_hooks.py
@@ -138,7 +138,10 @@ def _build_cuda_core(debug=False):
     extra_compile_args = []
     extra_link_args = []
     extra_cythonize_kwargs = {}
-    if sys.platform != "win32":
+    if sys.platform == "win32":
+        if debug:
+            raise RuntimeError("Debuggable builds are not supported on Windows.")
+    else:
         if debug:
             extra_cythonize_kwargs["gdb_debug"] = True
             extra_compile_args += ["-g", "-O0"]
@@ -266,7 +269,9 @@ def _add_cython_include_paths_to_pth(wheel_path: str) -> None:
 
 
 def build_editable(wheel_directory, config_settings=None, metadata_directory=None):
-    _build_cuda_core(debug=True)
+    debug_default = sys.platform != "win32"  # Debug builds not supported on Windows
+    debug = config_settings.get("debug", debug_default) if config_settings else debug_default
+    _build_cuda_core(debug=debug)
     wheel_name = _build_meta.build_editable(wheel_directory, config_settings, metadata_directory)
 
     # Patch the .pth file to add Cython include paths

--- a/cuda_core/build_hooks.py
+++ b/cuda_core/build_hooks.py
@@ -91,7 +91,7 @@ def _determine_cuda_major_version() -> str:
 _extensions = None
 
 
-def _build_cuda_core(strip=False):
+def _build_cuda_core(debug=False):
     # Customizing the build hooks is needed because we must defer cythonization until cuda-bindings,
     # now a required build-time dependency that's dynamically installed via the other hook below,
     # is installed. Otherwise, cimport any cuda.bindings modules would fail!
@@ -137,8 +137,15 @@ def _build_cuda_core(strip=False):
     all_include_dirs = [os.path.join(_get_cuda_path(), "include")]
     extra_compile_args = []
     extra_link_args = []
-    if strip and sys.platform == "linux":
-        extra_link_args += ["-Wl,--strip-all"]
+    extra_cythonize_kwargs = {}
+    if sys.platform != "win32":
+        if debug:
+            extra_cythonize_kwargs["gdb_debug"] = True
+            extra_compile_args += ["-g", "-O0"]
+            extra_compile_args += ["-D _GLIBCXX_ASSERTIONS"]
+        else:
+            extra_compile_args += ["-O3"]
+            extra_link_args += ["-Wl,--strip-all"]
     if COMPILE_FOR_COVERAGE:
         # CYTHON_TRACE_NOGIL indicates to trace nogil functions.  It is not
         # related to free-threading builds.
@@ -173,6 +180,7 @@ def _build_cuda_core(strip=False):
         nthreads=nthreads,
         compiler_directives=compiler_directives,
         compile_time_env=compile_time_env,
+        **extra_cythonize_kwargs,
     )
 
     return
@@ -258,7 +266,7 @@ def _add_cython_include_paths_to_pth(wheel_path: str) -> None:
 
 
 def build_editable(wheel_directory, config_settings=None, metadata_directory=None):
-    _build_cuda_core(strip=False)
+    _build_cuda_core(debug=True)
     wheel_name = _build_meta.build_editable(wheel_directory, config_settings, metadata_directory)
 
     # Patch the .pth file to add Cython include paths
@@ -269,7 +277,8 @@ def build_editable(wheel_directory, config_settings=None, metadata_directory=Non
 
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
-    _build_cuda_core(strip=True)
+    debug = config_settings.get("debug", False) if config_settings else False
+    _build_cuda_core(debug=debug)
     return _build_meta.build_wheel(wheel_directory, config_settings, metadata_directory)
 
 


### PR DESCRIPTION
This builds on top of #1883 and is an alternative to it.

There are three problems this is trying to solve:

- Since the move to `build_hooks.py`, debug builds have been broken, since there is no way to pass `--debug` in `sys.argv` to the underlying build.  This updates it to use a PEP 517 configuration flag instead, which can be passed through `pip` or `uv` etc.

- Tying debug builds directly to editable installs seems like the wrong approach.  Personally, I find editable installs to be more trouble than they are worth for compiled projects (such as this), and I like to install into multiple virtual environments with different versions of Python simultaneously, which you can't do with editable installs.  This retains the behavior that editable installs are always debuggable, but also makes it possible to build non-editable installs as debuggable.

- This ties debugging flags to stripping.  IMHO, there is never a need to build with `-O0 -g` and then strip symbols, so this links them together under a single config.