### PR TITLE
Fix IPC memory pool leak in nightly repeated test runs

### DIFF
--- a/cuda_core/tests/conftest.py
+++ b/cuda_core/tests/conftest.py
@@ -183,7 +183,8 @@ def ipc_memory_resource(request, ipc_device):
         mr = PinnedMemoryResource(options=options)
 
     assert mr.is_ipc_enabled
-    return mr
+    yield mr
+    mr.close()
 
 
 @pytest.fixture

--- a/cuda_core/tests/memory_ipc/test_errors.py
+++ b/cuda_core/tests/memory_ipc/test_errors.py
@@ -26,6 +26,7 @@ class ChildErrorHarness:
         # from PARENT_ACTION.
         self.device = ipc_device
         self.mr = ipc_memory_resource
+        self._extra_mrs = []
 
         # Start a child process to generate error info.
         pipe = [multiprocessing.Queue() for _ in range(2)]
@@ -42,6 +43,9 @@ class ChildErrorHarness:
         # Wait for the child process.
         process.join(timeout=CHILD_TIMEOUT_SEC)
         assert process.exitcode == 0
+
+        for mr in self._extra_mrs:
+            mr.close()
 
     def child_main(self, pipe, device, mr):
         """Child process that pushes IPC errors to a shared pipe for testing."""
@@ -78,6 +82,7 @@ class TestImportWrongMR(ChildErrorHarness):
     def PARENT_ACTION(self, queue):
         options = DeviceMemoryResourceOptions(max_size=POOL_SIZE, ipc_enabled=True)
         mr2 = DeviceMemoryResource(self.device, options=options)
+        self._extra_mrs.append(mr2)
         buffer = mr2.allocate(NBYTES)
         queue.put([self.mr, buffer.get_ipc_descriptor()])  # Note: mr does not own this buffer
 
@@ -117,6 +122,7 @@ class TestDanglingBuffer(ChildErrorHarness):
     def PARENT_ACTION(self, queue):
         options = DeviceMemoryResourceOptions(max_size=POOL_SIZE, ipc_enabled=True)
         mr2 = DeviceMemoryResource(self.device, options=options)
+        self._extra_mrs.append(mr2)
         self.buffer = mr2.allocate(NBYTES)
         buffer_s = pickle.dumps(self.buffer)
         queue.put(buffer_s)  # Note: mr2 not sent

--- a/cuda_core/tests/memory_ipc/test_errors.py
+++ b/cuda_core/tests/memory_ipc/test_errors.py
@@ -28,24 +28,25 @@ class ChildErrorHarness:
         self.mr = ipc_memory_resource
         self._extra_mrs = []
 
-        # Start a child process to generate error info.
-        pipe = [multiprocessing.Queue() for _ in range(2)]
-        process = multiprocessing.Process(target=self.child_main, args=(pipe, self.device, self.mr))
-        process.start()
+        try:
+            # Start a child process to generate error info.
+            pipe = [multiprocessing.Queue() for _ in range(2)]
+            process = multiprocessing.Process(target=self.child_main, args=(pipe, self.device, self.mr))
+            process.start()
 
-        # Interact.
-        self.PARENT_ACTION(pipe[0])
+            # Interact.
+            self.PARENT_ACTION(pipe[0])
 
-        # Check the error.
-        exc_type, exc_msg = pipe[1].get(timeout=CHILD_TIMEOUT_SEC)
-        self.ASSERT(exc_type, exc_msg)
+            # Check the error.
+            exc_type, exc_msg = pipe[1].get(timeout=CHILD_TIMEOUT_SEC)
+            self.ASSERT(exc_type, exc_msg)
 
-        # Wait for the child process.
-        process.join(timeout=CHILD_TIMEOUT_SEC)
-        assert process.exitcode == 0
-
-        for mr in self._extra_mrs:
-            mr.close()
+            # Wait for the child process.
+            process.join(timeout=CHILD_TIMEOUT_SEC)
+            assert process.exitcode == 0
+        finally:
+            for mr in self._extra_mrs:
+                mr.close()
 
     def child_main(self, pipe, device, mr):
         """Child process that pushes IPC errors to a shared pipe for testing."""

--- a/cuda_core/tests/memory_ipc/test_send_buffers.py
+++ b/cuda_core/tests/memory_ipc/test_send_buffers.py
@@ -26,27 +26,29 @@ class TestIpcSendBuffers:
         options = DeviceMemoryResourceOptions(max_size=POOL_SIZE, ipc_enabled=True)
         mrs = [DeviceMemoryResource(device, options=options) for _ in range(nmrs)]
 
