### PR TITLE
cuda.bindings: Update generated code

### DIFF
--- a/cuda_bindings/cuda/bindings/cufile.pxd
+++ b/cuda_bindings/cuda/bindings/cufile.pxd
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.9.1 to 13.2.0, generator version 0.3.1.dev1422+gf4812259e.d20260318. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.1 to 13.2.0, generator version 0.3.1.dev1568+g289771de9.d20260413. Do not modify it directly.
 
 from libc.stdint cimport intptr_t
 
@@ -80,6 +80,6 @@ cpdef stats_reset()
 cpdef get_stats_l1(intptr_t stats)
 cpdef get_stats_l2(intptr_t stats)
 cpdef get_stats_l3(intptr_t stats)
-cpdef size_t get_bar_size_in_kb(int gpu_ind_ex) except? 0
+cpdef size_t get_bar_size_in_kb(int gpu_index) except? 0
 cpdef set_parameter_posix_pool_slab_array(intptr_t size_values, intptr_t count_values, int len)
 cpdef get_parameter_posix_pool_slab_array(intptr_t size_values, intptr_t count_values, int len)

--- a/cuda_bindings/cuda/bindings/cufile.pyx
+++ b/cuda_bindings/cuda/bindings/cufile.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.9.1 to 13.2.0, generator version 0.3.1.dev1422+gf4812259e.d20260318. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.1 to 13.2.0, generator version 0.3.1.dev1568+g289771de9.d20260413. Do not modify it directly.
 
 cimport cython  # NOQA
 from libc cimport errno
@@ -74,7 +74,6 @@ _py_anon_pod1_dtype = _numpy.dtype((
         "handle": (_numpy.intp, 0),
     }
     ))
-
 
 cdef class _py_anon_pod1:
     """Empty-initialize an instance of `cuda_bindings_cufile__anon_pod1`.
@@ -389,20 +388,16 @@ io_events_dtype = _get_io_events_dtype_offsets()
 
 cdef class IOEvents:
     """Empty-initialize an array of `CUfileIOEvents_t`.
-
     The resulting object is of length `size` and of dtype `io_events_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `CUfileIOEvents_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=io_events_dtype)
@@ -728,20 +723,16 @@ per_gpu_stats_dtype = _get_per_gpu_stats_dtype_offsets()
 
 cdef class PerGpuStats:
     """Empty-initialize an array of `CUfilePerGpuStats_t`.
-
     The resulting object is of length `size` and of dtype `per_gpu_stats_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `CUfilePerGpuStats_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=per_gpu_stats_dtype)
@@ -1192,20 +1183,16 @@ descr_dtype = _get_descr_dtype_offsets()
 
 cdef class Descr:
     """Empty-initialize an array of `CUfileDescr_t`.
-
     The resulting object is of length `size` and of dtype `descr_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `CUfileDescr_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=descr_dtype)
@@ -1348,7 +1335,6 @@ _py_anon_pod2_dtype = _numpy.dtype((
         "batch": (_py_anon_pod3_dtype, 0),
     }
     ))
-
 
 cdef class _py_anon_pod2:
     """Empty-initialize an instance of `cuda_bindings_cufile__anon_pod2`.
@@ -2144,20 +2130,16 @@ io_params_dtype = _get_io_params_dtype_offsets()
 
 cdef class IOParams:
     """Empty-initialize an array of `CUfileIOParams_t`.
-
     The resulting object is of length `size` and of dtype `io_params_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `CUfileIOParams_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=io_params_dtype)
@@ -2641,7 +2623,6 @@ cdef class StatsLevel3:
             obj._owned = False
         obj._readonly = readonly
         return obj
-
 
 
 ###############################################################################
@@ -3252,10 +3233,10 @@ cpdef get_stats_l3(intptr_t stats):
     check_status(__status__)
 
 
-cpdef size_t get_bar_size_in_kb(int gpu_ind_ex) except? 0:
+cpdef size_t get_bar_size_in_kb(int gpu_index) except? 0:
     cdef size_t bar_size
     with nogil:
-        __status__ = cuFileGetBARSizeInKB(gpu_ind_ex, &bar_size)
+        __status__ = cuFileGetBARSizeInKB(gpu_index, &bar_size)
     check_status(__status__)
     return bar_size
 

--- a/cuda_bindings/cuda/bindings/cycufile.pxd
+++ b/cuda_bindings/cuda/bindings/cycufile.pxd
@@ -197,8 +197,10 @@ cdef extern from '<cufile.h>':
 cdef extern from '<cufile.h>':
     ctypedef void* CUfileHandle_t 'CUfileHandle_t'
 
+
 cdef extern from '<cufile.h>':
     ctypedef void* CUfileBatchHandle_t 'CUfileBatchHandle_t'
+
 
 cdef extern from '<cufile.h>':
     ctypedef struct CUfileError_t 'CUfileError_t':
@@ -365,7 +367,6 @@ cdef extern from '<cufile.h>':
         CUfileStatsLevel2_t detailed
         uint32_t num_gpus
         CUfilePerGpuStats_t per_gpu_stats[16]
-
 
 
 cdef extern from *:

--- a/cuda_bindings/cuda/bindings/cynvml.pxd
+++ b/cuda_bindings/cuda/bindings/cynvml.pxd
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.9.1 to 13.2.0, generator version 0.3.1.dev1422+gf4812259e.d20260318. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.1 to 13.2.0, generator version 0.3.1.dev1568+g289771de9.d20260413. Do not modify it directly.
 
 from libc.stdint cimport int64_t
 
@@ -817,12 +817,19 @@ ctypedef struct nvmlPlatformInfo_v2_t 'nvmlPlatformInfo_v2_t':
     unsigned char moduleId
 
 ctypedef unsigned int nvmlDeviceArchitecture_t 'nvmlDeviceArchitecture_t'
+
 ctypedef unsigned int nvmlBusType_t 'nvmlBusType_t'
+
 ctypedef unsigned int nvmlFanControlPolicy_t 'nvmlFanControlPolicy_t'
+
 ctypedef unsigned int nvmlPowerSource_t 'nvmlPowerSource_t'
+
 ctypedef unsigned char nvmlPowerScopeType_t 'nvmlPowerScopeType_t'
+
 ctypedef unsigned int nvmlVgpuTypeId_t 'nvmlVgpuTypeId_t'
+
 ctypedef unsigned int nvmlVgpuInstance_t 'nvmlVgpuInstance_t'
+
 ctypedef struct nvmlVgpuHeterogeneousMode_v1_t 'nvmlVgpuHeterogeneousMode_v1_t':
     unsigned int version
     unsigned int mode
@@ -862,11 +869,13 @@ ctypedef struct nvmlConfComputeGetKeyRotationThresholdInfo_v1_t 'nvmlConfCompute
     unsigned long long attackerAdvantage
 
 ctypedef unsigned char nvmlGpuFabricState_t 'nvmlGpuFabricState_t'
+
 ctypedef struct nvmlSystemDriverBranchInfo_v1_t 'nvmlSystemDriverBranchInfo_v1_t':
     unsigned int version
     char branch[80]
 
 ctypedef unsigned int nvmlAffinityScope_t 'nvmlAffinityScope_t'
+
 ctypedef struct nvmlTemperature_v1_t 'nvmlTemperature_v1_t':
     unsigned int version
     nvmlTemperatureSensors_t sensorType
@@ -915,12 +924,19 @@ ctypedef struct nvmlPdi_v1_t 'nvmlPdi_v1_t':
     unsigned long long value
 
 ctypedef void* nvmlDevice_t 'nvmlDevice_t'
+
 ctypedef void* nvmlGpuInstance_t 'nvmlGpuInstance_t'
+
 ctypedef void* nvmlUnit_t 'nvmlUnit_t'
+
 ctypedef void* nvmlEventSet_t 'nvmlEventSet_t'
+
 ctypedef void* nvmlSystemEventSet_t 'nvmlSystemEventSet_t'
+
 ctypedef void* nvmlComputeInstance_t 'nvmlComputeInstance_t'
+
 ctypedef void* nvmlGpmSample_t 'nvmlGpmSample_t'
+
 ctypedef struct nvmlPciInfo_t 'nvmlPciInfo_t':
     char busIdLegacy[16]
     unsigned int domain
@@ -1383,15 +1399,25 @@ ctypedef struct nvmlVgpuSchedulerState_v2_t 'nvmlVgpuSchedulerState_v2_t':
     unsigned int frequency
 
 ctypedef nvmlPciInfoExt_v1_t nvmlPciInfoExt_t 'nvmlPciInfoExt_t'
+
 ctypedef nvmlCoolerInfo_v1_t nvmlCoolerInfo_t 'nvmlCoolerInfo_t'
+
 ctypedef nvmlDramEncryptionInfo_v1_t nvmlDramEncryptionInfo_t 'nvmlDramEncryptionInfo_t'
+
 ctypedef nvmlMarginTemperature_v1_t nvmlMarginTemperature_t 'nvmlMarginTemperature_t'
+
 ctypedef nvmlClockOffset_v1_t nvmlClockOffset_t 'nvmlClockOffset_t'
+
 ctypedef nvmlFanSpeedInfo_v1_t nvmlFanSpeedInfo_t 'nvmlFanSpeedInfo_t'
+
 ctypedef nvmlDevicePerfModes_v1_t nvmlDevicePerfModes_t 'nvmlDevicePerfModes_t'
+
 ctypedef nvmlDeviceCurrentClockFreqs_v1_t nvmlDeviceCurrentClockFreqs_t 'nvmlDeviceCurrentClockFreqs_t'
+
 ctypedef nvmlEccSramErrorStatus_v1_t nvmlEccSramErrorStatus_t 'nvmlEccSramErrorStatus_t'
+
 ctypedef nvmlPlatformInfo_v2_t nvmlPlatformInfo_t 'nvmlPlatformInfo_t'
+
 ctypedef struct nvmlPowerValue_v2_t 'nvmlPowerValue_v2_t':
     unsigned int version
     nvmlPowerScopeType_t powerScope
@@ -1466,13 +1492,21 @@ ctypedef struct nvmlFBCSessionInfo_t 'nvmlFBCSessionInfo_t':
     unsigned int averageLatency
 
 ctypedef nvmlVgpuHeterogeneousMode_v1_t nvmlVgpuHeterogeneousMode_t 'nvmlVgpuHeterogeneousMode_t'
+
 ctypedef nvmlVgpuPlacementId_v1_t nvmlVgpuPlacementId_t 'nvmlVgpuPlacementId_t'
+
 ctypedef nvmlVgpuPlacementList_v2_t nvmlVgpuPlacementList_t 'nvmlVgpuPlacementList_t'
+
 ctypedef nvmlVgpuTypeBar1Info_v1_t nvmlVgpuTypeBar1Info_t 'nvmlVgpuTypeBar1Info_t'
+
 ctypedef nvmlVgpuRuntimeState_v1_t nvmlVgpuRuntimeState_t 'nvmlVgpuRuntimeState_t'
+
 ctypedef nvmlSystemConfComputeSettings_v1_t nvmlSystemConfComputeSettings_t 'nvmlSystemConfComputeSettings_t'
+
 ctypedef nvmlConfComputeSetKeyRotationThresholdInfo_v1_t nvmlConfComputeSetKeyRotationThresholdInfo_t 'nvmlConfComputeSetKeyRotationThresholdInfo_t'
+
 ctypedef nvmlConfComputeGetKeyRotationThresholdInfo_v1_t nvmlConfComputeGetKeyRotationThresholdInfo_t 'nvmlConfComputeGetKeyRotationThresholdInfo_t'
+
 ctypedef struct nvmlGpuFabricInfo_t 'nvmlGpuFabricInfo_t':
     unsigned char clusterUuid[16]
     nvmlReturn_t status
@@ -1497,16 +1531,27 @@ ctypedef struct nvmlGpuFabricInfo_v3_t 'nvmlGpuFabricInfo_v3_t':
     unsigned char healthSummary
 
 ctypedef nvmlSystemDriverBranchInfo_v1_t nvmlSystemDriverBranchInfo_t 'nvmlSystemDriverBranchInfo_t'
+
 ctypedef nvmlTemperature_v1_t nvmlTemperature_t 'nvmlTemperature_t'
+
 ctypedef nvmlNvlinkSupportedBwModes_v1_t nvmlNvlinkSupportedBwModes_t 'nvmlNvlinkSupportedBwModes_t'
+
 ctypedef nvmlNvlinkGetBwMode_v1_t nvmlNvlinkGetBwMode_t 'nvmlNvlinkGetBwMode_t'
+
 ctypedef nvmlNvlinkSetBwMode_v1_t nvmlNvlinkSetBwMode_t 'nvmlNvlinkSetBwMode_t'
+
 ctypedef nvmlDeviceCapabilities_v1_t nvmlDeviceCapabilities_t 'nvmlDeviceCapabilities_t'
+
 ctypedef nvmlPowerSmoothingProfile_v1_t nvmlPowerSmoothingProfile_t 'nvmlPowerSmoothingProfile_t'
+
 ctypedef nvmlPowerSmoothingState_v1_t nvmlPowerSmoothingState_t 'nvmlPowerSmoothingState_t'
+
 ctypedef nvmlDeviceAddressingMode_v1_t nvmlDeviceAddressingMode_t 'nvmlDeviceAddressingMode_t'
+
 ctypedef nvmlRepairStatus_v1_t nvmlRepairStatus_t 'nvmlRepairStatus_t'
+
 ctypedef nvmlPdi_v1_t nvmlPdi_t 'nvmlPdi_t'
+
 ctypedef struct nvmlEventData_t 'nvmlEventData_t':
     nvmlDevice_t device
     unsigned long long eventType
@@ -1706,8 +1751,11 @@ ctypedef struct nvmlVgpuSchedulerLogInfo_v2_t 'nvmlVgpuSchedulerLogInfo_v2_t':
     nvmlVgpuSchedulerLogEntry_v2_t logEntries[200]
 
 ctypedef nvmlVgpuTypeIdInfo_v1_t nvmlVgpuTypeIdInfo_t 'nvmlVgpuTypeIdInfo_t'
+
 ctypedef nvmlVgpuTypeMaxInstance_v1_t nvmlVgpuTypeMaxInstance_t 'nvmlVgpuTypeMaxInstance_t'
+
 ctypedef nvmlVgpuCreatablePlacementInfo_v1_t nvmlVgpuCreatablePlacementInfo_t 'nvmlVgpuCreatablePlacementInfo_t'
+
 ctypedef struct nvmlVgpuProcessesUtilizationInfo_v1_t 'nvmlVgpuProcessesUtilizationInfo_v1_t':
     unsigned int version
     unsigned int vgpuProcessCount
@@ -1715,11 +1763,17 @@ ctypedef struct nvmlVgpuProcessesUtilizationInfo_v1_t 'nvmlVgpuProcessesUtilizat
     nvmlVgpuProcessUtilizationInfo_v1_t* vgpuProcUtilArray
 
 ctypedef nvmlActiveVgpuInstanceInfo_v1_t nvmlActiveVgpuInstanceInfo_t 'nvmlActiveVgpuInstanceInfo_t'
+
 ctypedef nvmlGpuFabricInfo_v3_t nvmlGpuFabricInfoV_t 'nvmlGpuFabricInfoV_t'
+
 ctypedef nvmlSystemEventSetCreateRequest_v1_t nvmlSystemEventSetCreateRequest_t 'nvmlSystemEventSetCreateRequest_t'
+
 ctypedef nvmlSystemEventSetFreeRequest_v1_t nvmlSystemEventSetFreeRequest_t 'nvmlSystemEventSetFreeRequest_t'
+
 ctypedef nvmlSystemRegisterEventRequest_v1_t nvmlSystemRegisterEventRequest_t 'nvmlSystemRegisterEventRequest_t'
+
 ctypedef nvmlProcessDetailList_v1_t nvmlProcessDetailList_t 'nvmlProcessDetailList_t'
+
 ctypedef struct nvmlVgpuInstancesUtilizationInfo_v1_t 'nvmlVgpuInstancesUtilizationInfo_v1_t':
     unsigned int version
     nvmlValueType_t sampleValType
@@ -1733,7 +1787,9 @@ ctypedef struct nvmlPRMCounter_v1_t 'nvmlPRMCounter_v1_t':
     nvmlPRMCounterValue_v1_t counterValue
 
 ctypedef nvmlUUID_v1_t nvmlUUID_t 'nvmlUUID_t'
+
 ctypedef nvmlProcessesUtilizationInfo_v1_t nvmlProcessesUtilizationInfo_t 'nvmlProcessesUtilizationInfo_t'
+
 ctypedef struct nvmlVgpuSchedulerLog_t 'nvmlVgpuSchedulerLog_t':
     unsigned int engineId
     unsigned int schedulerPolicy
@@ -1781,6 +1837,7 @@ ctypedef struct nvmlGridLicensableFeatures_t 'nvmlGridLicensableFeatures_t':
     nvmlGridLicensableFeature_t gridLicensableFeatures[3]
 
 ctypedef nvmlSystemEventSetWaitRequest_v1_t nvmlSystemEventSetWaitRequest_t 'nvmlSystemEventSetWaitRequest_t'
+
 ctypedef struct nvmlGpmMetricsGet_t 'nvmlGpmMetricsGet_t':
     unsigned int version
     unsigned int numMetrics
@@ -1789,29 +1846,39 @@ ctypedef struct nvmlGpmMetricsGet_t 'nvmlGpmMetricsGet_t':
     nvmlGpmMetric_t metrics[333]
 
 ctypedef nvmlWorkloadPowerProfileInfo_v1_t nvmlWorkloadPowerProfileInfo_t 'nvmlWorkloadPowerProfileInfo_t'
+
 ctypedef nvmlWorkloadPowerProfileCurrentProfiles_v1_t nvmlWorkloadPowerProfileCurrentProfiles_t 'nvmlWorkloadPowerProfileCurrentProfiles_t'
+
 ctypedef nvmlWorkloadPowerProfileRequestedProfiles_v1_t nvmlWorkloadPowerProfileRequestedProfiles_t 'nvmlWorkloadPowerProfileRequestedProfiles_t'
+
 ctypedef nvmlEccSramUniqueUncorrectedErrorCounts_v1_t nvmlEccSramUniqueUncorrectedErrorCounts_t 'nvmlEccSramUniqueUncorrectedErrorCounts_t'
+
 ctypedef struct nvmlNvLinkInfo_v2_t 'nvmlNvLinkInfo_v2_t':
     unsigned int version
     unsigned int isNvleEnabled
     nvmlNvlinkFirmwareInfo_t firmwareInfo
 
 ctypedef nvmlVgpuProcessesUtilizationInfo_v1_t nvmlVgpuProcessesUtilizationInfo_t 'nvmlVgpuProcessesUtilizationInfo_t'
+
 ctypedef nvmlVgpuInstancesUtilizationInfo_v1_t nvmlVgpuInstancesUtilizationInfo_t 'nvmlVgpuInstancesUtilizationInfo_t'
+
 ctypedef struct nvmlPRMCounterList_v1_t 'nvmlPRMCounterList_v1_t':
     unsigned int numCounters
     nvmlPRMCounter_v1_t* counters
 
 ctypedef nvmlVgpuSchedulerStateInfo_v1_t nvmlVgpuSchedulerStateInfo_t 'nvmlVgpuSchedulerStateInfo_t'
+
 ctypedef nvmlVgpuSchedulerLogInfo_v1_t nvmlVgpuSchedulerLogInfo_t 'nvmlVgpuSchedulerLogInfo_t'
+
 ctypedef nvmlVgpuSchedulerState_v1_t nvmlVgpuSchedulerState_t 'nvmlVgpuSchedulerState_t'
+
 ctypedef struct nvmlWorkloadPowerProfileProfilesInfo_v1_t 'nvmlWorkloadPowerProfileProfilesInfo_v1_t':
     unsigned int version
     nvmlMask255_t perfProfilesMask
     nvmlWorkloadPowerProfileInfo_t perfProfile[255]
 
 ctypedef nvmlNvLinkInfo_v2_t nvmlNvLinkInfo_t 'nvmlNvLinkInfo_t'
+
 ctypedef nvmlWorkloadPowerProfileProfilesInfo_v1_t nvmlWorkloadPowerProfileProfilesInfo_t 'nvmlWorkloadPowerProfileProfilesInfo_t'
 
 

--- a/cuda_bindings/cuda/bindings/driver.pyx.in
+++ b/cuda_bindings/cuda/bindings/driver.pyx.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version 0.3.1.dev1422+gf4812259e.d20260318. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 0.3.1.dev1568+g289771de9.d20260413. Do not modify it directly.
 from typing import Any, Optional
 import cython
 import ctypes
