### PR TITLE
[no-ci] EXPERIMENT: release workflow input mockups

### DIFF
--- a/.github/workflows/release-mockup-multiple.yml
+++ b/.github/workflows/release-mockup-multiple.yml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Input-only mockup for the unified-form design.
+# This keeps separate tag fields visible in one workflow.
+
+name: "Release Mockup: multiple git tags"
+
+on:
+  workflow_dispatch:
+    inputs:
+      shared-git-tag:
+        description: "Shared release git tag for cuda-python / cuda-bindings (e.g. v13.2.0)"
+        required: false
+        type: string
+      shared-tag-target:
+        description: "For the shared vX.Y.Z tag only, choose whether to release cuda-python, cuda-bindings, or both."
+        required: true
+        type: choice
+        # Sentinel first option so the UI does not silently pick a real target.
+        # A real workflow would reject this value during validation.
+        options:
+          - -- select target for plain vX.Y.Z tags --
+          - cuda-python only
+          - cuda-bindings only
+          - cuda-python + cuda-bindings
+      cuda-core-git-tag:
+        description: "Release git tag for cuda-core (e.g. cuda-core-v0.7.0)"
+        required: false
+        type: string
+      cuda-pathfinder-git-tag:
+        description: "Release git tag for cuda-pathfinder (e.g. cuda-pathfinder-v1.5.3)"
+        required: false
+        type: string
+
+jobs:
+  mockup-only:
+    name: Mockup placeholder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: |
+          echo "This is an input-only workflow mockup."
+          echo "No release actions are defined here."

--- a/.github/workflows/release-mockup-single.yml
+++ b/.github/workflows/release-mockup-single.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Input-only mockup for the split-workflow design.
+# This models the shared-tag release family for cuda-python / cuda-bindings.
+
+name: "Release Mockup: single git tag"
+
+on:
+  workflow_dispatch:
+    inputs:
+      git-tag:
+        description: "Release git tag. Use vX.Y.Z for the shared cuda-python/cuda-bindings line, cuda-core-vX.Y.Z for cuda-core, or cuda-pathfinder-vX.Y.Z for cuda-pathfinder."
+        required: true
+        type: string
+      shared-tag-target:
+        description: "For plain vX.Y.Z tags only, choose whether to release cuda-python, cuda-bindings, or both."
+        required: true
+        type: choice
+        # Sentinel first option so the UI does not silently pick a real target.
+        # A real workflow would reject this value during validation.
+        options:
+          - -- select target for plain vX.Y.Z tags --
+          - cuda-python only
+          - cuda-bindings only
+          - cuda-python + cuda-bindings
+
+jobs:
+  mockup-only:
+    name: Mockup placeholder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: |
+          echo "This is an input-only workflow mockup."
+          echo "No release actions are defined here."


### PR DESCRIPTION
TOTALLY NOT FOR MERGING

Related to my review of PR #1907: see comments there.

___

**Screenshots**

**"Single" design**

<img width="426" height="611" alt="Screenshot 2026-04-17 at 11 57 37" src="https://github.com/user-attachments/assets/020a70a3-c927-4bef-adb9-7b37012f1138" />

___

**"Multiple" design**

<img width="391" height="709" alt="Screenshot 2026-04-17 at 11 58 16" src="https://github.com/user-attachments/assets/a53a3221-1224-4c3f-85be-c2c122b047f5" />
<img width="370" height="713" alt="Screenshot 2026-04-17 at 11 58 34" src="https://github.com/user-attachments/assets/f748436b-228c-45b0-b4a7-477ad1a83ccd" />
