### PR TITLE
Remove _SynchronousMemoryResource from cuda.core._memory public API

### DIFF
--- a/cuda_core/cuda/core/_device.pyx
+++ b/cuda_core/cuda/core/_device.pyx
@@ -1145,7 +1145,7 @@ class Device:
                 from cuda.core._memory import DeviceMemoryResource
                 self._memory_resource = DeviceMemoryResource(self._device_id)
             else:
-                from cuda.core._memory import _SynchronousMemoryResource
+                from cuda.core._memory._legacy import _SynchronousMemoryResource
                 self._memory_resource = _SynchronousMemoryResource(self._device_id)
 
         return self._memory_resource

--- a/cuda_core/cuda/core/_memory/_legacy.py
+++ b/cuda_core/cuda/core/_memory/_legacy.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -17,7 +17,7 @@ from cuda.core._utils.cuda_utils import (
     driver,
 )
 
-__all__ = ["LegacyPinnedMemoryResource", "_SynchronousMemoryResource"]
+__all__ = ["LegacyPinnedMemoryResource"]
 
 
 class LegacyPinnedMemoryResource(MemoryResource):

--- a/cuda_core/tests/test_launcher.py
+++ b/cuda_core/tests/test_launcher.py
@@ -24,7 +24,7 @@ from cuda.core import (
     ProgramOptions,
     launch,
 )
-from cuda.core._memory import _SynchronousMemoryResource
+from cuda.core._memory._legacy import _SynchronousMemoryResource
 from cuda.core._utils.cuda_utils import CUDAError
 
 


### PR DESCRIPTION
**Problem**: `_SynchronousMemoryResource` is a private symbol (underscore-prefixed) that was listed in `__all__` in `cuda/core/_memory/_legacy.py`, making it unintentionally part of the public API surface of `cuda.core._memory`.

**Fix**:
- Remove `_SynchronousMemoryResource` from `__all__` in `_legacy.py`
- Update internal imports in `_device.pyx` and `test_launcher.py` to use the full private module path (`cuda.core._memory._legacy`) instead of the package-level import

All existing tests pass (242 passed, 11 skipped across test_memory.py and test_launcher.py).