### PR TITLE
[no-ci] check_spdx.py: require explicit license decisions for top-level paths and related cleanup

### DIFF
--- a/.spdx-ignore
+++ b/.spdx-ignore
@@ -8,6 +8,9 @@ LICENSE
 requirements*.txt
 cuda_bindings/examples/*
 
+# Will be moved in (see https://github.com/NVIDIA/cuda-python/pull/1913#issuecomment-4252968149)
+cuda_bindings/benchmarks/*
+
 # Vendored
 cuda_core/cuda/core/_include/dlpack.h
 

--- a/cuda_bindings/pixi.toml
+++ b/cuda_bindings/pixi.toml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 [workspace]
 channels = ["conda-forge"]

--- a/toolshed/check_spdx.py
+++ b/toolshed/check_spdx.py
@@ -17,7 +17,12 @@ SPDX_FILE_COPYRIGHT_TEXT_PREFIX = b"-".join((b"SPDX", b"FileCopyrightText: "))
 
 LICENSE_IDENTIFIER_REGEX = re.compile(re.escape(SPDX_LICENSE_IDENTIFIER_PREFIX) + rb"(?P<license_identifier>[^\r\n]+)")
 
-EXPECTED_LICENSE_IDENTIFIERS = (("cuda_core/", "Apache-2.0"),)
+EXPECTED_LICENSE_IDENTIFIERS = (
+    ("cuda_bindings/", "LicenseRef-NVIDIA-SOFTWARE-LICENSE"),
+    ("cuda_core/", "Apache-2.0"),
+    ("cuda_pathfinder/", "Apache-2.0"),
+    ("cuda_python/", "LicenseRef-NVIDIA-SOFTWARE-LICENSE"),
+)
 
 SPDX_IGNORE_FILENAME = ".spdx-ignore"
 


### PR DESCRIPTION
# Accident note

The PR description below does **not** match what was actually merged into `main` in a8805e51.

GitHub merged the earlier branch state ending at c719fce4, which is what GitHub restored for `rwgk:expected_license_identifiers_cont`. The later follow-up changes described below were not pushed due to an unknown oversight.

Those later changes are now preserved for reference on `rwgk:expected_license_identifiers_cont_recovered` (see [comment below](https://github.com/NVIDIA/cuda-python/pull/1913#issuecomment-4271701561) for more details). Please read the remainder of this PR description as describing that recovered branch, not the merged result on `main`.

The missing commits were added to https://github.com/NVIDIA/cuda-python/pull/1948#issuecomment-4271805549 (needed there to guide fixing license identifiers).
___

Follow-on to PR #1897

## Summary

- Enforce an explicit SPDX license identifier for every top-level directory in the repository, so new paths can't slip in without a reviewed license decision.
- Keep top-level files on an explicit default of `Apache-2.0`.
- Continue to accommodate special cases, but treat them as exceptions we want to minimize rather than the default mechanism.
- Update `cuda_bindings/pixi.toml` to `LicenseRef-NVIDIA-SOFTWARE-LICENSE`.
- Fix the current non-benchmark special cases by updating
    - `.coveragerc`
    - `cuda_python_test_helpers/cuda_python_test_helpers/nvvm_bitcode.py`
    - `toolshed/build_static_bitcode_input.py`
    - `toolshed/dump_cutile_b64.py`

  to `Apache-2.0`.
- Keep `cuda_bindings/benchmarks/` as the only remaining special cases for now; those mixed-license cases will be handled in follow-on PRs (see [comment below](https://github.com/NVIDIA/cuda-python/pull/1913#issuecomment-4252968149)).

## Technical details

- Replace the old prefix-only SPDX policy handling in `toolshed/check_spdx.py` with explicit `TOP_LEVEL_DIRS_LICENSE_IDENTIFIERS` and `SPECIAL_CASE_LICENSE_IDENTIFIERS` mappings.
- Normalize repo-relative paths before matching so the checker behaves consistently across platforms.
- Make the checker fail when a file lives under a top-level directory that does not have an explicit expected license.
- Apply special cases by exact path or glob pattern, with longest-match wins so narrower overrides can coexist with broader rules.
- Improve license parsing by trimming common comment suffixes and decoding with replacement so malformed bytes still produce deterministic comparisons instead of being treated as missing headers.