-        # Allocate and fill memory.
-        buffers = [mr.allocate(NBYTES) for mr, _ in zip(cycle(mrs), range(NTASKS))]
-        pgen = PatternGen(device, NBYTES)
-        for buffer in buffers:
-            pgen.fill_buffer(buffer, seed=False)
+        try:
+            # Allocate and fill memory.
+            buffers = [mr.allocate(NBYTES) for mr, _ in zip(cycle(mrs), range(NTASKS))]
+            pgen = PatternGen(device, NBYTES)
+            for buffer in buffers:
+                pgen.fill_buffer(buffer, seed=False)
 
-        # Start the child process.
-        process = mp.Process(target=self.child_main, args=(device, buffers))
-        process.start()
+            # Start the child process.
+            process = mp.Process(target=self.child_main, args=(device, buffers))
+            process.start()
 
-        # Wait for the child process.
-        process.join(timeout=CHILD_TIMEOUT_SEC)
-        assert process.exitcode == 0
+            # Wait for the child process.
+            process.join(timeout=CHILD_TIMEOUT_SEC)
+            assert process.exitcode == 0
 
-        # Verify that the buffers were modified.
-        pgen = PatternGen(device, NBYTES)
-        for buffer in buffers:
-            pgen.verify_buffer(buffer, seed=True)
-            buffer.close()
-        for mr in mrs:
-            mr.close()
+            # Verify that the buffers were modified.
+            pgen = PatternGen(device, NBYTES)
+            for buffer in buffers:
+                pgen.verify_buffer(buffer, seed=True)
+                buffer.close()
+        finally:
+            for mr in mrs:
+                mr.close()
 
     def child_main(self, device, buffers):
         device.set_current()

--- a/cuda_core/tests/memory_ipc/test_send_buffers.py
+++ b/cuda_core/tests/memory_ipc/test_send_buffers.py
@@ -45,6 +45,8 @@ class TestIpcSendBuffers:
         for buffer in buffers:
             pgen.verify_buffer(buffer, seed=True)
             buffer.close()
+        for mr in mrs:
+            mr.close()
 
     def child_main(self, device, buffers):
         device.set_current()

--- a/cuda_core/tests/memory_ipc/test_workerpool.py
+++ b/cuda_core/tests/memory_ipc/test_workerpool.py
@@ -33,17 +33,20 @@ class TestIpcWorkerPool:
         device = ipc_device
         options = DeviceMemoryResourceOptions(max_size=POOL_SIZE, ipc_enabled=True)
         mrs = [DeviceMemoryResource(device, options=options) for _ in range(nmrs)]
-        buffers = [mr.allocate(NBYTES) for mr, _ in zip(cycle(mrs), range(NTASKS))]
 
-        with mp.Pool(NWORKERS) as pool:
-            pool.map(self.process_buffer, buffers)
+        try:
+            buffers = [mr.allocate(NBYTES) for mr, _ in zip(cycle(mrs), range(NTASKS))]
 
-        pgen = PatternGen(device, NBYTES)
-        for buffer in buffers:
-            pgen.verify_buffer(buffer, seed=True)
-            buffer.close()
-        for mr in mrs:
-            mr.close()
+            with mp.Pool(NWORKERS) as pool:
+                pool.map(self.process_buffer, buffers)
+
+            pgen = PatternGen(device, NBYTES)
+            for buffer in buffers:
+                pgen.verify_buffer(buffer, seed=True)
+                buffer.close()
+        finally:
+            for mr in mrs:
+                mr.close()
 
     def process_buffer(self, buffer):
         device = Device(buffer.memory_resource.device_id)
@@ -72,20 +75,23 @@ class TestIpcWorkerPoolUsingIPCDescriptors:
         device = ipc_device
         options = DeviceMemoryResourceOptions(max_size=POOL_SIZE, ipc_enabled=True)
         mrs = [DeviceMemoryResource(device, options=options) for _ in range(nmrs)]
-        buffers = [mr.allocate(NBYTES) for mr, _ in zip(cycle(mrs), range(NTASKS))]
 
-        with mp.Pool(NWORKERS, initializer=self.init_worker, initargs=(mrs,)) as pool:
-            pool.starmap(
-                self.process_buffer,
-                [(mrs.index(buffer.memory_resource), buffer.get_ipc_descriptor()) for buffer in buffers],
-            )
+        try:
+            buffers = [mr.allocate(NBYTES) for mr, _ in zip(cycle(mrs), range(NTASKS))]
 
