### PR TITLE
Fix pathfinder Windows cupti detection for CTK 13.2.1

### DIFF
--- a/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/descriptor_catalog.py
+++ b/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/descriptor_catalog.py
@@ -271,6 +271,7 @@ DESCRIPTOR_CATALOG: tuple[DescriptorSpec, ...] = (
         packaged_with="ctk",
         linux_sonames=("libcupti.so.12", "libcupti.so.13"),
         windows_dlls=(
+            "cupti64_2026.1.1.dll",
             "cupti64_2026.1.0.dll",
             "cupti64_2025.4.1.dll",
             "cupti64_2025.3.1.dll",

--- a/cuda_pathfinder/docs/nv-versions.json
+++ b/cuda_pathfinder/docs/nv-versions.json
@@ -4,6 +4,10 @@
         "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/latest/"
     },
     {
+        "version": "1.5.3",
+        "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/1.5.3/"
+    },
+    {
         "version": "1.5.2",
         "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/1.5.2/"
     },

--- a/cuda_pathfinder/docs/source/release/1.5.3-notes.rst
+++ b/cuda_pathfinder/docs/source/release/1.5.3-notes.rst
@@ -1,0 +1,14 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+.. py:currentmodule:: cuda.pathfinder
+
+``cuda-pathfinder`` 1.5.3 Release notes
+=======================================
+
+Highlights
+----------
+
+* Add support for the Windows CTK 13.2.1 CUPTI DLL name
+  ``cupti64_2026.1.1.dll`` so ``load_nvidia_dynamic_lib("cupti")`` can
+  recognize the installed library on CTK 13.2.1 systems.


### PR DESCRIPTION
- Add `cupti64_2026.1.1.dll` to the pathfinder descriptor catalog so `load_nvidia_dynamic_lib("cupti")` recognizes the DLL shipped with Windows CTK 13.2.1.
- Add the `cuda-pathfinder` `1.5.3` release notes and version-switcher entry.