### PR TITLE
fix(pathfinder): Linux .so glob fallback prefers newest (#1732)

### DIFF
--- a/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/search_platform.py
+++ b/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/search_platform.py
@@ -43,10 +43,16 @@ def _find_so_in_rel_dirs(
     for rel_dir in rel_dirs:
         sub_dir = tuple(rel_dir.split(os.path.sep))
         for abs_dir in find_sub_dirs_all_sitepackages(sub_dir):
+            # Exact unversioned match first; fall back to versioned names because some
+            # distros only ship lib<name>.so.<major> (e.g. conda libcupti). Only one match
+            # is expected in practice. Sort in reverse so the newest-sorting name wins if
+            # multiple coexist, matching the newest-first bias elsewhere in pathfinder
+            # (see LinuxSearchPlatform.find_in_lib_dir and load_dl_linux._candidate_sonames).
+            # Issue #1732 tracks the deferred question of raising on true ambiguity.
             so_name = os.path.join(abs_dir, so_basename)
             if os.path.isfile(so_name):
                 return so_name
-            for so_name in sorted(glob.glob(os.path.join(abs_dir, file_wild))):
+            for so_name in sorted(glob.glob(os.path.join(abs_dir, file_wild)), reverse=True):
                 if os.path.isfile(so_name):
                     return so_name
         sub_dirs_searched.append(sub_dir)
@@ -150,7 +156,8 @@ class LinuxSearchPlatform:
         file_wild = lib_searched_for + "*"
         # Only one match is expected, but to ensure deterministic behavior in unexpected
         # situations, and to be internally consistent, we sort in reverse order with the
-        # intent to return the newest version first.
+        # intent to return the newest version first. Issue #1732 tracks the deferred
+        # question of raising on true ambiguity.
         for so_name in sorted(glob.glob(os.path.join(lib_dir, file_wild)), reverse=True):
             if os.path.isfile(so_name):
                 return so_name

--- a/cuda_pathfinder/tests/test_search_steps.py
+++ b/cuda_pathfinder/tests/test_search_steps.py
@@ -148,6 +148,63 @@ class TestFindInSitePackages:
         assert result is None
         assert any("No such file" in m for m in ctx.error_messages)
 
+    # The next three tests cover the Linux glob fallback in
+    # cuda.pathfinder._dynamic_libs.search_platform._find_so_in_rel_dirs.
+    # The fallback triggers when the unversioned libfoo.so is absent but
+    # versioned libfoo.so.<major> files exist (e.g. some conda layouts).
+    # Issue #1732 tracks the decision to return the newest-sorting match
+    # deterministically; these tests lock in that policy at the
+    # site-packages call site.
+
+    def test_glob_fallback_returns_single_versioned_match(self, mocker, tmp_path):
+        lib_dir = tmp_path / "nvidia" / "cuda_runtime" / "lib"
+        lib_dir.mkdir(parents=True)
+        versioned = lib_dir / "libcudart.so.13"
+        versioned.touch()
+
+        mocker.patch(
+            f"{_PLAT_MOD}.find_sub_dirs_all_sitepackages",
+            return_value=[str(lib_dir)],
+        )
+
+        result = find_in_site_packages(_ctx(platform=LinuxSearchPlatform()))
+        assert result is not None
+        assert result.abs_path == str(versioned)
+        assert result.found_via == "site-packages"
+
+    def test_glob_fallback_returns_newest_of_multiple_matches(self, mocker, tmp_path):
+        lib_dir = tmp_path / "nvidia" / "cuda_runtime" / "lib"
+        lib_dir.mkdir(parents=True)
+        older = lib_dir / "libcudart.so.12"
+        newer = lib_dir / "libcudart.so.13"
+        older.touch()
+        newer.touch()
+
+        mocker.patch(
+            f"{_PLAT_MOD}.find_sub_dirs_all_sitepackages",
+            return_value=[str(lib_dir)],
+        )
+
+        result = find_in_site_packages(_ctx(platform=LinuxSearchPlatform()))
+        assert result is not None
+        assert result.abs_path == str(newer)
+        assert result.found_via == "site-packages"
+
+    def test_glob_fallback_zero_matches_returns_none(self, mocker, tmp_path):
+        lib_dir = tmp_path / "nvidia" / "cuda_runtime" / "lib"
+        lib_dir.mkdir(parents=True)
+        (lib_dir / "unrelated.txt").touch()
+
+        mocker.patch(
+            f"{_PLAT_MOD}.find_sub_dirs_all_sitepackages",
+            return_value=[str(lib_dir)],
+        )
+
+        ctx = _ctx(platform=LinuxSearchPlatform())
+        result = find_in_site_packages(ctx)
+        assert result is None
+        assert any("No such file" in m and "libcudart.so" in m for m in ctx.error_messages)
+
 
 # ---------------------------------------------------------------------------
 # find_in_conda
@@ -188,6 +245,54 @@ class TestFindInConda:
         assert result is not None
         assert result.abs_path == str(dll)
         assert result.found_via == "conda"
+
+    # The next three tests cover the Linux glob fallback in
+    # cuda.pathfinder._dynamic_libs.search_platform.LinuxSearchPlatform.find_in_lib_dir,
+    # which is exercised by find_in_conda (and find_in_cuda_path) when the
+    # resolved lib dir contains only versioned libfoo.so.<major> files.
+    # Issue #1732 tracks the decision to return the newest-sorting match
+    # deterministically; these tests lock in that policy at the conda /
+    # CUDA_PATH call site.
+
+    def test_glob_fallback_returns_single_versioned_match(self, mocker, tmp_path):
+        lib_dir = tmp_path / "lib"
+        lib_dir.mkdir()
+        versioned = lib_dir / "libcudart.so.13"
+        versioned.touch()
+
+        mocker.patch.dict(os.environ, {"CONDA_PREFIX": str(tmp_path)})
+
+        result = find_in_conda(_ctx(platform=LinuxSearchPlatform()))
+        assert result is not None
+        assert result.abs_path == str(versioned)
+        assert result.found_via == "conda"
+
+    def test_glob_fallback_returns_newest_of_multiple_matches(self, mocker, tmp_path):
+        lib_dir = tmp_path / "lib"
+        lib_dir.mkdir()
+        older = lib_dir / "libcudart.so.12"
+        newer = lib_dir / "libcudart.so.13"
+        older.touch()
+        newer.touch()
+
+        mocker.patch.dict(os.environ, {"CONDA_PREFIX": str(tmp_path)})
+
+        result = find_in_conda(_ctx(platform=LinuxSearchPlatform()))
+        assert result is not None
+        assert result.abs_path == str(newer)
+        assert result.found_via == "conda"
+
+    def test_glob_fallback_zero_matches_returns_none(self, mocker, tmp_path):
+        lib_dir = tmp_path / "lib"
+        lib_dir.mkdir()
+        (lib_dir / "unrelated.txt").touch()
+
+        mocker.patch.dict(os.environ, {"CONDA_PREFIX": str(tmp_path)})
+
+        ctx = _ctx(platform=LinuxSearchPlatform())
+        result = find_in_conda(ctx)
+        assert result is None
+        assert any("No such file" in m and "libcudart.so" in m for m in ctx.error_messages)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Resolves #1732.

## Summary

- `cuda_pathfinder/cuda/pathfinder/_dynamic_libs/search_platform.py`:
  `_find_so_in_rel_dirs` (the site-packages wheel lookup) now uses
  `sorted(..., reverse=True)` on its versioned-`.so` glob, matching the
  newest-first policy already used by `LinuxSearchPlatform.find_in_lib_dir`
  (the conda / `CUDA_PATH` lookup) and by the descriptor-driven
  already-loaded / system-search order in `load_dl_linux`/`load_dl_windows`.
- Added an inline comment at `_find_so_in_rel_dirs` documenting why the
  fallback exists, that a single match is expected in practice, the
  newest-first tie-breaker, and a pointer back to this issue.
- Appended the same issue pointer to the existing comment at
  `LinuxSearchPlatform.find_in_lib_dir`.
- `cuda_pathfinder/tests/test_search_steps.py`: added six tests (three per
  call site) locking in the newest-first policy: zero / one / multiple
  versioned matches at both the site-packages and conda/`CUDA_PATH` call
  sites, using `libcudart.so.12` / `libcudart.so.13` as the fixtures.

Behavioral changes to ambiguity handling (raising when multiple versioned
files coexist) remain deferred to #1038, consistent with the triage
decision recorded on #1732.

Original review thread:
https://github.com/NVIDIA/cuda-python/pull/1693#discussion_r2896777451

## Test plan

- [x] `pixi run pytest tests/` from `cuda_pathfinder/` — 966 passed, 4
      skipped (unchanged count except +6 new tests).
- [x] Ruff check + format pass on changed files.
- [x] Mypy on the changed source file — no new errors (same pre-existing
      set).
- [x] Sanity-checked that the new multi-match test fails on the
      pre-change sort by reverting the keyword locally.