### PR TITLE
test: relax graph update topology mismatch regex to not depend on docstring text

### DIFF
--- a/cuda_core/tests/graph/test_graph_update.py
+++ b/cuda_core/tests/graph/test_graph_update.py
@@ -191,7 +191,7 @@ def test_graph_update_topology_mismatch(init_cuda):
     launch(gb2, LaunchConfig(grid=1, block=1), empty_kernel)
     gb2.end_building()
 
-    expected = r"Graph update failed: The update failed because the topology changed \(CU_GRAPH_EXEC_UPDATE_ERROR_TOPOLOGY_CHANGED\)"
+    expected = r"Graph update failed: .+ \(CU_GRAPH_EXEC_UPDATE_ERROR_TOPOLOGY_CHANGED\)"
     with pytest.raises(CUDAError, match=expected):
         graph.update(gb2)
 


### PR DESCRIPTION
Fix test regex to be compatible with cuda-bindings that use IntEnum instead of FastEnum.  This is for bug [6075020](https://nvbugspro.nvidia.com/bug/6075020).

Test failed when using cuda-bindings 13.0.3 and cuda.core v0.7.0.
```
FAILED tests/graph/test_graph_update.py::test_graph_update_topology_mismtch  - AssertionError: Regex pattern did not match.
        expected = r"Graph update failed: The update failed because the topology changed \(CU_GRAPH_EXEC_UPDATE_ERROR_TOPOLOGY_CHANGED\)"
>       with pytest.raises(CUDAError, match=expected):
E       AssertionError: Regex pattern did not match.
E         Expected regex: 'Graph update failed: The update failed because the topology changed \\(CU_GRAPH_EXEC_UPDATE_ERROR_TOPOLOGY_CHANGED\\)'
E         Actual message: 'Graph update failed: CUDA Graph Update error types (CU_GRAPH_EXEC_UPDATE_ERROR_TOPOLOGY_CHANGED)'
```

Cause:
Graph.update() in _graph_builder.pyx constructs error messages using reason.`__doc__` on CUgraphExecUpdateResult enum members. This relies on per-member `__doc__` which is only available when cuda-bindings uses FastEnum.
However, cuda-bindings 13.0.3 uses IntEnum instead,  member.`__doc__` falls back to the docstring "CUDA Graph Update error types".  
The test case hardcoded the description and didn't consider this situation, causing a regex mismatch failure.

After the fix, the test could pass.
tests/graph/test_graph_update.py::test_graph_update_topology_mismatch PASSED [100%]

