### PR TITLE
[FIX]: cuda.core: simplify `_check_runtime_error` logic

### DIFF
--- a/cuda_core/cuda/core/_utils/cuda_utils.pyx
+++ b/cuda_core/cuda/core/_utils/cuda_utils.pyx
@@ -149,6 +149,13 @@ cdef object _RUNTIME_SUCCESS = runtime.cudaError_t.cudaSuccess
 cdef object _NVRTC_SUCCESS = nvrtc.nvrtcResult.NVRTC_SUCCESS
 
 
+def _known_runtime_error_name(error):
+    try:
+        return runtime.cudaError_t(error).name
+    except ValueError:
+        return None
+
+
 cpdef inline int _check_driver_error(cydriver.CUresult error) except?-1 nogil:
     if error == cydriver.CUresult.CUDA_SUCCESS:
         return 0
@@ -174,7 +181,9 @@ cpdef inline int _check_runtime_error(error) except?-1:
     name_err, name = runtime.cudaGetErrorName(error)
     if name_err != _RUNTIME_SUCCESS:
         raise CUDAError(f"UNEXPECTED ERROR CODE: {error}")
-    name = name.decode()
+    # Windows hybrid cudart can lag the generated bindings' enum table.
+    # Prefer the binding name for values the bindings know.
+    name = _known_runtime_error_name(error) or name.decode()
     expl = RUNTIME_CUDA_ERROR_EXPLANATIONS.get(int(error))
     if expl is not None:
         raise CUDAError(f"{name}: {expl}")

--- a/cuda_core/cuda/core/_utils/cuda_utils.pyx
+++ b/cuda_core/cuda/core/_utils/cuda_utils.pyx
@@ -149,13 +149,6 @@ cdef object _RUNTIME_SUCCESS = runtime.cudaError_t.cudaSuccess
 cdef object _NVRTC_SUCCESS = nvrtc.nvrtcResult.NVRTC_SUCCESS
 
 
-def _known_runtime_error_name(error):
-    try:
-        return runtime.cudaError_t(error).name
-    except ValueError:
-        return None
-
-
 cpdef inline int _check_driver_error(cydriver.CUresult error) except?-1 nogil:
     if error == cydriver.CUresult.CUDA_SUCCESS:
         return 0
@@ -178,12 +171,9 @@ cpdef inline int _check_driver_error(cydriver.CUresult error) except?-1 nogil:
 cpdef inline int _check_runtime_error(error) except?-1:
     if error == _RUNTIME_SUCCESS:
         return 0
-    name_err, name = runtime.cudaGetErrorName(error)
-    if name_err != _RUNTIME_SUCCESS:
-        raise CUDAError(f"UNEXPECTED ERROR CODE: {error}")
-    # Windows hybrid cudart can lag the generated bindings' enum table.
-    # Prefer the binding name for values the bindings know.
-    name = _known_runtime_error_name(error) or name.decode()
+    # `_check_error()` reaches this path only for `runtime.cudaError_t` values.
+    # Use the enum name directly because Windows hybrid cudart can lag that table.
+    name = error.name
     expl = RUNTIME_CUDA_ERROR_EXPLANATIONS.get(int(error))
     if expl is not None:
         raise CUDAError(f"{name}: {expl}")

--- a/cuda_core/tests/test_cuda_utils.py
+++ b/cuda_core/tests/test_cuda_utils.py
@@ -48,7 +48,6 @@ def test_check_driver_error():
 
 
 def test_check_runtime_error():
-    num_unexpected = 0
     for error in runtime.cudaError_t:
         if error == runtime.cudaError_t.cudaSuccess:
             assert cuda_utils._check_runtime_error(error) == 0
@@ -56,14 +55,7 @@ def test_check_runtime_error():
             with pytest.raises(cuda_utils.CUDAError) as e:
                 cuda_utils._check_runtime_error(error)
             msg = str(e)
