### PR TITLE
[no-ci] Trust any collaborator in restricted-paths guard

### DIFF
--- a/.github/workflows/restricted-paths-guard.yml
+++ b/.github/workflows/restricted-paths-guard.yml
@@ -167,7 +167,7 @@ jobs:
             fi
 
             case "$COLLABORATOR_PERMISSION" in
-              admin|maintain|triage|read)
+              admin|maintain|write|triage|read)
                 HAS_TRUSTED_SIGNAL=true
                 LABEL_ACTION="not needed (collaborator permission is a trusted signal)"
                 TRUSTED_SIGNALS="collaborator_permission:$COLLABORATOR_PERMISSION"

--- a/.github/workflows/restricted-paths-guard.yml
+++ b/.github/workflows/restricted-paths-guard.yml
@@ -29,6 +29,7 @@ jobs:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
           # Workflow policy inputs
           REVIEW_LABEL: Needs-Restricted-Paths-Review
@@ -113,9 +114,25 @@ jobs:
             echo '```'
           }
 
+          post_review_label_comment() {
+            local comment_body
+            printf -v comment_body '%s\n\n%s\n' \
+              "\`$REVIEW_LABEL\` was assigned by \`CI: Restricted Paths Guard\`." \
+              "For details, open [this workflow run]($RUN_URL) and click **Summary**."
+
+            if gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+              -f body="$comment_body" >/dev/null; then
+              COMMENT_ACTION="posted"
+            else
+              COMMENT_ACTION="failed (non-fatal)"
+              echo "::warning::Failed to post PR comment about newly added $REVIEW_LABEL."
+            fi
+          }
+
           HAS_TRUSTED_SIGNAL=false
           LABEL_ACTION="not needed (no restricted paths)"
           TRUSTED_SIGNALS="(none)"
+          COMMENT_ACTION="not needed"
 
           if [ "$TOUCHES_RESTRICTED_PATHS" = "true" ]; then
             # Distinguish a legitimate 404 "not a collaborator" response from
@@ -189,6 +206,7 @@ jobs:
               exit 1
             else
               LABEL_ACTION="added"
+              post_review_label_comment
             fi
           elif [ "$LABEL_ALREADY_PRESENT" = "true" ]; then
             LABEL_ACTION="left in place (manual removal required)"
@@ -203,6 +221,7 @@ jobs:
             echo "- **Restricted paths**: \`cuda_bindings/\`, \`cuda_python/\`"
             echo "- **Trusted signals**: $TRUSTED_SIGNALS"
             echo "- **Label action**: $LABEL_ACTION"
+            echo "- **Comment action**: $COMMENT_ACTION"
             if [ "$TOUCHES_RESTRICTED_PATHS" = "true" ]; then
               echo ""
               write_matching_restricted_paths

--- a/.github/workflows/restricted-paths-guard.yml
+++ b/.github/workflows/restricted-paths-guard.yml
@@ -167,7 +167,7 @@ jobs:
             fi
 
             case "$COLLABORATOR_PERMISSION" in
-              admin|maintain|write|triage|read)
+              admin|maintain|triage|read)
                 HAS_TRUSTED_SIGNAL=true
                 LABEL_ACTION="not needed (collaborator permission is a trusted signal)"
                 TRUSTED_SIGNALS="collaborator_permission:$COLLABORATOR_PERMISSION"

--- a/.github/workflows/restricted-paths-guard.yml
+++ b/.github/workflows/restricted-paths-guard.yml
@@ -6,8 +6,7 @@ name: "CI: Restricted Paths Guard"
 on:
   # Run on drafts too so maintainers get early awareness on WIP PRs.
   # Label updates on fork PRs require pull_request_target permissions.
-  # TEMPORARY: Using pull_request for testing; revert to pull_request_target before merge.
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize

--- a/.github/workflows/restricted-paths-guard.yml
+++ b/.github/workflows/restricted-paths-guard.yml
@@ -149,13 +149,13 @@ jobs:
             fi
 
             case "$COLLABORATOR_PERMISSION" in
-              admin|maintain|write)
+              admin|maintain|write|triage|read)
                 HAS_TRUSTED_SIGNAL=true
                 LABEL_ACTION="not needed (collaborator permission is a trusted signal)"
                 TRUSTED_SIGNALS="collaborator_permission:$COLLABORATOR_PERMISSION"
                 ;;
               *)
-                # triage, read, or none: not a trusted signal
+                # none: not a trusted signal
                 ;;
             esac
           fi

--- a/.github/workflows/restricted-paths-guard.yml
+++ b/.github/workflows/restricted-paths-guard.yml
@@ -6,7 +6,8 @@ name: "CI: Restricted Paths Guard"
 on:
   # Run on drafts too so maintainers get early awareness on WIP PRs.
   # Label updates on fork PRs require pull_request_target permissions.
-  pull_request_target:
+  # TEMPORARY: Using pull_request for testing; revert to pull_request_target before merge.
+  pull_request:
     types:
       - opened
       - synchronize

--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
-# XXX DUMMY CHANGE FOR TESTING restricted-paths-guard.yml - REMOVE BEFORE MERGE XXX
 [build-system]
 requires = [
     "setuptools>=80.0.0",

--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
+# XXX DUMMY CHANGE FOR TESTING restricted-paths-guard.yml - REMOVE BEFORE MERGE XXX
 [build-system]
 requires = [
     "setuptools>=80.0.0",


### PR DESCRIPTION
The main rationale for this change is that the restricted-paths guard is meant to distinguish collaborators from non-collaborators, not to distinguish write-capable collaborators from read- or triage-level collaborators.

In practice, the current workflow is stricter than that: it only trusts `admin`, `maintain`, and `write` from the collaborator-permission API. That produced a false positive on PR #1821, where the author is an org member and a repository collaborator, but the collaborator API returned `read`, so touching `cuda_bindings/` incorrectly caused `Needs-Restricted-Paths-Review` to be applied.

This change widens the trusted set to any collaborator permission level: `read`, `triage`, `write`, `maintain`, or `admin`. `none` remains untrusted, and non-`200|404` API errors still fail the workflow instead of applying the label from an unknown state.

While touching the same workflow, this branch also adds a small usability improvement: when `CI: Restricted Paths Guard` newly assigns `Needs-Restricted-Paths-Review`, it posts a short PR comment with a direct link to the workflow run. The goal is to make it much easier for authors and reviewers to find the job Summary that explains why the label was applied, instead of having to hunt through the Actions UI.

Tested successfully via the temporary/scratch PR #2011