### PR TITLE
BUG: NVML system events may only be registered once per process

### DIFF
--- a/cuda_core/cuda/core/system/_system_events.pyx
+++ b/cuda_core/cuda/core/system/_system_events.pyx
@@ -81,13 +81,15 @@ cdef class RegisteredSystemEvents:
 
         initialize()
 
+        self._event_set = 0
         self._event_set = nvml.system_event_set_create()
         # If this raises, the event needs to be freed and this is handled by
         # this class's __dealloc__ method.
         nvml.system_register_events(event_bitmask, self._event_set)
 
     def __dealloc__(self):
-        nvml.system_event_set_free(self._event_set)
+        if self._event_set != 0:
+            nvml.system_event_set_free(self._event_set)
 
     def wait(self, timeout_ms: int = 0, buffer_size: int = 1) -> SystemEvents:
         """

--- a/cuda_core/tests/system/test_system_events.py
+++ b/cuda_core/tests/system/test_system_events.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -22,6 +22,10 @@ def test_register_events():
 
     # Also, some hardware doesn't support any event types.
 
-    events = system.register_events([system.SystemEventType.GPU_DRIVER_UNBIND])
+    try:
+        events = system.register_events([system.SystemEventType.GPU_DRIVER_UNBIND])
+    except system.UnknownError:
+        pytest.skip("system events may only be registered once per process")
+
     with pytest.raises(system.TimeoutError):
         events.wait(timeout_ms=500, buffer_size=1)


### PR DESCRIPTION
This should fix the nightly tests that are currently failing.
