### PR TITLE
[no-ci] Update actions/labeler pin to include #917 fix

### DIFF
--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -20,4 +20,4 @@ jobs:
       pull-requests: write
     steps:
       - name: Apply labels
-        uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b  # v6.0.1
+        uses: actions/labeler@e52e4fb63ed5cd0e07abaad9826b2a893ccb921f  # main (include actions/labeler#917)


### PR DESCRIPTION
## Summary

- Pin `actions/labeler` to `e52e4fb` which includes [actions/labeler#917](https://github.com/actions/labeler/pull/917) — "Preserve manually added labels during workflow run and refine label sync logic"
- The previous pin (`634933e` / v6.0.1) has a bug where labels added by other workflows during the same run can be removed even with `sync-labels: false`
- This caused `Needs-Restricted-Paths-Review` (applied by `restricted-paths-guard.yml`) to be immediately stripped when `pr-auto-label.yml` ran concurrently — see #1967 for the full investigation
- The fix has not been included in any `actions/labeler` release yet (latest is still v6.0.1), so we pin to a commit on `main` directly. We do not pin at the latest `main` HEAD because their CI on `main` currently fails. We should update to a tagged release once one is published.

## Test plan

- [ ] Open a test PR that touches a restricted path and verify `Needs-Restricted-Paths-Review` persists after the auto-labeler runs
- [ ] Verify module labels (`cuda.bindings`, `cuda.core`, etc.) are still applied correctly

-- Leo's bot