### PR TITLE
Skip the tests when the requested NVML function is unavailable

### DIFF
--- a/cuda_bindings/cuda/bindings/_test_helpers/arch_check.py
+++ b/cuda_bindings/cuda/bindings/_test_helpers/arch_check.py
@@ -8,6 +8,7 @@ from functools import cache
 import pytest
 
 from cuda.bindings import nvml
+from cuda.bindings._internal.utils import FunctionNotFoundError as NvmlSymbolNotFoundError
 
 
 @cache
@@ -49,9 +50,10 @@ def unsupported_before(device: int, expected_device_arch: nvml.DeviceArch | str 
 
         try:
             yield
-        except nvml.NotSupportedError:
-            # The API call raised NotSupportedError, so we skip the test, but
-            # don't fail it
+        except (nvml.NotSupportedError, nvml.FunctionNotFoundError, NvmlSymbolNotFoundError):
+            # The API call raised NotSupportedError, NVML status FunctionNotFoundError,
+            # or NvmlSymbolNotFoundError (symbol absent from the loaded NVML DLL), so we
+            # skip the test but don't fail it
             pytest.skip(
                 f"Unsupported call for device architecture {nvml.DeviceArch(device_arch).name} "
                 f"on device '{nvml.device_get_name(device)}'"

--- a/cuda_core/tests/system/test_system_device.py
+++ b/cuda_core/tests/system/test_system_device.py
@@ -586,7 +586,7 @@ def test_clock():
             with unsupported_before(device, DeviceArch.MAXWELL):
                 try:
                     offsets = clock.get_offsets(pstate)
-                except system.InvalidArgumentError:
+                except (system.InvalidArgumentError, system.NotFoundError):
                     pass
                 else:
                     assert isinstance(offsets, system.ClockOffsets)


### PR DESCRIPTION
Skip the tests when nvml function couldn't be found in the installed driver.  

FAILED tests/system/test_system_device.py::test_addressing_mode - cuda.bindings._internal.utils.FunctionNotFoundError: function nvmlDeviceGetAddressingMode is not found
FAILED tests/system/test_system_device.py::test_repair_status - cuda.bindings._internal.utils.FunctionNotFoundError: function nvmlDeviceGetRepairStatus is not found
FAILED tests/system/test_system_device.py::test_clock - cuda.bindings.nvml.NotFoundError: Not Found

No output when using driver 576.57. 
dumpbin /exports C:\Windows\System32\nvml.dll |findstr /i "nvmlDeviceGetAddressingMode nvmlDeviceGetRepairStatus"

After the fix, the tests could be skipped instead of failure.

collected 3 items

tests/system/test_system_device.py::test_clock SKIPPED (Unsupported call for device architecture B...)
tests/system/test_system_device.py::test_repair_status SKIPPED (Unsupported call for device archit...)
tests/system/test_system_device.py::test_addressing_mode SKIPPED (Unsupported call for device arch...)

