### PR TITLE
build(cuda_bindings): declare cuda-pathfinder as a host-dependency

### DIFF
--- a/cuda_bindings/pixi.toml
+++ b/cuda_bindings/pixi.toml
@@ -121,6 +121,7 @@ setuptools = ">=80"
 setuptools-scm = ">=8"
 cython = ">=3.2,<3.3"
 pyclibrary = ">=0.1.7"
+cuda-pathfinder = { path = "../cuda_pathfinder" }
 cuda-cudart-static = "*"
 cuda-nvrtc-dev = "*"
 cuda-profiler-api = "*"


### PR DESCRIPTION
## Problem

Building `cuda_bindings` from source through the pixi path-dependency workflow fails because `cuda_pathfinder` is not available at build time.

`pixi-build-python` invokes `pip install --no-build-isolation` against the pixi host environment. `--no-build-isolation` bypasses `[build-system] requires` from `pyproject.toml`, so anything listed only there (including `cuda-pathfinder`) is not provisioned before the build runs. The build then fails as soon as the setup step tries to import or resolve `cuda_pathfinder`.

## Fix

Add `cuda-pathfinder = { path = "../cuda_pathfinder" }` to `[package.host-dependencies]` in `cuda_bindings/pixi.toml`. With the dependency declared in the pixi manifest, pixi installs it into the host env before the no-isolation build runs, and the build succeeds.