### PR TITLE
Remove `enable = "cpython-freethreading"` lines in cuda_bindings, cuda_core pyproject.toml files

### DIFF
--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -73,7 +73,6 @@ readme = { file = ["DESCRIPTION.rst"], content-type = "text/x-rst" }
 
 [tool.cibuildwheel]
 skip = "*-musllinux_*"
-enable = "cpython-freethreading"
 build-verbosity = 1
 
 [tool.cibuildwheel.linux]

--- a/cuda_core/pyproject.toml
+++ b/cuda_core/pyproject.toml
@@ -109,7 +109,6 @@ git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--mat
 
 [tool.cibuildwheel]
 skip = "*-musllinux_*"
-enable = "cpython-freethreading"
 build-verbosity = 1
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
Thanks @ngoldbaum for alerting us via #1965 that this cleanup is needed for compatibility with the next release of cibuildwheel!