### PR TITLE
BUG: Handle error return in nvJitLinkGetErrorLogSize and nvJitLinkGetErrorLog

### DIFF
--- a/cuda_core/cuda/core/_linker.pyx
+++ b/cuda_core/cuda/core/_linker.pyx
@@ -106,11 +106,11 @@ cdef class Linker:
         cdef char* c_log_ptr
         if self._use_nvjitlink:
             c_h = as_cu(self._nvjitlink_handle)
-            cynvjitlink.nvJitLinkGetErrorLogSize(c_h, &c_log_size)
+            HANDLE_RETURN_NVJITLINK(c_h, cynvjitlink.nvJitLinkGetErrorLogSize(c_h, &c_log_size))
             log = bytearray(c_log_size)
             if c_log_size > 0:
                 c_log_ptr = <char*>(<bytearray>log)
-                cynvjitlink.nvJitLinkGetErrorLog(c_h, c_log_ptr)
+                HANDLE_RETURN_NVJITLINK(c_h, cynvjitlink.nvJitLinkGetErrorLog(c_h, c_log_ptr))
             return log.decode("utf-8", errors="backslashreplace")
         else:
             return (<bytearray>self._drv_log_bufs[2]).decode(
@@ -132,11 +132,11 @@ cdef class Linker:
         cdef char* c_log_ptr
         if self._use_nvjitlink:
             c_h = as_cu(self._nvjitlink_handle)
-            cynvjitlink.nvJitLinkGetInfoLogSize(c_h, &c_log_size)
+            HANDLE_RETURN_NVJITLINK(c_h, cynvjitlink.nvJitLinkGetInfoLogSize(c_h, &c_log_size))
             log = bytearray(c_log_size)
             if c_log_size > 0:
                 c_log_ptr = <char*>(<bytearray>log)
-                cynvjitlink.nvJitLinkGetInfoLog(c_h, c_log_ptr)
+                HANDLE_RETURN_NVJITLINK(c_h, cynvjitlink.nvJitLinkGetInfoLog(c_h, c_log_ptr))
             return log.decode("utf-8", errors="backslashreplace")
         else:
             return (<bytearray>self._drv_log_bufs[0]).decode(


### PR DESCRIPTION
While not strictly an API issue, this was found as part of the API audit in #1951.