-            if "UNEXPECTED ERROR CODE" in msg:
-                num_unexpected += 1
-            else:
-                # Example repr(error): <cudaError_t.cudaErrorUnknown: 999>
-                enum_name = repr(error).split(".", 1)[1].split(":", 1)[0]
-                assert enum_name in msg
-    # Smoke test: We don't want most to be unexpected.
-    assert num_unexpected < len(driver.CUresult) * 0.5
+            assert error.name in msg
 
 
 def test_driver_error_enum_has_non_empty_docstring():
@@ -177,22 +169,6 @@ def test_check_runtime_error_attaches_explanation():
 
     assert str(e.value) == f"{name.decode()}: {expl}"
     assert str(e.value) != f"{name.decode()}: {desc.decode()}"
-
-
-def test_check_runtime_error_uses_binding_name_for_known_runtime_error(monkeypatch):
-    error = runtime.cudaError_t.cudaErrorInvalidValue
-    runtime_name = b"runtime-provided-name"
-
-    def cuda_get_error_name(_error):
-        return runtime.cudaError_t.cudaSuccess, runtime_name
-
-    monkeypatch.setattr(cuda_utils.runtime, "cudaGetErrorName", cuda_get_error_name)
-
-    with pytest.raises(cuda_utils.CUDAError) as e:
-        cuda_utils._check_runtime_error(error)
-
-    assert str(e.value).startswith(f"{error.name}: ")
-    assert runtime_name.decode() not in str(e.value)
 
 
 def test_precondition():

--- a/cuda_core/tests/test_cuda_utils.py
+++ b/cuda_core/tests/test_cuda_utils.py
@@ -179,6 +179,22 @@ def test_check_runtime_error_attaches_explanation():
     assert str(e.value) != f"{name.decode()}: {desc.decode()}"
 
 
+def test_check_runtime_error_uses_binding_name_for_known_runtime_error(monkeypatch):
+    error = runtime.cudaError_t.cudaErrorInvalidValue
+    runtime_name = b"runtime-provided-name"
+
+    def cuda_get_error_name(_error):
+        return runtime.cudaError_t.cudaSuccess, runtime_name
+
+    monkeypatch.setattr(cuda_utils.runtime, "cudaGetErrorName", cuda_get_error_name)
+
+    with pytest.raises(cuda_utils.CUDAError) as e:
+        cuda_utils._check_runtime_error(error)
+
+    assert str(e.value).startswith(f"{error.name}: ")
+    assert runtime_name.decode() not in str(e.value)
+
+
 def test_precondition():
     def checker(*args, what=""):
         if args[0] < 0:


### PR DESCRIPTION
## Summary

While investigating nvbugs 6115382, inspecting the `cuda.core` error-handling path revealed that `_check_runtime_error()` can be simplified structurally.

`_check_error()` only routes `runtime.cudaError_t` values into `_check_runtime_error()`. Because the function already receives a `runtime.cudaError_t` enum member, it can use `error.name` directly instead of calling `runtime.cudaGetErrorName()` first and decoding the returned string.

This keeps runtime error formatting aligned with the generated bindings enum and removes a runtime name lookup that is unnecessary in the normal `cuda.core` path.

## Rationale

Before this change, `_check_runtime_error()` asked the runtime library for the error name even though the function had already been given a `runtime.cudaError_t` enum member. In the expected path, the name lookup was therefore recovering information already present on the enum object.

Using `error.name` is also a better fit for the situation that prompted this investigation. When the Windows runtime library's error-name table lags the generated `cuda.bindings` enum table, the enum member still carries the correct installed-bindings name, so the raised `CUDAError` continues to use a stable and specific error name.

## Test Simplification

The runtime-side test can be simplified for the same reason. Since `test_check_runtime_error()` iterates over `runtime.cudaError_t` members, it now exercises a path where the error name always comes from `error.name`.

That means the runtime test no longer needs to account for an `UNEXPECTED ERROR CODE` branch in this loop. The test can directly assert that each non-success runtime error message includes `error.name`.

## Side Note

The same structural simplification does not apply to `_check_driver_error()`. The driver-side path still performs meaningful lookup through the driver API and retains explicit handling for unexpected codes, so its current `cuGetErrorName()` / `cuGetErrorString()` structure remains appropriate.