### PR TITLE
Update .gitignore after #1900

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,6 @@ cuda_bindings/cuda/bindings/_bindings/cyruntime.pxd
 cuda_bindings/cuda/bindings/_bindings/cyruntime.pyx
 cuda_bindings/cuda/bindings/_bindings/cyruntime_ptds.pxd
 cuda_bindings/cuda/bindings/_bindings/cyruntime_ptds.pyx
-cuda_bindings/cuda/bindings/_bindings/cynvrtc.pxd
-cuda_bindings/cuda/bindings/_bindings/cynvrtc.pyx
 cuda_bindings/cuda/bindings/_internal/_nvml.pyx
 cuda_bindings/cuda/bindings/_internal/cufile.pyx
 cuda_bindings/cuda/bindings/_internal/nvfatbin.pyx
@@ -42,14 +40,10 @@ cuda_bindings/cuda/bindings/cyruntime.pxd
 cuda_bindings/cuda/bindings/cyruntime.pyx
 cuda_bindings/cuda/bindings/cyruntime_functions.pxi
 cuda_bindings/cuda/bindings/cyruntime_types.pxi
-cuda_bindings/cuda/bindings/cynvrtc.pxd
-cuda_bindings/cuda/bindings/cynvrtc.pyx
 cuda_bindings/cuda/bindings/driver.pxd
 cuda_bindings/cuda/bindings/driver.pyx
 cuda_bindings/cuda/bindings/runtime.pxd
 cuda_bindings/cuda/bindings/runtime.pyx
-cuda_bindings/cuda/bindings/nvrtc.pxd
-cuda_bindings/cuda/bindings/nvrtc.pyx
 cuda_bindings/cuda/bindings/utils/_get_handle.pyx
 
 # Version files from setuptools_scm


### PR DESCRIPTION
I missed that we should probably have updated this in #1900, since these files are now "ok to be committed".  Not critical, but git tooling could get confused without this.