### PR TITLE
cuda.core: fix _arr_is_c_contiguous discriminator for numba arrays

### DIFF
--- a/cuda_core/tests/test_utils.py
+++ b/cuda_core/tests/test_utils.py
@@ -102,7 +102,7 @@ def _arr_size(arr):
 def _arr_is_c_contiguous(arr):
     if torch is not None and isinstance(arr, torch.Tensor):
         return arr.is_contiguous()
-    return arr.flags.c_contiguous if hasattr(arr, "flags") else arr.flags["C_CONTIGUOUS"]
+    return arr.flags.c_contiguous if hasattr(arr.flags, "c_contiguous") else arr.flags["C_CONTIGUOUS"]
 
 
 def _arr_is_writeable(arr):


### PR DESCRIPTION
## Summary

Fix the discriminator in `_arr_is_c_contiguous` so the numba-cuda
parametrizations of the `StridedMemoryView` GPU tests pass instead of
raising `AttributeError`.

## Changes

`_arr_is_c_contiguous` (in `cuda_core/tests/test_utils.py`) checked
`hasattr(arr, "flags")`, which is `True` for both numpy arrays and
numba `DeviceNDArray`. For numba `arr.flags` is a plain `dict`, so the
truthy branch falls into `arr.flags.c_contiguous` and raises:

```
AttributeError: 'dict' object has no attribute 'c_contiguous'
```

Discriminate on the flags object instead, mirroring the sibling
`_arr_is_writeable` helper a few lines below:

```python
return arr.flags.c_contiguous if hasattr(arr.flags, "c_contiguous") else arr.flags["C_CONTIGUOUS"]
```

One-character placement bug; one-line patch.

## Test Coverage

Unblocks the six numba-cuda parametrizations that have been failing:

- `TestViewGPU::test_args_viewable_as_strided_memory_gpu[numba-cuda-int8]`
- `TestViewGPU::test_args_viewable_as_strided_memory_gpu[numba-cuda-float32]`
- `TestViewGPU::test_strided_memory_view_cpu[numba-cuda-int8]`
- `TestViewGPU::test_strided_memory_view_cpu[numba-cuda-float32]`
- `TestViewGPU::test_strided_memory_view_init[numba-cuda-int8]`
- `TestViewGPU::test_strided_memory_view_init[numba-cuda-float32]`

Verified locally on a GPU host: the previously failing parametrizations
now pass, no other tests regress.

Pre-commit clean (`pre-commit run --all-files`).
