### PR TITLE
ci: guard fromJSON in detect-changes against empty pr-info output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,15 @@ jobs:
         id: filter
         if: ${{ startsWith(github.ref_name, 'pull-request/') }}
         env:
-          BASE_REF: ${{ fromJSON(steps.pr-info.outputs.pr-info).base.ref }}
+          # GitHub Actions evaluates step-level `env:` expressions eagerly —
+          # the step's `if:` gate does NOT short-circuit them. On non-PR
+          # events (push/tag/schedule), `pr-info` is skipped and its outputs
+          # are empty strings, so `fromJSON('')` would raise a template error
+          # and fail the step despite `if:` being false. Guard the
+          # `fromJSON` call with a short-circuit so the expression resolves
+          # to an empty string on non-PR events; the step is still gated
+          # off by `if:`, so `BASE_REF` is never consumed there.
+          BASE_REF: ${{ steps.pr-info.outputs.pr-info && fromJSON(steps.pr-info.outputs.pr-info).base.ref || '' }}
         run: |
           # Diff against the merge base with the PR's actual target branch.
           # Uses merge-base so diverged branches only show files changed on


### PR DESCRIPTION
## Summary

- The `detect-changes` job's `Detect changed paths` step has an `if:` gate that should skip it on non-PR events, but GitHub Actions evaluates step-level `env:` expressions eagerly — the `if:` does not short-circuit them.
- On push to `main`, tag, or schedule events the preceding `Resolve PR base branch` (`pr-info`) step is skipped and its outputs are empty strings, so `fromJSON(steps.pr-info.outputs.pr-info)` raises a template error and the step fails despite its `if:` being false. That cascades into `Check job status` and turns the whole run red (see [run 24566662170](https://github.com/NVIDIA/cuda-python/actions/runs/24566662170/job/71828554003)).
- Guard the `fromJSON` call with a short-circuit so the expression resolves to an empty string on non-PR events. On PR events the expression still evaluates to the PR's actual base ref, so behavior introduced in #1908 is preserved.

## Test plan

- [ ] After merge, the next push-to-`main` CI run reaches a successful `Check job status` instead of failing at `detect-changes / Detect changed paths`.
- [ ] PR CI runs (including backport-target PRs resolved via `nv-gha-runners/get-pr-info`) still classify changed paths correctly and gate the bindings test matrix as before.