-        pgen = PatternGen(device, NBYTES)
-        for buffer in buffers:
-            pgen.verify_buffer(buffer, seed=True)
-            buffer.close()
-        for mr in mrs:
-            mr.close()
+            with mp.Pool(NWORKERS, initializer=self.init_worker, initargs=(mrs,)) as pool:
+                pool.starmap(
+                    self.process_buffer,
+                    [(mrs.index(buffer.memory_resource), buffer.get_ipc_descriptor()) for buffer in buffers],
+                )
+
+            pgen = PatternGen(device, NBYTES)
+            for buffer in buffers:
+                pgen.verify_buffer(buffer, seed=True)
+                buffer.close()
+        finally:
+            for mr in mrs:
+                mr.close()
 
     def process_buffer(self, mr_idx, buffer_desc):
         mr = self.mrs[mr_idx]
@@ -119,17 +125,20 @@ class TestIpcWorkerPoolUsingRegistry:
         device = ipc_device
         options = DeviceMemoryResourceOptions(max_size=POOL_SIZE, ipc_enabled=True)
         mrs = [DeviceMemoryResource(device, options=options) for _ in range(nmrs)]
-        buffers = [mr.allocate(NBYTES) for mr, _ in zip(cycle(mrs), range(NTASKS))]
 
-        with mp.Pool(NWORKERS, initializer=self.init_worker, initargs=(mrs,)) as pool:
-            pool.starmap(self.process_buffer, [(device, pickle.dumps(buffer)) for buffer in buffers])
+        try:
+            buffers = [mr.allocate(NBYTES) for mr, _ in zip(cycle(mrs), range(NTASKS))]
 
-        pgen = PatternGen(device, NBYTES)
-        for buffer in buffers:
-            pgen.verify_buffer(buffer, seed=True)
-            buffer.close()
-        for mr in mrs:
-            mr.close()
+            with mp.Pool(NWORKERS, initializer=self.init_worker, initargs=(mrs,)) as pool:
+                pool.starmap(self.process_buffer, [(device, pickle.dumps(buffer)) for buffer in buffers])
+
+            pgen = PatternGen(device, NBYTES)
+            for buffer in buffers:
+                pgen.verify_buffer(buffer, seed=True)
+                buffer.close()
+        finally:
+            for mr in mrs:
+                mr.close()
 
     def process_buffer(self, device, buffer_s):
         device.set_current()

--- a/cuda_core/tests/memory_ipc/test_workerpool.py
+++ b/cuda_core/tests/memory_ipc/test_workerpool.py
@@ -42,6 +42,8 @@ class TestIpcWorkerPool:
         for buffer in buffers:
             pgen.verify_buffer(buffer, seed=True)
             buffer.close()
+        for mr in mrs:
+            mr.close()
 
     def process_buffer(self, buffer):
         device = Device(buffer.memory_resource.device_id)
@@ -82,6 +84,8 @@ class TestIpcWorkerPoolUsingIPCDescriptors:
         for buffer in buffers:
             pgen.verify_buffer(buffer, seed=True)
             buffer.close()
+        for mr in mrs:
+            mr.close()
 
     def process_buffer(self, mr_idx, buffer_desc):
         mr = self.mrs[mr_idx]
@@ -124,6 +128,8 @@ class TestIpcWorkerPoolUsingRegistry:
         for buffer in buffers:
             pgen.verify_buffer(buffer, seed=True)
             buffer.close()
+        for mr in mrs:
+            mr.close()
 
     def process_buffer(self, device, buffer_s):
         device.set_current()


### PR DESCRIPTION
## Summary

- IPC test fixtures and test methods create `DeviceMemoryResource`/`PinnedMemoryResource` instances that are never closed
- Under single-run CI (`--count=1`) this is harmless, but nightly scheduled CI runs with `pytest-repeat --count=100` (introduced in PR #1574), accumulating ~200+ leaked CUDA mempools and POSIX fd exports per test file
- Around iteration 83, pool creation segfaults inside `ipc_memory_resource` fixture at `conftest.py:179` — this is why **every** nightly test matrix job has been red since 2026-02-05
- Convert `ipc_memory_resource` fixture from `return` to `yield` + `mr.close()` teardown
- Close locally-created memory resources in `test_errors`, `test_send_buffers`, and `test_workerpool` after child processes join

## Test plan

- [ ] Nightly CI scheduled run passes (all matrix cells that previously segfaulted in `memory_ipc/test_errors.py::TestDanglingBuffer`)
- [ ] Push CI passes (single-run, verifies no behavioral regression from adding `close()` calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)