### PR TITLE
[no-ci] Reduce nightly test repetitions from 100 to 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,7 +343,7 @@ jobs:
       build-type: pull-request
       host-platform: ${{ matrix.host-platform }}
       build-ctk-ver: ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
-      nruns: ${{ (github.event_name == 'schedule' && 100) || 1}}
+      nruns: ${{ (github.event_name == 'schedule' && 5) || 1}}
       skip-bindings-test: ${{ !fromJSON(needs.detect-changes.outputs.test_bindings) }}
 
   # See test-linux-64 for why test jobs are split by platform.
@@ -368,7 +368,7 @@ jobs:
       build-type: pull-request
       host-platform: ${{ matrix.host-platform }}
       build-ctk-ver: ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
-      nruns: ${{ (github.event_name == 'schedule' && 100) || 1}}
+      nruns: ${{ (github.event_name == 'schedule' && 5) || 1}}
       skip-bindings-test: ${{ !fromJSON(needs.detect-changes.outputs.test_bindings) }}
 
   # See test-linux-64 for why test jobs are split by platform.
@@ -393,7 +393,7 @@ jobs:
       build-type: pull-request
       host-platform: ${{ matrix.host-platform }}
       build-ctk-ver: ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
-      nruns: ${{ (github.event_name == 'schedule' && 100) || 1}}
+      nruns: ${{ (github.event_name == 'schedule' && 5) || 1}}
       skip-bindings-test: ${{ !fromJSON(needs.detect-changes.outputs.test_bindings) }}
 
   doc:


### PR DESCRIPTION
The nightly schedule (`cron: "0 0 * * *"`) sets `nruns: 100`, which passes `--count=100` to pytest — every test is repeated 100 times. Combined with the full PR test matrix (~60 configurations across linux-64, linux-aarch64, and win-64), this causes 6–12 hour runtimes that saturate the runner queue and block daytime PR CI.

Our nightly CI has never been able to finish, nor is it ever green:
https://github.com/NVIDIA/cuda-python/actions/workflows/ci.yml?query=event%3Aschedule

This PR reduces `nruns` from 100 to 5 for all three test platform jobs. Five repetitions still surface flaky tests while cutting nightly runtime by ~20×.

-- Leo's bot