### PR TITLE
cuda.bindings benchmarks part 5

### DIFF
--- a/benchmarks/cuda_bindings/README.md
+++ b/benchmarks/cuda_bindings/README.md
@@ -47,7 +47,7 @@ To run the benchmarks combine the environment and task:
 ```bash
 # Run the Python benchmarks in the wheel environment
 pixi run -e wheel bench
-pixi run -e wheel bench--min-time 0.1
+pixi run -e wheel bench --min-time 0.1
 
 # Run the Python benchmarks in the source environment
 pixi run -e source bench

--- a/benchmarks/cuda_bindings/README.md
+++ b/benchmarks/cuda_bindings/README.md
@@ -47,12 +47,14 @@ To run the benchmarks combine the environment and task:
 ```bash
 # Run the Python benchmarks in the wheel environment
 pixi run -e wheel bench
+pixi run -e wheel bench--min-time 0.1
 
 # Run the Python benchmarks in the source environment
 pixi run -e source bench
 
 # Run the C++ benchmarks
 pixi run -e wheel bench-cpp
+pixi run -e wheel bench-cpp --min-time 0.1
 ```
 
 Both runners automatically save results to JSON files in the benchmarks

--- a/benchmarks/cuda_bindings/benchmarks/cpp/bench_event.cpp
+++ b/benchmarks/cuda_bindings/benchmarks/cpp/bench_event.cpp
@@ -45,6 +45,11 @@ int main(int argc, char** argv) {
     check_cu(cuStreamSynchronize(stream), "cuStreamSynchronize failed");
 
     bench::BenchmarkSuite suite(options);
+    // Drain the persistent stream after calibration so event_record (which
+    // enqueues onto the stream) and event_synchronize start from a known state.
+    suite.set_post_calibrate([&]() {
+        check_cu(cuStreamSynchronize(stream), "post-calibrate sync failed");
+    });
 
     // --- event_create_destroy ---
     {

--- a/benchmarks/cuda_bindings/benchmarks/cpp/bench_launch.cpp
+++ b/benchmarks/cuda_bindings/benchmarks/cpp/bench_launch.cpp
@@ -238,6 +238,12 @@ int main(int argc, char** argv) {
     void* struct_params[] = {&struct_2048B};
 
     bench::BenchmarkSuite suite(options);
+    // After calibration, drain the persistent stream so the first measured
+    // sample does not start on a backlogged stream. Calibration for enqueue-
+    // style ops (kernel launches) may queue many thousands of operations.
+    suite.set_post_calibrate([&]() {
+        check_cu(cuStreamSynchronize(stream), "post-calibrate sync failed");
+    });
 
     suite.run("launch.launch_empty_kernel", [&]() {
         check_cu(cuLaunchKernel(empty_kernel, 1, 1, 1, 1, 1, 1, 0, stream, nullptr, nullptr),

--- a/benchmarks/cuda_bindings/benchmarks/cpp/bench_memory.cpp
+++ b/benchmarks/cuda_bindings/benchmarks/cpp/bench_memory.cpp
@@ -52,6 +52,11 @@ int main(int argc, char** argv) {
     uint8_t host_dst[COPY_SIZE] = {};
 
     bench::BenchmarkSuite suite(options);
+    // Drain the persistent stream after calibration so async benchmarks
+    // (mem_alloc_async_free_async) don't start measurement on a backlogged stream.
+    suite.set_post_calibrate([&]() {
+        check_cu(cuStreamSynchronize(stream), "post-calibrate sync failed");
+    });
 
     // --- mem_alloc_free ---
     {

--- a/benchmarks/cuda_bindings/benchmarks/cpp/bench_stream.cpp
+++ b/benchmarks/cuda_bindings/benchmarks/cpp/bench_stream.cpp
@@ -38,6 +38,12 @@ int main(int argc, char** argv) {
     check_cu(cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING), "cuStreamCreate failed");
 
     bench::BenchmarkSuite suite(options);
+    // Drain the persistent stream after calibration for completeness.
+    // stream_create_destroy uses a local stream, but stream_query/synchronize
+    // observe the persistent one.
+    suite.set_post_calibrate([&]() {
+        check_cu(cuStreamSynchronize(stream), "post-calibrate sync failed");
+    });
 
     // --- stream_create_destroy ---
     {

--- a/benchmarks/cuda_bindings/benchmarks/cpp/bench_support.hpp
+++ b/benchmarks/cuda_bindings/benchmarks/cpp/bench_support.hpp
@@ -11,6 +11,7 @@
 #include <cstdlib>
 #include <ctime>
 #include <fstream>
+#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <string>
@@ -24,7 +25,10 @@ struct Options {
     std::uint64_t values = 20;
     std::uint64_t runs = 20;
     double min_time_sec = 0.0;
-    std::uint64_t max_loops = 1000000;
+    // Safety cap for the calibration doubling loop. Set high enough that even
+    // sub-nanosecond ops can reach typical --min-time targets (e.g. 100ms).
+    // A warning is printed if calibration hits this cap before reaching min-time.
+    std::uint64_t max_loops = 100000000;
     std::uint64_t calibrate_rounds = 3;
     std::string output_path;
     std::string benchmark_name;
@@ -85,7 +89,7 @@ inline Options parse_args(int argc, char** argv) {
                       << "  --values N      Timed values per run (default: 20)\n"
                       << "  --runs N        Number of runs (default: 20)\n"
                       << "  --min-time S    Calibrate loops to reach S seconds per value\n"
-                      << "  --max-loops N   Max loops used during calibration (default: 1000000)\n"
+                      << "  --max-loops N   Safety cap for calibration loop count (default: 100000000)\n"
                       << "  --calibrate-rounds N  Calibration passes (default: 3)\n"
                       << "  -o, --output F  Write pyperf-compatible JSON to file\n"
                       << "  --name S        Benchmark name (overrides default)\n";
@@ -113,18 +117,34 @@ inline std::string iso_now() {
 }
 
 // Calibrate loop count to hit a minimum wall time per value.
+// Returns the chosen loop count. If `capped_out` is non-null, it is set to
+// true when calibration reached `max_loops` before hitting `min_time_sec`
+// (meaning --min-time was NOT actually satisfied by the calibration).
 template <typename Fn>
-std::uint64_t calibrate_loops(const Options& options, Fn&& fn) {
+std::uint64_t calibrate_loops(
+    const Options& options,
+    Fn&& fn,
+    bool* capped_out = nullptr,
+    double* last_elapsed_out = nullptr
+) {
     if (options.min_time_sec <= 0.0) {
+        if (capped_out) *capped_out = false;
+        if (last_elapsed_out) *last_elapsed_out = 0.0;
         return options.loops;
     }
 
-    std::uint64_t best = 1;
-    const std::uint64_t max_loops = std::max<std::uint64_t>(1, options.max_loops);
+    // Allow callers (e.g. the explicit-loop overload) to request a minimum
+    // starting loop count via options.loops.
+    const std::uint64_t start_loops = std::max<std::uint64_t>(1, options.loops);
+    std::uint64_t best = start_loops;
+    const std::uint64_t max_loops = std::max<std::uint64_t>(start_loops, options.max_loops);
     const std::uint64_t rounds = std::max<std::uint64_t>(1, options.calibrate_rounds);
 
+    bool capped = false;
+    double last_elapsed = 0.0;
+
     for (std::uint64_t round = 0; round < rounds; ++round) {
-        std::uint64_t loops = 1;
+        std::uint64_t loops = start_loops;
         double elapsed = 0.0;
 
         while (true) {
@@ -135,7 +155,11 @@ std::uint64_t calibrate_loops(const Options& options, Fn&& fn) {
             const auto t1 = std::chrono::steady_clock::now();
             elapsed = std::chrono::duration<double>(t1 - t0).count();
 
-            if (elapsed >= options.min_time_sec || loops >= max_loops) {
+            if (elapsed >= options.min_time_sec) {
+                break;
+            }
+            if (loops >= max_loops) {
+                capped = true;
                 break;
             }
             if (loops > max_loops / 2) {
@@ -148,8 +172,11 @@ std::uint64_t calibrate_loops(const Options& options, Fn&& fn) {
         if (loops > best) {
             best = loops;
         }
+        last_elapsed = elapsed;
     }
 
+    if (capped_out) *capped_out = capped;
+    if (last_elapsed_out) *last_elapsed_out = last_elapsed;
     return best;
 }
 
@@ -295,28 +322,59 @@ class BenchmarkSuite {
 public:
     explicit BenchmarkSuite(Options options) : options_(std::move(options)) {}
 
+    // Post-calibration hook. If set, invoked after calibration and before the
+    // first measured warmup/value, for every benchmark in this suite. Intended
+    // for async benchmarks that need to drain state left behind by calibration
+    // (e.g. cuStreamSynchronize on a persistent stream). Can be overridden
+    // per-call via the `post_calibrate` parameter on `run()`.
+    void set_post_calibrate(std::function<void()> hook) {
+        post_calibrate_ = std::move(hook);
+    }
+
     // Run a benchmark and record it. The name is used as the benchmark ID.
+    // If --min-time is set, loop count is auto-calibrated. `post_calibrate`,
+    // if provided, runs after calibration and before measurement.
     template <typename Fn>
-    void run(const std::string& name, Fn&& fn) {
+    void run(
+        const std::string& name,
+        Fn&& fn,
+        std::function<void()> post_calibrate = {}
+    ) {
         std::uint64_t loops = options_.loops;
         Options custom = options_;
         if (options_.min_time_sec > 0.0) {
-            loops = calibrate_loops(options_, fn);
+            loops = calibrate_and_warn(name, options_, fn);
             custom.loops = loops;
+            invoke_post_calibrate(post_calibrate);
         }
         auto results = run_benchmark(custom, std::forward<Fn>(fn));
         print_summary(name, results);
         entries_.push_back({name, loops, std::move(results)});
     }
 
-    // Run a benchmark with a custom loop count (for slow operations like compilation).
+    // Run a benchmark with a custom loop count (used as a floor for fast ops
+    // or a fixed count for slow ops like compilation). When --min-time is set,
+    // calibration still runs but starts from `loops_override` as the minimum.
     template <typename Fn>
-    void run(const std::string& name, std::uint64_t loops_override, Fn&& fn) {
+    void run(
+        const std::string& name,
+        std::uint64_t loops_override,
+        Fn&& fn,
+        std::function<void()> post_calibrate = {}
+    ) {
+        std::uint64_t loops = loops_override;
         Options custom = options_;
         custom.loops = loops_override;
+        if (options_.min_time_sec > 0.0) {
+            Options calib_opts = options_;
+            calib_opts.loops = loops_override;  // floor
+            loops = calibrate_and_warn(name, calib_opts, fn);
+            custom.loops = loops;
+            invoke_post_calibrate(post_calibrate);
+        }
         auto results = run_benchmark(custom, std::forward<Fn>(fn));
         print_summary(name, results);
-        entries_.push_back({name, loops_override, std::move(results)});
+        entries_.push_back({name, loops, std::move(results)});
     }
 
     // Write all collected benchmarks to the output file (if -o was given).
@@ -329,6 +387,36 @@ public:
 private:
     Options options_;
     std::vector<BenchmarkEntry> entries_;
+    std::function<void()> post_calibrate_;
+
+    void invoke_post_calibrate(const std::function<void()>& per_call) const {
+        if (per_call) {
+            per_call();
+        } else if (post_calibrate_) {
+            post_calibrate_();
+        }
+    }
+
+    template <typename Fn>
+    std::uint64_t calibrate_and_warn(
+        const std::string& name,
+        const Options& calib_opts,
+        Fn&& fn
+    ) const {
+        bool capped = false;
+        double last_elapsed = 0.0;
+        std::uint64_t loops = calibrate_loops(
+            calib_opts, std::forward<Fn>(fn), &capped, &last_elapsed
+        );
+        if (capped) {
+            std::cerr << "WARNING: " << name
+                      << ": calibration hit --max-loops (" << calib_opts.max_loops
+                      << ") before reaching --min-time (" << calib_opts.min_time_sec
+                      << "s). Last sample: " << last_elapsed
+                      << "s. Raise --max-loops to satisfy --min-time for this benchmark.\n";
+        }
+        return loops;
+    }
 
     static void write_multi_pyperf_json(
         const std::string& output_path,

--- a/benchmarks/cuda_bindings/benchmarks/cpp/bench_support.hpp
+++ b/benchmarks/cuda_bindings/benchmarks/cpp/bench_support.hpp
@@ -6,6 +6,7 @@
 
 #include <chrono>
 #include <cmath>
+#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
 #include <ctime>
@@ -22,6 +23,9 @@ struct Options {
     std::uint64_t warmups = 5;
     std::uint64_t values = 20;
     std::uint64_t runs = 20;
+    double min_time_sec = 0.0;
+    std::uint64_t max_loops = 1000000;
+    std::uint64_t calibrate_rounds = 3;
     std::string output_path;
     std::string benchmark_name;
 };
@@ -46,6 +50,18 @@ inline Options parse_args(int argc, char** argv) {
             options.warmups = std::strtoull(argv[++i], nullptr, 10);
             continue;
         }
+        if (arg == "--min-time" && i + 1 < argc) {
+            options.min_time_sec = std::strtod(argv[++i], nullptr);
+            continue;
+        }
+        if (arg == "--max-loops" && i + 1 < argc) {
+            options.max_loops = std::strtoull(argv[++i], nullptr, 10);
+            continue;
+        }
+        if (arg == "--calibrate-rounds" && i + 1 < argc) {
+            options.calibrate_rounds = std::strtoull(argv[++i], nullptr, 10);
+            continue;
+        }
         if (arg == "--values" && i + 1 < argc) {
             options.values = std::strtoull(argv[++i], nullptr, 10);
             continue;
@@ -68,6 +84,9 @@ inline Options parse_args(int argc, char** argv) {
                       << "  --warmups N     Warmup values per run (default: 5)\n"
                       << "  --values N      Timed values per run (default: 20)\n"
                       << "  --runs N        Number of runs (default: 20)\n"
+                      << "  --min-time S    Calibrate loops to reach S seconds per value\n"
+                      << "  --max-loops N   Max loops used during calibration (default: 1000000)\n"
+                      << "  --calibrate-rounds N  Calibration passes (default: 3)\n"
                       << "  -o, --output F  Write pyperf-compatible JSON to file\n"
                       << "  --name S        Benchmark name (overrides default)\n";
             std::exit(0);
@@ -91,6 +110,47 @@ inline std::string iso_now() {
     char buf[64];
     std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &tm);
     return std::string(buf);
+}
+
+// Calibrate loop count to hit a minimum wall time per value.
+template <typename Fn>
+std::uint64_t calibrate_loops(const Options& options, Fn&& fn) {
+    if (options.min_time_sec <= 0.0) {
+        return options.loops;
+    }
+
+    std::uint64_t best = 1;
+    const std::uint64_t max_loops = std::max<std::uint64_t>(1, options.max_loops);
+    const std::uint64_t rounds = std::max<std::uint64_t>(1, options.calibrate_rounds);
+
+    for (std::uint64_t round = 0; round < rounds; ++round) {
+        std::uint64_t loops = 1;
+        double elapsed = 0.0;
+
+        while (true) {
+            const auto t0 = std::chrono::steady_clock::now();
+            for (std::uint64_t i = 0; i < loops; ++i) {
+                fn();
+            }
+            const auto t1 = std::chrono::steady_clock::now();
+            elapsed = std::chrono::duration<double>(t1 - t0).count();
+
+            if (elapsed >= options.min_time_sec || loops >= max_loops) {
+                break;
+            }
+            if (loops > max_loops / 2) {
+                loops = max_loops;
+            } else {
+                loops *= 2;
+            }
+        }
+
+        if (loops > best) {
+            best = loops;
+        }
+    }
+
+    return best;
 }
 
 // Run a benchmark function. The function signature is: void fn() — one call = one operation.
@@ -238,9 +298,15 @@ public:
     // Run a benchmark and record it. The name is used as the benchmark ID.
     template <typename Fn>
     void run(const std::string& name, Fn&& fn) {
-        auto results = run_benchmark(options_, std::forward<Fn>(fn));
+        std::uint64_t loops = options_.loops;
+        Options custom = options_;
+        if (options_.min_time_sec > 0.0) {
+            loops = calibrate_loops(options_, fn);
+            custom.loops = loops;
+        }
+        auto results = run_benchmark(custom, std::forward<Fn>(fn));
         print_summary(name, results);
-        entries_.push_back({name, options_.loops, std::move(results)});
+        entries_.push_back({name, loops, std::move(results)});
     }
 
     // Run a benchmark with a custom loop count (for slow operations like compilation).

--- a/benchmarks/cuda_bindings/benchmarks/cpp/bench_support.hpp
+++ b/benchmarks/cuda_bindings/benchmarks/cpp/bench_support.hpp
@@ -124,6 +124,7 @@ template <typename Fn>
 std::uint64_t calibrate_loops(
     const Options& options,
     Fn&& fn,
+    const std::function<void()>& post_calibrate = {},
     bool* capped_out = nullptr,
     double* last_elapsed_out = nullptr
 ) {
@@ -136,15 +137,19 @@ std::uint64_t calibrate_loops(
     // Allow callers (e.g. the explicit-loop overload) to request a minimum
     // starting loop count via options.loops.
     const std::uint64_t start_loops = std::max<std::uint64_t>(1, options.loops);
-    std::uint64_t best = start_loops;
     const std::uint64_t max_loops = std::max<std::uint64_t>(start_loops, options.max_loops);
     const std::uint64_t rounds = std::max<std::uint64_t>(1, options.calibrate_rounds);
 
-    bool capped = false;
-    double last_elapsed = 0.0;
+    // Track the round that produced the best (largest) loop count so the
+    // returned loop count, capped flag, and last-elapsed time all describe
+    // the same round.
+    std::uint64_t best_loops = 0;
+    bool best_capped = false;
+    double best_elapsed = 0.0;
 
     for (std::uint64_t round = 0; round < rounds; ++round) {
         std::uint64_t loops = start_loops;
+        bool round_capped = false;
         double elapsed = 0.0;
 
         while (true) {
@@ -155,11 +160,17 @@ std::uint64_t calibrate_loops(
             const auto t1 = std::chrono::steady_clock::now();
             elapsed = std::chrono::duration<double>(t1 - t0).count();
 
+            // Drain any state left behind by this probe (e.g. queued async
+            // work on a persistent stream) before the next probe, the next
+            // round, or the first measured warmup/value runs.
+            if (post_calibrate) {
+                post_calibrate();
+            }
             if (elapsed >= options.min_time_sec) {
                 break;
             }
             if (loops >= max_loops) {
-                capped = true;
+                round_capped = true;
                 break;
             }
             if (loops > max_loops / 2) {
@@ -169,15 +180,16 @@ std::uint64_t calibrate_loops(
             }
         }
 
-        if (loops > best) {
-            best = loops;
+        if (loops >= best_loops) {
+            best_loops = loops;
+            best_capped = round_capped;
+            best_elapsed = elapsed;
         }
-        last_elapsed = elapsed;
     }
 
-    if (capped_out) *capped_out = capped;
-    if (last_elapsed_out) *last_elapsed_out = last_elapsed;
-    return best;
+    if (capped_out) *capped_out = best_capped;
+    if (last_elapsed_out) *last_elapsed_out = best_elapsed;
+    return best_loops;
 }
 
 // Run a benchmark function. The function signature is: void fn() — one call = one operation.
@@ -322,18 +334,18 @@ class BenchmarkSuite {
 public:
     explicit BenchmarkSuite(Options options) : options_(std::move(options)) {}
 
-    // Post-calibration hook. If set, invoked after calibration and before the
-    // first measured warmup/value, for every benchmark in this suite. Intended
-    // for async benchmarks that need to drain state left behind by calibration
-    // (e.g. cuStreamSynchronize on a persistent stream). Can be overridden
-    // per-call via the `post_calibrate` parameter on `run()`.
+    // Post-calibration hook. If set, invoked between calibration probes so
+    // async benchmarks can drain state left behind by each probe before the
+    // next one runs. The final probe leaves the benchmark in a drained state
+    // before the first measured warmup/value. Can be overridden per-call via
+    // the `post_calibrate` parameter on `run()`.
     void set_post_calibrate(std::function<void()> hook) {
         post_calibrate_ = std::move(hook);
     }
 
     // Run a benchmark and record it. The name is used as the benchmark ID.
     // If --min-time is set, loop count is auto-calibrated. `post_calibrate`,
-    // if provided, runs after calibration and before measurement.
+    // if provided, runs between calibration probes to reset async state.
     template <typename Fn>
     void run(
         const std::string& name,
@@ -343,9 +355,8 @@ public:
         std::uint64_t loops = options_.loops;
         Options custom = options_;
         if (options_.min_time_sec > 0.0) {
-            loops = calibrate_and_warn(name, options_, fn);
+            loops = calibrate_and_warn(name, options_, fn, select_post_calibrate(post_calibrate));
             custom.loops = loops;
-            invoke_post_calibrate(post_calibrate);
         }
         auto results = run_benchmark(custom, std::forward<Fn>(fn));
         print_summary(name, results);
@@ -368,9 +379,8 @@ public:
         if (options_.min_time_sec > 0.0) {
             Options calib_opts = options_;
             calib_opts.loops = loops_override;  // floor
-            loops = calibrate_and_warn(name, calib_opts, fn);
+            loops = calibrate_and_warn(name, calib_opts, fn, select_post_calibrate(post_calibrate));
             custom.loops = loops;
-            invoke_post_calibrate(post_calibrate);
         }
         auto results = run_benchmark(custom, std::forward<Fn>(fn));
         print_summary(name, results);
@@ -389,24 +399,24 @@ private:
     std::vector<BenchmarkEntry> entries_;
     std::function<void()> post_calibrate_;
 
-    void invoke_post_calibrate(const std::function<void()>& per_call) const {
+    std::function<void()> select_post_calibrate(const std::function<void()>& per_call) const {
         if (per_call) {
-            per_call();
-        } else if (post_calibrate_) {
-            post_calibrate_();
+            return per_call;
         }
+        return post_calibrate_;
     }
 
     template <typename Fn>
     std::uint64_t calibrate_and_warn(
         const std::string& name,
         const Options& calib_opts,
-        Fn&& fn
+        Fn&& fn,
+        const std::function<void()>& post_calibrate
     ) const {
         bool capped = false;
         double last_elapsed = 0.0;
         std::uint64_t loops = calibrate_loops(
-            calib_opts, std::forward<Fn>(fn), &capped, &last_elapsed
+            calib_opts, std::forward<Fn>(fn), post_calibrate, &capped, &last_elapsed
         );
         if (capped) {
             std::cerr << "WARNING: " << name

--- a/benchmarks/cuda_bindings/compare.py
+++ b/benchmarks/cuda_bindings/compare.py
@@ -29,12 +29,25 @@ def load_benchmarks(path: Path) -> dict[str, list[float]]:
                 name = run.get("metadata", {}).get("name", "")
                 if name:
                     break
-        values = []
+        values: list[float] = []
         for run in bench.get("runs", []):
             values.extend(run.get("values", []))
         if name and values:
             results[name] = values
     return results
+
+
+def stats(values: list[float]) -> tuple[float, float, float, int]:
+    mean = statistics.mean(values)
+    stdev = statistics.pstdev(values) if len(values) > 1 else 0.0
+    rsd = (stdev / mean) if mean else 0.0
+    return mean, stdev, rsd, len(values)
+
+
+def fmt_rsd(rsd: float | None) -> str:
+    if rsd is None:
+        return "-"
+    return f"{rsd * 100:.1f}%"
 
 
 def fmt_ns(seconds: float) -> str:
@@ -58,6 +71,12 @@ def main() -> None:
         default=DEFAULT_CPP,
         help=f"C++ results JSON (default: {DEFAULT_CPP.name})",
     )
+    parser.add_argument(
+        "--target-us",
+        type=float,
+        default=1.0,
+        help="Overhead target in microseconds (default: 1.0)",
+    )
     args = parser.parse_args()
 
     if not args.python.exists():
@@ -79,13 +98,16 @@ def main() -> None:
 
     # Header
     if cpp_benchmarks:
-        header = f"{'Benchmark':<{name_width}}  {'C++ (mean)':>12}  {'Python (mean)':>14}  {'Overhead':>10}"
+        header = (
+            f"{'Benchmark':<{name_width}}  {'C++ (mean)':>12}  {'C++ RSD':>8}  "
+            f"{'Python (mean)':>14}  {'Py RSD':>7}  {'Overhead':>10}  {'Target':>6}"
+        )
         sep = "-" * len(header)
         print(sep)
         print(header)
         print(sep)
     else:
-        header = f"{'Benchmark':<{name_width}}  {'Python (mean)':>14}"
+        header = f"{'Benchmark':<{name_width}}  {'Python (mean)':>14}  {'Py RSD':>7}"
         sep = "-" * len(header)
         print(sep)
         print(header)
@@ -95,21 +117,31 @@ def main() -> None:
         py_vals = py_benchmarks.get(name)
         cpp_vals = cpp_benchmarks.get(name)
 
-        py_str = fmt_ns(statistics.mean(py_vals)) if py_vals else "-"
-        cpp_str = fmt_ns(statistics.mean(cpp_vals)) if cpp_vals else "-"
+        py_stats = stats(py_vals) if py_vals else None
+        cpp_stats = stats(cpp_vals) if cpp_vals else None
 
-        if py_vals and cpp_vals:
-            py_mean = statistics.mean(py_vals)
-            cpp_mean = statistics.mean(cpp_vals)
+        py_str = fmt_ns(py_stats[0]) if py_stats else "-"
+        cpp_str = fmt_ns(cpp_stats[0]) if cpp_stats else "-"
+        py_rsd = fmt_rsd(py_stats[2]) if py_stats else "-"
+        cpp_rsd = fmt_rsd(cpp_stats[2]) if cpp_stats else "-"
+
+        if py_stats and cpp_stats:
+            py_mean = py_stats[0]
+            cpp_mean = cpp_stats[0]
             overhead_ns = (py_mean - cpp_mean) * 1e9
             overhead_str = f"+{overhead_ns:.0f} ns"
+            target = "OK" if overhead_ns <= args.target_us * 1000 else "FAIL"
         else:
             overhead_str = "-"
+            target = "-"
 
         if cpp_benchmarks:
-            print(f"{name:<{name_width}}  {cpp_str:>12}  {py_str:>14}  {overhead_str:>10}")
+            print(
+                f"{name:<{name_width}}  {cpp_str:>12}  {cpp_rsd:>8}  "
+                f"{py_str:>14}  {py_rsd:>7}  {overhead_str:>10}  {target:>6}"
+            )
         else:
-            print(f"{name:<{name_width}}  {py_str:>14}")
+            print(f"{name:<{name_width}}  {py_str:>14}  {py_rsd:>7}")
 
     print(sep)
 

--- a/benchmarks/cuda_bindings/compare.py
+++ b/benchmarks/cuda_bindings/compare.py
@@ -123,7 +123,7 @@ def main() -> None:
             py_mean = py_stats[0]
             cpp_mean = cpp_stats[0]
             overhead_ns = (py_mean - cpp_mean) * 1e9
-            overhead_str = f"+{overhead_ns:.0f} ns"
+            overhead_str = f"{overhead_ns:+.0f} ns"
         else:
             overhead_str = "-"
 

--- a/benchmarks/cuda_bindings/compare.py
+++ b/benchmarks/cuda_bindings/compare.py
@@ -71,12 +71,6 @@ def main() -> None:
         default=DEFAULT_CPP,
         help=f"C++ results JSON (default: {DEFAULT_CPP.name})",
     )
-    parser.add_argument(
-        "--target-us",
-        type=float,
-        default=1.0,
-        help="Overhead target in microseconds (default: 1.0)",
-    )
     args = parser.parse_args()
 
     if not args.python.exists():
@@ -100,7 +94,7 @@ def main() -> None:
     if cpp_benchmarks:
         header = (
             f"{'Benchmark':<{name_width}}  {'C++ (mean)':>12}  {'C++ RSD':>8}  "
-            f"{'Python (mean)':>14}  {'Py RSD':>7}  {'Overhead':>10}  {'Target':>6}"
+            f"{'Python (mean)':>14}  {'Py RSD':>7}  {'Overhead':>10}"
         )
         sep = "-" * len(header)
         print(sep)
@@ -130,15 +124,13 @@ def main() -> None:
             cpp_mean = cpp_stats[0]
             overhead_ns = (py_mean - cpp_mean) * 1e9
             overhead_str = f"+{overhead_ns:.0f} ns"
-            target = "OK" if overhead_ns <= args.target_us * 1000 else "FAIL"
         else:
             overhead_str = "-"
-            target = "-"
 
         if cpp_benchmarks:
             print(
                 f"{name:<{name_width}}  {cpp_str:>12}  {cpp_rsd:>8}  "
-                f"{py_str:>14}  {py_rsd:>7}  {overhead_str:>10}  {target:>6}"
+                f"{py_str:>14}  {py_rsd:>7}  {overhead_str:>10}"
             )
         else:
             print(f"{name:<{name_width}}  {py_str:>14}  {py_rsd:>7}")

--- a/benchmarks/cuda_bindings/compare.py
+++ b/benchmarks/cuda_bindings/compare.py
@@ -128,10 +128,7 @@ def main() -> None:
             overhead_str = "-"
 
         if cpp_benchmarks:
-            print(
-                f"{name:<{name_width}}  {cpp_str:>12}  {cpp_rsd:>8}  "
-                f"{py_str:>14}  {py_rsd:>7}  {overhead_str:>10}"
-            )
+            print(f"{name:<{name_width}}  {cpp_str:>12}  {cpp_rsd:>8}  {py_str:>14}  {py_rsd:>7}  {overhead_str:>10}")
         else:
             print(f"{name:<{name_width}}  {py_str:>14}  {py_rsd:>7}")
 


### PR DESCRIPTION
## Description

Follow up https://github.com/NVIDIA/cuda-python/issues/1580

This one is to discuss and improve Cpp harness to make a more stable data collection.

I added a with min-time flag and to report the min/std on the compare.

This is the last one i got, where most of them are <2%.

`stream.stream_create_destroy` did went back from like 8% to 6% when I collected more time.

```
-----------------------------------------------------------------------------------------------------
Benchmark                                   C++ (mean)   C++ RSD   Python (mean)   Py RSD    Overhead
-----------------------------------------------------------------------------------------------------
ctx_device.ctx_get_current                        6 ns      1.6%          111 ns     1.3%     +105 ns
ctx_device.ctx_get_device                         9 ns      1.5%          116 ns     1.7%     +107 ns
ctx_device.ctx_set_current                        8 ns      1.0%          101 ns     2.8%      +93 ns
ctx_device.device_get                             6 ns      4.4%          127 ns     2.4%     +121 ns
ctx_device.device_get_attribute                   8 ns      1.6%          190 ns     1.5%     +182 ns
event.event_create_destroy                       79 ns      1.3%          307 ns     2.0%     +228 ns
event.event_query                                77 ns      1.2%          210 ns     7.1%     +133 ns
event.event_record                               88 ns      1.2%          221 ns     2.2%     +133 ns
event.event_synchronize                          98 ns      1.2%          225 ns     3.2%     +128 ns
launch.launch_16_args                          1.59 us      1.2%         3.12 us     1.6%    +1528 ns
launch.launch_16_args_pre_packed               1.57 us      0.5%         1.97 us     0.3%     +395 ns
launch.launch_2048b                            1.68 us      1.9%         2.50 us     1.6%     +820 ns
launch.launch_256_args                         2.34 us      0.9%        16.50 us     1.8%   +14158 ns
launch.launch_512_args                         3.33 us      0.8%        31.31 us     1.7%   +27973 ns
launch.launch_512_args_pre_packed              3.37 us      1.2%         3.77 us     0.8%     +392 ns
launch.launch_512_bools                        3.39 us      0.7%        57.82 us     3.2%   +54435 ns
launch.launch_512_bytes                        3.40 us      0.7%        59.53 us     2.8%   +56134 ns
launch.launch_512_doubles                      3.32 us      0.7%        86.76 us     3.6%   +83438 ns
launch.launch_512_ints                         3.18 us      0.8%        60.59 us     3.6%   +57411 ns
launch.launch_512_longlongs                    3.31 us      0.7%        65.91 us     2.4%   +62605 ns
launch.launch_empty_kernel                     1.62 us      1.9%         1.87 us     1.4%     +250 ns
launch.launch_small_kernel                     1.57 us      0.3%         2.22 us     1.2%     +651 ns
memory.mem_alloc_async_free_async               386 ns      1.1%          747 ns     1.7%     +361 ns
memory.mem_alloc_free                          1.55 us      2.2%         1.98 us     1.5%     +429 ns
memory.memcpy_dtod                             2.07 us      0.5%         2.29 us     1.4%     +219 ns
memory.memcpy_dtoh                             4.99 us      0.3%         5.42 us     0.8%     +437 ns
memory.memcpy_htod                             3.94 us      0.2%         4.00 us     1.0%      +61 ns
module.func_get_attribute                        14 ns      1.5%          212 ns     1.8%     +198 ns
module.module_get_function                       33 ns      1.7%          179 ns     1.9%     +146 ns
module.module_load_unload                      7.73 us      0.7%         8.26 us     1.4%     +528 ns
nvrtc.nvrtc_compile_program                 7194.82 us      1.2%      7294.98 us     1.1%  +100158 ns
nvrtc.nvrtc_create_program                       68 ns      1.2%          670 ns     1.8%     +603 ns
nvrtc.nvrtc_create_program_100_headers        11.08 us      3.7%        13.14 us     3.0%    +2052 ns
pointer_attributes.pointer_get_attribute         27 ns      1.6%          487 ns     2.1%     +460 ns
stream.stream_create_destroy                   3.48 us      6.1%         3.53 us     1.6%      +57 ns
stream.stream_query                              84 ns      1.5%          217 ns     2.2%     +133 ns
stream.stream_synchronize                       115 ns      1.1%          243 ns     2.8%     +128 ns
-----------------------------------------------------------------------------------------------------
```

This makes me feel a bit better about those numbers but the Python ones do seem more stable except `event.event_query`.

If we think its worth it to do the process isolation for the Cpp one let me know and I will take a look.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
