### PR TITLE
Fix pyperf params on CI

### DIFF
--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -267,7 +267,7 @@ jobs:
         run: |
           pip install pyperf
           pushd cuda_bindings/benchmarks
-          python run_pyperf.py --fast --loops 1 --min-time 1
+          python run_pyperf.py --fast --min-time 1
           popd
 
       - name: Run cuda.core tests

--- a/cuda_bindings/benchmarks/pixi.toml
+++ b/cuda_bindings/benchmarks/pixi.toml
@@ -54,7 +54,7 @@ source = { features = ["cu13", "cu13-source", "bench", "cpp-bench", "dev", "bind
 cmd = ["python", "$PIXI_PROJECT_ROOT/run_pyperf.py"]
 
 [target.linux.tasks.bench-smoke-test]
-cmd = ["python", "$PIXI_PROJECT_ROOT/run_pyperf.py", "--fast", "--loops", "1", "--min-time", "0"
+cmd = ["python", "$PIXI_PROJECT_ROOT/run_pyperf.py", "--fast", "--min-time", "1"
 ]
 
 [target.linux.tasks.bench-legacy]


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes [<!-- Link issue here -->](https://github.com/NVIDIA/cuda-python/issues/1885#event-24427387586)

<!-- Provide a standalone description of changes in this PR. -->

Trying to fix the cuda.bindings benchmarks on CI again.

I think dropping the loops params should let pyperf do its calibration and should solve this.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
