### PR TITLE
bug fix: constrain cuda.core test installs to the requested CTK minor

### DIFF
--- a/ci/tools/run-tests
+++ b/ci/tools/run-tests
@@ -74,14 +74,14 @@ elif [[ "${test_module}" == "core" ]]; then
 
   pushd ./cuda_core
   CUDA_VER_MINOR="$(cut -d '.' -f 1-2 <<< "${CUDA_VER}")"
+  # Constrain cuda-toolkit to the requested CTK version to avoid
+  # pip pulling in a newer nvidia-cuda-runtime that conflicts with it.
   if [[ "${LOCAL_CTK}" == 1 ]]; then
     # We already installed cuda-bindings, and all CTK components exist locally,
     # so just install the test dependencies.
-    # Constrain cuda-toolkit to match the local CTK version to avoid
-    # pip pulling in a newer nvidia-cuda-runtime that conflicts with it.
     pip install "${CUDA_CORE_ARTIFACTS_DIR}"/*.whl --group "test-cu${TEST_CUDA_MAJOR}${FREE_THREADING}" "cuda-toolkit==${CUDA_VER_MINOR}.*"
   else
-    pip install $(ls "${CUDA_CORE_ARTIFACTS_DIR}"/*.whl)["cu${TEST_CUDA_MAJOR}"] --group "test-cu${TEST_CUDA_MAJOR}${FREE_THREADING}"
+    pip install $(ls "${CUDA_CORE_ARTIFACTS_DIR}"/*.whl)["cu${TEST_CUDA_MAJOR}"] --group "test-cu${TEST_CUDA_MAJOR}${FREE_THREADING}" "cuda-toolkit==${CUDA_VER_MINOR}.*"
   fi
   echo "Running core tests"
   ${SANITIZER_CMD} pytest -rxXs -v --durations=0 --randomly-dont-reorganize tests/

--- a/ci/tools/run-tests
+++ b/ci/tools/run-tests
@@ -74,15 +74,15 @@ elif [[ "${test_module}" == "core" ]]; then
 
   pushd ./cuda_core
   CUDA_VER_MINOR="$(cut -d '.' -f 1-2 <<< "${CUDA_VER}")"
+  # Start from the built wheel path, then add the published cuda.bindings extra
+  # when this job is resolving against wheel-installed CTK packages.
+  WHL_EXTRA=("${CUDA_CORE_ARTIFACTS_DIR}"/*.whl)
+  if [[ "${LOCAL_CTK}" != 1 ]]; then
+    WHL_EXTRA=("${WHL_EXTRA[0]}[cu${TEST_CUDA_MAJOR}]")
+  fi
   # Constrain cuda-toolkit to the requested CTK version to avoid
   # pip pulling in a newer nvidia-cuda-runtime that conflicts with it.
-  if [[ "${LOCAL_CTK}" == 1 ]]; then
-    # We already installed cuda-bindings, and all CTK components exist locally,
-    # so just install the test dependencies.
-    pip install "${CUDA_CORE_ARTIFACTS_DIR}"/*.whl --group "test-cu${TEST_CUDA_MAJOR}${FREE_THREADING}" "cuda-toolkit==${CUDA_VER_MINOR}.*"
-  else
-    pip install $(ls "${CUDA_CORE_ARTIFACTS_DIR}"/*.whl)["cu${TEST_CUDA_MAJOR}"] --group "test-cu${TEST_CUDA_MAJOR}${FREE_THREADING}" "cuda-toolkit==${CUDA_VER_MINOR}.*"
-  fi
+  pip install "${WHL_EXTRA[@]}" --group "test-cu${TEST_CUDA_MAJOR}${FREE_THREADING}" "cuda-toolkit==${CUDA_VER_MINOR}.*"
   echo "Running core tests"
   ${SANITIZER_CMD} pytest -rxXs -v --durations=0 --randomly-dont-reorganize tests/
   # Currently our CI always installs the latest bindings (from either major version).


### PR DESCRIPTION
xref: https://github.com/NVIDIA/cuda-python/issues/1851#issuecomment-4238025578

Fix latent bug discovered while reviewing #1851 with the team.

Without the explicit `cuda-toolkit==${CUDA_VER_MINOR}.*` pin, `pip` can satisfy the broad major-version requirements with a newer CUDA Toolkit minor than the one selected by the CI matrix. In practice, that can either pull a newer nvidia-cuda-runtime than the local CTK provides or make the wheel-backed job silently test the wrong CTK minor, reducing the value of the matrix and masking minor-version-specific regressions.

## Changes

- pin the `cuda-toolkit` dependency in `ci/tools/run-tests` to the matrix-selected CUDA toolkit minor for `cuda.core` test installs
- apply that pin in both the local-CTK and wheel-backed install paths so pip does not resolve a newer runtime than the job is meant to cover
- simplify the install flow by selecting the wheel target once via `WHL_EXTRA`, only adding the `cu${TEST_CUDA_MAJOR}` extra when the run needs published `cuda-bindings`
