### PR TITLE
Pin and check the hash of yq on Windows

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -82,13 +82,19 @@ jobs:
         # see https://github.com/actions/runner-images/issues/7443.
         if: ${{ startsWith(inputs.host-platform, 'win') }}
         env:
-          # doesn't seem there's an easy way to avoid hard-coding it?
-          YQ_URL: https://github.com/mikefarah/yq/releases/latest/download/yq_windows_amd64.exe
+          YQ_VERSION: v4.52.5
+          YQ_SHA256: 47594981f3848a4b4447494adeca9555f908f7cf0a89c4da3fd0243a4631da1c
           YQ_DIR: yq_latest
         shell: pwsh -command ". '{0}'"
         run: |
+          $yqUrl = "https://github.com/mikefarah/yq/releases/download/${env:YQ_VERSION}/yq_windows_amd64.exe"
           mkdir -Force -ErrorAction SilentlyContinue "${env:YQ_DIR}" | Out-Null
-          Invoke-WebRequest -UseBasicParsing -OutFile "${env:YQ_DIR}/yq.exe" -Uri "$env:YQ_URL"
+          Invoke-WebRequest -UseBasicParsing -OutFile "${env:YQ_DIR}/yq.exe" -Uri "$yqUrl"
+          $hash = (Get-FileHash -Algorithm SHA256 "${env:YQ_DIR}/yq.exe").Hash.ToLower()
+          if ($hash -ne $env:YQ_SHA256) {
+            Write-Error "SHA256 mismatch for yq: expected $env:YQ_SHA256, got $hash"
+            exit 1
+          }
           ls -l $env:YQ_DIR
           echo "$((Get-Location).Path)\\$env:YQ_DIR" >> $env:GITHUB_PATH
           $env:Path += ";$((Get-Location).Path)\\$env:YQ_DIR"

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -84,7 +84,7 @@ jobs:
         env:
           YQ_VERSION: v4.52.5
           YQ_SHA256: 47594981f3848a4b4447494adeca9555f908f7cf0a89c4da3fd0243a4631da1c
-          YQ_DIR: yq_latest
+          YQ_DIR: yq
         shell: pwsh -command ". '{0}'"
         run: |
           $yqUrl = "https://github.com/mikefarah/yq/releases/download/${env:YQ_VERSION}/yq_windows_amd64.exe"


### PR DESCRIPTION
To prevent sidechain attack.

(Suggested and implemented by Claude Opus 4.6)
