### PR TITLE
Faster benchmarking smoke tests

### DIFF
--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -275,7 +275,7 @@ jobs:
         run: |
           pip install pyperf
           pushd benchmarks/cuda_bindings
-          python run_pyperf.py --fast --min-time 1
+          python run_pyperf.py --debug-single-value
           popd
 
       - name: Run cuda.core tests

--- a/benchmarks/cuda_bindings/pixi.toml
+++ b/benchmarks/cuda_bindings/pixi.toml
@@ -55,8 +55,7 @@ source = { features = ["cu13", "cu13-source", "bench", "cpp-bench", "dev", "bind
 cmd = ["python", "$PIXI_PROJECT_ROOT/run_pyperf.py"]
 
 [target.linux.tasks.bench-smoke-test]
-cmd = ["python", "$PIXI_PROJECT_ROOT/run_pyperf.py", "--fast", "--min-time", "1"
-]
+cmd = ["python", "$PIXI_PROJECT_ROOT/run_pyperf.py", "--debug-single-value"]
 
 [target.linux.tasks.bench-legacy]
 cmd = "pytest --benchmark-only --override-ini 'addopts=' $PIXI_PROJECT_ROOT/pytest-legacy/"


### PR DESCRIPTION
The benchmarking smoke tests, while super valuable for making sure our benchmarks don't bitrot, are taking ~20min out of the ~27min total run time for CI.

This reduces the smoke test time to 13s.  Running each benchmark exactly once should be enough to detect any obvious breakage.

Hopefully this should still be good enough.  What do you think, @danielfrg?