@@ -27562,7 +27562,7 @@ def cuCtxCreate(ctxCreateParams : Optional[CUctxCreateParams], unsigned int flag
         pdev = int(CUdevice(dev))
     cydev = <cydriver.CUdevice>pdev
     cdef CUcontext pctx = CUcontext()
-    cdef cydriver.CUctxCreateParams* cyctxCreateParams_ptr = ctxCreateParams._pvt_ptr if ctxCreateParams is not None else NULL
+    cdef cydriver.CUctxCreateParams* cyctxCreateParams_ptr = <cydriver.CUctxCreateParams*>ctxCreateParams._pvt_ptr if ctxCreateParams is not None else NULL
     with nogil:
         err = cydriver.cuCtxCreate(<cydriver.CUcontext*>pctx._pvt_ptr, cyctxCreateParams_ptr, flags, cydev)
     if err != cydriver.CUDA_SUCCESS:
@@ -32636,7 +32636,7 @@ def cuMemcpy2D(pCopy : Optional[CUDA_MEMCPY2D]):
     --------
     :py:obj:`~.cuArray3DCreate`, :py:obj:`~.cuArray3DGetDescriptor`, :py:obj:`~.cuArrayCreate`, :py:obj:`~.cuArrayDestroy`, :py:obj:`~.cuArrayGetDescriptor`, :py:obj:`~.cuMemAlloc`, :py:obj:`~.cuMemAllocHost`, :py:obj:`~.cuMemAllocPitch`, :py:obj:`~.cuMemcpy2DAsync`, :py:obj:`~.cuMemcpy2DUnaligned`, :py:obj:`~.cuMemcpy3D`, :py:obj:`~.cuMemcpy3DAsync`, :py:obj:`~.cuMemcpyAtoA`, :py:obj:`~.cuMemcpyAtoD`, :py:obj:`~.cuMemcpyAtoH`, :py:obj:`~.cuMemcpyAtoHAsync`, :py:obj:`~.cuMemcpyDtoA`, :py:obj:`~.cuMemcpyDtoD`, :py:obj:`~.cuMemcpyDtoDAsync`, :py:obj:`~.cuMemcpyDtoH`, :py:obj:`~.cuMemcpyDtoHAsync`, :py:obj:`~.cuMemcpyHtoA`, :py:obj:`~.cuMemcpyHtoAAsync`, :py:obj:`~.cuMemcpyHtoD`, :py:obj:`~.cuMemcpyHtoDAsync`, :py:obj:`~.cuMemFree`, :py:obj:`~.cuMemFreeHost`, :py:obj:`~.cuMemGetAddressRange`, :py:obj:`~.cuMemGetInfo`, :py:obj:`~.cuMemHostAlloc`, :py:obj:`~.cuMemHostGetDevicePointer`, :py:obj:`~.cuMemsetD2D8`, :py:obj:`~.cuMemsetD2D16`, :py:obj:`~.cuMemsetD2D32`, :py:obj:`~.cuMemsetD8`, :py:obj:`~.cuMemsetD16`, :py:obj:`~.cuMemsetD32`, :py:obj:`~.cudaMemcpy2D`, :py:obj:`~.cudaMemcpy2DToArray`, :py:obj:`~.cudaMemcpy2DFromArray`
     """
-    cdef cydriver.CUDA_MEMCPY2D* cypCopy_ptr = pCopy._pvt_ptr if pCopy is not None else NULL
+    cdef cydriver.CUDA_MEMCPY2D* cypCopy_ptr = <cydriver.CUDA_MEMCPY2D*>pCopy._pvt_ptr if pCopy is not None else NULL
     with nogil:
         err = cydriver.cuMemcpy2D(cypCopy_ptr)
     return (_CUresult(err),)
@@ -32763,7 +32763,7 @@ def cuMemcpy2DUnaligned(pCopy : Optional[CUDA_MEMCPY2D]):
     --------
     :py:obj:`~.cuArray3DCreate`, :py:obj:`~.cuArray3DGetDescriptor`, :py:obj:`~.cuArrayCreate`, :py:obj:`~.cuArrayDestroy`, :py:obj:`~.cuArrayGetDescriptor`, :py:obj:`~.cuMemAlloc`, :py:obj:`~.cuMemAllocHost`, :py:obj:`~.cuMemAllocPitch`, :py:obj:`~.cuMemcpy2D`, :py:obj:`~.cuMemcpy2DAsync`, :py:obj:`~.cuMemcpy3D`, :py:obj:`~.cuMemcpy3DAsync`, :py:obj:`~.cuMemcpyAtoA`, :py:obj:`~.cuMemcpyAtoD`, :py:obj:`~.cuMemcpyAtoH`, :py:obj:`~.cuMemcpyAtoHAsync`, :py:obj:`~.cuMemcpyDtoA`, :py:obj:`~.cuMemcpyDtoD`, :py:obj:`~.cuMemcpyDtoDAsync`, :py:obj:`~.cuMemcpyDtoH`, :py:obj:`~.cuMemcpyDtoHAsync`, :py:obj:`~.cuMemcpyHtoA`, :py:obj:`~.cuMemcpyHtoAAsync`, :py:obj:`~.cuMemcpyHtoD`, :py:obj:`~.cuMemcpyHtoDAsync`, :py:obj:`~.cuMemFree`, :py:obj:`~.cuMemFreeHost`, :py:obj:`~.cuMemGetAddressRange`, :py:obj:`~.cuMemGetInfo`, :py:obj:`~.cuMemHostAlloc`, :py:obj:`~.cuMemHostGetDevicePointer`, :py:obj:`~.cuMemsetD2D8`, :py:obj:`~.cuMemsetD2D16`, :py:obj:`~.cuMemsetD2D32`, :py:obj:`~.cuMemsetD8`, :py:obj:`~.cuMemsetD16`, :py:obj:`~.cuMemsetD32`, :py:obj:`~.cudaMemcpy2D`, :py:obj:`~.cudaMemcpy2DToArray`, :py:obj:`~.cudaMemcpy2DFromArray`
     """
-    cdef cydriver.CUDA_MEMCPY2D* cypCopy_ptr = pCopy._pvt_ptr if pCopy is not None else NULL
+    cdef cydriver.CUDA_MEMCPY2D* cypCopy_ptr = <cydriver.CUDA_MEMCPY2D*>pCopy._pvt_ptr if pCopy is not None else NULL
     with nogil:
         err = cydriver.cuMemcpy2DUnaligned(cypCopy_ptr)
     return (_CUresult(err),)
@@ -32893,7 +32893,7 @@ def cuMemcpy3D(pCopy : Optional[CUDA_MEMCPY3D]):
     --------
     :py:obj:`~.cuArray3DCreate`, :py:obj:`~.cuArray3DGetDescriptor`, :py:obj:`~.cuArrayCreate`, :py:obj:`~.cuArrayDestroy`, :py:obj:`~.cuArrayGetDescriptor`, :py:obj:`~.cuMemAlloc`, :py:obj:`~.cuMemAllocHost`, :py:obj:`~.cuMemAllocPitch`, :py:obj:`~.cuMemcpy2D`, :py:obj:`~.cuMemcpy2DAsync`, :py:obj:`~.cuMemcpy2DUnaligned`, :py:obj:`~.cuMemcpy3DAsync`, :py:obj:`~.cuMemcpyAtoA`, :py:obj:`~.cuMemcpyAtoD`, :py:obj:`~.cuMemcpyAtoH`, :py:obj:`~.cuMemcpyAtoHAsync`, :py:obj:`~.cuMemcpyDtoA`, :py:obj:`~.cuMemcpyDtoD`, :py:obj:`~.cuMemcpyDtoDAsync`, :py:obj:`~.cuMemcpyDtoH`, :py:obj:`~.cuMemcpyDtoHAsync`, :py:obj:`~.cuMemcpyHtoA`, :py:obj:`~.cuMemcpyHtoAAsync`, :py:obj:`~.cuMemcpyHtoD`, :py:obj:`~.cuMemcpyHtoDAsync`, :py:obj:`~.cuMemFree`, :py:obj:`~.cuMemFreeHost`, :py:obj:`~.cuMemGetAddressRange`, :py:obj:`~.cuMemGetInfo`, :py:obj:`~.cuMemHostAlloc`, :py:obj:`~.cuMemHostGetDevicePointer`, :py:obj:`~.cuMemsetD2D8`, :py:obj:`~.cuMemsetD2D16`, :py:obj:`~.cuMemsetD2D32`, :py:obj:`~.cuMemsetD8`, :py:obj:`~.cuMemsetD16`, :py:obj:`~.cuMemsetD32`, :py:obj:`~.cudaMemcpy3D`
     """
-    cdef cydriver.CUDA_MEMCPY3D* cypCopy_ptr = pCopy._pvt_ptr if pCopy is not None else NULL
+    cdef cydriver.CUDA_MEMCPY3D* cypCopy_ptr = <cydriver.CUDA_MEMCPY3D*>pCopy._pvt_ptr if pCopy is not None else NULL
     with nogil:
         err = cydriver.cuMemcpy3D(cypCopy_ptr)
     return (_CUresult(err),)
@@ -32923,7 +32923,7 @@ def cuMemcpy3DPeer(pCopy : Optional[CUDA_MEMCPY3D_PEER]):
     --------
     :py:obj:`~.cuMemcpyDtoD`, :py:obj:`~.cuMemcpyPeer`, :py:obj:`~.cuMemcpyDtoDAsync`, :py:obj:`~.cuMemcpyPeerAsync`, :py:obj:`~.cuMemcpy3DPeerAsync`, :py:obj:`~.cudaMemcpy3DPeer`
     """
-    cdef cydriver.CUDA_MEMCPY3D_PEER* cypCopy_ptr = pCopy._pvt_ptr if pCopy is not None else NULL
+    cdef cydriver.CUDA_MEMCPY3D_PEER* cypCopy_ptr = <cydriver.CUDA_MEMCPY3D_PEER*>pCopy._pvt_ptr if pCopy is not None else NULL
     with nogil:
         err = cydriver.cuMemcpy3DPeer(cypCopy_ptr)
     return (_CUresult(err),)
@@ -33491,7 +33491,7 @@ def cuMemcpy2DAsync(pCopy : Optional[CUDA_MEMCPY2D], hStream):
     else:
         phStream = int(CUstream(hStream))
     cyhStream = <cydriver.CUstream><void_ptr>phStream
-    cdef cydriver.CUDA_MEMCPY2D* cypCopy_ptr = pCopy._pvt_ptr if pCopy is not None else NULL
+    cdef cydriver.CUDA_MEMCPY2D* cypCopy_ptr = <cydriver.CUDA_MEMCPY2D*>pCopy._pvt_ptr if pCopy is not None else NULL
     with nogil:
         err = cydriver.cuMemcpy2DAsync(cypCopy_ptr, cyhStream)
     return (_CUresult(err),)
@@ -33631,7 +33631,7 @@ def cuMemcpy3DAsync(pCopy : Optional[CUDA_MEMCPY3D], hStream):
     else:
         phStream = int(CUstream(hStream))
     cyhStream = <cydriver.CUstream><void_ptr>phStream
-    cdef cydriver.CUDA_MEMCPY3D* cypCopy_ptr = pCopy._pvt_ptr if pCopy is not None else NULL
+    cdef cydriver.CUDA_MEMCPY3D* cypCopy_ptr = <cydriver.CUDA_MEMCPY3D*>pCopy._pvt_ptr if pCopy is not None else NULL
     with nogil:
         err = cydriver.cuMemcpy3DAsync(cypCopy_ptr, cyhStream)
     return (_CUresult(err),)
@@ -33671,7 +33671,7 @@ def cuMemcpy3DPeerAsync(pCopy : Optional[CUDA_MEMCPY3D_PEER], hStream):
     else:
         phStream = int(CUstream(hStream))
     cyhStream = <cydriver.CUstream><void_ptr>phStream
-    cdef cydriver.CUDA_MEMCPY3D_PEER* cypCopy_ptr = pCopy._pvt_ptr if pCopy is not None else NULL
+    cdef cydriver.CUDA_MEMCPY3D_PEER* cypCopy_ptr = <cydriver.CUDA_MEMCPY3D_PEER*>pCopy._pvt_ptr if pCopy is not None else NULL
     with nogil:
         err = cydriver.cuMemcpy3DPeerAsync(cypCopy_ptr, cyhStream)
     return (_CUresult(err),)
@@ -34044,7 +34044,7 @@ def cuMemcpyWithAttributesAsync(dst, src, size_t size, attr : Optional[CUmemcpyA
     else:
         pdst = int(CUdeviceptr(dst))
     cydst = <cydriver.CUdeviceptr><void_ptr>pdst
-    cdef cydriver.CUmemcpyAttributes* cyattr_ptr = attr._pvt_ptr if attr is not None else NULL
+    cdef cydriver.CUmemcpyAttributes* cyattr_ptr = <cydriver.CUmemcpyAttributes*>attr._pvt_ptr if attr is not None else NULL
     with nogil:
         err = cydriver.cuMemcpyWithAttributesAsync(cydst, cysrc, size, cyattr_ptr, cyhStream)
     return (_CUresult(err),)
@@ -34092,7 +34092,7 @@ def cuMemcpy3DWithAttributesAsync(op : Optional[CUDA_MEMCPY3D_BATCH_OP], unsigne
     else:
         phStream = int(CUstream(hStream))
     cyhStream = <cydriver.CUstream><void_ptr>phStream
-    cdef cydriver.CUDA_MEMCPY3D_BATCH_OP* cyop_ptr = op._pvt_ptr if op is not None else NULL
+    cdef cydriver.CUDA_MEMCPY3D_BATCH_OP* cyop_ptr = <cydriver.CUDA_MEMCPY3D_BATCH_OP*>op._pvt_ptr if op is not None else NULL
     with nogil:
         err = cydriver.cuMemcpy3DWithAttributesAsync(cyop_ptr, flags, cyhStream)
     return (_CUresult(err),)
@@ -34745,7 +34745,7 @@ def cuArrayCreate(pAllocateArray : Optional[CUDA_ARRAY_DESCRIPTOR]):
     :py:obj:`~.cuArray3DCreate`, :py:obj:`~.cuArray3DGetDescriptor`, :py:obj:`~.cuArrayDestroy`, :py:obj:`~.cuArrayGetDescriptor`, :py:obj:`~.cuMemAlloc`, :py:obj:`~.cuMemAllocHost`, :py:obj:`~.cuMemAllocPitch`, :py:obj:`~.cuMemcpy2D`, :py:obj:`~.cuMemcpy2DAsync`, :py:obj:`~.cuMemcpy2DUnaligned`, :py:obj:`~.cuMemcpy3D`, :py:obj:`~.cuMemcpy3DAsync`, :py:obj:`~.cuMemcpyAtoA`, :py:obj:`~.cuMemcpyAtoD`, :py:obj:`~.cuMemcpyAtoH`, :py:obj:`~.cuMemcpyAtoHAsync`, :py:obj:`~.cuMemcpyDtoA`, :py:obj:`~.cuMemcpyDtoD`, :py:obj:`~.cuMemcpyDtoDAsync`, :py:obj:`~.cuMemcpyDtoH`, :py:obj:`~.cuMemcpyDtoHAsync`, :py:obj:`~.cuMemcpyHtoA`, :py:obj:`~.cuMemcpyHtoAAsync`, :py:obj:`~.cuMemcpyHtoD`, :py:obj:`~.cuMemcpyHtoDAsync`, :py:obj:`~.cuMemFree`, :py:obj:`~.cuMemFreeHost`, :py:obj:`~.cuMemGetAddressRange`, :py:obj:`~.cuMemGetInfo`, :py:obj:`~.cuMemHostAlloc`, :py:obj:`~.cuMemHostGetDevicePointer`, :py:obj:`~.cuMemsetD2D8`, :py:obj:`~.cuMemsetD2D16`, :py:obj:`~.cuMemsetD2D32`, :py:obj:`~.cuMemsetD8`, :py:obj:`~.cuMemsetD16`, :py:obj:`~.cuMemsetD32`, :py:obj:`~.cudaMallocArray`
     """
     cdef CUarray pHandle = CUarray()
-    cdef cydriver.CUDA_ARRAY_DESCRIPTOR* cypAllocateArray_ptr = pAllocateArray._pvt_ptr if pAllocateArray is not None else NULL
+    cdef cydriver.CUDA_ARRAY_DESCRIPTOR* cypAllocateArray_ptr = <cydriver.CUDA_ARRAY_DESCRIPTOR*>pAllocateArray._pvt_ptr if pAllocateArray is not None else NULL
     with nogil:
         err = cydriver.cuArrayCreate(<cydriver.CUarray*>pHandle._pvt_ptr, cypAllocateArray_ptr)
     if err != cydriver.CUDA_SUCCESS:
@@ -35245,7 +35245,7 @@ def cuArray3DCreate(pAllocateArray : Optional[CUDA_ARRAY3D_DESCRIPTOR]):
     :py:obj:`~.cuArray3DGetDescriptor`, :py:obj:`~.cuArrayCreate`, :py:obj:`~.cuArrayDestroy`, :py:obj:`~.cuArrayGetDescriptor`, :py:obj:`~.cuMemAlloc`, :py:obj:`~.cuMemAllocHost`, :py:obj:`~.cuMemAllocPitch`, :py:obj:`~.cuMemcpy2D`, :py:obj:`~.cuMemcpy2DAsync`, :py:obj:`~.cuMemcpy2DUnaligned`, :py:obj:`~.cuMemcpy3D`, :py:obj:`~.cuMemcpy3DAsync`, :py:obj:`~.cuMemcpyAtoA`, :py:obj:`~.cuMemcpyAtoD`, :py:obj:`~.cuMemcpyAtoH`, :py:obj:`~.cuMemcpyAtoHAsync`, :py:obj:`~.cuMemcpyDtoA`, :py:obj:`~.cuMemcpyDtoD`, :py:obj:`~.cuMemcpyDtoDAsync`, :py:obj:`~.cuMemcpyDtoH`, :py:obj:`~.cuMemcpyDtoHAsync`, :py:obj:`~.cuMemcpyHtoA`, :py:obj:`~.cuMemcpyHtoAAsync`, :py:obj:`~.cuMemcpyHtoD`, :py:obj:`~.cuMemcpyHtoDAsync`, :py:obj:`~.cuMemFree`, :py:obj:`~.cuMemFreeHost`, :py:obj:`~.cuMemGetAddressRange`, :py:obj:`~.cuMemGetInfo`, :py:obj:`~.cuMemHostAlloc`, :py:obj:`~.cuMemHostGetDevicePointer`, :py:obj:`~.cuMemsetD2D8`, :py:obj:`~.cuMemsetD2D16`, :py:obj:`~.cuMemsetD2D32`, :py:obj:`~.cuMemsetD8`, :py:obj:`~.cuMemsetD16`, :py:obj:`~.cuMemsetD32`, :py:obj:`~.cudaMalloc3DArray`
     """
     cdef CUarray pHandle = CUarray()
-    cdef cydriver.CUDA_ARRAY3D_DESCRIPTOR* cypAllocateArray_ptr = pAllocateArray._pvt_ptr if pAllocateArray is not None else NULL
+    cdef cydriver.CUDA_ARRAY3D_DESCRIPTOR* cypAllocateArray_ptr = <cydriver.CUDA_ARRAY3D_DESCRIPTOR*>pAllocateArray._pvt_ptr if pAllocateArray is not None else NULL
     with nogil:
         err = cydriver.cuArray3DCreate(<cydriver.CUarray*>pHandle._pvt_ptr, cypAllocateArray_ptr)
     if err != cydriver.CUDA_SUCCESS:
@@ -35415,7 +35415,7 @@ def cuMipmappedArrayCreate(pMipmappedArrayDesc : Optional[CUDA_ARRAY3D_DESCRIPTO
     :py:obj:`~.cuMipmappedArrayDestroy`, :py:obj:`~.cuMipmappedArrayGetLevel`, :py:obj:`~.cuArrayCreate`, :py:obj:`~.cudaMallocMipmappedArray`
     """
     cdef CUmipmappedArray pHandle = CUmipmappedArray()
-    cdef cydriver.CUDA_ARRAY3D_DESCRIPTOR* cypMipmappedArrayDesc_ptr = pMipmappedArrayDesc._pvt_ptr if pMipmappedArrayDesc is not None else NULL
+    cdef cydriver.CUDA_ARRAY3D_DESCRIPTOR* cypMipmappedArrayDesc_ptr = <cydriver.CUDA_ARRAY3D_DESCRIPTOR*>pMipmappedArrayDesc._pvt_ptr if pMipmappedArrayDesc is not None else NULL
     with nogil:
         err = cydriver.cuMipmappedArrayCreate(<cydriver.CUmipmappedArray*>pHandle._pvt_ptr, cypMipmappedArrayDesc_ptr, numMipmapLevels)
     if err != cydriver.CUDA_SUCCESS:
@@ -35662,7 +35662,7 @@ def cuMemBatchDecompressAsync(paramsArray : Optional[CUmemDecompressParams], siz
     else:
         pstream = int(CUstream(stream))
     cystream = <cydriver.CUstream><void_ptr>pstream
-    cdef cydriver.CUmemDecompressParams* cyparamsArray_ptr = paramsArray._pvt_ptr if paramsArray is not None else NULL
+    cdef cydriver.CUmemDecompressParams* cyparamsArray_ptr = <cydriver.CUmemDecompressParams*>paramsArray._pvt_ptr if paramsArray is not None else NULL
     cdef size_t errorIndex = 0
     with nogil:
         err = cydriver.cuMemBatchDecompressAsync(cyparamsArray_ptr, count, flags, &errorIndex, cystream)
@@ -35848,7 +35848,7 @@ def cuMemCreate(size_t size, prop : Optional[CUmemAllocationProp], unsigned long
     :py:obj:`~.cuMemRelease`, :py:obj:`~.cuMemExportToShareableHandle`, :py:obj:`~.cuMemImportFromShareableHandle`
     """
     cdef CUmemGenericAllocationHandle handle = CUmemGenericAllocationHandle()
-    cdef cydriver.CUmemAllocationProp* cyprop_ptr = prop._pvt_ptr if prop is not None else NULL
+    cdef cydriver.CUmemAllocationProp* cyprop_ptr = <cydriver.CUmemAllocationProp*>prop._pvt_ptr if prop is not None else NULL
     with nogil:
         err = cydriver.cuMemCreate(<cydriver.CUmemGenericAllocationHandle*>handle._pvt_ptr, size, cyprop_ptr, flags)
     if err != cydriver.CUDA_SUCCESS:
@@ -36310,7 +36310,7 @@ def cuMemGetAccess(location : Optional[CUmemLocation], ptr):
         pptr = int(CUdeviceptr(ptr))
     cyptr = <cydriver.CUdeviceptr><void_ptr>pptr
     cdef unsigned long long flags = 0
-    cdef cydriver.CUmemLocation* cylocation_ptr = location._pvt_ptr if location is not None else NULL
+    cdef cydriver.CUmemLocation* cylocation_ptr = <cydriver.CUmemLocation*>location._pvt_ptr if location is not None else NULL
     with nogil:
         err = cydriver.cuMemGetAccess(&flags, cylocation_ptr, cyptr)
     if err != cydriver.CUDA_SUCCESS:
@@ -36459,7 +36459,7 @@ def cuMemGetAllocationGranularity(prop : Optional[CUmemAllocationProp], option n
     :py:obj:`~.cuMemCreate`, :py:obj:`~.cuMemMap`
     """
     cdef size_t granularity = 0
-    cdef cydriver.CUmemAllocationProp* cyprop_ptr = prop._pvt_ptr if prop is not None else NULL
+    cdef cydriver.CUmemAllocationProp* cyprop_ptr = <cydriver.CUmemAllocationProp*>prop._pvt_ptr if prop is not None else NULL
     cdef cydriver.CUmemAllocationGranularity_flags cyoption = int(option)
     with nogil:
         err = cydriver.cuMemGetAllocationGranularity(&granularity, cyprop_ptr, cyoption)
@@ -36976,7 +36976,7 @@ def cuMemPoolGetAccess(memPool, location : Optional[CUmemLocation]):
         pmemPool = int(CUmemoryPool(memPool))
     cymemPool = <cydriver.CUmemoryPool><void_ptr>pmemPool
     cdef cydriver.CUmemAccess_flags flags
-    cdef cydriver.CUmemLocation* cylocation_ptr = location._pvt_ptr if location is not None else NULL
+    cdef cydriver.CUmemLocation* cylocation_ptr = <cydriver.CUmemLocation*>location._pvt_ptr if location is not None else NULL
     with nogil:
         err = cydriver.cuMemPoolGetAccess(&flags, cymemPool, cylocation_ptr)
     if err != cydriver.CUDA_SUCCESS:
@@ -37075,7 +37075,7 @@ def cuMemPoolCreate(poolProps : Optional[CUmemPoolProps]):
     Specifying CU_MEM_HANDLE_TYPE_NONE creates a memory pool that will not support IPC.
     """
     cdef CUmemoryPool pool = CUmemoryPool()
-    cdef cydriver.CUmemPoolProps* cypoolProps_ptr = poolProps._pvt_ptr if poolProps is not None else NULL
+    cdef cydriver.CUmemPoolProps* cypoolProps_ptr = <cydriver.CUmemPoolProps*>poolProps._pvt_ptr if poolProps is not None else NULL
     with nogil:
         err = cydriver.cuMemPoolCreate(<cydriver.CUmemoryPool*>pool._pvt_ptr, cypoolProps_ptr)
     if err != cydriver.CUDA_SUCCESS:
@@ -37165,7 +37165,7 @@ def cuMemGetDefaultMemPool(location : Optional[CUmemLocation], typename not None
     :py:obj:`~.cuMemAllocAsync`, :py:obj:`~.cuMemPoolTrimTo`, :py:obj:`~.cuMemPoolGetAttribute`, :py:obj:`~.cuMemPoolSetAttribute`, :py:obj:`~.cuMemPoolSetAccess`, :py:obj:`~.cuMemGetMemPool`, :py:obj:`~.cuMemPoolCreate`
     """
     cdef CUmemoryPool pool_out = CUmemoryPool()
-    cdef cydriver.CUmemLocation* cylocation_ptr = location._pvt_ptr if location is not None else NULL
+    cdef cydriver.CUmemLocation* cylocation_ptr = <cydriver.CUmemLocation*>location._pvt_ptr if location is not None else NULL
     cdef cydriver.CUmemAllocationType cytypename = int(typename)
     with nogil:
         err = cydriver.cuMemGetDefaultMemPool(<cydriver.CUmemoryPool*>pool_out._pvt_ptr, cylocation_ptr, cytypename)
@@ -37218,7 +37218,7 @@ def cuMemGetMemPool(location : Optional[CUmemLocation], typename not None : CUme
     :py:obj:`~.cuDeviceGetDefaultMemPool`, :py:obj:`~.cuMemPoolCreate`, :py:obj:`~.cuDeviceSetMemPool`, :py:obj:`~.cuMemSetMemPool`
     """
     cdef CUmemoryPool pool = CUmemoryPool()
-    cdef cydriver.CUmemLocation* cylocation_ptr = location._pvt_ptr if location is not None else NULL
+    cdef cydriver.CUmemLocation* cylocation_ptr = <cydriver.CUmemLocation*>location._pvt_ptr if location is not None else NULL
     cdef cydriver.CUmemAllocationType cytypename = int(typename)
     with nogil:
         err = cydriver.cuMemGetMemPool(<cydriver.CUmemoryPool*>pool._pvt_ptr, cylocation_ptr, cytypename)
@@ -37286,7 +37286,7 @@ def cuMemSetMemPool(location : Optional[CUmemLocation], typename not None : CUme
     else:
         ppool = int(CUmemoryPool(pool))
     cypool = <cydriver.CUmemoryPool><void_ptr>ppool
-    cdef cydriver.CUmemLocation* cylocation_ptr = location._pvt_ptr if location is not None else NULL
+    cdef cydriver.CUmemLocation* cylocation_ptr = <cydriver.CUmemLocation*>location._pvt_ptr if location is not None else NULL
     cdef cydriver.CUmemAllocationType cytypename = int(typename)
     with nogil:
         err = cydriver.cuMemSetMemPool(cylocation_ptr, cytypename, cypool)
@@ -37547,7 +37547,7 @@ def cuMemPoolImportPointer(pool, shareData : Optional[CUmemPoolPtrExportData]):
         ppool = int(CUmemoryPool(pool))
     cypool = <cydriver.CUmemoryPool><void_ptr>ppool
     cdef CUdeviceptr ptr_out = CUdeviceptr()
-    cdef cydriver.CUmemPoolPtrExportData* cyshareData_ptr = shareData._pvt_ptr if shareData is not None else NULL
+    cdef cydriver.CUmemPoolPtrExportData* cyshareData_ptr = <cydriver.CUmemPoolPtrExportData*>shareData._pvt_ptr if shareData is not None else NULL
     with nogil:
         err = cydriver.cuMemPoolImportPointer(<cydriver.CUdeviceptr*>ptr_out._pvt_ptr, cypool, cyshareData_ptr)
     if err != cydriver.CUDA_SUCCESS:
@@ -37610,7 +37610,7 @@ def cuMulticastCreate(prop : Optional[CUmulticastObjectProp]):
     :py:obj:`~.cuMulticastBindAddr_v2`, :py:obj:`~.cuMulticastBindMem_v2`
     """
     cdef CUmemGenericAllocationHandle mcHandle = CUmemGenericAllocationHandle()
-    cdef cydriver.CUmulticastObjectProp* cyprop_ptr = prop._pvt_ptr if prop is not None else NULL
+    cdef cydriver.CUmulticastObjectProp* cyprop_ptr = <cydriver.CUmulticastObjectProp*>prop._pvt_ptr if prop is not None else NULL
     with nogil:
         err = cydriver.cuMulticastCreate(<cydriver.CUmemGenericAllocationHandle*>mcHandle._pvt_ptr, cyprop_ptr)
     if err != cydriver.CUDA_SUCCESS:
@@ -38132,7 +38132,7 @@ def cuMulticastGetGranularity(prop : Optional[CUmulticastObjectProp], option not
     :py:obj:`~.cuMulticastBindMem_v2`, :py:obj:`~.cuMulticastBindAddr_v2`
     """
     cdef size_t granularity = 0
-    cdef cydriver.CUmulticastObjectProp* cyprop_ptr = prop._pvt_ptr if prop is not None else NULL
+    cdef cydriver.CUmulticastObjectProp* cyprop_ptr = <cydriver.CUmulticastObjectProp*>prop._pvt_ptr if prop is not None else NULL
     cdef cydriver.CUmulticastGranularity_flags cyoption = int(option)
     with nogil:
         err = cydriver.cuMulticastGetGranularity(&granularity, cyprop_ptr, cyoption)
@@ -39589,7 +39589,7 @@ def cuStreamBeginCaptureToCig(hStream, streamCigCaptureParams : Optional[CUstrea
     else:
         phStream = int(CUstream(hStream))
     cyhStream = <cydriver.CUstream><void_ptr>phStream
-    cdef cydriver.CUstreamCigCaptureParams* cystreamCigCaptureParams_ptr = streamCigCaptureParams._pvt_ptr if streamCigCaptureParams is not None else NULL
+    cdef cydriver.CUstreamCigCaptureParams* cystreamCigCaptureParams_ptr = <cydriver.CUstreamCigCaptureParams*>streamCigCaptureParams._pvt_ptr if streamCigCaptureParams is not None else NULL
     with nogil:
         err = cydriver.cuStreamBeginCaptureToCig(cyhStream, cystreamCigCaptureParams_ptr)
     return (_CUresult(err),)
@@ -41046,7 +41046,7 @@ def cuStreamSetAttribute(hStream, attr not None : CUstreamAttrID, value : Option
         phStream = int(CUstream(hStream))
     cyhStream = <cydriver.CUstream><void_ptr>phStream
     cdef cydriver.CUstreamAttrID cyattr = int(attr)
-    cdef cydriver.CUstreamAttrValue* cyvalue_ptr = value._pvt_ptr if value is not None else NULL
+    cdef cydriver.CUstreamAttrValue* cyvalue_ptr = <cydriver.CUstreamAttrValue*>value._pvt_ptr if value is not None else NULL
     with nogil:
         err = cydriver.cuStreamSetAttribute(cyhStream, cyattr, cyvalue_ptr)
     return (_CUresult(err),)
@@ -41589,7 +41589,7 @@ def cuImportExternalMemory(memHandleDesc : Optional[CUDA_EXTERNAL_MEMORY_HANDLE_
     and Cache Control" chapter from Vulkan specification.
     """
     cdef CUexternalMemory extMem_out = CUexternalMemory()
-    cdef cydriver.CUDA_EXTERNAL_MEMORY_HANDLE_DESC* cymemHandleDesc_ptr = memHandleDesc._pvt_ptr if memHandleDesc is not None else NULL
+    cdef cydriver.CUDA_EXTERNAL_MEMORY_HANDLE_DESC* cymemHandleDesc_ptr = <cydriver.CUDA_EXTERNAL_MEMORY_HANDLE_DESC*>memHandleDesc._pvt_ptr if memHandleDesc is not None else NULL
     with nogil:
         err = cydriver.cuImportExternalMemory(<cydriver.CUexternalMemory*>extMem_out._pvt_ptr, cymemHandleDesc_ptr)
     if err != cydriver.CUDA_SUCCESS:
@@ -41659,7 +41659,7 @@ def cuExternalMemoryGetMappedBuffer(extMem, bufferDesc : Optional[CUDA_EXTERNAL_
         pextMem = int(CUexternalMemory(extMem))
     cyextMem = <cydriver.CUexternalMemory><void_ptr>pextMem
     cdef CUdeviceptr devPtr = CUdeviceptr()
-    cdef cydriver.CUDA_EXTERNAL_MEMORY_BUFFER_DESC* cybufferDesc_ptr = bufferDesc._pvt_ptr if bufferDesc is not None else NULL
+    cdef cydriver.CUDA_EXTERNAL_MEMORY_BUFFER_DESC* cybufferDesc_ptr = <cydriver.CUDA_EXTERNAL_MEMORY_BUFFER_DESC*>bufferDesc._pvt_ptr if bufferDesc is not None else NULL
     with nogil:
         err = cydriver.cuExternalMemoryGetMappedBuffer(<cydriver.CUdeviceptr*>devPtr._pvt_ptr, cyextMem, cybufferDesc_ptr)
     if err != cydriver.CUDA_SUCCESS:
@@ -41735,7 +41735,7 @@ def cuExternalMemoryGetMappedMipmappedArray(extMem, mipmapDesc : Optional[CUDA_E
         pextMem = int(CUexternalMemory(extMem))
     cyextMem = <cydriver.CUexternalMemory><void_ptr>pextMem
     cdef CUmipmappedArray mipmap = CUmipmappedArray()
-    cdef cydriver.CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC* cymipmapDesc_ptr = mipmapDesc._pvt_ptr if mipmapDesc is not None else NULL
+    cdef cydriver.CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC* cymipmapDesc_ptr = <cydriver.CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC*>mipmapDesc._pvt_ptr if mipmapDesc is not None else NULL
     with nogil:
         err = cydriver.cuExternalMemoryGetMappedMipmappedArray(<cydriver.CUmipmappedArray*>mipmap._pvt_ptr, cyextMem, cymipmapDesc_ptr)
     if err != cydriver.CUDA_SUCCESS:
@@ -41921,7 +41921,7 @@ def cuImportExternalSemaphore(semHandleDesc : Optional[CUDA_EXTERNAL_SEMAPHORE_H
     :py:obj:`~.cuDestroyExternalSemaphore`, :py:obj:`~.cuSignalExternalSemaphoresAsync`, :py:obj:`~.cuWaitExternalSemaphoresAsync`
     """
     cdef CUexternalSemaphore extSem_out = CUexternalSemaphore()
-    cdef cydriver.CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC* cysemHandleDesc_ptr = semHandleDesc._pvt_ptr if semHandleDesc is not None else NULL
+    cdef cydriver.CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC* cysemHandleDesc_ptr = <cydriver.CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC*>semHandleDesc._pvt_ptr if semHandleDesc is not None else NULL
     with nogil:
         err = cydriver.cuImportExternalSemaphore(<cydriver.CUexternalSemaphore*>extSem_out._pvt_ptr, cysemHandleDesc_ptr)
     if err != cydriver.CUDA_SUCCESS:
@@ -43514,7 +43514,7 @@ def cuLaunchKernelEx(config : Optional[CUlaunchConfig], f, kernelParams, void_pt
     else:
         pf = int(CUfunction(f))
     cyf = <cydriver.CUfunction><void_ptr>pf
-    cdef cydriver.CUlaunchConfig* cyconfig_ptr = config._pvt_ptr if config is not None else NULL
+    cdef cydriver.CUlaunchConfig* cyconfig_ptr = <cydriver.CUlaunchConfig*>config._pvt_ptr if config is not None else NULL
     cykernelParams = _HelperKernelParams(kernelParams)
     cdef void** cykernelParams_ptr = <void**><void_ptr>cykernelParams.ckernelParams
     with nogil:
@@ -44712,7 +44712,7 @@ def cuGraphAddKernelNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | li
     elif len(dependencies) == 1:
         cydependencies = <cydriver.CUgraphNode*>(<CUgraphNode>dependencies[0])._pvt_ptr
     if numDependencies > <size_t>len(dependencies): raise RuntimeError("List is too small: " + str(len(dependencies)) + " < " + str(numDependencies))
-    cdef cydriver.CUDA_KERNEL_NODE_PARAMS* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUDA_KERNEL_NODE_PARAMS* cynodeParams_ptr = <cydriver.CUDA_KERNEL_NODE_PARAMS*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphAddKernelNode(<cydriver.CUgraphNode*>phGraphNode._pvt_ptr, cyhGraph, cydependencies, numDependencies, cynodeParams_ptr)
     if len(dependencies) > 1 and cydependencies is not NULL:
@@ -44803,7 +44803,7 @@ def cuGraphKernelNodeSetParams(hNode, nodeParams : Optional[CUDA_KERNEL_NODE_PAR
     else:
         phNode = int(CUgraphNode(hNode))
     cyhNode = <cydriver.CUgraphNode><void_ptr>phNode
-    cdef cydriver.CUDA_KERNEL_NODE_PARAMS* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUDA_KERNEL_NODE_PARAMS* cynodeParams_ptr = <cydriver.CUDA_KERNEL_NODE_PARAMS*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphKernelNodeSetParams(cyhNode, cynodeParams_ptr)
     return (_CUresult(err),)
@@ -44890,7 +44890,7 @@ def cuGraphAddMemcpyNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | li
     elif len(dependencies) == 1:
         cydependencies = <cydriver.CUgraphNode*>(<CUgraphNode>dependencies[0])._pvt_ptr
     if numDependencies > <size_t>len(dependencies): raise RuntimeError("List is too small: " + str(len(dependencies)) + " < " + str(numDependencies))
-    cdef cydriver.CUDA_MEMCPY3D* cycopyParams_ptr = copyParams._pvt_ptr if copyParams is not None else NULL
+    cdef cydriver.CUDA_MEMCPY3D* cycopyParams_ptr = <cydriver.CUDA_MEMCPY3D*>copyParams._pvt_ptr if copyParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphAddMemcpyNode(<cydriver.CUgraphNode*>phGraphNode._pvt_ptr, cyhGraph, cydependencies, numDependencies, cycopyParams_ptr, cyctx)
     if len(dependencies) > 1 and cydependencies is not NULL:
@@ -44972,7 +44972,7 @@ def cuGraphMemcpyNodeSetParams(hNode, nodeParams : Optional[CUDA_MEMCPY3D]):
     else:
         phNode = int(CUgraphNode(hNode))
     cyhNode = <cydriver.CUgraphNode><void_ptr>phNode
-    cdef cydriver.CUDA_MEMCPY3D* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUDA_MEMCPY3D* cynodeParams_ptr = <cydriver.CUDA_MEMCPY3D*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphMemcpyNodeSetParams(cyhNode, cynodeParams_ptr)
     return (_CUresult(err),)
@@ -45049,7 +45049,7 @@ def cuGraphAddMemsetNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | li
     elif len(dependencies) == 1:
         cydependencies = <cydriver.CUgraphNode*>(<CUgraphNode>dependencies[0])._pvt_ptr
     if numDependencies > <size_t>len(dependencies): raise RuntimeError("List is too small: " + str(len(dependencies)) + " < " + str(numDependencies))
-    cdef cydriver.CUDA_MEMSET_NODE_PARAMS* cymemsetParams_ptr = memsetParams._pvt_ptr if memsetParams is not None else NULL
+    cdef cydriver.CUDA_MEMSET_NODE_PARAMS* cymemsetParams_ptr = <cydriver.CUDA_MEMSET_NODE_PARAMS*>memsetParams._pvt_ptr if memsetParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphAddMemsetNode(<cydriver.CUgraphNode*>phGraphNode._pvt_ptr, cyhGraph, cydependencies, numDependencies, cymemsetParams_ptr, cyctx)
     if len(dependencies) > 1 and cydependencies is not NULL:
@@ -45131,7 +45131,7 @@ def cuGraphMemsetNodeSetParams(hNode, nodeParams : Optional[CUDA_MEMSET_NODE_PAR
     else:
         phNode = int(CUgraphNode(hNode))
     cyhNode = <cydriver.CUgraphNode><void_ptr>phNode
-    cdef cydriver.CUDA_MEMSET_NODE_PARAMS* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUDA_MEMSET_NODE_PARAMS* cynodeParams_ptr = <cydriver.CUDA_MEMSET_NODE_PARAMS*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphMemsetNodeSetParams(cyhNode, cynodeParams_ptr)
     return (_CUresult(err),)
@@ -45198,7 +45198,7 @@ def cuGraphAddHostNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | list
     elif len(dependencies) == 1:
         cydependencies = <cydriver.CUgraphNode*>(<CUgraphNode>dependencies[0])._pvt_ptr
     if numDependencies > <size_t>len(dependencies): raise RuntimeError("List is too small: " + str(len(dependencies)) + " < " + str(numDependencies))
-    cdef cydriver.CUDA_HOST_NODE_PARAMS* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUDA_HOST_NODE_PARAMS* cynodeParams_ptr = <cydriver.CUDA_HOST_NODE_PARAMS*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphAddHostNode(<cydriver.CUgraphNode*>phGraphNode._pvt_ptr, cyhGraph, cydependencies, numDependencies, cynodeParams_ptr)
     if len(dependencies) > 1 and cydependencies is not NULL:
@@ -45280,7 +45280,7 @@ def cuGraphHostNodeSetParams(hNode, nodeParams : Optional[CUDA_HOST_NODE_PARAMS]
     else:
         phNode = int(CUgraphNode(hNode))
     cyhNode = <cydriver.CUgraphNode><void_ptr>phNode
-    cdef cydriver.CUDA_HOST_NODE_PARAMS* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUDA_HOST_NODE_PARAMS* cynodeParams_ptr = <cydriver.CUDA_HOST_NODE_PARAMS*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphHostNodeSetParams(cyhNode, cynodeParams_ptr)
     return (_CUresult(err),)
@@ -45873,7 +45873,7 @@ def cuGraphAddExternalSemaphoresSignalNode(hGraph, dependencies : Optional[tuple
     elif len(dependencies) == 1:
         cydependencies = <cydriver.CUgraphNode*>(<CUgraphNode>dependencies[0])._pvt_ptr
     if numDependencies > <size_t>len(dependencies): raise RuntimeError("List is too small: " + str(len(dependencies)) + " < " + str(numDependencies))
-    cdef cydriver.CUDA_EXT_SEM_SIGNAL_NODE_PARAMS* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUDA_EXT_SEM_SIGNAL_NODE_PARAMS* cynodeParams_ptr = <cydriver.CUDA_EXT_SEM_SIGNAL_NODE_PARAMS*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphAddExternalSemaphoresSignalNode(<cydriver.CUgraphNode*>phGraphNode._pvt_ptr, cyhGraph, cydependencies, numDependencies, cynodeParams_ptr)
     if len(dependencies) > 1 and cydependencies is not NULL:
@@ -45962,7 +45962,7 @@ def cuGraphExternalSemaphoresSignalNodeSetParams(hNode, nodeParams : Optional[CU
     else:
         phNode = int(CUgraphNode(hNode))
     cyhNode = <cydriver.CUgraphNode><void_ptr>phNode
-    cdef cydriver.CUDA_EXT_SEM_SIGNAL_NODE_PARAMS* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUDA_EXT_SEM_SIGNAL_NODE_PARAMS* cynodeParams_ptr = <cydriver.CUDA_EXT_SEM_SIGNAL_NODE_PARAMS*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphExternalSemaphoresSignalNodeSetParams(cyhNode, cynodeParams_ptr)
     return (_CUresult(err),)
@@ -46030,7 +46030,7 @@ def cuGraphAddExternalSemaphoresWaitNode(hGraph, dependencies : Optional[tuple[C
     elif len(dependencies) == 1:
         cydependencies = <cydriver.CUgraphNode*>(<CUgraphNode>dependencies[0])._pvt_ptr
     if numDependencies > <size_t>len(dependencies): raise RuntimeError("List is too small: " + str(len(dependencies)) + " < " + str(numDependencies))
-    cdef cydriver.CUDA_EXT_SEM_WAIT_NODE_PARAMS* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUDA_EXT_SEM_WAIT_NODE_PARAMS* cynodeParams_ptr = <cydriver.CUDA_EXT_SEM_WAIT_NODE_PARAMS*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphAddExternalSemaphoresWaitNode(<cydriver.CUgraphNode*>phGraphNode._pvt_ptr, cyhGraph, cydependencies, numDependencies, cynodeParams_ptr)
     if len(dependencies) > 1 and cydependencies is not NULL:
@@ -46119,7 +46119,7 @@ def cuGraphExternalSemaphoresWaitNodeSetParams(hNode, nodeParams : Optional[CUDA
     else:
         phNode = int(CUgraphNode(hNode))
     cyhNode = <cydriver.CUgraphNode><void_ptr>phNode
-    cdef cydriver.CUDA_EXT_SEM_WAIT_NODE_PARAMS* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUDA_EXT_SEM_WAIT_NODE_PARAMS* cynodeParams_ptr = <cydriver.CUDA_EXT_SEM_WAIT_NODE_PARAMS*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphExternalSemaphoresWaitNodeSetParams(cyhNode, cynodeParams_ptr)
     return (_CUresult(err),)
@@ -46190,7 +46190,7 @@ def cuGraphAddBatchMemOpNode(hGraph, dependencies : Optional[tuple[CUgraphNode] 
     elif len(dependencies) == 1:
         cydependencies = <cydriver.CUgraphNode*>(<CUgraphNode>dependencies[0])._pvt_ptr
     if numDependencies > <size_t>len(dependencies): raise RuntimeError("List is too small: " + str(len(dependencies)) + " < " + str(numDependencies))
-    cdef cydriver.CUDA_BATCH_MEM_OP_NODE_PARAMS* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUDA_BATCH_MEM_OP_NODE_PARAMS* cynodeParams_ptr = <cydriver.CUDA_BATCH_MEM_OP_NODE_PARAMS*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphAddBatchMemOpNode(<cydriver.CUgraphNode*>phGraphNode._pvt_ptr, cyhGraph, cydependencies, numDependencies, cynodeParams_ptr)
     if len(dependencies) > 1 and cydependencies is not NULL:
@@ -46280,7 +46280,7 @@ def cuGraphBatchMemOpNodeSetParams(hNode, nodeParams : Optional[CUDA_BATCH_MEM_O
     else:
         phNode = int(CUgraphNode(hNode))
     cyhNode = <cydriver.CUgraphNode><void_ptr>phNode
-    cdef cydriver.CUDA_BATCH_MEM_OP_NODE_PARAMS* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUDA_BATCH_MEM_OP_NODE_PARAMS* cynodeParams_ptr = <cydriver.CUDA_BATCH_MEM_OP_NODE_PARAMS*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphBatchMemOpNodeSetParams(cyhNode, cynodeParams_ptr)
     return (_CUresult(err),)
@@ -46351,7 +46351,7 @@ def cuGraphExecBatchMemOpNodeSetParams(hGraphExec, hNode, nodeParams : Optional[
     else:
         phGraphExec = int(CUgraphExec(hGraphExec))
     cyhGraphExec = <cydriver.CUgraphExec><void_ptr>phGraphExec
-    cdef cydriver.CUDA_BATCH_MEM_OP_NODE_PARAMS* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUDA_BATCH_MEM_OP_NODE_PARAMS* cynodeParams_ptr = <cydriver.CUDA_BATCH_MEM_OP_NODE_PARAMS*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphExecBatchMemOpNodeSetParams(cyhGraphExec, cyhNode, cynodeParams_ptr)
     return (_CUresult(err),)
@@ -46459,7 +46459,7 @@ def cuGraphAddMemAllocNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | 
     elif len(dependencies) == 1:
         cydependencies = <cydriver.CUgraphNode*>(<CUgraphNode>dependencies[0])._pvt_ptr
     if numDependencies > <size_t>len(dependencies): raise RuntimeError("List is too small: " + str(len(dependencies)) + " < " + str(numDependencies))
-    cdef cydriver.CUDA_MEM_ALLOC_NODE_PARAMS* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUDA_MEM_ALLOC_NODE_PARAMS* cynodeParams_ptr = <cydriver.CUDA_MEM_ALLOC_NODE_PARAMS*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphAddMemAllocNode(<cydriver.CUgraphNode*>phGraphNode._pvt_ptr, cyhGraph, cydependencies, numDependencies, cynodeParams_ptr)
     if len(dependencies) > 1 and cydependencies is not NULL:
@@ -47980,7 +47980,7 @@ def cuGraphInstantiateWithParams(hGraph, instantiateParams : Optional[CUDA_GRAPH
         phGraph = int(CUgraph(hGraph))
     cyhGraph = <cydriver.CUgraph><void_ptr>phGraph
     cdef CUgraphExec phGraphExec = CUgraphExec()
-    cdef cydriver.CUDA_GRAPH_INSTANTIATE_PARAMS* cyinstantiateParams_ptr = instantiateParams._pvt_ptr if instantiateParams is not None else NULL
+    cdef cydriver.CUDA_GRAPH_INSTANTIATE_PARAMS* cyinstantiateParams_ptr = <cydriver.CUDA_GRAPH_INSTANTIATE_PARAMS*>instantiateParams._pvt_ptr if instantiateParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphInstantiateWithParams(<cydriver.CUgraphExec*>phGraphExec._pvt_ptr, cyhGraph, cyinstantiateParams_ptr)
     if err != cydriver.CUDA_SUCCESS:
@@ -48106,7 +48106,7 @@ def cuGraphExecKernelNodeSetParams(hGraphExec, hNode, nodeParams : Optional[CUDA
     else:
         phGraphExec = int(CUgraphExec(hGraphExec))
     cyhGraphExec = <cydriver.CUgraphExec><void_ptr>phGraphExec
-    cdef cydriver.CUDA_KERNEL_NODE_PARAMS* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUDA_KERNEL_NODE_PARAMS* cynodeParams_ptr = <cydriver.CUDA_KERNEL_NODE_PARAMS*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphExecKernelNodeSetParams(cyhGraphExec, cyhNode, cynodeParams_ptr)
     return (_CUresult(err),)
@@ -48181,7 +48181,7 @@ def cuGraphExecMemcpyNodeSetParams(hGraphExec, hNode, copyParams : Optional[CUDA
     else:
         phGraphExec = int(CUgraphExec(hGraphExec))
     cyhGraphExec = <cydriver.CUgraphExec><void_ptr>phGraphExec
-    cdef cydriver.CUDA_MEMCPY3D* cycopyParams_ptr = copyParams._pvt_ptr if copyParams is not None else NULL
+    cdef cydriver.CUDA_MEMCPY3D* cycopyParams_ptr = <cydriver.CUDA_MEMCPY3D*>copyParams._pvt_ptr if copyParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphExecMemcpyNodeSetParams(cyhGraphExec, cyhNode, cycopyParams_ptr, cyctx)
     return (_CUresult(err),)
@@ -48261,7 +48261,7 @@ def cuGraphExecMemsetNodeSetParams(hGraphExec, hNode, memsetParams : Optional[CU
     else:
         phGraphExec = int(CUgraphExec(hGraphExec))
     cyhGraphExec = <cydriver.CUgraphExec><void_ptr>phGraphExec
-    cdef cydriver.CUDA_MEMSET_NODE_PARAMS* cymemsetParams_ptr = memsetParams._pvt_ptr if memsetParams is not None else NULL
+    cdef cydriver.CUDA_MEMSET_NODE_PARAMS* cymemsetParams_ptr = <cydriver.CUDA_MEMSET_NODE_PARAMS*>memsetParams._pvt_ptr if memsetParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphExecMemsetNodeSetParams(cyhGraphExec, cyhNode, cymemsetParams_ptr, cyctx)
     return (_CUresult(err),)
@@ -48316,7 +48316,7 @@ def cuGraphExecHostNodeSetParams(hGraphExec, hNode, nodeParams : Optional[CUDA_H
     else:
         phGraphExec = int(CUgraphExec(hGraphExec))
     cyhGraphExec = <cydriver.CUgraphExec><void_ptr>phGraphExec
-    cdef cydriver.CUDA_HOST_NODE_PARAMS* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUDA_HOST_NODE_PARAMS* cynodeParams_ptr = <cydriver.CUDA_HOST_NODE_PARAMS*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphExecHostNodeSetParams(cyhGraphExec, cyhNode, cynodeParams_ptr)
     return (_CUresult(err),)
@@ -48572,7 +48572,7 @@ def cuGraphExecExternalSemaphoresSignalNodeSetParams(hGraphExec, hNode, nodePara
     else:
         phGraphExec = int(CUgraphExec(hGraphExec))
     cyhGraphExec = <cydriver.CUgraphExec><void_ptr>phGraphExec
-    cdef cydriver.CUDA_EXT_SEM_SIGNAL_NODE_PARAMS* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUDA_EXT_SEM_SIGNAL_NODE_PARAMS* cynodeParams_ptr = <cydriver.CUDA_EXT_SEM_SIGNAL_NODE_PARAMS*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphExecExternalSemaphoresSignalNodeSetParams(cyhGraphExec, cyhNode, cynodeParams_ptr)
     return (_CUresult(err),)
@@ -48632,7 +48632,7 @@ def cuGraphExecExternalSemaphoresWaitNodeSetParams(hGraphExec, hNode, nodeParams
     else:
         phGraphExec = int(CUgraphExec(hGraphExec))
     cyhGraphExec = <cydriver.CUgraphExec><void_ptr>phGraphExec
-    cdef cydriver.CUDA_EXT_SEM_WAIT_NODE_PARAMS* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUDA_EXT_SEM_WAIT_NODE_PARAMS* cynodeParams_ptr = <cydriver.CUDA_EXT_SEM_WAIT_NODE_PARAMS*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphExecExternalSemaphoresWaitNodeSetParams(cyhGraphExec, cyhNode, cynodeParams_ptr)
     return (_CUresult(err),)
@@ -49250,7 +49250,7 @@ def cuGraphKernelNodeSetAttribute(hNode, attr not None : CUkernelNodeAttrID, val
         phNode = int(CUgraphNode(hNode))
     cyhNode = <cydriver.CUgraphNode><void_ptr>phNode
     cdef cydriver.CUkernelNodeAttrID cyattr = int(attr)
-    cdef cydriver.CUkernelNodeAttrValue* cyvalue_ptr = value._pvt_ptr if value is not None else NULL
+    cdef cydriver.CUkernelNodeAttrValue* cyvalue_ptr = <cydriver.CUkernelNodeAttrValue*>value._pvt_ptr if value is not None else NULL
     with nogil:
         err = cydriver.cuGraphKernelNodeSetAttribute(cyhNode, cyattr, cyvalue_ptr)
     return (_CUresult(err),)
@@ -49637,7 +49637,7 @@ def cuGraphAddNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | list[CUg
             string.memcpy(&cydependencyData[idx], (<CUgraphEdgeData>dependencyData[idx])._pvt_ptr, sizeof(cydriver.CUgraphEdgeData))
     elif len(dependencyData) == 1:
         cydependencyData = (<CUgraphEdgeData>dependencyData[0])._pvt_ptr
-    cdef cydriver.CUgraphNodeParams* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUgraphNodeParams* cynodeParams_ptr = <cydriver.CUgraphNodeParams*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphAddNode(<cydriver.CUgraphNode*>phGraphNode._pvt_ptr, cyhGraph, cydependencies, cydependencyData, numDependencies, cynodeParams_ptr)
     if len(dependencies) > 1 and cydependencies is not NULL:
@@ -49687,7 +49687,7 @@ def cuGraphNodeSetParams(hNode, nodeParams : Optional[CUgraphNodeParams]):
     else:
         phNode = int(CUgraphNode(hNode))
     cyhNode = <cydriver.CUgraphNode><void_ptr>phNode
-    cdef cydriver.CUgraphNodeParams* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUgraphNodeParams* cynodeParams_ptr = <cydriver.CUgraphNodeParams*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphNodeSetParams(cyhNode, cynodeParams_ptr)
     return (_CUresult(err),)
@@ -49800,7 +49800,7 @@ def cuGraphExecNodeSetParams(hGraphExec, hNode, nodeParams : Optional[CUgraphNod
     else:
         phGraphExec = int(CUgraphExec(hGraphExec))
     cyhGraphExec = <cydriver.CUgraphExec><void_ptr>phGraphExec
-    cdef cydriver.CUgraphNodeParams* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cydriver.CUgraphNodeParams* cynodeParams_ptr = <cydriver.CUgraphNodeParams*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cydriver.cuGraphExecNodeSetParams(cyhGraphExec, cyhNode, cynodeParams_ptr)
     return (_CUresult(err),)
@@ -50263,7 +50263,7 @@ def cuOccupancyMaxPotentialClusterSize(func, config : Optional[CUlaunchConfig]):
         pfunc = int(CUfunction(func))
     cyfunc = <cydriver.CUfunction><void_ptr>pfunc
     cdef int clusterSize = 0
-    cdef cydriver.CUlaunchConfig* cyconfig_ptr = config._pvt_ptr if config is not None else NULL
+    cdef cydriver.CUlaunchConfig* cyconfig_ptr = <cydriver.CUlaunchConfig*>config._pvt_ptr if config is not None else NULL
     with nogil:
         err = cydriver.cuOccupancyMaxPotentialClusterSize(&clusterSize, cyfunc, cyconfig_ptr)
     if err != cydriver.CUDA_SUCCESS:
@@ -50323,7 +50323,7 @@ def cuOccupancyMaxActiveClusters(func, config : Optional[CUlaunchConfig]):
         pfunc = int(CUfunction(func))
     cyfunc = <cydriver.CUfunction><void_ptr>pfunc
     cdef int numClusters = 0
-    cdef cydriver.CUlaunchConfig* cyconfig_ptr = config._pvt_ptr if config is not None else NULL
+    cdef cydriver.CUlaunchConfig* cyconfig_ptr = <cydriver.CUlaunchConfig*>config._pvt_ptr if config is not None else NULL
     with nogil:
         err = cydriver.cuOccupancyMaxActiveClusters(&numClusters, cyfunc, cyconfig_ptr)
     if err != cydriver.CUDA_SUCCESS:
@@ -50587,7 +50587,7 @@ def cuTexRefSetAddress2D(hTexRef, desc : Optional[CUDA_ARRAY_DESCRIPTOR], dptr, 
     else:
         phTexRef = int(CUtexref(hTexRef))
     cyhTexRef = <cydriver.CUtexref><void_ptr>phTexRef
-    cdef cydriver.CUDA_ARRAY_DESCRIPTOR* cydesc_ptr = desc._pvt_ptr if desc is not None else NULL
+    cdef cydriver.CUDA_ARRAY_DESCRIPTOR* cydesc_ptr = <cydriver.CUDA_ARRAY_DESCRIPTOR*>desc._pvt_ptr if desc is not None else NULL
     with nogil:
         err = cydriver.cuTexRefSetAddress2D(cyhTexRef, cydesc_ptr, cydptr, Pitch)
     return (_CUresult(err),)
@@ -51957,9 +51957,9 @@ def cuTexObjectCreate(pResDesc : Optional[CUDA_RESOURCE_DESC], pTexDesc : Option
     :py:obj:`~.cuTexObjectDestroy`, :py:obj:`~.cudaCreateTextureObject`
     """
     cdef CUtexObject pTexObject = CUtexObject()
-    cdef cydriver.CUDA_RESOURCE_DESC* cypResDesc_ptr = pResDesc._pvt_ptr if pResDesc is not None else NULL
-    cdef cydriver.CUDA_TEXTURE_DESC* cypTexDesc_ptr = pTexDesc._pvt_ptr if pTexDesc is not None else NULL
-    cdef cydriver.CUDA_RESOURCE_VIEW_DESC* cypResViewDesc_ptr = pResViewDesc._pvt_ptr if pResViewDesc is not None else NULL
+    cdef cydriver.CUDA_RESOURCE_DESC* cypResDesc_ptr = <cydriver.CUDA_RESOURCE_DESC*>pResDesc._pvt_ptr if pResDesc is not None else NULL
+    cdef cydriver.CUDA_TEXTURE_DESC* cypTexDesc_ptr = <cydriver.CUDA_TEXTURE_DESC*>pTexDesc._pvt_ptr if pTexDesc is not None else NULL
+    cdef cydriver.CUDA_RESOURCE_VIEW_DESC* cypResViewDesc_ptr = <cydriver.CUDA_RESOURCE_VIEW_DESC*>pResViewDesc._pvt_ptr if pResViewDesc is not None else NULL
     with nogil:
         err = cydriver.cuTexObjectCreate(<cydriver.CUtexObject*>pTexObject._pvt_ptr, cypResDesc_ptr, cypTexDesc_ptr, cypResViewDesc_ptr)
     if err != cydriver.CUDA_SUCCESS:
@@ -52161,7 +52161,7 @@ def cuSurfObjectCreate(pResDesc : Optional[CUDA_RESOURCE_DESC]):
     :py:obj:`~.cuSurfObjectDestroy`, :py:obj:`~.cudaCreateSurfaceObject`
     """
     cdef CUsurfObject pSurfObject = CUsurfObject()
-    cdef cydriver.CUDA_RESOURCE_DESC* cypResDesc_ptr = pResDesc._pvt_ptr if pResDesc is not None else NULL
+    cdef cydriver.CUDA_RESOURCE_DESC* cypResDesc_ptr = <cydriver.CUDA_RESOURCE_DESC*>pResDesc._pvt_ptr if pResDesc is not None else NULL
     with nogil:
         err = cydriver.cuSurfObjectCreate(<cydriver.CUsurfObject*>pSurfObject._pvt_ptr, cypResDesc_ptr)
     if err != cydriver.CUDA_SUCCESS:
@@ -53258,7 +53258,7 @@ def cuTensorMapReplaceAddress(tensorMap : Optional[CUtensorMap], globalAddress):
     --------
     :py:obj:`~.cuTensorMapEncodeTiled`, :py:obj:`~.cuTensorMapEncodeIm2col`, :py:obj:`~.cuTensorMapEncodeIm2colWide`
     """
-    cdef cydriver.CUtensorMap* cytensorMap_ptr = tensorMap._pvt_ptr if tensorMap is not None else NULL
+    cdef cydriver.CUtensorMap* cytensorMap_ptr = <cydriver.CUtensorMap*>tensorMap._pvt_ptr if tensorMap is not None else NULL
     cdef _HelperInputVoidPtrStruct cyglobalAddressHelper
     cdef void* cyglobalAddress = _helper_input_void_ptr(globalAddress, &cyglobalAddressHelper)
     with nogil:
@@ -54765,7 +54765,7 @@ def cuGetExportTable(pExportTableId : Optional[CUuuid]):
         None
     """
     cdef void_ptr ppExportTable = 0
-    cdef cydriver.CUuuid* cypExportTableId_ptr = pExportTableId._pvt_ptr if pExportTableId is not None else NULL
+    cdef cydriver.CUuuid* cypExportTableId_ptr = <cydriver.CUuuid*>pExportTableId._pvt_ptr if pExportTableId is not None else NULL
     with nogil:
         err = cydriver.cuGetExportTable(<const void**>&ppExportTable, cypExportTableId_ptr)
     if err != cydriver.CUDA_SUCCESS:
@@ -55193,7 +55193,7 @@ def cuDevSmResourceSplitByCount(unsigned int nbGroups, input_ : Optional[CUdevRe
         if cyresult is NULL:
             raise MemoryError('Failed to allocate length x size memory: ' + str(nbGroups) + 'x' + str(sizeof(cydriver.CUdevResource)))
     cdef unsigned int cynbGroups = nbGroups
-    cdef cydriver.CUdevResource* cyinput__ptr = input_._pvt_ptr if input_ is not None else NULL
+    cdef cydriver.CUdevResource* cyinput__ptr = <cydriver.CUdevResource*>input_._pvt_ptr if input_ is not None else NULL
     cdef CUdevResource remainder = CUdevResource()
     with nogil:
         err = cydriver.cuDevSmResourceSplitByCount(cyresult, &cynbGroups, cyinput__ptr, <cydriver.CUdevResource*>remainder._pvt_ptr, flags, minCount)
@@ -55356,7 +55356,7 @@ def cuDevSmResourceSplit(unsigned int nbGroups, input_ : Optional[CUdevResource]
         cyresult = <cydriver.CUdevResource*>calloc(nbGroups, sizeof(cydriver.CUdevResource))
         if cyresult is NULL:
             raise MemoryError('Failed to allocate length x size memory: ' + str(nbGroups) + 'x' + str(sizeof(cydriver.CUdevResource)))
-    cdef cydriver.CUdevResource* cyinput__ptr = input_._pvt_ptr if input_ is not None else NULL
+    cdef cydriver.CUdevResource* cyinput__ptr = <cydriver.CUdevResource*>input_._pvt_ptr if input_ is not None else NULL
     cdef CUdevResource remainder = CUdevResource()
     cdef cydriver.CU_DEV_SM_RESOURCE_GROUP_PARAMS* cygroupParams = NULL
     if len(groupParams) > 1:
@@ -56095,7 +56095,7 @@ def cuCheckpointProcessLock(int pid, args : Optional[CUcheckpointLockArgs]):
     CUresult
         :py:obj:`~.CUDA_SUCCESS` :py:obj:`~.CUDA_ERROR_INVALID_VALUE` :py:obj:`~.CUDA_ERROR_NOT_INITIALIZED` :py:obj:`~.CUDA_ERROR_ILLEGAL_STATE` :py:obj:`~.CUDA_ERROR_NOT_SUPPORTED` :py:obj:`~.CUDA_ERROR_NOT_READY`
     """
-    cdef cydriver.CUcheckpointLockArgs* cyargs_ptr = args._pvt_ptr if args is not None else NULL
+    cdef cydriver.CUcheckpointLockArgs* cyargs_ptr = <cydriver.CUcheckpointLockArgs*>args._pvt_ptr if args is not None else NULL
     with nogil:
         err = cydriver.cuCheckpointProcessLock(pid, cyargs_ptr)
     return (_CUresult(err),)
@@ -56126,7 +56126,7 @@ def cuCheckpointProcessCheckpoint(int pid, args : Optional[CUcheckpointCheckpoin
     CUresult
         :py:obj:`~.CUDA_SUCCESS` :py:obj:`~.CUDA_ERROR_INVALID_VALUE` :py:obj:`~.CUDA_ERROR_NOT_INITIALIZED` :py:obj:`~.CUDA_ERROR_ILLEGAL_STATE` :py:obj:`~.CUDA_ERROR_NOT_SUPPORTED`
     """
-    cdef cydriver.CUcheckpointCheckpointArgs* cyargs_ptr = args._pvt_ptr if args is not None else NULL
+    cdef cydriver.CUcheckpointCheckpointArgs* cyargs_ptr = <cydriver.CUcheckpointCheckpointArgs*>args._pvt_ptr if args is not None else NULL
     with nogil:
         err = cydriver.cuCheckpointProcessCheckpoint(pid, cyargs_ptr)
     return (_CUresult(err),)
@@ -56167,7 +56167,7 @@ def cuCheckpointProcessRestore(int pid, args : Optional[CUcheckpointRestoreArgs]
     --------
     :py:obj:`~.cuInit`
     """
-    cdef cydriver.CUcheckpointRestoreArgs* cyargs_ptr = args._pvt_ptr if args is not None else NULL
+    cdef cydriver.CUcheckpointRestoreArgs* cyargs_ptr = <cydriver.CUcheckpointRestoreArgs*>args._pvt_ptr if args is not None else NULL
     with nogil:
         err = cydriver.cuCheckpointProcessRestore(pid, cyargs_ptr)
     return (_CUresult(err),)
@@ -56196,7 +56196,7 @@ def cuCheckpointProcessUnlock(int pid, args : Optional[CUcheckpointUnlockArgs]):
     CUresult
         :py:obj:`~.CUDA_SUCCESS` :py:obj:`~.CUDA_ERROR_INVALID_VALUE` :py:obj:`~.CUDA_ERROR_NOT_INITIALIZED` :py:obj:`~.CUDA_ERROR_ILLEGAL_STATE` :py:obj:`~.CUDA_ERROR_NOT_SUPPORTED`
     """
-    cdef cydriver.CUcheckpointUnlockArgs* cyargs_ptr = args._pvt_ptr if args is not None else NULL
+    cdef cydriver.CUcheckpointUnlockArgs* cyargs_ptr = <cydriver.CUcheckpointUnlockArgs*>args._pvt_ptr if args is not None else NULL
     with nogil:
         err = cydriver.cuCheckpointProcessUnlock(pid, cyargs_ptr)
     return (_CUresult(err),)
@@ -56815,7 +56815,7 @@ def cuEGLStreamProducerReturnFrame(conn, eglframe : Optional[CUeglFrame], pStrea
         cyconn = <cydriver.CUeglStreamConnection*><void_ptr>conn
     else:
         raise TypeError("Argument 'conn' is not instance of type (expected <class 'int, driver.CUeglStreamConnection'>, found " + str(type(conn)))
-    cdef cydriver.CUeglFrame* cyeglframe_ptr = eglframe._pvt_ptr if eglframe is not None else NULL
+    cdef cydriver.CUeglFrame* cyeglframe_ptr = <cydriver.CUeglFrame*>eglframe._pvt_ptr if eglframe is not None else NULL
     with nogil:
         err = cydriver.cuEGLStreamProducerReturnFrame(cyconn, cyeglframe_ptr, cypStream)
     return (_CUresult(err),)

--- a/cuda_bindings/cuda/bindings/nvml.pxd
+++ b/cuda_bindings/cuda/bindings/nvml.pxd
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.9.1 to 13.2.0, generator version 0.3.1.dev1422+gf4812259e.d20260318. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.1 to 13.2.0, generator version 0.3.1.dev1568+g289771de9.d20260413. Do not modify it directly.
 
 from libc.stdint cimport intptr_t
 
@@ -154,7 +154,7 @@ cpdef int system_get_cuda_driver_version_v2() except 0
 cpdef str system_get_process_name(unsigned int pid)
 cpdef object system_get_hic_version()
 cpdef unsigned int unit_get_count() except? 0
-cpdef intptr_t unit_get_handle_by_index(unsigned int ind_ex) except? 0
+cpdef intptr_t unit_get_handle_by_index(unsigned int index) except? 0
 cpdef object unit_get_unit_info(intptr_t unit)
 cpdef object unit_get_led_state(intptr_t unit)
 cpdef object unit_get_psu_info(intptr_t unit)
@@ -162,7 +162,7 @@ cpdef unsigned int unit_get_temperature(intptr_t unit, unsigned int type) except
 cpdef object unit_get_fan_speed_info(intptr_t unit)
 cpdef unsigned int device_get_count_v2() except? 0
 cpdef object device_get_attributes_v2(intptr_t device)
-cpdef intptr_t device_get_handle_by_index_v2(unsigned int ind_ex) except? 0
+cpdef intptr_t device_get_handle_by_index_v2(unsigned int index) except? 0
 cpdef intptr_t device_get_handle_by_serial(serial) except? 0
 cpdef intptr_t device_get_handle_by_uuid(uuid) except? 0
 cpdef intptr_t device_get_handle_by_pci_bus_id_v2(pci_bus_id) except? 0
@@ -179,7 +179,7 @@ cpdef device_set_cpu_affinity(intptr_t device)
 cpdef device_clear_cpu_affinity(intptr_t device)
 cpdef unsigned int device_get_numa_node_id(intptr_t device) except? 0
 cpdef int device_get_topology_common_ancestor(intptr_t device1, intptr_t device2) except? -1
-cpdef int device_get_p2p_status(intptr_t device1, intptr_t device2, int p2p_ind_ex) except? -1
+cpdef int device_get_p2p_status(intptr_t device1, intptr_t device2, int p2p_index) except? -1
 cpdef str device_get_uuid(intptr_t device)
 cpdef unsigned int device_get_minor_number(intptr_t device) except? 0
 cpdef str device_get_board_part_number(intptr_t device)
@@ -216,7 +216,7 @@ cpdef unsigned int device_get_fan_control_policy_v2(intptr_t device, unsigned in
 cpdef unsigned int device_get_num_fans(intptr_t device) except? 0
 cpdef object device_get_cooler_info(intptr_t device)
 cpdef unsigned int device_get_temperature_threshold(intptr_t device, int threshold_type) except? 0
-cpdef object device_get_thermal_settings(intptr_t device, unsigned int sensor_ind_ex)
+cpdef object device_get_thermal_settings(intptr_t device, unsigned int sensor_index)
 cpdef int device_get_performance_state(intptr_t device) except? -1
 cpdef unsigned long long device_get_current_clocks_event_reasons(intptr_t device) except? 0
 cpdef unsigned long long device_get_supported_clocks_event_reasons(intptr_t device) except? 0
@@ -347,7 +347,7 @@ cpdef unsigned int vgpu_type_get_gpu_instance_profile_id(unsigned int vgpu_type_
 cpdef tuple vgpu_type_get_device_id(unsigned int vgpu_type_id)
 cpdef unsigned long long vgpu_type_get_framebuffer_size(unsigned int vgpu_type_id) except? 0
 cpdef unsigned int vgpu_type_get_num_display_heads(unsigned int vgpu_type_id) except? 0
-cpdef tuple vgpu_type_get_resolution(unsigned int vgpu_type_id, unsigned int display_ind_ex)
+cpdef tuple vgpu_type_get_resolution(unsigned int vgpu_type_id, unsigned int display_index)
 cpdef str vgpu_type_get_license(unsigned int vgpu_type_id)
 cpdef unsigned int vgpu_type_get_frame_rate_limit(unsigned int vgpu_type_id) except? 0
 cpdef unsigned int vgpu_type_get_max_instances(intptr_t device, unsigned int vgpu_type_id) except? 0
@@ -386,7 +386,7 @@ cpdef object vgpu_instance_get_accounting_stats(unsigned int vgpu_instance, unsi
 cpdef vgpu_instance_clear_accounting_pids(unsigned int vgpu_instance)
 cpdef object vgpu_instance_get_license_info_v2(unsigned int vgpu_instance)
 cpdef unsigned int get_excluded_device_count() except? 0
-cpdef object get_excluded_device_info_by_index(unsigned int ind_ex)
+cpdef object get_excluded_device_info_by_index(unsigned int index)
 cpdef int device_set_mig_mode(intptr_t device, unsigned int mode) except? -1
 cpdef tuple device_get_mig_mode(intptr_t device)
 cpdef object device_get_gpu_instance_possible_placements_v2(intptr_t device, unsigned int profile_id)
@@ -408,7 +408,7 @@ cpdef unsigned int device_is_mig_device_handle(intptr_t device) except? 0
 cpdef unsigned int device_get_gpu_instance_id(intptr_t device) except? 0
 cpdef unsigned int device_get_compute_instance_id(intptr_t device) except? 0
 cpdef unsigned int device_get_max_mig_device_count(intptr_t device) except? 0
-cpdef intptr_t device_get_mig_device_handle_by_index(intptr_t device, unsigned int ind_ex) except? 0
+cpdef intptr_t device_get_mig_device_handle_by_index(intptr_t device, unsigned int index) except? 0
 cpdef intptr_t device_get_device_handle_from_mig_device_handle(intptr_t mig_device) except? 0
 cpdef device_power_smoothing_activate_preset_profile(intptr_t device, intptr_t profile)
 cpdef device_power_smoothing_update_preset_profile_param(intptr_t device, intptr_t profile)

--- a/cuda_bindings/cuda/bindings/nvml.pyx
+++ b/cuda_bindings/cuda/bindings/nvml.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.9.1 to 13.2.0, generator version 0.3.1.dev1422+gf4812259e.d20260318. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.1 to 13.2.0, generator version 0.3.1.dev1568+g289771de9.d20260413. Do not modify it directly.
 
 cimport cython  # NOQA
 
@@ -2061,7 +2061,6 @@ cdef object _nvml_error_factory(int status):
     return NvmlError(status)
 
 
-
 @cython.profile(False)
 cpdef int check_status(int status) except 1 nogil:
     if status != 0:
@@ -3174,20 +3173,16 @@ process_info_dtype = _get_process_info_dtype_offsets()
 
 cdef class ProcessInfo:
     """Empty-initialize an array of `nvmlProcessInfo_t`.
-
     The resulting object is of length `size` and of dtype `process_info_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlProcessInfo_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=process_info_dtype)
@@ -3356,20 +3351,16 @@ process_detail_v1_dtype = _get_process_detail_v1_dtype_offsets()
 
 cdef class ProcessDetail_v1:
     """Empty-initialize an array of `nvmlProcessDetail_v1_t`.
-
     The resulting object is of length `size` and of dtype `process_detail_v1_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlProcessDetail_v1_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=process_detail_v1_dtype)
@@ -4083,20 +4074,16 @@ bridge_chip_info_dtype = _get_bridge_chip_info_dtype_offsets()
 
 cdef class BridgeChipInfo:
     """Empty-initialize an array of `nvmlBridgeChipInfo_t`.
-
     The resulting object is of length `size` and of dtype `bridge_chip_info_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlBridgeChipInfo_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=bridge_chip_info_dtype)
@@ -4236,7 +4223,6 @@ value_dtype = _numpy.dtype((
         "us_val": (_numpy.uint16, 0),
     }
     ))
-
 
 cdef class Value:
     """Empty-initialize an instance of `nvmlValue_t`.
@@ -4604,7 +4590,7 @@ cdef class _py_anon_pod0:
 cdef _get_cooler_info_v1_dtype_offsets():
     cdef nvmlCoolerInfo_v1_t pod = nvmlCoolerInfo_v1_t()
     return _numpy.dtype({
-        'names': ['version', 'ind_ex', 'signal_type', 'target'],
+        'names': ['version', 'index', 'signal_type', 'target'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.int32, _numpy.int32],
         'offsets': [
             (<intptr_t>&(pod.version)) - (<intptr_t>&pod),
@@ -4695,12 +4681,12 @@ cdef class CoolerInfo_v1:
         self._ptr[0].version = val
 
     @property
-    def ind_ex(self):
+    def index(self):
         """int: the cooler index"""
         return self._ptr[0].index
 
-    @ind_ex.setter
-    def ind_ex(self, val):
+    @index.setter
+    def index(self, val):
         if self._readonly:
             raise ValueError("This CoolerInfo_v1 instance is read-only")
         self._ptr[0].index = val
@@ -4784,20 +4770,16 @@ clk_mon_fault_info_dtype = _get_clk_mon_fault_info_dtype_offsets()
 
 cdef class ClkMonFaultInfo:
     """Empty-initialize an array of `nvmlClkMonFaultInfo_t`.
-
     The resulting object is of length `size` and of dtype `clk_mon_fault_info_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlClkMonFaultInfo_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=clk_mon_fault_info_dtype)
@@ -5136,20 +5118,16 @@ process_utilization_sample_dtype = _get_process_utilization_sample_dtype_offsets
 
 cdef class ProcessUtilizationSample:
     """Empty-initialize an array of `nvmlProcessUtilizationSample_t`.
-
     The resulting object is of length `size` and of dtype `process_utilization_sample_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlProcessUtilizationSample_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=process_utilization_sample_dtype)
@@ -5343,20 +5321,16 @@ process_utilization_info_v1_dtype = _get_process_utilization_info_v1_dtype_offse
 
 cdef class ProcessUtilizationInfo_v1:
     """Empty-initialize an array of `nvmlProcessUtilizationInfo_v1_t`.
-
     The resulting object is of length `size` and of dtype `process_utilization_info_v1_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlProcessUtilizationInfo_v1_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=process_utilization_info_v1_dtype)
@@ -5828,7 +5802,7 @@ cdef class EccSramErrorStatus_v1:
 cdef _get_platform_info_v1_dtype_offsets():
     cdef nvmlPlatformInfo_v1_t pod = nvmlPlatformInfo_v1_t()
     return _numpy.dtype({
-        'names': ['version', 'ib_guid', 'rack_guid', 'chassis_physical_slot_number', 'compute_slot_ind_ex', 'node_ind_ex', 'peer_type', 'module_id'],
+        'names': ['version', 'ib_guid', 'rack_guid', 'chassis_physical_slot_number', 'compute_slot_index', 'node_index', 'peer_type', 'module_id'],
         'formats': [_numpy.uint32, (_numpy.uint8, 16), (_numpy.uint8, 16), _numpy.uint8, _numpy.uint8, _numpy.uint8, _numpy.uint8, _numpy.uint8],
         'offsets': [
             (<intptr_t>&(pod.version)) - (<intptr_t>&pod),
@@ -5968,23 +5942,23 @@ cdef class PlatformInfo_v1:
         self._ptr[0].chassisPhysicalSlotNumber = val
 
     @property
-    def compute_slot_ind_ex(self):
+    def compute_slot_index(self):
         """int: The index within the compute slots in the rack containing this GPU (does not include switches)"""
         return self._ptr[0].computeSlotIndex
 
-    @compute_slot_ind_ex.setter
-    def compute_slot_ind_ex(self, val):
+    @compute_slot_index.setter
+    def compute_slot_index(self, val):
         if self._readonly:
             raise ValueError("This PlatformInfo_v1 instance is read-only")
         self._ptr[0].computeSlotIndex = val
 
     @property
-    def node_ind_ex(self):
+    def node_index(self):
         """int: Index of the node within the slot containing this GPU."""
         return self._ptr[0].nodeIndex
 
-    @node_ind_ex.setter
-    def node_ind_ex(self, val):
+    @node_index.setter
+    def node_index(self, val):
         if self._readonly:
             raise ValueError("This PlatformInfo_v1 instance is read-only")
         self._ptr[0].nodeIndex = val
@@ -6055,7 +6029,7 @@ cdef class PlatformInfo_v1:
 cdef _get_platform_info_v2_dtype_offsets():
     cdef nvmlPlatformInfo_v2_t pod = nvmlPlatformInfo_v2_t()
     return _numpy.dtype({
-        'names': ['version', 'ib_guid', 'chassis_serial_number', 'slot_number', 'tray_ind_ex', 'host_id', 'peer_type', 'module_id'],
+        'names': ['version', 'ib_guid', 'chassis_serial_number', 'slot_number', 'tray_index', 'host_id', 'peer_type', 'module_id'],
         'formats': [_numpy.uint32, (_numpy.uint8, 16), (_numpy.uint8, 16), _numpy.uint8, _numpy.uint8, _numpy.uint8, _numpy.uint8, _numpy.uint8],
         'offsets': [
             (<intptr_t>&(pod.version)) - (<intptr_t>&pod),
@@ -6195,12 +6169,12 @@ cdef class PlatformInfo_v2:
         self._ptr[0].slotNumber = val
 
     @property
-    def tray_ind_ex(self):
+    def tray_index(self):
         """int: The tray index within the compute slots in the chassis containing this GPU (does not include switches)"""
         return self._ptr[0].trayIndex
 
-    @tray_ind_ex.setter
-    def tray_ind_ex(self, val):
+    @tray_index.setter
+    def tray_index(self, val):
         if self._readonly:
             raise ValueError("This PlatformInfo_v2 instance is read-only")
         self._ptr[0].trayIndex = val
@@ -6792,20 +6766,16 @@ vgpu_process_utilization_info_v1_dtype = _get_vgpu_process_utilization_info_v1_d
 
 cdef class VgpuProcessUtilizationInfo_v1:
     """Empty-initialize an array of `nvmlVgpuProcessUtilizationInfo_v1_t`.
-
     The resulting object is of length `size` and of dtype `vgpu_process_utilization_info_v1_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlVgpuProcessUtilizationInfo_v1_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=vgpu_process_utilization_info_v1_dtype)
@@ -7313,20 +7283,16 @@ vgpu_scheduler_log_entry_dtype = _get_vgpu_scheduler_log_entry_dtype_offsets()
 
 cdef class VgpuSchedulerLogEntry:
     """Empty-initialize an array of `nvmlVgpuSchedulerLogEntry_t`.
-
     The resulting object is of length `size` and of dtype `vgpu_scheduler_log_entry_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlVgpuSchedulerLogEntry_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=vgpu_scheduler_log_entry_dtype)
@@ -8425,6 +8391,7 @@ cdef class VgpuTypeIdInfo_v1:
         object _owner
         bint _owned
         bint _readonly
+        dict _refs
 
     def __init__(self):
         self._ptr = <nvmlVgpuTypeIdInfo_v1_t *>calloc(1, sizeof(nvmlVgpuTypeIdInfo_v1_t))
@@ -8433,6 +8400,7 @@ cdef class VgpuTypeIdInfo_v1:
         self._owner = None
         self._owned = True
         self._readonly = False
+        self._refs = {}
 
     def __dealloc__(self):
         cdef nvmlVgpuTypeIdInfo_v1_t *ptr
@@ -8548,6 +8516,7 @@ cdef class VgpuTypeIdInfo_v1:
             obj._owner = owner
             obj._owned = False
         obj._readonly = readonly
+        obj._refs = {}
         return obj
 
 
@@ -8577,6 +8546,7 @@ cdef class ActiveVgpuInstanceInfo_v1:
         object _owner
         bint _owned
         bint _readonly
+        dict _refs
 
     def __init__(self):
         self._ptr = <nvmlActiveVgpuInstanceInfo_v1_t *>calloc(1, sizeof(nvmlActiveVgpuInstanceInfo_v1_t))
@@ -8585,6 +8555,7 @@ cdef class ActiveVgpuInstanceInfo_v1:
         self._owner = None
         self._owned = True
         self._readonly = False
+        self._refs = {}
 
     def __dealloc__(self):
         cdef nvmlActiveVgpuInstanceInfo_v1_t *ptr
@@ -8700,6 +8671,7 @@ cdef class ActiveVgpuInstanceInfo_v1:
             obj._owner = owner
             obj._owned = False
         obj._readonly = readonly
+        obj._refs = {}
         return obj
 
 
@@ -8898,20 +8870,16 @@ hwbc_entry_dtype = _get_hwbc_entry_dtype_offsets()
 
 cdef class HwbcEntry:
     """Empty-initialize an array of `nvmlHwbcEntry_t`.
-
     The resulting object is of length `size` and of dtype `hwbc_entry_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlHwbcEntry_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=hwbc_entry_dtype)
@@ -9554,20 +9522,16 @@ unit_fan_info_dtype = _get_unit_fan_info_dtype_offsets()
 
 cdef class UnitFanInfo:
     """Empty-initialize an array of `nvmlUnitFanInfo_t`.
-
     The resulting object is of length `size` and of dtype `unit_fan_info_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlUnitFanInfo_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=unit_fan_info_dtype)
@@ -9890,20 +9854,16 @@ system_event_data_v1_dtype = _get_system_event_data_v1_dtype_offsets()
 
 cdef class SystemEventData_v1:
     """Empty-initialize an array of `nvmlSystemEventData_v1_t`.
-
     The resulting object is of length `size` and of dtype `system_event_data_v1_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlSystemEventData_v1_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=system_event_data_v1_dtype)
@@ -10245,20 +10205,16 @@ encoder_session_info_dtype = _get_encoder_session_info_dtype_offsets()
 
 cdef class EncoderSessionInfo:
     """Empty-initialize an array of `nvmlEncoderSessionInfo_t`.
-
     The resulting object is of length `size` and of dtype `encoder_session_info_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlEncoderSessionInfo_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=encoder_session_info_dtype)
@@ -10633,20 +10589,16 @@ fbc_session_info_dtype = _get_fbc_session_info_dtype_offsets()
 
 cdef class FBCSessionInfo:
     """Empty-initialize an array of `nvmlFBCSessionInfo_t`.
-
     The resulting object is of length `size` and of dtype `fbc_session_info_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlFBCSessionInfo_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=fbc_session_info_dtype)
@@ -13072,20 +13024,16 @@ gpu_instance_placement_dtype = _get_gpu_instance_placement_dtype_offsets()
 
 cdef class GpuInstancePlacement:
     """Empty-initialize an array of `nvmlGpuInstancePlacement_t`.
-
     The resulting object is of length `size` and of dtype `gpu_instance_placement_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlGpuInstancePlacement_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=gpu_instance_placement_dtype)
@@ -13508,20 +13456,16 @@ compute_instance_placement_dtype = _get_compute_instance_placement_dtype_offsets
 
 cdef class ComputeInstancePlacement:
     """Empty-initialize an array of `nvmlComputeInstancePlacement_t`.
-
     The resulting object is of length `size` and of dtype `compute_instance_placement_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlComputeInstancePlacement_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=compute_instance_placement_dtype)
@@ -14645,20 +14589,16 @@ ecc_sram_unique_uncorrected_error_entry_v1_dtype = _get_ecc_sram_unique_uncorrec
 
 cdef class EccSramUniqueUncorrectedErrorEntry_v1:
     """Empty-initialize an array of `nvmlEccSramUniqueUncorrectedErrorEntry_v1_t`.
-
     The resulting object is of length `size` and of dtype `ecc_sram_unique_uncorrected_error_entry_v1_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlEccSramUniqueUncorrectedErrorEntry_v1_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=ecc_sram_unique_uncorrected_error_entry_v1_dtype)
@@ -15679,20 +15619,16 @@ vgpu_scheduler_log_entry_v2_dtype = _get_vgpu_scheduler_log_entry_v2_dtype_offse
 
 cdef class VgpuSchedulerLogEntry_v2:
     """Empty-initialize an array of `nvmlVgpuSchedulerLogEntry_v2_t`.
-
     The resulting object is of length `size` and of dtype `vgpu_scheduler_log_entry_v2_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlVgpuSchedulerLogEntry_v2_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=vgpu_scheduler_log_entry_v2_dtype)
@@ -16508,20 +16444,16 @@ sample_dtype = _get_sample_dtype_offsets()
 
 cdef class Sample:
     """Empty-initialize an array of `nvmlSample_t`.
-
     The resulting object is of length `size` and of dtype `sample_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlSample_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=sample_dtype)
@@ -16667,20 +16599,16 @@ vgpu_instance_utilization_sample_dtype = _get_vgpu_instance_utilization_sample_d
 
 cdef class VgpuInstanceUtilizationSample:
     """Empty-initialize an array of `nvmlVgpuInstanceUtilizationSample_t`.
-
     The resulting object is of length `size` and of dtype `vgpu_instance_utilization_sample_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlVgpuInstanceUtilizationSample_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=vgpu_instance_utilization_sample_dtype)
@@ -16866,20 +16794,16 @@ vgpu_instance_utilization_info_v1_dtype = _get_vgpu_instance_utilization_info_v1
 
 cdef class VgpuInstanceUtilizationInfo_v1:
     """Empty-initialize an array of `nvmlVgpuInstanceUtilizationInfo_v1_t`.
-
     The resulting object is of length `size` and of dtype `vgpu_instance_utilization_info_v1_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlVgpuInstanceUtilizationInfo_v1_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=vgpu_instance_utilization_info_v1_dtype)
@@ -17082,20 +17006,16 @@ field_value_dtype = _get_field_value_dtype_offsets()
 
 cdef class FieldValue:
     """Empty-initialize an array of `nvmlFieldValue_t`.
-
     The resulting object is of length `size` and of dtype `field_value_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlFieldValue_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=field_value_dtype)
@@ -18210,7 +18130,6 @@ vgpu_scheduler_params_dtype = _numpy.dtype((
     }
     ))
 
-
 cdef class VgpuSchedulerParams:
     """Empty-initialize an instance of `nvmlVgpuSchedulerParams_t`.
 
@@ -18349,7 +18268,6 @@ vgpu_scheduler_set_params_dtype = _numpy.dtype((
         "vgpu_sched_data": (_py_anon_pod5_dtype, 0),
     }
     ))
-
 
 cdef class VgpuSchedulerSetParams:
     """Empty-initialize an instance of `nvmlVgpuSchedulerSetParams_t`.
@@ -18658,20 +18576,16 @@ grid_licensable_feature_dtype = _get_grid_licensable_feature_dtype_offsets()
 
 cdef class GridLicensableFeature:
     """Empty-initialize an array of `nvmlGridLicensableFeature_t`.
-
     The resulting object is of length `size` and of dtype `grid_licensable_feature_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlGridLicensableFeature_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=grid_licensable_feature_dtype)
@@ -20229,20 +20143,16 @@ prm_counter_v1_dtype = _get_prm_counter_v1_dtype_offsets()
 
 cdef class PRMCounter_v1:
     """Empty-initialize an array of `nvmlPRMCounter_v1_t`.
-
     The resulting object is of length `size` and of dtype `prm_counter_v1_dtype`.
     If default-constructed, the instance represents a single struct.
 
     Args:
         size (int): number of structs, default=1.
 
-
     .. seealso:: `nvmlPRMCounter_v1_t`
     """
     cdef:
         readonly object _data
-
-
 
     def __init__(self, size=1):
         arr = _numpy.empty(size, dtype=prm_counter_v1_dtype)
@@ -21601,7 +21511,6 @@ cdef class NvLinkInfo_v2:
         return obj
 
 
-
 cpdef init_v2():
     """Initialize NVML, but don't initialize any GPUs yet.
 
@@ -21651,6 +21560,9 @@ cpdef str error_string(int result):
 cpdef str system_get_driver_version():
     """Retrieves the version of the system's graphics driver.
 
+    Returns:
+        char: Reference in which to return the version identifier.
+
     .. seealso:: `nvmlSystemGetDriverVersion`
     """
     cdef unsigned int length = 80
@@ -21663,6 +21575,9 @@ cpdef str system_get_driver_version():
 
 cpdef str system_get_nvml_version():
     """Retrieves the version of the NVML library.
+
+    Returns:
+        char: Reference in which to return the version identifier.
 
     .. seealso:: `nvmlSystemGetNVMLVersion`
     """
@@ -21710,6 +21625,9 @@ cpdef str system_get_process_name(unsigned int pid):
     Args:
         pid (unsigned int): The identifier of the process.
 
+    Returns:
+        char: Reference in which to return the process name.
+
     .. seealso:: `nvmlSystemGetProcessName`
     """
     cdef unsigned int length = 1024
@@ -21722,6 +21640,9 @@ cpdef str system_get_process_name(unsigned int pid):
 
 cpdef object system_get_hic_version():
     """Retrieves the IDs and firmware versions for any Host Interface Cards (HICs) in the system.
+
+    Returns:
+        nvmlHwbcEntry_t: Array holding information about hwbc.
 
     .. seealso:: `nvmlSystemGetHicVersion`
     """
@@ -21754,11 +21675,11 @@ cpdef unsigned int unit_get_count() except? 0:
     return unit_count
 
 
-cpdef intptr_t unit_get_handle_by_index(unsigned int ind_ex) except? 0:
-    """Acquire the handle for a particular unit, based on its ind_ex.
+cpdef intptr_t unit_get_handle_by_index(unsigned int index) except? 0:
+    """Acquire the handle for a particular unit, based on its index.
 
     Args:
-        ind_ex (unsigned int): The ind_ex of the target unit, >= 0 and < ``unitCount``.
+        index (unsigned int): The index of the target unit, >= 0 and < ``unitCount``.
 
     Returns:
         intptr_t: Reference in which to return the unit handle.
@@ -21767,7 +21688,7 @@ cpdef intptr_t unit_get_handle_by_index(unsigned int ind_ex) except? 0:
     """
     cdef Unit unit
     with nogil:
-        __status__ = nvmlUnitGetHandleByIndex(ind_ex, &unit)
+        __status__ = nvmlUnitGetHandleByIndex(index, &unit)
     check_status(__status__)
     return <intptr_t>unit
 
@@ -21901,11 +21822,11 @@ cpdef object device_get_attributes_v2(intptr_t device):
     return attributes_py
 
 
-cpdef intptr_t device_get_handle_by_index_v2(unsigned int ind_ex) except? 0:
-    """Acquire the handle for a particular device, based on its ind_ex.
+cpdef intptr_t device_get_handle_by_index_v2(unsigned int index) except? 0:
+    """Acquire the handle for a particular device, based on its index.
 
     Args:
-        ind_ex (unsigned int): The ind_ex of the target GPU, >= 0 and < ``accessibleDevices``.
+        index (unsigned int): The index of the target GPU, >= 0 and < ``accessibleDevices``.
 
     Returns:
         intptr_t: Reference in which to return the device handle.
@@ -21914,7 +21835,7 @@ cpdef intptr_t device_get_handle_by_index_v2(unsigned int ind_ex) except? 0:
     """
     cdef Device device
     with nogil:
-        __status__ = nvmlDeviceGetHandleByIndex_v2(ind_ex, &device)
+        __status__ = nvmlDeviceGetHandleByIndex_v2(index, &device)
     check_status(__status__)
     return <intptr_t>device
 
@@ -21991,6 +21912,9 @@ cpdef str device_get_name(intptr_t device):
     Args:
         device (intptr_t): The identifier of the target device.
 
+    Returns:
+        char: Reference in which to return the product name.
+
     .. seealso:: `nvmlDeviceGetName`
     """
     cdef unsigned int length = 96
@@ -22030,11 +21954,11 @@ cpdef unsigned int device_get_index(intptr_t device) except? 0:
 
     .. seealso:: `nvmlDeviceGetIndex`
     """
-    cdef unsigned int ind_ex
+    cdef unsigned int index
     with nogil:
-        __status__ = nvmlDeviceGetIndex(<Device>device, &ind_ex)
+        __status__ = nvmlDeviceGetIndex(<Device>device, &index)
     check_status(__status__)
-    return ind_ex
+    return index
 
 
 cpdef str device_get_serial(intptr_t device):
@@ -22042,6 +21966,9 @@ cpdef str device_get_serial(intptr_t device):
 
     Args:
         device (intptr_t): The identifier of the target device.
+
+    Returns:
+        char: Reference in which to return the board/module serial number.
 
     .. seealso:: `nvmlDeviceGetSerial`
     """
@@ -22095,8 +22022,11 @@ cpdef object device_get_memory_affinity(intptr_t device, unsigned int node_set_s
 
     Args:
         device (intptr_t): The identifier of the target device.
-        node_set_size (unsigned int): The size of the nodeSet array that is safe to access.
-        scope (unsigned int): Array reference in which to return a bitmask of NODEs, 64 NODEs per unsigned long on 64-bit machines, 32 on 32-bit machines.
+        node_set_size (unsigned int): The size of the node_set array that is safe to access.
+        scope (unsigned int): Scope that change the default behavior.
+
+    Returns:
+        unsigned long: Array reference in which to return a bitmask of NODEs, 64 NODEs per unsigned long on 64-bit machines, 32 on 32-bit machines.
 
     .. seealso:: `nvmlDeviceGetMemoryAffinity`
     """
@@ -22115,8 +22045,11 @@ cpdef object device_get_cpu_affinity_within_scope(intptr_t device, unsigned int 
 
     Args:
         device (intptr_t): The identifier of the target device.
-        cpu_set_size (unsigned int): The size of the cpuSet array that is safe to access.
-        scope (unsigned int): Array reference in which to return a bitmask of CPUs, 64 CPUs per unsigned long on 64-bit machines, 32 on 32-bit machines.
+        cpu_set_size (unsigned int): The size of the cpu_set array that is safe to access.
+        scope (unsigned int): Scope that change the default behavior.
+
+    Returns:
+        unsigned long: Array reference in which to return a bitmask of CPUs, 64 CPUs per unsigned long on 64-bit machines, 32 on 32-bit machines.
 
     .. seealso:: `nvmlDeviceGetCpuAffinityWithinScope`
     """
@@ -22135,7 +22068,10 @@ cpdef object device_get_cpu_affinity(intptr_t device, unsigned int cpu_set_size)
 
     Args:
         device (intptr_t): The identifier of the target device.
-        cpu_set_size (unsigned int): The size of the cpuSet array that is safe to access.
+        cpu_set_size (unsigned int): The size of the cpu_set array that is safe to access.
+
+    Returns:
+        unsigned long: Array reference in which to return a bitmask of CPUs, 64 CPUs per unsigned long on 64-bit machines, 32 on 32-bit machines.
 
     .. seealso:: `nvmlDeviceGetCpuAffinity`
     """
@@ -22212,22 +22148,22 @@ cpdef int device_get_topology_common_ancestor(intptr_t device1, intptr_t device2
     return <int>path_info
 
 
-cpdef int device_get_p2p_status(intptr_t device1, intptr_t device2, int p2p_ind_ex) except? -1:
+cpdef int device_get_p2p_status(intptr_t device1, intptr_t device2, int p2p_index) except? -1:
     """Retrieve the status for a given p2p capability index between a given pair of GPU.
 
     Args:
         device1 (intptr_t): The first device.
         device2 (intptr_t): The second device.
-        p2p_ind_ex (GpuP2PCapsIndex): p2p Capability Index being looked for between ``device1`` and ``device2``.
+        p2p_index (GpuP2PCapsIndex): p2p Capability Index being looked for between ``device1`` and ``device2``.
 
     Returns:
-        int: Reference in which to return the status of the ``p2p_ind_ex`` between ``device1`` and ``device2``.
+        int: Reference in which to return the status of the ``p2p_index`` between ``device1`` and ``device2``.
 
     .. seealso:: `nvmlDeviceGetP2PStatus`
     """
     cdef _GpuP2PStatus p2p_status
     with nogil:
-        __status__ = nvmlDeviceGetP2PStatus(<Device>device1, <Device>device2, <_GpuP2PCapsIndex>p2p_ind_ex, &p2p_status)
+        __status__ = nvmlDeviceGetP2PStatus(<Device>device1, <Device>device2, <_GpuP2PCapsIndex>p2p_index, &p2p_status)
     check_status(__status__)
     return <int>p2p_status
 
@@ -22237,6 +22173,9 @@ cpdef str device_get_uuid(intptr_t device):
 
     Args:
         device (intptr_t): The identifier of the target device.
+
+    Returns:
+        char: Reference in which to return the GPU UUID.
 
     .. seealso:: `nvmlDeviceGetUUID`
     """
@@ -22272,6 +22211,9 @@ cpdef str device_get_board_part_number(intptr_t device):
     Args:
         device (intptr_t): Identifier of the target device.
 
+    Returns:
+        char: Reference to the buffer to return.
+
     .. seealso:: `nvmlDeviceGetBoardPartNumber`
     """
     cdef unsigned int length = 80
@@ -22289,6 +22231,9 @@ cpdef str device_get_inforom_version(intptr_t device, int object):
         device (intptr_t): The identifier of the target device.
         object (InforomObject): The target infoROM object.
 
+    Returns:
+        char: Reference in which to return the infoROM version.
+
     .. seealso:: `nvmlDeviceGetInforomVersion`
     """
     cdef unsigned int length = 16
@@ -22304,6 +22249,9 @@ cpdef str device_get_inforom_image_version(intptr_t device):
 
     Args:
         device (intptr_t): The identifier of the target device.
+
+    Returns:
+        char: Reference in which to return the infoROM image version.
 
     .. seealso:: `nvmlDeviceGetInforomImageVersion`
     """
@@ -22689,6 +22637,9 @@ cpdef object device_get_supported_memory_clocks(intptr_t device):
     Args:
         device (intptr_t): The identifier of the target device.
 
+    Returns:
+        unsigned int: Reference in which to return the clock in MHz.
+
     .. seealso:: `nvmlDeviceGetSupportedMemoryClocks`
     """
     cdef unsigned int[1] count = [0]
@@ -22712,6 +22663,9 @@ cpdef object device_get_supported_graphics_clocks(intptr_t device, unsigned int 
         device (intptr_t): The identifier of the target device.
         memory_clock_m_hz (unsigned int): Memory clock for which to return possible graphics clocks.
 
+    Returns:
+        unsigned int: Reference in which to return the clocks in MHz.
+
     .. seealso:: `nvmlDeviceGetSupportedGraphicsClocks`
     """
     cdef unsigned int[1] count = [0]
@@ -22729,7 +22683,7 @@ cpdef object device_get_supported_graphics_clocks(intptr_t device, unsigned int 
 
 
 cpdef tuple device_get_auto_boosted_clocks_enabled(intptr_t device):
-    """Retrieve the current state of Auto Boosted clocks on a device and store it in ``isEnabled``.
+    """Retrieve the current state of Auto Boosted clocks on a device and store it in ``is_enabled``.
 
     Args:
         device (intptr_t): The identifier of the target device.
@@ -22904,12 +22858,12 @@ cpdef unsigned int device_get_temperature_threshold(intptr_t device, int thresho
     return temp
 
 
-cpdef object device_get_thermal_settings(intptr_t device, unsigned int sensor_ind_ex):
+cpdef object device_get_thermal_settings(intptr_t device, unsigned int sensor_index):
     """Used to execute a list of thermal system instructions.
 
     Args:
         device (intptr_t): The identifier of the target device.
-        sensor_ind_ex (unsigned int): The index of the thermal sensor.
+        sensor_index (unsigned int): The index of the thermal sensor.
 
     Returns:
         nvmlGpuThermalSettings_t: Reference in which to return the thermal sensor information.
@@ -22919,7 +22873,7 @@ cpdef object device_get_thermal_settings(intptr_t device, unsigned int sensor_in
     cdef GpuThermalSettings p_thermal_settings_py = GpuThermalSettings()
     cdef nvmlGpuThermalSettings_t *p_thermal_settings = <nvmlGpuThermalSettings_t *><intptr_t>(p_thermal_settings_py._get_ptr())
     with nogil:
-        __status__ = nvmlDeviceGetThermalSettings(<Device>device, sensor_ind_ex, p_thermal_settings)
+        __status__ = nvmlDeviceGetThermalSettings(<Device>device, sensor_index, p_thermal_settings)
     check_status(__status__)
     return p_thermal_settings_py
 
@@ -23350,7 +23304,7 @@ cpdef int device_get_default_ecc_mode(intptr_t device) except? -1:
 
 
 cpdef unsigned int device_get_board_id(intptr_t device) except? 0:
-    """Retrieves the device boardId from 0-N. Devices with the same boardId indicate GPUs connected to the same PLX. Use in conjunction with :func:`device_get_multi_gpu_board` to decide if they are on the same board as well. The boardId returned is a unique ID for the current configuration. Uniqueness and ordering across reboots and system configurations is not guaranteed (i.e. if a Tesla K40c returns 0x100 and the two GPUs on a Tesla K10 in the same system returns 0x200 it is not guaranteed they will always return those values but they will always be different from each other).
+    """Retrieves the device board_id from 0-N. Devices with the same board_id indicate GPUs connected to the same PLX. Use in conjunction with :func:`device_get_multi_gpu_board` to decide if they are on the same board as well. The board_id returned is a unique ID for the current configuration. Uniqueness and ordering across reboots and system configurations is not guaranteed (i.e. if a Tesla K40c returns 0x100 and the two GPUs on a Tesla K10 in the same system returns 0x200 it is not guaranteed they will always return those values but they will always be different from each other).
 
     Args:
         device (intptr_t): The identifier of the target device.
@@ -23368,7 +23322,7 @@ cpdef unsigned int device_get_board_id(intptr_t device) except? 0:
 
 
 cpdef unsigned int device_get_multi_gpu_board(intptr_t device) except? 0:
-    """Retrieves whether the device is on a Multi-GPU Board Devices that are on multi-GPU boards will set ``multiGpuBool`` to a non-zero value.
+    """Retrieves whether the device is on a Multi-GPU Board Devices that are on multi-GPU boards will set ``multi_gpu_bool`` to a non-zero value.
 
     Args:
         device (intptr_t): The identifier of the target device.
@@ -23516,6 +23470,9 @@ cpdef object device_get_encoder_sessions(intptr_t device):
     Args:
         device (intptr_t): The identifier of the target device.
 
+    Returns:
+        nvmlEncoderSessionInfo_t: Reference in which to return the session information.
+
     .. seealso:: `nvmlDeviceGetEncoderSessions`
     """
     cdef unsigned int[1] session_count = [0]
@@ -23623,6 +23580,9 @@ cpdef object device_get_fbc_sessions(intptr_t device):
     Args:
         device (intptr_t): The identifier of the target device.
 
+    Returns:
+        nvmlFBCSessionInfo_t: Reference in which to return the session information.
+
     .. seealso:: `nvmlDeviceGetFBCSessions`
     """
     cdef unsigned int[1] session_count = [0]
@@ -23667,6 +23627,9 @@ cpdef str device_get_vbios_version(intptr_t device):
     Args:
         device (intptr_t): The identifier of the target device.
 
+    Returns:
+        char: Reference to which to return the VBIOS version.
+
     .. seealso:: `nvmlDeviceGetVbiosVersion`
     """
     cdef unsigned int length = 32
@@ -23702,6 +23665,9 @@ cpdef object device_get_compute_running_processes_v3(intptr_t device):
     Args:
         device (intptr_t): The device handle or MIG device handle.
 
+    Returns:
+        nvmlProcessInfo_t: Reference in which to return the process information.
+
     .. seealso:: `nvmlDeviceGetComputeRunningProcesses_v3`
     """
     cdef unsigned int[1] info_count = [0]
@@ -23724,6 +23690,9 @@ cpdef object device_get_graphics_running_processes_v3(intptr_t device):
     Args:
         device (intptr_t): The device handle or MIG device handle.
 
+    Returns:
+        nvmlProcessInfo_t: Reference in which to return the process information.
+
     .. seealso:: `nvmlDeviceGetGraphicsRunningProcesses_v3`
     """
     cdef unsigned int[1] info_count = [0]
@@ -23745,6 +23714,9 @@ cpdef object device_get_mps_compute_running_processes_v3(intptr_t device):
 
     Args:
         device (intptr_t): The device handle or MIG device handle.
+
+    Returns:
+        nvmlProcessInfo_t: Reference in which to return the process information.
 
     .. seealso:: `nvmlDeviceGetMPSComputeRunningProcesses_v3`
     """
@@ -24215,6 +24187,9 @@ cpdef object device_get_accounting_pids(intptr_t device):
     Args:
         device (intptr_t): The identifier of the target device.
 
+    Returns:
+        unsigned int: Reference in which to return list of process ids.
+
     .. seealso:: `nvmlDeviceGetAccountingPids`
     """
     cdef unsigned int[1] count = [0]
@@ -24256,6 +24231,9 @@ cpdef object device_get_retired_pages(intptr_t device, int cause):
         device (intptr_t): The identifier of the target device.
         cause (PageRetirementCause): Filter page addresses by cause of retirement.
 
+    Returns:
+        unsigned long long: Buffer to write the page addresses into.
+
     .. seealso:: `nvmlDeviceGetRetiredPages`
     """
     cdef unsigned int[1] page_count = [0]
@@ -24291,7 +24269,7 @@ cpdef int device_get_retired_pages_pending_status(intptr_t device) except? -1:
 
 
 cpdef tuple device_get_remapped_rows(intptr_t device):
-    """Get number of remapped rows. The number of rows reported will be based on the cause of the remapping. isPending indicates whether or not there are pending remappings. A reset will be required to actually remap the row. failureOccurred will be set if a row remapping ever failed in the past. A pending remapping won't affect future work on the GPU since error-containment and dynamic page blacklisting will take care of that.
+    """Get number of remapped rows. The number of rows reported will be based on the cause of the remapping. is_pending indicates whether or not there are pending remappings. A reset will be required to actually remap the row. failure_occurred will be set if a row remapping ever failed in the past. A pending remapping won't affect future work on the GPU since error-containment and dynamic page blacklisting will take care of that.
 
     Args:
         device (intptr_t): The identifier of the target device.
@@ -24377,7 +24355,10 @@ cpdef object device_get_process_utilization(intptr_t device, unsigned long long 
 
     Args:
         device (intptr_t): The identifier of the target device.
-        last_seen_time_stamp (unsigned long long): Pointer to caller-supplied buffer in which guest process utilization samples are returned.
+        last_seen_time_stamp (unsigned long long): Return only samples with timestamp greater than last_seen_time_stamp.
+
+    Returns:
+        nvmlProcessUtilizationSample_t: Pointer to caller-supplied buffer in which guest process utilization samples are returned.
 
     .. seealso:: `nvmlDeviceGetProcessUtilization`
     """
@@ -25183,6 +25164,9 @@ cpdef str vgpu_type_get_class(unsigned int vgpu_type_id):
     Args:
         vgpu_type_id (unsigned int): Handle to vGPU type.
 
+    Returns:
+        char: Pointer to string array to return class in.
+
     .. seealso:: `nvmlVgpuTypeGetClass`
     """
     cdef unsigned int[1] size = [0]
@@ -25275,12 +25259,12 @@ cpdef unsigned int vgpu_type_get_num_display_heads(unsigned int vgpu_type_id) ex
     return num_display_heads
 
 
-cpdef tuple vgpu_type_get_resolution(unsigned int vgpu_type_id, unsigned int display_ind_ex):
+cpdef tuple vgpu_type_get_resolution(unsigned int vgpu_type_id, unsigned int display_index):
     """Retrieve vGPU display head's maximum supported resolution.
 
     Args:
         vgpu_type_id (unsigned int): Handle to vGPU type.
-        display_ind_ex (unsigned int): Zero-based index of display head.
+        display_index (unsigned int): Zero-based index of display head.
 
     Returns:
         A 2-tuple containing:
@@ -25293,7 +25277,7 @@ cpdef tuple vgpu_type_get_resolution(unsigned int vgpu_type_id, unsigned int dis
     cdef unsigned int xdim
     cdef unsigned int ydim
     with nogil:
-        __status__ = nvmlVgpuTypeGetResolution(<nvmlVgpuTypeId_t>vgpu_type_id, display_ind_ex, &xdim, &ydim)
+        __status__ = nvmlVgpuTypeGetResolution(<nvmlVgpuTypeId_t>vgpu_type_id, display_index, &xdim, &ydim)
     check_status(__status__)
     return (xdim, ydim)
 
@@ -25303,6 +25287,9 @@ cpdef str vgpu_type_get_license(unsigned int vgpu_type_id):
 
     Args:
         vgpu_type_id (unsigned int): Handle to vGPU type.
+
+    Returns:
+        char: Pointer to buffer to return license info.
 
     .. seealso:: `nvmlVgpuTypeGetLicense`
     """
@@ -25395,6 +25382,9 @@ cpdef str vgpu_instance_get_uuid(unsigned int vgpu_instance):
     Args:
         vgpu_instance (unsigned int): Identifier of the target vGPU instance.
 
+    Returns:
+        char: Pointer to caller-supplied buffer to hold vGPU UUID.
+
     .. seealso:: `nvmlVgpuInstanceGetUUID`
     """
     cdef unsigned int size = 80
@@ -25410,6 +25400,9 @@ cpdef str vgpu_instance_get_vm_driver_version(unsigned int vgpu_instance):
 
     Args:
         vgpu_instance (unsigned int): Identifier of the target vGPU instance.
+
+    Returns:
+        char: Caller-supplied buffer to return driver version string.
 
     .. seealso:: `nvmlVgpuInstanceGetVmDriverVersion`
     """
@@ -25464,7 +25457,7 @@ cpdef unsigned int vgpu_instance_get_type(unsigned int vgpu_instance) except? 0:
         vgpu_instance (unsigned int): Identifier of the target vGPU instance.
 
     Returns:
-        unsigned int: Reference to return the vgpuTypeId.
+        unsigned int: Reference to return the vgpu_type_id.
 
     .. seealso:: `nvmlVgpuInstanceGetType`
     """
@@ -25573,6 +25566,9 @@ cpdef object vgpu_instance_get_encoder_sessions(unsigned int vgpu_instance):
     Args:
         vgpu_instance (unsigned int): Identifier of the target vGPU instance.
 
+    Returns:
+        nvmlEncoderSessionInfo_t: Reference to caller supplied array in which the list of session information us returned.
+
     .. seealso:: `nvmlVgpuInstanceGetEncoderSessions`
     """
     cdef unsigned int[1] session_count = [0]
@@ -25614,6 +25610,9 @@ cpdef object vgpu_instance_get_fbc_sessions(unsigned int vgpu_instance):
     Args:
         vgpu_instance (unsigned int): Identifier of the target vGPU instance.
 
+    Returns:
+        nvmlFBCSessionInfo_t: Reference in which to return the session information.
+
     .. seealso:: `nvmlVgpuInstanceGetFBCSessions`
     """
     cdef unsigned int[1] session_count = [0]
@@ -25654,6 +25653,9 @@ cpdef str vgpu_instance_get_gpu_pci_id(unsigned int vgpu_instance):
     Args:
         vgpu_instance (unsigned int): Identifier of the target vGPU instance.
 
+    Returns:
+        char: Caller-supplied buffer to return vGPU PCI Id string.
+
     .. seealso:: `nvmlVgpuInstanceGetGpuPciId`
     """
     cdef unsigned int[1] length = [0]
@@ -25671,7 +25673,7 @@ cpdef str vgpu_instance_get_gpu_pci_id(unsigned int vgpu_instance):
 
 
 cpdef unsigned int vgpu_type_get_capabilities(unsigned int vgpu_type_id, int capability) except? 0:
-    """Retrieve the requested capability for a given vGPU type. Refer to the ``nvmlVgpuCapability_t`` structure for the specific capabilities that can be queried. The return value in ``capResult`` should be treated as a boolean, with a non-zero value indicating that the capability is supported.
+    """Retrieve the requested capability for a given vGPU type. Refer to the ``nvmlVgpuCapability_t`` structure for the specific capabilities that can be queried. The return value in ``cap_result`` should be treated as a boolean, with a non-zero value indicating that the capability is supported.
 
     Args:
         vgpu_type_id (unsigned int): Handle to vGPU type.
@@ -25694,6 +25696,9 @@ cpdef str vgpu_instance_get_mdev_uuid(unsigned int vgpu_instance):
 
     Args:
         vgpu_instance (unsigned int): Identifier of the target vGPU instance.
+
+    Returns:
+        char: Pointer to caller-supplied buffer to hold MDEV UUID.
 
     .. seealso:: `nvmlVgpuInstanceGetMdevUUID`
     """
@@ -25727,7 +25732,7 @@ cpdef object gpu_instance_get_vgpu_scheduler_state(intptr_t gpu_instance):
         gpu_instance (intptr_t): The GPU instance handle.
 
     Returns:
-        nvmlVgpuSchedulerStateInfo_v1_t: Reference in which ``pSchedulerStateInfo`` is returned.
+        nvmlVgpuSchedulerStateInfo_v1_t: Reference in which ``p_scheduler_state_info`` is returned.
 
     .. seealso:: `nvmlGpuInstanceGetVgpuSchedulerState`
     """
@@ -25741,13 +25746,13 @@ cpdef object gpu_instance_get_vgpu_scheduler_state(intptr_t gpu_instance):
 
 
 cpdef object gpu_instance_get_vgpu_scheduler_log(intptr_t gpu_instance):
-    """Returns the vGPU scheduler logs for the given GPU instance. ``pSchedulerLogInfo`` points to a caller-allocated structure to contain the logs. The number of elements returned will never exceed ``NVML_SCHEDULER_SW_MAX_LOG_ENTRIES``.
+    """Returns the vGPU scheduler logs for the given GPU instance. ``p_scheduler_log_info`` points to a caller-allocated structure to contain the logs. The number of elements returned will never exceed ``NVML_SCHEDULER_SW_MAX_LOG_ENTRIES``.
 
     Args:
         gpu_instance (intptr_t): The GPU instance handle.
 
     Returns:
-        nvmlVgpuSchedulerLogInfo_v1_t: Reference in which ``pSchedulerLogInfo`` is written.
+        nvmlVgpuSchedulerLogInfo_v1_t: Reference in which ``p_scheduler_log_info`` is written.
 
     .. seealso:: `nvmlGpuInstanceGetVgpuSchedulerLog`
     """
@@ -25766,6 +25771,9 @@ cpdef str device_get_pgpu_metadata_string(intptr_t device):
     Args:
         device (intptr_t): The identifier of the target device.
 
+    Returns:
+        char: Pointer to caller-supplied buffer into which ``pgpu_metadata`` is written.
+
     .. seealso:: `nvmlDeviceGetPgpuMetadataString`
     """
     cdef unsigned int[1] buffer_size = [0]
@@ -25783,13 +25791,13 @@ cpdef str device_get_pgpu_metadata_string(intptr_t device):
 
 
 cpdef object device_get_vgpu_scheduler_log(intptr_t device):
-    """Returns the vGPU Software scheduler logs. ``pSchedulerLog`` points to a caller-allocated structure to contain the logs. The number of elements returned will never exceed ``NVML_SCHEDULER_SW_MAX_LOG_ENTRIES``.
+    """Returns the vGPU Software scheduler logs. ``p_scheduler_log`` points to a caller-allocated structure to contain the logs. The number of elements returned will never exceed ``NVML_SCHEDULER_SW_MAX_LOG_ENTRIES``.
 
     Args:
         device (intptr_t): The identifier of the target ``device``.
 
     Returns:
-        nvmlVgpuSchedulerLog_t: Reference in which ``pSchedulerLog`` is written.
+        nvmlVgpuSchedulerLog_t: Reference in which ``p_scheduler_log`` is written.
 
     .. seealso:: `nvmlDeviceGetVgpuSchedulerLog`
     """
@@ -25808,7 +25816,7 @@ cpdef object device_get_vgpu_scheduler_state(intptr_t device):
         device (intptr_t): The identifier of the target ``device``.
 
     Returns:
-        nvmlVgpuSchedulerGetState_t: Reference in which ``pSchedulerState`` is returned.
+        nvmlVgpuSchedulerGetState_t: Reference in which ``p_scheduler_state`` is returned.
 
     .. seealso:: `nvmlDeviceGetVgpuSchedulerState`
     """
@@ -25827,7 +25835,7 @@ cpdef object device_get_vgpu_scheduler_capabilities(intptr_t device):
         device (intptr_t): The identifier of the target ``device``.
 
     Returns:
-        nvmlVgpuSchedulerCapabilities_t: Reference in which ``pCapabilities`` is written.
+        nvmlVgpuSchedulerCapabilities_t: Reference in which ``p_capabilities`` is written.
 
     .. seealso:: `nvmlDeviceGetVgpuSchedulerCapabilities`
     """
@@ -25913,6 +25921,9 @@ cpdef object vgpu_instance_get_accounting_pids(unsigned int vgpu_instance):
     Args:
         vgpu_instance (unsigned int): The identifier of the target vGPU instance.
 
+    Returns:
+        unsigned int: Reference in which to return list of process ids.
+
     .. seealso:: `nvmlVgpuInstanceGetAccountingPids`
     """
     cdef unsigned int[1] count = [0]
@@ -25996,11 +26007,11 @@ cpdef unsigned int get_excluded_device_count() except? 0:
     return device_count
 
 
-cpdef object get_excluded_device_info_by_index(unsigned int ind_ex):
-    """Acquire the device information for an excluded GPU device, based on its ind_ex.
+cpdef object get_excluded_device_info_by_index(unsigned int index):
+    """Acquire the device information for an excluded GPU device, based on its index.
 
     Args:
-        ind_ex (unsigned int): The ind_ex of the target GPU, >= 0 and < ``deviceCount``.
+        index (unsigned int): The index of the target GPU, >= 0 and < ``deviceCount``.
 
     Returns:
         nvmlExcludedDeviceInfo_t: Reference in which to return the device information.
@@ -26010,7 +26021,7 @@ cpdef object get_excluded_device_info_by_index(unsigned int ind_ex):
     cdef ExcludedDeviceInfo info_py = ExcludedDeviceInfo()
     cdef nvmlExcludedDeviceInfo_t *info = <nvmlExcludedDeviceInfo_t *><intptr_t>(info_py._get_ptr())
     with nogil:
-        __status__ = nvmlGetExcludedDeviceInfoByIndex(ind_ex, info)
+        __status__ = nvmlGetExcludedDeviceInfoByIndex(index, info)
     check_status(__status__)
     return info_py
 
@@ -26023,7 +26034,7 @@ cpdef int device_set_mig_mode(intptr_t device, unsigned int mode) except? -1:
         mode (unsigned int): The mode to be set, ``NVML_DEVICE_MIG_DISABLE`` or ``NVML_DEVICE_MIG_ENABLE``.
 
     Returns:
-        int: The activationStatus status.
+        int: The activation_status status.
 
     .. seealso:: `nvmlDeviceSetMigMode`
     """
@@ -26062,6 +26073,9 @@ cpdef object device_get_gpu_instance_possible_placements_v2(intptr_t device, uns
     Args:
         device (intptr_t): The identifier of the target device.
         profile_id (unsigned int): The GPU instance profile ID. See ``nvmlDeviceGetGpuInstanceProfileInfo``.
+
+    Returns:
+        nvmlGpuInstancePlacement_t: Returns placements allowed for the profile. Can be NULL to discover number of allowed placements for this profile. If non-NULL must be large enough to accommodate the placements supported by the profile.
 
     .. seealso:: `nvmlDeviceGetGpuInstancePossiblePlacements_v2`
     """
@@ -26235,6 +26249,9 @@ cpdef object gpu_instance_get_compute_instance_possible_placements(intptr_t gpu_
     Args:
         gpu_instance (intptr_t): The identifier of the target GPU instance.
         profile_id (unsigned int): The compute instance profile ID. See ``nvmlGpuInstanceGetComputeInstanceProfileInfo``.
+
+    Returns:
+        nvmlComputeInstancePlacement_t: Returns placements allowed for the profile. Can be NULL to discover number of allowed placements for this profile. If non-NULL must be large enough to accommodate the placements supported by the profile.
 
     .. seealso:: `nvmlGpuInstanceGetComputeInstancePossiblePlacements`
     """
@@ -26414,12 +26431,12 @@ cpdef unsigned int device_get_max_mig_device_count(intptr_t device) except? 0:
     return count
 
 
-cpdef intptr_t device_get_mig_device_handle_by_index(intptr_t device, unsigned int ind_ex) except? 0:
-    """Get MIG device handle for the given ind_ex under its parent NVML device.
+cpdef intptr_t device_get_mig_device_handle_by_index(intptr_t device, unsigned int index) except? 0:
+    """Get MIG device handle for the given index under its parent NVML device.
 
     Args:
         device (intptr_t): Reference to the parent GPU device handle.
-        ind_ex (unsigned int): Index of the MIG device.
+        index (unsigned int): Index of the MIG device.
 
     Returns:
         intptr_t: Reference to the MIG device handle.
@@ -26428,7 +26445,7 @@ cpdef intptr_t device_get_mig_device_handle_by_index(intptr_t device, unsigned i
     """
     cdef Device mig_device
     with nogil:
-        __status__ = nvmlDeviceGetMigDeviceHandleByIndex(<Device>device, ind_ex, &mig_device)
+        __status__ = nvmlDeviceGetMigDeviceHandleByIndex(<Device>device, index, &mig_device)
     check_status(__status__)
     return <intptr_t>mig_device
 
@@ -26586,7 +26603,7 @@ cpdef object device_get_vgpu_scheduler_state_v2(intptr_t device):
         device (intptr_t): The identifier of the target ``device``.
 
     Returns:
-        nvmlVgpuSchedulerStateInfo_v2_t: Reference in which ``pSchedulerStateInfo`` is returned.
+        nvmlVgpuSchedulerStateInfo_v2_t: Reference in which ``p_scheduler_state_info`` is returned.
 
     .. seealso:: `nvmlDeviceGetVgpuSchedulerState_v2`
     """
@@ -26605,7 +26622,7 @@ cpdef object gpu_instance_get_vgpu_scheduler_state_v2(intptr_t gpu_instance):
         gpu_instance (intptr_t): The GPU instance handle.
 
     Returns:
-        nvmlVgpuSchedulerStateInfo_v2_t: Reference in which ``pSchedulerStateInfo`` is returned.
+        nvmlVgpuSchedulerStateInfo_v2_t: Reference in which ``p_scheduler_state_info`` is returned.
 
     .. seealso:: `nvmlGpuInstanceGetVgpuSchedulerState_v2`
     """
@@ -26618,13 +26635,13 @@ cpdef object gpu_instance_get_vgpu_scheduler_state_v2(intptr_t gpu_instance):
 
 
 cpdef object device_get_vgpu_scheduler_log_v2(intptr_t device):
-    """Returns the vGPU Software scheduler logs for the device. ``pSchedulerLogInfo`` points to a caller-allocated structure to contain the logs. The number of elements returned will never exceed ``NVML_SCHEDULER_SW_MAX_LOG_ENTRIES``.
+    """Returns the vGPU Software scheduler logs for the device. ``p_scheduler_log_info`` points to a caller-allocated structure to contain the logs. The number of elements returned will never exceed ``NVML_SCHEDULER_SW_MAX_LOG_ENTRIES``.
 
     Args:
         device (intptr_t): The identifier of the target ``device``.
 
     Returns:
-        nvmlVgpuSchedulerLogInfo_v2_t: Reference in which ``pSchedulerLogInfo`` is written.
+        nvmlVgpuSchedulerLogInfo_v2_t: Reference in which ``p_scheduler_log_info`` is written.
 
     .. seealso:: `nvmlDeviceGetVgpuSchedulerLog_v2`
     """
@@ -26637,13 +26654,13 @@ cpdef object device_get_vgpu_scheduler_log_v2(intptr_t device):
 
 
 cpdef object gpu_instance_get_vgpu_scheduler_log_v2(intptr_t gpu_instance):
-    """Returns the vGPU scheduler logs for the given GPU instance. ``pSchedulerLogInfo`` points to a caller-allocated structure to contain the logs. The number of elements returned will never exceed ``NVML_SCHEDULER_SW_MAX_LOG_ENTRIES``.
+    """Returns the vGPU scheduler logs for the given GPU instance. ``p_scheduler_log_info`` points to a caller-allocated structure to contain the logs. The number of elements returned will never exceed ``NVML_SCHEDULER_SW_MAX_LOG_ENTRIES``.
 
     Args:
         gpu_instance (intptr_t): The GPU instance handle.
 
     Returns:
-        nvmlVgpuSchedulerLogInfo_v2_t: Reference in which ``pSchedulerLogInfo`` is written.
+        nvmlVgpuSchedulerLogInfo_v2_t: Reference in which ``p_scheduler_log_info`` is written.
 
     .. seealso:: `nvmlGpuInstanceGetVgpuSchedulerLog_v2`
     """

--- a/cuda_bindings/cuda/bindings/runtime.pyx.in
+++ b/cuda_bindings/cuda/bindings/runtime.pyx.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.2.0, generator version 0.3.1.dev1422+gf4812259e.d20260318. Do not modify it directly.
+# This code was automatically generated with version 13.2.0, generator version 0.3.1.dev1568+g289771de9.d20260413. Do not modify it directly.
 from typing import Any, Optional
 import cython
 import ctypes
@@ -21245,7 +21245,7 @@ def cudaDeviceGetLimit(limit not None : cudaLimit):
 def cudaDeviceGetTexture1DLinearMaxWidth(fmtDesc : Optional[cudaChannelFormatDesc], int device):
     """"""
     cdef size_t maxWidthInElements = 0
-    cdef cyruntime.cudaChannelFormatDesc* cyfmtDesc_ptr = fmtDesc._pvt_ptr if fmtDesc is not None else NULL
+    cdef cyruntime.cudaChannelFormatDesc* cyfmtDesc_ptr = <cyruntime.cudaChannelFormatDesc*>fmtDesc._pvt_ptr if fmtDesc is not None else NULL
     with nogil:
         err = cyruntime.cudaDeviceGetTexture1DLinearMaxWidth(&maxWidthInElements, cyfmtDesc_ptr, device)
     if err != cyruntime.cudaSuccess:
@@ -22672,7 +22672,7 @@ def cudaChooseDevice(prop : Optional[cudaDeviceProp]):
     :py:obj:`~.cudaGetDeviceCount`, :py:obj:`~.cudaGetDevice`, :py:obj:`~.cudaSetDevice`, :py:obj:`~.cudaGetDeviceProperties`, :py:obj:`~.cudaInitDevice`
     """
     cdef int device = 0
-    cdef cyruntime.cudaDeviceProp* cyprop_ptr = prop._pvt_ptr if prop is not None else NULL
+    cdef cyruntime.cudaDeviceProp* cyprop_ptr = <cyruntime.cudaDeviceProp*>prop._pvt_ptr if prop is not None else NULL
     with nogil:
         err = cyruntime.cudaChooseDevice(&device, cyprop_ptr)
     if err != cyruntime.cudaSuccess:
@@ -23413,7 +23413,7 @@ def cudaStreamSetAttribute(hStream, attr not None : cudaStreamAttrID, value : Op
         phStream = int(cudaStream_t(hStream))
     cyhStream = <cyruntime.cudaStream_t><void_ptr>phStream
     cdef cyruntime.cudaStreamAttrID cyattr = int(attr)
-    cdef cyruntime.cudaStreamAttrValue* cyvalue_ptr = value._pvt_ptr if value is not None else NULL
+    cdef cyruntime.cudaStreamAttrValue* cyvalue_ptr = <cyruntime.cudaStreamAttrValue*>value._pvt_ptr if value is not None else NULL
     with nogil:
         err = cyruntime.cudaStreamSetAttribute(cyhStream, cyattr, cyvalue_ptr)
     return (_cudaError_t(err),)
@@ -24901,7 +24901,7 @@ def cudaImportExternalMemory(memHandleDesc : Optional[cudaExternalMemoryHandleDe
     and Cache Control" chapter from Vulkan specification.
     """
     cdef cudaExternalMemory_t extMem_out = cudaExternalMemory_t()
-    cdef cyruntime.cudaExternalMemoryHandleDesc* cymemHandleDesc_ptr = memHandleDesc._pvt_ptr if memHandleDesc is not None else NULL
+    cdef cyruntime.cudaExternalMemoryHandleDesc* cymemHandleDesc_ptr = <cyruntime.cudaExternalMemoryHandleDesc*>memHandleDesc._pvt_ptr if memHandleDesc is not None else NULL
     with nogil:
         err = cyruntime.cudaImportExternalMemory(<cyruntime.cudaExternalMemory_t*>extMem_out._pvt_ptr, cymemHandleDesc_ptr)
     if err != cyruntime.cudaSuccess:
@@ -24969,7 +24969,7 @@ def cudaExternalMemoryGetMappedBuffer(extMem, bufferDesc : Optional[cudaExternal
         pextMem = int(cudaExternalMemory_t(extMem))
     cyextMem = <cyruntime.cudaExternalMemory_t><void_ptr>pextMem
     cdef void_ptr devPtr = 0
-    cdef cyruntime.cudaExternalMemoryBufferDesc* cybufferDesc_ptr = bufferDesc._pvt_ptr if bufferDesc is not None else NULL
+    cdef cyruntime.cudaExternalMemoryBufferDesc* cybufferDesc_ptr = <cyruntime.cudaExternalMemoryBufferDesc*>bufferDesc._pvt_ptr if bufferDesc is not None else NULL
     with nogil:
         err = cyruntime.cudaExternalMemoryGetMappedBuffer(<void**>&devPtr, cyextMem, cybufferDesc_ptr)
     if err != cyruntime.cudaSuccess:
@@ -25041,7 +25041,7 @@ def cudaExternalMemoryGetMappedMipmappedArray(extMem, mipmapDesc : Optional[cuda
         pextMem = int(cudaExternalMemory_t(extMem))
     cyextMem = <cyruntime.cudaExternalMemory_t><void_ptr>pextMem
     cdef cudaMipmappedArray_t mipmap = cudaMipmappedArray_t()
-    cdef cyruntime.cudaExternalMemoryMipmappedArrayDesc* cymipmapDesc_ptr = mipmapDesc._pvt_ptr if mipmapDesc is not None else NULL
+    cdef cyruntime.cudaExternalMemoryMipmappedArrayDesc* cymipmapDesc_ptr = <cyruntime.cudaExternalMemoryMipmappedArrayDesc*>mipmapDesc._pvt_ptr if mipmapDesc is not None else NULL
     with nogil:
         err = cyruntime.cudaExternalMemoryGetMappedMipmappedArray(<cyruntime.cudaMipmappedArray_t*>mipmap._pvt_ptr, cyextMem, cymipmapDesc_ptr)
     if err != cyruntime.cudaSuccess:
@@ -25228,7 +25228,7 @@ def cudaImportExternalSemaphore(semHandleDesc : Optional[cudaExternalSemaphoreHa
     :py:obj:`~.cudaDestroyExternalSemaphore`, :py:obj:`~.cudaSignalExternalSemaphoresAsync`, :py:obj:`~.cudaWaitExternalSemaphoresAsync`
     """
     cdef cudaExternalSemaphore_t extSem_out = cudaExternalSemaphore_t()
-    cdef cyruntime.cudaExternalSemaphoreHandleDesc* cysemHandleDesc_ptr = semHandleDesc._pvt_ptr if semHandleDesc is not None else NULL
+    cdef cyruntime.cudaExternalSemaphoreHandleDesc* cysemHandleDesc_ptr = <cyruntime.cudaExternalSemaphoreHandleDesc*>semHandleDesc._pvt_ptr if semHandleDesc is not None else NULL
     with nogil:
         err = cyruntime.cudaImportExternalSemaphore(<cyruntime.cudaExternalSemaphore_t*>extSem_out._pvt_ptr, cysemHandleDesc_ptr)
     if err != cyruntime.cudaSuccess:
@@ -26544,7 +26544,7 @@ def cudaMallocArray(desc : Optional[cudaChannelFormatDesc], size_t width, size_t
     :py:obj:`~.cudaMalloc`, :py:obj:`~.cudaMallocPitch`, :py:obj:`~.cudaFree`, :py:obj:`~.cudaFreeArray`, :py:obj:`~.cudaMallocHost (C API)`, :py:obj:`~.cudaFreeHost`, :py:obj:`~.cudaMalloc3D`, :py:obj:`~.cudaMalloc3DArray`, :py:obj:`~.cudaHostAlloc`, :py:obj:`~.cuArrayCreate`
     """
     cdef cudaArray_t array = cudaArray_t()
-    cdef cyruntime.cudaChannelFormatDesc* cydesc_ptr = desc._pvt_ptr if desc is not None else NULL
+    cdef cyruntime.cudaChannelFormatDesc* cydesc_ptr = <cyruntime.cudaChannelFormatDesc*>desc._pvt_ptr if desc is not None else NULL
     with nogil:
         err = cyruntime.cudaMallocArray(<cyruntime.cudaArray_t*>array._pvt_ptr, cydesc_ptr, width, height, flags)
     if err != cyruntime.cudaSuccess:
@@ -27209,7 +27209,7 @@ def cudaMalloc3DArray(desc : Optional[cudaChannelFormatDesc], extent not None : 
     :py:obj:`~.cudaMalloc3D`, :py:obj:`~.cudaMalloc`, :py:obj:`~.cudaMallocPitch`, :py:obj:`~.cudaFree`, :py:obj:`~.cudaFreeArray`, :py:obj:`~.cudaMallocHost (C API)`, :py:obj:`~.cudaFreeHost`, :py:obj:`~.cudaHostAlloc`, make_cudaExtent, :py:obj:`~.cuArray3DCreate`
     """
     cdef cudaArray_t array = cudaArray_t()
-    cdef cyruntime.cudaChannelFormatDesc* cydesc_ptr = desc._pvt_ptr if desc is not None else NULL
+    cdef cyruntime.cudaChannelFormatDesc* cydesc_ptr = <cyruntime.cudaChannelFormatDesc*>desc._pvt_ptr if desc is not None else NULL
     with nogil:
         err = cyruntime.cudaMalloc3DArray(<cyruntime.cudaArray_t*>array._pvt_ptr, cydesc_ptr, extent._pvt_ptr[0], flags)
     if err != cyruntime.cudaSuccess:
@@ -27335,7 +27335,7 @@ def cudaMallocMipmappedArray(desc : Optional[cudaChannelFormatDesc], extent not 
     :py:obj:`~.cudaMalloc3D`, :py:obj:`~.cudaMalloc`, :py:obj:`~.cudaMallocPitch`, :py:obj:`~.cudaFree`, :py:obj:`~.cudaFreeArray`, :py:obj:`~.cudaMallocHost (C API)`, :py:obj:`~.cudaFreeHost`, :py:obj:`~.cudaHostAlloc`, make_cudaExtent, :py:obj:`~.cuMipmappedArrayCreate`
     """
     cdef cudaMipmappedArray_t mipmappedArray = cudaMipmappedArray_t()
-    cdef cyruntime.cudaChannelFormatDesc* cydesc_ptr = desc._pvt_ptr if desc is not None else NULL
+    cdef cyruntime.cudaChannelFormatDesc* cydesc_ptr = <cyruntime.cudaChannelFormatDesc*>desc._pvt_ptr if desc is not None else NULL
     with nogil:
         err = cyruntime.cudaMallocMipmappedArray(<cyruntime.cudaMipmappedArray_t*>mipmappedArray._pvt_ptr, cydesc_ptr, extent._pvt_ptr[0], numLevels, flags)
     if err != cyruntime.cudaSuccess:
@@ -27470,7 +27470,7 @@ def cudaMemcpy3D(p : Optional[cudaMemcpy3DParms]):
     --------
     :py:obj:`~.cudaMalloc3D`, :py:obj:`~.cudaMalloc3DArray`, :py:obj:`~.cudaMemset3D`, :py:obj:`~.cudaMemcpy3DAsync`, :py:obj:`~.cudaMemcpy`, :py:obj:`~.cudaMemcpy2D`, :py:obj:`~.cudaMemcpy2DToArray`, :py:obj:`~.cudaMemcpy2DFromArray`, :py:obj:`~.cudaMemcpy2DArrayToArray`, :py:obj:`~.cudaMemcpyToSymbol`, :py:obj:`~.cudaMemcpyFromSymbol`, :py:obj:`~.cudaMemcpyAsync`, :py:obj:`~.cudaMemcpy2DAsync`, :py:obj:`~.cudaMemcpy2DToArrayAsync`, :py:obj:`~.cudaMemcpy2DFromArrayAsync`, :py:obj:`~.cudaMemcpyToSymbolAsync`, :py:obj:`~.cudaMemcpyFromSymbolAsync`, make_cudaExtent, make_cudaPos, :py:obj:`~.cuMemcpy3D`
     """
-    cdef cyruntime.cudaMemcpy3DParms* cyp_ptr = p._pvt_ptr if p is not None else NULL
+    cdef cyruntime.cudaMemcpy3DParms* cyp_ptr = <cyruntime.cudaMemcpy3DParms*>p._pvt_ptr if p is not None else NULL
     with nogil:
         err = cyruntime.cudaMemcpy3D(cyp_ptr)
     return (_cudaError_t(err),)
@@ -27507,7 +27507,7 @@ def cudaMemcpy3DPeer(p : Optional[cudaMemcpy3DPeerParms]):
     --------
     :py:obj:`~.cudaMemcpy`, :py:obj:`~.cudaMemcpyPeer`, :py:obj:`~.cudaMemcpyAsync`, :py:obj:`~.cudaMemcpyPeerAsync`, :py:obj:`~.cudaMemcpy3DPeerAsync`, :py:obj:`~.cuMemcpy3DPeer`
     """
-    cdef cyruntime.cudaMemcpy3DPeerParms* cyp_ptr = p._pvt_ptr if p is not None else NULL
+    cdef cyruntime.cudaMemcpy3DPeerParms* cyp_ptr = <cyruntime.cudaMemcpy3DPeerParms*>p._pvt_ptr if p is not None else NULL
     with nogil:
         err = cyruntime.cudaMemcpy3DPeer(cyp_ptr)
     return (_cudaError_t(err),)
@@ -27612,7 +27612,7 @@ def cudaMemcpy3DAsync(p : Optional[cudaMemcpy3DParms], stream):
     else:
         pstream = int(cudaStream_t(stream))
     cystream = <cyruntime.cudaStream_t><void_ptr>pstream
-    cdef cyruntime.cudaMemcpy3DParms* cyp_ptr = p._pvt_ptr if p is not None else NULL
+    cdef cyruntime.cudaMemcpy3DParms* cyp_ptr = <cyruntime.cudaMemcpy3DParms*>p._pvt_ptr if p is not None else NULL
     with nogil:
         err = cyruntime.cudaMemcpy3DAsync(cyp_ptr, cystream)
     return (_cudaError_t(err),)
@@ -27652,7 +27652,7 @@ def cudaMemcpy3DPeerAsync(p : Optional[cudaMemcpy3DPeerParms], stream):
     else:
         pstream = int(cudaStream_t(stream))
     cystream = <cyruntime.cudaStream_t><void_ptr>pstream
-    cdef cyruntime.cudaMemcpy3DPeerParms* cyp_ptr = p._pvt_ptr if p is not None else NULL
+    cdef cyruntime.cudaMemcpy3DPeerParms* cyp_ptr = <cyruntime.cudaMemcpy3DPeerParms*>p._pvt_ptr if p is not None else NULL
     with nogil:
         err = cyruntime.cudaMemcpy3DPeerAsync(cyp_ptr, cystream)
     return (_cudaError_t(err),)
@@ -28831,7 +28831,7 @@ def cudaMemcpyWithAttributesAsync(dst, src, size_t size, attr : Optional[cudaMem
     cdef void* cydst = _helper_input_void_ptr(dst, &cydstHelper)
     cdef _HelperInputVoidPtrStruct cysrcHelper
     cdef void* cysrc = _helper_input_void_ptr(src, &cysrcHelper)
-    cdef cyruntime.cudaMemcpyAttributes* cyattr_ptr = attr._pvt_ptr if attr is not None else NULL
+    cdef cyruntime.cudaMemcpyAttributes* cyattr_ptr = <cyruntime.cudaMemcpyAttributes*>attr._pvt_ptr if attr is not None else NULL
     with nogil:
         err = cyruntime.cudaMemcpyWithAttributesAsync(cydst, cysrc, size, cyattr_ptr, cystream)
     _helper_input_void_ptr_free(&cydstHelper)
@@ -28881,7 +28881,7 @@ def cudaMemcpy3DWithAttributesAsync(op : Optional[cudaMemcpy3DBatchOp], unsigned
     else:
         pstream = int(cudaStream_t(stream))
     cystream = <cyruntime.cudaStream_t><void_ptr>pstream
-    cdef cyruntime.cudaMemcpy3DBatchOp* cyop_ptr = op._pvt_ptr if op is not None else NULL
+    cdef cyruntime.cudaMemcpy3DBatchOp* cyop_ptr = <cyruntime.cudaMemcpy3DBatchOp*>op._pvt_ptr if op is not None else NULL
     with nogil:
         err = cyruntime.cudaMemcpy3DWithAttributesAsync(cyop_ptr, flags, cystream)
     return (_cudaError_t(err),)
@@ -31095,7 +31095,7 @@ def cudaMemPoolGetAccess(memPool, location : Optional[cudaMemLocation]):
         pmemPool = int(cudaMemPool_t(memPool))
     cymemPool = <cyruntime.cudaMemPool_t><void_ptr>pmemPool
     cdef cyruntime.cudaMemAccessFlags flags
-    cdef cyruntime.cudaMemLocation* cylocation_ptr = location._pvt_ptr if location is not None else NULL
+    cdef cyruntime.cudaMemLocation* cylocation_ptr = <cyruntime.cudaMemLocation*>location._pvt_ptr if location is not None else NULL
     with nogil:
         err = cyruntime.cudaMemPoolGetAccess(&flags, cymemPool, cylocation_ptr)
     if err != cyruntime.cudaSuccess:
@@ -31195,7 +31195,7 @@ def cudaMemPoolCreate(poolProps : Optional[cudaMemPoolProps]):
     Specifying :py:obj:`~.cudaMemHandleTypeNone` creates a memory pool that will not support IPC.
     """
     cdef cudaMemPool_t memPool = cudaMemPool_t()
-    cdef cyruntime.cudaMemPoolProps* cypoolProps_ptr = poolProps._pvt_ptr if poolProps is not None else NULL
+    cdef cyruntime.cudaMemPoolProps* cypoolProps_ptr = <cyruntime.cudaMemPoolProps*>poolProps._pvt_ptr if poolProps is not None else NULL
     with nogil:
         err = cyruntime.cudaMemPoolCreate(<cyruntime.cudaMemPool_t*>memPool._pvt_ptr, cypoolProps_ptr)
     if err != cyruntime.cudaSuccess:
@@ -31285,7 +31285,7 @@ def cudaMemGetDefaultMemPool(location : Optional[cudaMemLocation], typename not 
     :py:obj:`~.cuMemAllocAsync`, :py:obj:`~.cuMemPoolTrimTo`, :py:obj:`~.cuMemPoolGetAttribute`, :py:obj:`~.cuMemPoolSetAttribute`, cuMemPoolSetAccess, :py:obj:`~.cuMemGetMemPool`, :py:obj:`~.cuMemPoolCreate`
     """
     cdef cudaMemPool_t memPool = cudaMemPool_t()
-    cdef cyruntime.cudaMemLocation* cylocation_ptr = location._pvt_ptr if location is not None else NULL
+    cdef cyruntime.cudaMemLocation* cylocation_ptr = <cyruntime.cudaMemLocation*>location._pvt_ptr if location is not None else NULL
     cdef cyruntime.cudaMemAllocationType cytypename = int(typename)
     with nogil:
         err = cyruntime.cudaMemGetDefaultMemPool(<cyruntime.cudaMemPool_t*>memPool._pvt_ptr, cylocation_ptr, cytypename)
@@ -31339,7 +31339,7 @@ def cudaMemGetMemPool(location : Optional[cudaMemLocation], typename not None : 
     :py:obj:`~.cuDeviceGetDefaultMemPool`, :py:obj:`~.cuMemPoolCreate`, :py:obj:`~.cuDeviceSetMemPool`, :py:obj:`~.cuMemSetMemPool`
     """
     cdef cudaMemPool_t memPool = cudaMemPool_t()
-    cdef cyruntime.cudaMemLocation* cylocation_ptr = location._pvt_ptr if location is not None else NULL
+    cdef cyruntime.cudaMemLocation* cylocation_ptr = <cyruntime.cudaMemLocation*>location._pvt_ptr if location is not None else NULL
     cdef cyruntime.cudaMemAllocationType cytypename = int(typename)
     with nogil:
         err = cyruntime.cudaMemGetMemPool(<cyruntime.cudaMemPool_t*>memPool._pvt_ptr, cylocation_ptr, cytypename)
@@ -31408,7 +31408,7 @@ def cudaMemSetMemPool(location : Optional[cudaMemLocation], typename not None : 
     else:
         pmemPool = int(cudaMemPool_t(memPool))
     cymemPool = <cyruntime.cudaMemPool_t><void_ptr>pmemPool
-    cdef cyruntime.cudaMemLocation* cylocation_ptr = location._pvt_ptr if location is not None else NULL
+    cdef cyruntime.cudaMemLocation* cylocation_ptr = <cyruntime.cudaMemLocation*>location._pvt_ptr if location is not None else NULL
     cdef cyruntime.cudaMemAllocationType cytypename = int(typename)
     with nogil:
         err = cyruntime.cudaMemSetMemPool(cylocation_ptr, cytypename, cymemPool)
@@ -31659,7 +31659,7 @@ def cudaMemPoolImportPointer(memPool, exportData : Optional[cudaMemPoolPtrExport
         pmemPool = int(cudaMemPool_t(memPool))
     cymemPool = <cyruntime.cudaMemPool_t><void_ptr>pmemPool
     cdef void_ptr ptr = 0
-    cdef cyruntime.cudaMemPoolPtrExportData* cyexportData_ptr = exportData._pvt_ptr if exportData is not None else NULL
+    cdef cyruntime.cudaMemPoolPtrExportData* cyexportData_ptr = <cyruntime.cudaMemPoolPtrExportData*>exportData._pvt_ptr if exportData is not None else NULL
     with nogil:
         err = cyruntime.cudaMemPoolImportPointer(<void**>&ptr, cymemPool, cyexportData_ptr)
     if err != cyruntime.cudaSuccess:
@@ -32551,9 +32551,9 @@ def cudaCreateTextureObject(pResDesc : Optional[cudaResourceDesc], pTexDesc : Op
     :py:obj:`~.cudaDestroyTextureObject`, :py:obj:`~.cuTexObjectCreate`
     """
     cdef cudaTextureObject_t pTexObject = cudaTextureObject_t()
-    cdef cyruntime.cudaResourceDesc* cypResDesc_ptr = pResDesc._pvt_ptr if pResDesc is not None else NULL
-    cdef cyruntime.cudaTextureDesc* cypTexDesc_ptr = pTexDesc._pvt_ptr if pTexDesc is not None else NULL
-    cdef cyruntime.cudaResourceViewDesc* cypResViewDesc_ptr = pResViewDesc._pvt_ptr if pResViewDesc is not None else NULL
+    cdef cyruntime.cudaResourceDesc* cypResDesc_ptr = <cyruntime.cudaResourceDesc*>pResDesc._pvt_ptr if pResDesc is not None else NULL
+    cdef cyruntime.cudaTextureDesc* cypTexDesc_ptr = <cyruntime.cudaTextureDesc*>pTexDesc._pvt_ptr if pTexDesc is not None else NULL
+    cdef cyruntime.cudaResourceViewDesc* cypResViewDesc_ptr = <cyruntime.cudaResourceViewDesc*>pResViewDesc._pvt_ptr if pResViewDesc is not None else NULL
     with nogil:
         err = cyruntime.cudaCreateTextureObject(<cyruntime.cudaTextureObject_t*>pTexObject._pvt_ptr, cypResDesc_ptr, cypTexDesc_ptr, cypResViewDesc_ptr)
     if err != cyruntime.cudaSuccess:
@@ -32754,7 +32754,7 @@ def cudaCreateSurfaceObject(pResDesc : Optional[cudaResourceDesc]):
     :py:obj:`~.cudaDestroySurfaceObject`, :py:obj:`~.cuSurfObjectCreate`
     """
     cdef cudaSurfaceObject_t pSurfObject = cudaSurfaceObject_t()
-    cdef cyruntime.cudaResourceDesc* cypResDesc_ptr = pResDesc._pvt_ptr if pResDesc is not None else NULL
+    cdef cyruntime.cudaResourceDesc* cypResDesc_ptr = <cyruntime.cudaResourceDesc*>pResDesc._pvt_ptr if pResDesc is not None else NULL
     with nogil:
         err = cyruntime.cudaCreateSurfaceObject(<cyruntime.cudaSurfaceObject_t*>pSurfObject._pvt_ptr, cypResDesc_ptr)
     if err != cyruntime.cudaSuccess:
@@ -33246,7 +33246,7 @@ def cudaGraphAddKernelNode(graph, pDependencies : Optional[tuple[cudaGraphNode_t
     elif len(pDependencies) == 1:
         cypDependencies = <cyruntime.cudaGraphNode_t*>(<cudaGraphNode_t>pDependencies[0])._pvt_ptr
     if numDependencies > <size_t>len(pDependencies): raise RuntimeError("List is too small: " + str(len(pDependencies)) + " < " + str(numDependencies))
-    cdef cyruntime.cudaKernelNodeParams* cypNodeParams_ptr = pNodeParams._pvt_ptr if pNodeParams is not None else NULL
+    cdef cyruntime.cudaKernelNodeParams* cypNodeParams_ptr = <cyruntime.cudaKernelNodeParams*>pNodeParams._pvt_ptr if pNodeParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphAddKernelNode(<cyruntime.cudaGraphNode_t*>pGraphNode._pvt_ptr, cygraph, cypDependencies, numDependencies, cypNodeParams_ptr)
     if len(pDependencies) > 1 and cypDependencies is not NULL:
@@ -33337,7 +33337,7 @@ def cudaGraphKernelNodeSetParams(node, pNodeParams : Optional[cudaKernelNodePara
     else:
         pnode = int(cudaGraphNode_t(node))
     cynode = <cyruntime.cudaGraphNode_t><void_ptr>pnode
-    cdef cyruntime.cudaKernelNodeParams* cypNodeParams_ptr = pNodeParams._pvt_ptr if pNodeParams is not None else NULL
+    cdef cyruntime.cudaKernelNodeParams* cypNodeParams_ptr = <cyruntime.cudaKernelNodeParams*>pNodeParams._pvt_ptr if pNodeParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphKernelNodeSetParams(cynode, cypNodeParams_ptr)
     return (_cudaError_t(err),)
@@ -33470,7 +33470,7 @@ def cudaGraphKernelNodeSetAttribute(hNode, attr not None : cudaKernelNodeAttrID,
         phNode = int(cudaGraphNode_t(hNode))
     cyhNode = <cyruntime.cudaGraphNode_t><void_ptr>phNode
     cdef cyruntime.cudaKernelNodeAttrID cyattr = int(attr)
-    cdef cyruntime.cudaKernelNodeAttrValue* cyvalue_ptr = value._pvt_ptr if value is not None else NULL
+    cdef cyruntime.cudaKernelNodeAttrValue* cyvalue_ptr = <cyruntime.cudaKernelNodeAttrValue*>value._pvt_ptr if value is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphKernelNodeSetAttribute(cyhNode, cyattr, cyvalue_ptr)
     return (_cudaError_t(err),)
@@ -33542,7 +33542,7 @@ def cudaGraphAddMemcpyNode(graph, pDependencies : Optional[tuple[cudaGraphNode_t
     elif len(pDependencies) == 1:
         cypDependencies = <cyruntime.cudaGraphNode_t*>(<cudaGraphNode_t>pDependencies[0])._pvt_ptr
     if numDependencies > <size_t>len(pDependencies): raise RuntimeError("List is too small: " + str(len(pDependencies)) + " < " + str(numDependencies))
-    cdef cyruntime.cudaMemcpy3DParms* cypCopyParams_ptr = pCopyParams._pvt_ptr if pCopyParams is not None else NULL
+    cdef cyruntime.cudaMemcpy3DParms* cypCopyParams_ptr = <cyruntime.cudaMemcpy3DParms*>pCopyParams._pvt_ptr if pCopyParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphAddMemcpyNode(<cyruntime.cudaGraphNode_t*>pGraphNode._pvt_ptr, cygraph, cypDependencies, numDependencies, cypCopyParams_ptr)
     if len(pDependencies) > 1 and cypDependencies is not NULL:
@@ -33754,7 +33754,7 @@ def cudaGraphMemcpyNodeSetParams(node, pNodeParams : Optional[cudaMemcpy3DParms]
     else:
         pnode = int(cudaGraphNode_t(node))
     cynode = <cyruntime.cudaGraphNode_t><void_ptr>pnode
-    cdef cyruntime.cudaMemcpy3DParms* cypNodeParams_ptr = pNodeParams._pvt_ptr if pNodeParams is not None else NULL
+    cdef cyruntime.cudaMemcpy3DParms* cypNodeParams_ptr = <cyruntime.cudaMemcpy3DParms*>pNodeParams._pvt_ptr if pNodeParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphMemcpyNodeSetParams(cynode, cypNodeParams_ptr)
     return (_cudaError_t(err),)
@@ -33904,7 +33904,7 @@ def cudaGraphAddMemsetNode(graph, pDependencies : Optional[tuple[cudaGraphNode_t
     elif len(pDependencies) == 1:
         cypDependencies = <cyruntime.cudaGraphNode_t*>(<cudaGraphNode_t>pDependencies[0])._pvt_ptr
     if numDependencies > <size_t>len(pDependencies): raise RuntimeError("List is too small: " + str(len(pDependencies)) + " < " + str(numDependencies))
-    cdef cyruntime.cudaMemsetParams* cypMemsetParams_ptr = pMemsetParams._pvt_ptr if pMemsetParams is not None else NULL
+    cdef cyruntime.cudaMemsetParams* cypMemsetParams_ptr = <cyruntime.cudaMemsetParams*>pMemsetParams._pvt_ptr if pMemsetParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphAddMemsetNode(<cyruntime.cudaGraphNode_t*>pGraphNode._pvt_ptr, cygraph, cypDependencies, numDependencies, cypMemsetParams_ptr)
     if len(pDependencies) > 1 and cypDependencies is not NULL:
@@ -33986,7 +33986,7 @@ def cudaGraphMemsetNodeSetParams(node, pNodeParams : Optional[cudaMemsetParams])
     else:
         pnode = int(cudaGraphNode_t(node))
     cynode = <cyruntime.cudaGraphNode_t><void_ptr>pnode
-    cdef cyruntime.cudaMemsetParams* cypNodeParams_ptr = pNodeParams._pvt_ptr if pNodeParams is not None else NULL
+    cdef cyruntime.cudaMemsetParams* cypNodeParams_ptr = <cyruntime.cudaMemsetParams*>pNodeParams._pvt_ptr if pNodeParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphMemsetNodeSetParams(cynode, cypNodeParams_ptr)
     return (_cudaError_t(err),)
@@ -34053,7 +34053,7 @@ def cudaGraphAddHostNode(graph, pDependencies : Optional[tuple[cudaGraphNode_t] 
     elif len(pDependencies) == 1:
         cypDependencies = <cyruntime.cudaGraphNode_t*>(<cudaGraphNode_t>pDependencies[0])._pvt_ptr
     if numDependencies > <size_t>len(pDependencies): raise RuntimeError("List is too small: " + str(len(pDependencies)) + " < " + str(numDependencies))
-    cdef cyruntime.cudaHostNodeParams* cypNodeParams_ptr = pNodeParams._pvt_ptr if pNodeParams is not None else NULL
+    cdef cyruntime.cudaHostNodeParams* cypNodeParams_ptr = <cyruntime.cudaHostNodeParams*>pNodeParams._pvt_ptr if pNodeParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphAddHostNode(<cyruntime.cudaGraphNode_t*>pGraphNode._pvt_ptr, cygraph, cypDependencies, numDependencies, cypNodeParams_ptr)
     if len(pDependencies) > 1 and cypDependencies is not NULL:
@@ -34135,7 +34135,7 @@ def cudaGraphHostNodeSetParams(node, pNodeParams : Optional[cudaHostNodeParams])
     else:
         pnode = int(cudaGraphNode_t(node))
     cynode = <cyruntime.cudaGraphNode_t><void_ptr>pnode
-    cdef cyruntime.cudaHostNodeParams* cypNodeParams_ptr = pNodeParams._pvt_ptr if pNodeParams is not None else NULL
+    cdef cyruntime.cudaHostNodeParams* cypNodeParams_ptr = <cyruntime.cudaHostNodeParams*>pNodeParams._pvt_ptr if pNodeParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphHostNodeSetParams(cynode, cypNodeParams_ptr)
     return (_cudaError_t(err),)
@@ -34550,7 +34550,7 @@ def cudaGraphAddExternalSemaphoresSignalNode(graph, pDependencies : Optional[tup
     elif len(pDependencies) == 1:
         cypDependencies = <cyruntime.cudaGraphNode_t*>(<cudaGraphNode_t>pDependencies[0])._pvt_ptr
     if numDependencies > <size_t>len(pDependencies): raise RuntimeError("List is too small: " + str(len(pDependencies)) + " < " + str(numDependencies))
-    cdef cyruntime.cudaExternalSemaphoreSignalNodeParams* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cyruntime.cudaExternalSemaphoreSignalNodeParams* cynodeParams_ptr = <cyruntime.cudaExternalSemaphoreSignalNodeParams*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphAddExternalSemaphoresSignalNode(<cyruntime.cudaGraphNode_t*>pGraphNode._pvt_ptr, cygraph, cypDependencies, numDependencies, cynodeParams_ptr)
     if len(pDependencies) > 1 and cypDependencies is not NULL:
@@ -34594,7 +34594,7 @@ def cudaGraphExternalSemaphoresSignalNodeSetParams(hNode, nodeParams : Optional[
     else:
         phNode = int(cudaGraphNode_t(hNode))
     cyhNode = <cyruntime.cudaGraphNode_t><void_ptr>phNode
-    cdef cyruntime.cudaExternalSemaphoreSignalNodeParams* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cyruntime.cudaExternalSemaphoreSignalNodeParams* cynodeParams_ptr = <cyruntime.cudaExternalSemaphoreSignalNodeParams*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphExternalSemaphoresSignalNodeSetParams(cyhNode, cynodeParams_ptr)
     return (_cudaError_t(err),)
@@ -34628,7 +34628,7 @@ def cudaGraphAddExternalSemaphoresWaitNode(graph, pDependencies : Optional[tuple
     elif len(pDependencies) == 1:
         cypDependencies = <cyruntime.cudaGraphNode_t*>(<cudaGraphNode_t>pDependencies[0])._pvt_ptr
     if numDependencies > <size_t>len(pDependencies): raise RuntimeError("List is too small: " + str(len(pDependencies)) + " < " + str(numDependencies))
-    cdef cyruntime.cudaExternalSemaphoreWaitNodeParams* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cyruntime.cudaExternalSemaphoreWaitNodeParams* cynodeParams_ptr = <cyruntime.cudaExternalSemaphoreWaitNodeParams*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphAddExternalSemaphoresWaitNode(<cyruntime.cudaGraphNode_t*>pGraphNode._pvt_ptr, cygraph, cypDependencies, numDependencies, cynodeParams_ptr)
     if len(pDependencies) > 1 and cypDependencies is not NULL:
@@ -34672,7 +34672,7 @@ def cudaGraphExternalSemaphoresWaitNodeSetParams(hNode, nodeParams : Optional[cu
     else:
         phNode = int(cudaGraphNode_t(hNode))
     cyhNode = <cyruntime.cudaGraphNode_t><void_ptr>phNode
-    cdef cyruntime.cudaExternalSemaphoreWaitNodeParams* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cyruntime.cudaExternalSemaphoreWaitNodeParams* cynodeParams_ptr = <cyruntime.cudaExternalSemaphoreWaitNodeParams*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphExternalSemaphoresWaitNodeSetParams(cyhNode, cynodeParams_ptr)
     return (_cudaError_t(err),)
@@ -34706,7 +34706,7 @@ def cudaGraphAddMemAllocNode(graph, pDependencies : Optional[tuple[cudaGraphNode
     elif len(pDependencies) == 1:
         cypDependencies = <cyruntime.cudaGraphNode_t*>(<cudaGraphNode_t>pDependencies[0])._pvt_ptr
     if numDependencies > <size_t>len(pDependencies): raise RuntimeError("List is too small: " + str(len(pDependencies)) + " < " + str(numDependencies))
-    cdef cyruntime.cudaMemAllocNodeParams* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cyruntime.cudaMemAllocNodeParams* cynodeParams_ptr = <cyruntime.cudaMemAllocNodeParams*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphAddMemAllocNode(<cyruntime.cudaGraphNode_t*>pGraphNode._pvt_ptr, cygraph, cypDependencies, numDependencies, cynodeParams_ptr)
     if len(pDependencies) > 1 and cypDependencies is not NULL:
@@ -36403,7 +36403,7 @@ def cudaGraphInstantiateWithParams(graph, instantiateParams : Optional[cudaGraph
         pgraph = int(cudaGraph_t(graph))
     cygraph = <cyruntime.cudaGraph_t><void_ptr>pgraph
     cdef cudaGraphExec_t pGraphExec = cudaGraphExec_t()
-    cdef cyruntime.cudaGraphInstantiateParams* cyinstantiateParams_ptr = instantiateParams._pvt_ptr if instantiateParams is not None else NULL
+    cdef cyruntime.cudaGraphInstantiateParams* cyinstantiateParams_ptr = <cyruntime.cudaGraphInstantiateParams*>instantiateParams._pvt_ptr if instantiateParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphInstantiateWithParams(<cyruntime.cudaGraphExec_t*>pGraphExec._pvt_ptr, cygraph, cyinstantiateParams_ptr)
     if err != cyruntime.cudaSuccess:
@@ -36530,7 +36530,7 @@ def cudaGraphExecKernelNodeSetParams(hGraphExec, node, pNodeParams : Optional[cu
     else:
         phGraphExec = int(cudaGraphExec_t(hGraphExec))
     cyhGraphExec = <cyruntime.cudaGraphExec_t><void_ptr>phGraphExec
-    cdef cyruntime.cudaKernelNodeParams* cypNodeParams_ptr = pNodeParams._pvt_ptr if pNodeParams is not None else NULL
+    cdef cyruntime.cudaKernelNodeParams* cypNodeParams_ptr = <cyruntime.cudaKernelNodeParams*>pNodeParams._pvt_ptr if pNodeParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphExecKernelNodeSetParams(cyhGraphExec, cynode, cypNodeParams_ptr)
     return (_cudaError_t(err),)
@@ -36595,7 +36595,7 @@ def cudaGraphExecMemcpyNodeSetParams(hGraphExec, node, pNodeParams : Optional[cu
     else:
         phGraphExec = int(cudaGraphExec_t(hGraphExec))
     cyhGraphExec = <cyruntime.cudaGraphExec_t><void_ptr>phGraphExec
-    cdef cyruntime.cudaMemcpy3DParms* cypNodeParams_ptr = pNodeParams._pvt_ptr if pNodeParams is not None else NULL
+    cdef cyruntime.cudaMemcpy3DParms* cypNodeParams_ptr = <cyruntime.cudaMemcpy3DParms*>pNodeParams._pvt_ptr if pNodeParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphExecMemcpyNodeSetParams(cyhGraphExec, cynode, cypNodeParams_ptr)
     return (_cudaError_t(err),)
@@ -36766,7 +36766,7 @@ def cudaGraphExecMemsetNodeSetParams(hGraphExec, node, pNodeParams : Optional[cu
     else:
         phGraphExec = int(cudaGraphExec_t(hGraphExec))
     cyhGraphExec = <cyruntime.cudaGraphExec_t><void_ptr>phGraphExec
-    cdef cyruntime.cudaMemsetParams* cypNodeParams_ptr = pNodeParams._pvt_ptr if pNodeParams is not None else NULL
+    cdef cyruntime.cudaMemsetParams* cypNodeParams_ptr = <cyruntime.cudaMemsetParams*>pNodeParams._pvt_ptr if pNodeParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphExecMemsetNodeSetParams(cyhGraphExec, cynode, cypNodeParams_ptr)
     return (_cudaError_t(err),)
@@ -36821,7 +36821,7 @@ def cudaGraphExecHostNodeSetParams(hGraphExec, node, pNodeParams : Optional[cuda
     else:
         phGraphExec = int(cudaGraphExec_t(hGraphExec))
     cyhGraphExec = <cyruntime.cudaGraphExec_t><void_ptr>phGraphExec
-    cdef cyruntime.cudaHostNodeParams* cypNodeParams_ptr = pNodeParams._pvt_ptr if pNodeParams is not None else NULL
+    cdef cyruntime.cudaHostNodeParams* cypNodeParams_ptr = <cyruntime.cudaHostNodeParams*>pNodeParams._pvt_ptr if pNodeParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphExecHostNodeSetParams(cyhGraphExec, cynode, cypNodeParams_ptr)
     return (_cudaError_t(err),)
@@ -36950,7 +36950,7 @@ def cudaGraphExecExternalSemaphoresSignalNodeSetParams(hGraphExec, hNode, nodePa
     else:
         phGraphExec = int(cudaGraphExec_t(hGraphExec))
     cyhGraphExec = <cyruntime.cudaGraphExec_t><void_ptr>phGraphExec
-    cdef cyruntime.cudaExternalSemaphoreSignalNodeParams* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cyruntime.cudaExternalSemaphoreSignalNodeParams* cynodeParams_ptr = <cyruntime.cudaExternalSemaphoreSignalNodeParams*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphExecExternalSemaphoresSignalNodeSetParams(cyhGraphExec, cyhNode, cynodeParams_ptr)
     return (_cudaError_t(err),)
@@ -36977,7 +36977,7 @@ def cudaGraphExecExternalSemaphoresWaitNodeSetParams(hGraphExec, hNode, nodePara
     else:
         phGraphExec = int(cudaGraphExec_t(hGraphExec))
     cyhGraphExec = <cyruntime.cudaGraphExec_t><void_ptr>phGraphExec
-    cdef cyruntime.cudaExternalSemaphoreWaitNodeParams* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cyruntime.cudaExternalSemaphoreWaitNodeParams* cynodeParams_ptr = <cyruntime.cudaExternalSemaphoreWaitNodeParams*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphExecExternalSemaphoresWaitNodeSetParams(cyhGraphExec, cyhNode, cynodeParams_ptr)
     return (_cudaError_t(err),)
@@ -37882,7 +37882,7 @@ def cudaGraphAddNode(graph, pDependencies : Optional[tuple[cudaGraphNode_t] | li
             string.memcpy(&cydependencyData[idx], (<cudaGraphEdgeData>dependencyData[idx])._pvt_ptr, sizeof(cyruntime.cudaGraphEdgeData))
     elif len(dependencyData) == 1:
         cydependencyData = (<cudaGraphEdgeData>dependencyData[0])._pvt_ptr
-    cdef cyruntime.cudaGraphNodeParams* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cyruntime.cudaGraphNodeParams* cynodeParams_ptr = <cyruntime.cudaGraphNodeParams*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphAddNode(<cyruntime.cudaGraphNode_t*>pGraphNode._pvt_ptr, cygraph, cypDependencies, cydependencyData, numDependencies, cynodeParams_ptr)
     if len(pDependencies) > 1 and cypDependencies is not NULL:
@@ -37932,7 +37932,7 @@ def cudaGraphNodeSetParams(node, nodeParams : Optional[cudaGraphNodeParams]):
     else:
         pnode = int(cudaGraphNode_t(node))
     cynode = <cyruntime.cudaGraphNode_t><void_ptr>pnode
-    cdef cyruntime.cudaGraphNodeParams* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cyruntime.cudaGraphNodeParams* cynodeParams_ptr = <cyruntime.cudaGraphNodeParams*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphNodeSetParams(cynode, cynodeParams_ptr)
     return (_cudaError_t(err),)
@@ -38045,7 +38045,7 @@ def cudaGraphExecNodeSetParams(graphExec, node, nodeParams : Optional[cudaGraphN
     else:
         pgraphExec = int(cudaGraphExec_t(graphExec))
     cygraphExec = <cyruntime.cudaGraphExec_t><void_ptr>pgraphExec
-    cdef cyruntime.cudaGraphNodeParams* cynodeParams_ptr = nodeParams._pvt_ptr if nodeParams is not None else NULL
+    cdef cyruntime.cudaGraphNodeParams* cynodeParams_ptr = <cyruntime.cudaGraphNodeParams*>nodeParams._pvt_ptr if nodeParams is not None else NULL
     with nogil:
         err = cyruntime.cudaGraphExecNodeSetParams(cygraphExec, cynode, cynodeParams_ptr)
     return (_cudaError_t(err),)
@@ -39152,7 +39152,7 @@ def cudaDevSmResourceSplitByCount(unsigned int nbGroups, input_ : Optional[cudaD
         if cyresult is NULL:
             raise MemoryError('Failed to allocate length x size memory: ' + str(nbGroups) + 'x' + str(sizeof(cyruntime.cudaDevResource)))
     cdef unsigned int cynbGroups = nbGroups
-    cdef cyruntime.cudaDevResource* cyinput__ptr = input_._pvt_ptr if input_ is not None else NULL
+    cdef cyruntime.cudaDevResource* cyinput__ptr = <cyruntime.cudaDevResource*>input_._pvt_ptr if input_ is not None else NULL
     cdef cudaDevResource remaining = cudaDevResource()
     with nogil:
         err = cyruntime.cudaDevSmResourceSplitByCount(cyresult, &cynbGroups, cyinput__ptr, <cyruntime.cudaDevResource*>remaining._pvt_ptr, flags, minCount)
@@ -39314,7 +39314,7 @@ def cudaDevSmResourceSplit(unsigned int nbGroups, input_ : Optional[cudaDevResou
         cyresult = <cyruntime.cudaDevResource*>calloc(nbGroups, sizeof(cyruntime.cudaDevResource))
         if cyresult is NULL:
             raise MemoryError('Failed to allocate length x size memory: ' + str(nbGroups) + 'x' + str(sizeof(cyruntime.cudaDevResource)))
-    cdef cyruntime.cudaDevResource* cyinput__ptr = input_._pvt_ptr if input_ is not None else NULL
+    cdef cyruntime.cudaDevResource* cyinput__ptr = <cyruntime.cudaDevResource*>input_._pvt_ptr if input_ is not None else NULL
     cdef cudaDevResource remainder = cudaDevResource()
     cdef cyruntime.cudaDevSmResourceGroupParams* cygroupParams = NULL
     if len(groupParams) > 1:
@@ -39986,7 +39986,7 @@ def cudaDeviceGetExecutionCtx(int device):
 def cudaGetExportTable(pExportTableId : Optional[cudaUUID_t]):
     """"""
     cdef void_ptr ppExportTable = 0
-    cdef cyruntime.cudaUUID_t* cypExportTableId_ptr = pExportTableId._pvt_ptr if pExportTableId is not None else NULL
+    cdef cyruntime.cudaUUID_t* cypExportTableId_ptr = <cyruntime.cudaUUID_t*>pExportTableId._pvt_ptr if pExportTableId is not None else NULL
     with nogil:
         err = cyruntime.cudaGetExportTable(<const void**>&ppExportTable, cypExportTableId_ptr)
     if err != cyruntime.cudaSuccess:
@@ -40691,7 +40691,7 @@ def cudaEGLStreamProducerReturnFrame(conn, eglframe : Optional[cudaEglFrame], pS
         cyconn = <cyruntime.cudaEglStreamConnection*><void_ptr>conn
     else:
         raise TypeError("Argument 'conn' is not instance of type (expected <class 'int, runtime.cudaEglStreamConnection'>, found " + str(type(conn)))
-    cdef cyruntime.cudaEglFrame* cyeglframe_ptr = eglframe._pvt_ptr if eglframe is not None else NULL
+    cdef cyruntime.cudaEglFrame* cyeglframe_ptr = <cyruntime.cudaEglFrame*>eglframe._pvt_ptr if eglframe is not None else NULL
     with nogil:
         err = cyruntime.cudaEGLStreamProducerReturnFrame(cyconn, cyeglframe_ptr, cypStream)
     return (_cudaError_t(err),)


### PR DESCRIPTION
This catches `cuda.bindings` up with a number of recent changes to the code generator.

These are

- whitespace
- documentation fixes, particularly matching documentation to the correct arguments and return values
- Fixing the `ind_ex` argument naming bug

