### PR TITLE
[no-ci] CI: add dedicated merge gate for restricted-paths review

### DIFF
--- a/.github/workflows/restricted-paths-review-gate.yml
+++ b/.github/workflows/restricted-paths-review-gate.yml
@@ -4,9 +4,9 @@
 name: "CI: Restricted Paths Review Gate"
 
 on:
-  # Temporary for PR-level testing before this workflow exists on the base
-  # branch. Switch back to pull_request_target before merging.
-  pull_request:
+  # Keep this separate from pr-metadata-check.yml so only the
+  # Needs-Restricted-Paths-Review policy becomes merge-blocking.
+  pull_request_target:
     types:
       - opened
       - synchronize

--- a/.github/workflows/restricted-paths-review-gate.yml
+++ b/.github/workflows/restricted-paths-review-gate.yml
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "CI: Restricted Paths Review Gate"
+
+on:
+  # Keep this separate from pr-metadata-check.yml so only the
+  # Needs-Restricted-Paths-Review policy becomes merge-blocking.
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
+      - unlabeled
+
+jobs:
+  restricted-paths-review-gate:
+    name: Restricted paths review gate
+    if: github.repository_owner == 'NVIDIA'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check for merge-blocking restricted-paths label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          REPO: ${{ github.repository }}
+          REVIEW_LABEL: Needs-Restricted-Paths-Review
+        run: |
+          set -euo pipefail
+
+          if ! LIVE_LABELS=$(
+            gh pr view "${PR_NUMBER}" --repo "${REPO}" \
+              --json labels \
+              --jq '[.labels[].name]'
+          ); then
+            echo "::error::Failed to inspect the current PR labels."
+            {
+              echo "## Restricted Paths Review Gate Failed"
+              echo ""
+              echo "- **Error**: Failed to inspect the current PR labels."
+              echo ""
+              echo "Please update the PR at: $PR_URL"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          CURRENT_LABELS=$(jq -r '
+            if length == 0 then
+              "(none)"
+            else
+              join(", ")
+            end
+          ' <<<"$LIVE_LABELS")
+
+          if jq -e --arg label "$REVIEW_LABEL" '.[] == $label' <<<"$LIVE_LABELS" >/dev/null; then
+            echo "::error::The $REVIEW_LABEL label is present. Remove it after restricted-paths review is complete."
+            {
+              echo "## Restricted Paths Review Gate Failed"
+              echo ""
+              echo "- **Blocking label**: \`$REVIEW_LABEL\`"
+              echo "- **Current labels**: $CURRENT_LABELS"
+              echo "- **Why this failed**: This label means the PR touched \`cuda_bindings/\` or \`cuda_python/\` without a trusted author signal."
+              echo "- **How to unblock merge**: A maintainer must review the restricted-paths policy decision and remove \`$REVIEW_LABEL\` manually when the PR is allowed to merge."
+              echo ""
+              echo "Please update the PR at: $PR_URL"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          {
+            echo "## Restricted Paths Review Gate Passed"
+            echo ""
+            echo "- **Blocking label absent**: \`$REVIEW_LABEL\`"
+            echo "- **Current labels**: $CURRENT_LABELS"
+            echo "- **Result**: This gate does not block merging."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/restricted-paths-review-gate.yml
+++ b/.github/workflows/restricted-paths-review-gate.yml
@@ -4,9 +4,9 @@
 name: "CI: Restricted Paths Review Gate"
 
 on:
-  # Keep this separate from pr-metadata-check.yml so only the
-  # Needs-Restricted-Paths-Review policy becomes merge-blocking.
-  pull_request_target:
+  # Temporary for PR-level testing before this workflow exists on the base
+  # branch. Switch back to pull_request_target before merging.
+  pull_request:
     types:
       - opened
       - synchronize


### PR DESCRIPTION
## Summary

Follow-on to PR #1878

Add a dedicated GitHub Actions workflow, `restricted-paths-review-gate.yml`, that fails when the `Needs-Restricted-Paths-Review` label is present on a PR.

This keeps the merge-blocking behavior narrowly scoped to the restricted-paths policy, instead of making the broader checks in `pr-metadata-check.yml` required.

## Why a separate workflow

- `pr-metadata-check.yml` is not currently merge-blocking.
- Reusing `pr-metadata-check.yml` would mix two different policies:
  PR metadata hygiene and restricted-paths review.
- A dedicated gate gives us one required check with one clear meaning:
  if `Needs-Restricted-Paths-Review` is present, merging is blocked until a maintainer removes the label.

## Behavior

- The existing `restricted-paths-guard.yml` workflow continues to assign `Needs-Restricted-Paths-Review` when an untrusted author touches `cuda_bindings/` or `cuda_python/`.
- The new `restricted-paths-review-gate.yml` workflow reads the live PR labels and:
  - fails if `Needs-Restricted-Paths-Review` is present
  - passes otherwise
- This is implemented as a separate `pull_request_target` workflow so it can be used as a required status check in branch protection / rulesets.

## Important rollout detail

This PR adds the workflow only. The check does not become merge-blocking until a repo admin adds the new check to the repository ruleset after this PR is merged.

## Post-merge admin steps

1. Open or update a PR so the new workflow runs at least once from the base branch, and GitHub records the check context.
2. Go to `Settings` -> `Rules` -> `Rulesets` -> `Prevent committing without PR`.
3. Edit `Required status checks`.
4. Add the check named `Restricted paths review gate`.
5. Save the ruleset.
6. Verify on a PR with `Needs-Restricted-Paths-Review`: merging should be blocked while the label is present, and unblocked after a maintainer removes it.

## Branch-scope note

The existing `Prevent committing without PR` ruleset applies to:

- `main`
- `12.9.x`
- `11.8.x`
- `release/**/*`

If the new gate should apply to all of those branches, editing that existing ruleset is the right approach.

If the new gate should apply only to `main`, the better follow-up is to create a separate ruleset scoped only to `refs/heads/main` and require `Restricted paths review gate` there.

___

Made with Cursor GPT-5.4 Extra High Fast