### PR TITLE
test(cufile): prime libcufile to avoid SIGFPE from 1.17.1 state-poisoning bug

### DIFF
--- a/cuda_bindings/tests/test_cufile.py
+++ b/cuda_bindings/tests/test_cufile.py
@@ -140,6 +140,52 @@ def ctx():
     cuda.cuDevicePrimaryCtxRelease(device)
 
 
+@pytest.fixture(scope="module", autouse=True)
+def _cufile_driver_prewarm():
+    """Prime libcufile with one driver_open/close cycle before any test runs.
+
+    The cuFile test module mixes two incompatible regimes:
+
+    - Driver-open tests (buf_register_*, cufile_read_write, batch_io, stats,
+      etc.) need cuFileDriverOpen; they use the function-scope `driver`
+      fixture to open/close per test.
+    - Driver-closed tests (test_set_get_parameter_*, test_set_parameter_posix_*)
+      must run with the driver CLOSED — libcufile rejects parameter-set calls
+      when the driver is open (DRIVER_ALREADY_OPEN, 5026).
+
+    Workaround for NVIDIA libcufile 1.17.1 bug: calling cuFileSetParameterSizeT
+    (or similar pre-open configuration APIs) BEFORE the first cuFileDriverOpen
+    leaves an internal version list uninitialized such that a later
+    cuFileDriverOpen SIGFPEs in CUFileDrv::ReadVersionInfo (div-by-zero).
+    Under random ordering, a driver-closed test can run before any
+    driver-open test, poisoning libcufile and tearing down pytest with a fatal
+    signal on the next driver_open.
+
+    One open/close cycle up front primes libcufile's version list. After that,
+    both regimes work: the per-test `driver` fixture can open/close freely,
+    and parameter-set tests run against the (now properly initialized) closed
+    driver.
+
+    Note: per-test driver_open/close is not ideal on throughput grounds, but
+    it is forced by the libcufile API — parameter-set tests cannot coexist
+    with a session-wide open driver.
+    """
+    (err,) = cuda.cuInit(0)
+    assert err == cuda.CUresult.CUDA_SUCCESS
+    err, device = cuda.cuDeviceGet(0)
+    assert err == cuda.CUresult.CUDA_SUCCESS
+    err, dctx = cuda.cuDevicePrimaryCtxRetain(device)
+    assert err == cuda.CUresult.CUDA_SUCCESS
+    (err,) = cuda.cuCtxSetCurrent(dctx)
+    assert err == cuda.CUresult.CUDA_SUCCESS
+    try:
+        cufile.driver_open()
+        cufile.driver_close()
+    finally:
+        cuda.cuDevicePrimaryCtxRelease(device)
+    yield
+
+
 @pytest.fixture
 def driver(ctx):
     cufile.driver_open()
@@ -1896,8 +1942,7 @@ def driver_config(slab_sizes, slab_counts):
 @pytest.mark.skipif(
     cufileVersionLessThan(1150), reason="cuFile parameter APIs require cuFile library version 13.0 or later"
 )
-@pytest.mark.usefixtures("ctx")
-def test_set_parameter_posix_pool_slab_array(slab_sizes, slab_counts, driver_config):
+def test_set_parameter_posix_pool_slab_array(slab_sizes, slab_counts, driver_config, driver):
     """Test cuFile POSIX pool slab array configuration."""
     # After setting parameters, retrieve them back to verify
     n_slab_sizes = len(slab_sizes)
@@ -1907,12 +1952,7 @@ def test_set_parameter_posix_pool_slab_array(slab_sizes, slab_counts, driver_con
     retrieved_sizes_addr = ctypes.addressof(retrieved_sizes)
     retrieved_counts_addr = ctypes.addressof(retrieved_counts)
 
-    # Open cuFile driver AFTER setting parameters
-    cufile.driver_open()
-    try:
-        cufile.get_parameter_posix_pool_slab_array(retrieved_sizes_addr, retrieved_counts_addr, n_slab_sizes)
-    finally:
-        cufile.driver_close()
+    cufile.get_parameter_posix_pool_slab_array(retrieved_sizes_addr, retrieved_counts_addr, n_slab_sizes)
 
     # Verify they match what we set
     assert list(retrieved_sizes) == slab_sizes

--- a/cuda_bindings/tests/test_cufile.py
+++ b/cuda_bindings/tests/test_cufile.py
@@ -183,7 +183,6 @@ def _cufile_driver_prewarm():
         cufile.driver_close()
     finally:
         cuda.cuDevicePrimaryCtxRelease(device)
-    yield
 
 
 @pytest.fixture


### PR DESCRIPTION
## Problem

Under `pytest-randomly`, `tests/test_cufile.py` can fatally crash the pytest process with `SIGFPE` — not a caught exception, an actual floating-point exception tearing down the interpreter. The crash is deterministic given specific orderings (reproduced with seed `2758108007`).

Under gdb the faulting instruction is an unguarded `div %rcx` with `%rcx = 0` inside `CUFileDrv::ReadVersionInfo(bool)`, reached from `cuFileDriverOpen+0xe` in `libcufile.so` (libcufile 1.17.1).

## Root cause (libcufile 1.17.1 bug)

Calling `cuFileSetParameterSizeT` — or any of the other parameter-set APIs that are documented as usable before `cuFileDriverOpen` — BEFORE the first `cuFileDriverOpen` leaves an internal version list uninitialized. The next `cuFileDriverOpen` then divides by the list's zero length.

Minimal repro with the shipped library:

```
pytest tests/test_cufile.py::test_set_get_parameter_size_t \
       tests/test_cufile.py::test_buf_register_invalid_flags
```

Reversing the order passes — the `buf_register` test implicitly opens/closes the driver first, initializing the list. Random ordering will hit the bad order whenever any driver-closed parameter-set test happens to sort before any driver-open test.

This needs an upstream libcufile fix (bounds-check before the division, or initialize the list in the parameter-set path). The two cufile-test regimes cannot be merged around it either — parameter-set tests require the driver CLOSED (libcufile returns `DRIVER_ALREADY_OPEN (5026)` otherwise), while I/O and registration tests require it OPEN.

## Fix

Add a module-scope autouse fixture `_cufile_driver_prewarm` that runs one `driver_open` / `driver_close` cycle before any test in `test_cufile.py` executes. That single cycle initializes libcufile's internal version list; afterwards both regimes work under any ordering:

- Driver-open tests (`buf_register_*`, `cufile_read_write`, `batch_io`, stats, etc.) continue to use the function-scope `driver` fixture to open/close per test.
- Driver-closed tests (`test_set_get_parameter_*`, `test_set_parameter_posix_*`) run against a properly initialized closed driver.

The per-test `driver_open`/`driver_close` pattern is preserved — not ideal on throughput grounds, but forced by the libcufile API, as noted in the fixture docstring.

Secondary cleanup: `test_set_parameter_posix_pool_slab_array` was the only test with an inline `driver_open` / `try/finally: driver_close` block. Pytest fixture ordering guarantees `driver_config` (which calls `set_parameter_posix_pool_slab_array` while the driver is closed) runs before the `driver` fixture opens it, so the inline pair was replaced by adding `driver` to the test signature. The redundant `@pytest.mark.usefixtures("ctx")` was dropped since `driver` already depends on `ctx`.