### PR TITLE
Drop 3.13t builds from cibuildwheel configuration

### DIFF
--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -73,7 +73,6 @@ readme = { file = ["DESCRIPTION.rst"], content-type = "text/x-rst" }
 
 [tool.cibuildwheel]
 skip = "*-musllinux_*"
-enable = "cpython-freethreading"
 build-verbosity = 1
 
 [tool.cibuildwheel.linux]

--- a/cuda_core/pyproject.toml
+++ b/cuda_core/pyproject.toml
@@ -109,7 +109,6 @@ git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--mat
 
 [tool.cibuildwheel]
 skip = "*-musllinux_*"
-enable = "cpython-freethreading"
 build-verbosity = 1
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
## Description

See the note at https://cibuildwheel.pypa.io/en/stable/changelog/#v341 and https://github.com/pypa/cibuildwheel/pull/2787.

This option will be removed in the next release of cibuildwheel. It is only needed to produce 3.13t wheels; 3.14t and future free-threaded wheels happen without any special configuration.

According to the 0.5.0 release notes, 3.13t support is already dropped.

I'm going through repositories on GitHub that enable this option and sending in PRs to disable it. Happy to answer questions about this.

If you're curious why 3.13t support is going away so soon, see https://py-free-threading.github.io/ci/#building-free-threaded-wheels-with-cibuildwheel for further guidance.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
