### PR TITLE
nvbug6084615: Don't assert anything about content of nvmlSystemGetDriverBranch

### DIFF
--- a/cuda_core/tests/system/test_system_system.py
+++ b/cuda_core/tests/system/test_system_system.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -101,4 +101,3 @@ def test_get_driver_branch():
     driver_branch = system.get_driver_branch()
     assert isinstance(driver_branch, str)
     assert len(driver_branch) > 0
-    assert driver_branch[0] == "r"


### PR DESCRIPTION
I confirmed with the upstream NVML tests -- this is all that it does as well.  :shrug:
