### PR TITLE
BUG: Make nvmlGetFieldValues robust to empty field list

### DIFF
--- a/cuda_bindings/cuda/bindings/nvml.pyx
+++ b/cuda_bindings/cuda/bindings/nvml.pyx
@@ -27030,6 +27030,11 @@ cpdef object device_get_field_values(intptr_t device, values):
     cdef FieldValue values_ = _cast_field_values(values)
     cdef nvmlFieldValue_t *ptr = <nvmlFieldValue_t *>values_._get_ptr()
     cdef unsigned int valuesCount = len(values)
+
+    # Passing a valuesCount of 0 to nvmlDeviceGetFieldValues returns NVML_INVALID_ARGUMENT
+    if valuesCount == 0:
+        return values_
+
     with nogil:
         __status__ = nvmlDeviceGetFieldValues(<Device>device, valuesCount, ptr)
     check_status(__status__)
@@ -27049,6 +27054,10 @@ cpdef  device_clear_field_values(intptr_t device, values):
     cdef FieldValue values_ = _cast_field_values(values)
     cdef nvmlFieldValue_t *ptr = <nvmlFieldValue_t *>values_._get_ptr()
     cdef unsigned int valuesCount = len(values)
+
+    # Passing a valuesCount of 0 to nvmlDeviceClearFieldValues returns NVML_INVALID_ARGUMENT
+    if valuesCount == 0:
+        return values_
 
     with nogil:
         __status__ = nvmlDeviceClearFieldValues(<Device>device, valuesCount, ptr)

--- a/cuda_bindings/tests/nvml/test_nvlink.py
+++ b/cuda_bindings/tests/nvml/test_nvlink.py
@@ -10,6 +10,11 @@ def test_nvlink_get_link_count(all_devices):
     Checks that the link count of the device is same.
     """
     for device in all_devices:
+        fields = nvml.FieldValue(0)
+        assert len(nvml.device_get_field_values(device, fields)) == 0
+        
+        assert len(nvml.device_get_field_values(device, [])) == 0
+
         fields = nvml.FieldValue(1)
         fields[0].field_id = nvml.FieldId.DEV_NVLINK_LINK_COUNT
         value = nvml.device_get_field_values(device, fields)[0]

--- a/cuda_bindings/tests/nvml/test_nvlink.py
+++ b/cuda_bindings/tests/nvml/test_nvlink.py
@@ -12,7 +12,7 @@ def test_nvlink_get_link_count(all_devices):
     for device in all_devices:
         fields = nvml.FieldValue(0)
         assert len(nvml.device_get_field_values(device, fields)) == 0
-        
+
         assert len(nvml.device_get_field_values(device, [])) == 0
 
         fields = nvml.FieldValue(1)

--- a/cuda_core/cuda/core/system/_device.pyx
+++ b/cuda_core/cuda/core/system/_device.pyx
@@ -661,6 +661,11 @@ cdef class Device:
         :obj:`~_device.FieldValues`
             Container of field values corresponding to the requested field IDs.
         """
+        # Passing a field_ids array of length 0 raises an InvalidArgumentError,
+        # so avoid that.
+        if len(field_ids) == 0:
+            return FieldValues(nvml.FieldValue(0))
+
         return FieldValues(nvml.device_get_field_values(self._handle, field_ids))
 
     def clear_field_values(self, field_ids: list[int | tuple[int, int]]) -> None:
@@ -675,6 +680,11 @@ cdef class Device:
             Each item may be either a single value from the :class:`FieldId`
             enum, or a pair of (:class:`FieldId`, scope ID).
         """
+        # Passing a field_ids array of length 0 raises an InvalidArgumentError,
+        # so avoid that.
+        if len(field_ids) == 0:
+            return
+
         nvml.device_clear_field_values(self._handle, field_ids)
 
     ##########################################################################

--- a/cuda_core/tests/system/test_system_device.py
+++ b/cuda_core/tests/system/test_system_device.py
@@ -360,7 +360,7 @@ def test_field_values():
         # TODO: Are there any fields that return double's?  It would be good to
         # test those.
 
-        assert len(device.get_field_values([])) == 0    
+        assert len(device.get_field_values([])) == 0
 
         field_ids = [
             system.FieldId.DEV_TOTAL_ENERGY_CONSUMPTION,

--- a/cuda_core/tests/system/test_system_device.py
+++ b/cuda_core/tests/system/test_system_device.py
@@ -360,6 +360,8 @@ def test_field_values():
         # TODO: Are there any fields that return double's?  It would be good to
         # test those.
 
+        assert len(device.get_field_values([])) == 0    
+
         field_ids = [
             system.FieldId.DEV_TOTAL_ENERGY_CONSUMPTION,
             system.FieldId.DEV_PCIE_COUNT_TX_BYTES,


### PR DESCRIPTION
`nvmlDeviceGetFieldValues` and `nvmlDeviceClearFieldValues` raise an `INVALID_ARGUMENT` error when given an empty set of field values.  This is really confusing from a user perspective: We should just return an empty result in that case.

This is inline with what pynvml.py does, so makes it easier to migrate.
