### PR TITLE
pathfinder: add toolkit-info parser and display-driver release helpers

### DIFF
--- a/cuda_pathfinder/cuda/pathfinder/_utils/driver_info.py
+++ b/cuda_pathfinder/cuda/pathfinder/_utils/driver_info.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import ctypes
 import functools
+import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import cast
@@ -15,9 +16,17 @@ from cuda.pathfinder._dynamic_libs.load_nvidia_dynamic_lib import (
 from cuda.pathfinder._utils.platform_aware import IS_WINDOWS
 from cuda.pathfinder._utils.toolkit_info import EncodedCudaVersion
 
+_NVML_SUCCESS = 0
+_NVML_SYSTEM_DRIVER_VERSION_BUFFER_LENGTH = 80
+_DRIVER_RELEASE_VERSION_RE = re.compile(r"^\d+(?:\.\d+){1,2}$")
+
 
 class QueryDriverCudaVersionError(RuntimeError):
     """Raised when ``query_driver_cuda_version()`` cannot determine the CUDA driver version."""
+
+
+class QueryDriverReleaseVersionError(RuntimeError):
+    """Raised when ``query_driver_release_version()`` cannot determine the display-driver release version."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -44,6 +53,37 @@ class DriverCudaVersion(EncodedCudaVersion):
     """
 
 
+@dataclass(frozen=True, slots=True)
+class DriverReleaseVersion:
+    """
+    Display-driver release version shown as ``Driver Version`` in ``nvidia-smi``.
+
+    Example ``nvidia-smi`` output::
+
+        +---------------------------------------------------------------------+
+        | NVIDIA-SMI 595.58.03  Driver Version: 595.58.03  CUDA Version: 13.2 |
+        +---------------------------------------------------------------------+
+
+    For the example above, ``DriverReleaseVersion(text="595.58.03",
+    components=(595, 58, 3), branch=595)`` corresponds to ``Driver Version:
+    595.58.03``. The ``branch`` field is the first numeric component because
+    NVIDIA's compatibility docs publish minimum display-driver requirements in
+    branch form such as ``>= 580`` for CUDA 13.x minor-version compatibility.
+    """
+
+    text: str
+    components: tuple[int, ...]
+    branch: int
+
+    @classmethod
+    def from_text(cls, text: str) -> DriverReleaseVersion:
+        normalized_text = text.strip()
+        if not _DRIVER_RELEASE_VERSION_RE.fullmatch(normalized_text):
+            raise ValueError(f"Invalid driver release version text: {text!r}")
+        components = tuple(int(component) for component in normalized_text.split("."))
+        return cls(text=normalized_text, components=components, branch=components[0])
+
+
 @functools.cache
 def query_driver_cuda_version() -> DriverCudaVersion:
     """Return the CUDA driver version parsed into its major/minor components."""
@@ -52,6 +92,15 @@ def query_driver_cuda_version() -> DriverCudaVersion:
         return cast(DriverCudaVersion, DriverCudaVersion.from_encoded(encoded))
     except Exception as exc:
         raise QueryDriverCudaVersionError("Failed to query the CUDA driver version.") from exc
+
+
+@functools.cache
+def query_driver_release_version() -> DriverReleaseVersion:
+    """Return the display-driver release version parsed into branch/components."""
+    try:
+        return DriverReleaseVersion.from_text(_query_driver_release_version_text())
+    except Exception as exc:
+        raise QueryDriverReleaseVersionError("Failed to query the display-driver release version.") from exc
 
 
 def _query_driver_cuda_version_int() -> int:
@@ -72,3 +121,44 @@ def _query_driver_cuda_version_int() -> int:
     if status != 0:
         raise RuntimeError(f"Failed to query CUDA driver version via cuDriverGetVersion() (status={status}).")
     return version.value
+
+
+def _query_driver_release_version_text() -> str:
+    """Return the display-driver release version from ``nvmlSystemGetDriverVersion()``."""
+    loaded_nvml = _load_nvidia_dynamic_lib("nvml")
+    nvml_lib = ctypes.CDLL(loaded_nvml.abs_path)
+
+    nvml_init_v2 = nvml_lib.nvmlInit_v2
+    nvml_init_v2.argtypes = []
+    nvml_init_v2.restype = ctypes.c_int
+
+    nvml_system_get_driver_version = nvml_lib.nvmlSystemGetDriverVersion
+    nvml_system_get_driver_version.argtypes = [ctypes.POINTER(ctypes.c_char), ctypes.c_uint]
+    nvml_system_get_driver_version.restype = ctypes.c_int
+
+    nvml_shutdown = nvml_lib.nvmlShutdown
+    nvml_shutdown.argtypes = []
+    nvml_shutdown.restype = ctypes.c_int
+
+    init_status = nvml_init_v2()
+    if init_status != _NVML_SUCCESS:
+        raise RuntimeError(f"Failed to initialize NVML via nvmlInit_v2() (status={init_status}).")
+
+    try:
+        version_buffer = ctypes.create_string_buffer(_NVML_SYSTEM_DRIVER_VERSION_BUFFER_LENGTH)
+        status = nvml_system_get_driver_version(version_buffer, _NVML_SYSTEM_DRIVER_VERSION_BUFFER_LENGTH)
+        if status != _NVML_SUCCESS:
+            raise RuntimeError(
+                f"Failed to query driver release version via nvmlSystemGetDriverVersion() (status={status})."
+            )
+        release_version = version_buffer.value.decode()
+    except BaseException as exc:
+        shutdown_status = nvml_shutdown()
+        if shutdown_status != _NVML_SUCCESS:
+            raise RuntimeError(f"Failed to shut down NVML via nvmlShutdown() (status={shutdown_status}).") from exc
+        raise
+
+    shutdown_status = nvml_shutdown()
+    if shutdown_status != _NVML_SUCCESS:
+        raise RuntimeError(f"Failed to shut down NVML via nvmlShutdown() (status={shutdown_status}).")
+    return release_version

--- a/cuda_pathfinder/cuda/pathfinder/_utils/driver_info.py
+++ b/cuda_pathfinder/cuda/pathfinder/_utils/driver_info.py
@@ -7,11 +7,13 @@ import ctypes
 import functools
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import cast
 
 from cuda.pathfinder._dynamic_libs.load_nvidia_dynamic_lib import (
     load_nvidia_dynamic_lib as _load_nvidia_dynamic_lib,
 )
 from cuda.pathfinder._utils.platform_aware import IS_WINDOWS
+from cuda.pathfinder._utils.toolkit_info import EncodedCudaVersion
 
 
 class QueryDriverCudaVersionError(RuntimeError):
@@ -19,7 +21,7 @@ class QueryDriverCudaVersionError(RuntimeError):
 
 
 @dataclass(frozen=True, slots=True)
-class DriverCudaVersion:
+class DriverCudaVersion(EncodedCudaVersion):
     """
     CUDA-facing driver version reported by ``cuDriverGetVersion()``.
 
@@ -41,21 +43,13 @@ class DriverCudaVersion:
     to ``Driver Version: 595.58.03``.
     """
 
-    encoded: int
-    major: int
-    minor: int
-
 
 @functools.cache
 def query_driver_cuda_version() -> DriverCudaVersion:
     """Return the CUDA driver version parsed into its major/minor components."""
     try:
         encoded = _query_driver_cuda_version_int()
-        return DriverCudaVersion(
-            encoded=encoded,
-            major=encoded // 1000,
-            minor=(encoded % 1000) // 10,
-        )
+        return cast(DriverCudaVersion, DriverCudaVersion.from_encoded(encoded))
     except Exception as exc:
         raise QueryDriverCudaVersionError("Failed to query the CUDA driver version.") from exc
 

--- a/cuda_pathfinder/cuda/pathfinder/_utils/driver_info.py
+++ b/cuda_pathfinder/cuda/pathfinder/_utils/driver_info.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import ctypes
 import functools
 import re
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import cast
@@ -140,6 +141,9 @@ def _query_driver_release_version_text() -> str:
     nvml_shutdown.argtypes = []
     nvml_shutdown.restype = ctypes.c_int
 
+    # NVML's init/shutdown pair is reference-counted (see "Initialization and
+    # Cleanup" in the NVML API docs), so this balanced pair is safe even when
+    # the caller has already initialized NVML elsewhere in the process.
     init_status = nvml_init_v2()
     if init_status != _NVML_SUCCESS:
         raise RuntimeError(f"Failed to initialize NVML via nvmlInit_v2() (status={init_status}).")
@@ -152,13 +156,13 @@ def _query_driver_release_version_text() -> str:
                 f"Failed to query driver release version via nvmlSystemGetDriverVersion() (status={status})."
             )
         release_version = version_buffer.value.decode()
-    except BaseException as exc:
+    finally:
+        # Balance the init_v2() above unconditionally. If the body already
+        # raised, let that error win; a non-zero shutdown status here would
+        # only mask the more useful root cause (Python keeps it on
+        # ``__context__`` for debugging). ``sys.exc_info()[1]`` is the
+        # currently-propagating exception inside the finally, or None.
         shutdown_status = nvml_shutdown()
-        if shutdown_status != _NVML_SUCCESS:
-            raise RuntimeError(f"Failed to shut down NVML via nvmlShutdown() (status={shutdown_status}).") from exc
-        raise
-
-    shutdown_status = nvml_shutdown()
-    if shutdown_status != _NVML_SUCCESS:
-        raise RuntimeError(f"Failed to shut down NVML via nvmlShutdown() (status={shutdown_status}).")
+        if shutdown_status != _NVML_SUCCESS and sys.exc_info()[1] is None:
+            raise RuntimeError(f"Failed to shut down NVML via nvmlShutdown() (status={shutdown_status}).")
     return release_version

--- a/cuda_pathfinder/cuda/pathfinder/_utils/toolkit_info.py
+++ b/cuda_pathfinder/cuda/pathfinder/_utils/toolkit_info.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import functools
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+_CUDA_VERSION_RE = re.compile(r"^\s*#\s*define\s+CUDA_VERSION\s+(?P<encoded>\d+)\b", re.MULTILINE)
+
+
+class ReadCudaHeaderVersionError(RuntimeError):
+    """Raised when ``read_cuda_header_version()`` cannot determine the CTK version from ``cuda.h``."""
+
+
+@dataclass(frozen=True, slots=True)
+class CudaToolkitVersion:
+    """CUDA Toolkit version encoded by the ``CUDA_VERSION`` macro in ``cuda.h``."""
+
+    encoded: int
+    major: int
+    minor: int
+
+
+def parse_cuda_header_version(header_text: str) -> CudaToolkitVersion | None:
+    """Parse the CUDA Toolkit major/minor version from ``cuda.h`` text."""
+    match = _CUDA_VERSION_RE.search(header_text)
+    if match is None:
+        return None
+    encoded = int(match.group("encoded"))
+    return CudaToolkitVersion(
+        encoded=encoded,
+        major=encoded // 1000,
+        minor=(encoded % 1000) // 10,
+    )
+
+
+@functools.cache
+def read_cuda_header_version(cuda_header_path: str) -> CudaToolkitVersion:
+    """Read and parse the CUDA Toolkit major/minor version from ``cuda.h``."""
+    try:
+        header_text = Path(cuda_header_path).read_text(encoding="utf-8", errors="replace")
+        version = parse_cuda_header_version(header_text)
+        if version is None:
+            raise RuntimeError(f"{cuda_header_path!r} does not define CUDA_VERSION.")
+        return version
+    except Exception as exc:
+        raise ReadCudaHeaderVersionError(
+            f"Failed to read the CUDA Toolkit version from cuda.h at {cuda_header_path!r}."
+        ) from exc

--- a/cuda_pathfinder/cuda/pathfinder/_utils/toolkit_info.py
+++ b/cuda_pathfinder/cuda/pathfinder/_utils/toolkit_info.py
@@ -7,8 +7,46 @@ import functools
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TypeVar
 
 _CUDA_VERSION_RE = re.compile(r"^\s*#\s*define\s+CUDA_VERSION\s+(?P<encoded>\d+)\b", re.MULTILINE)
+EncodedCudaVersionT = TypeVar("EncodedCudaVersionT", bound="EncodedCudaVersion")
+
+
+@dataclass(frozen=True, slots=True)
+class EncodedCudaVersion:
+    """CUDA major/minor version represented in CUDA's integer ``encoded`` form."""
+
+    encoded: int
+    major: int
+    minor: int
+
+    @classmethod
+    def from_encoded(cls: type[EncodedCudaVersionT], encoded: int | str) -> EncodedCudaVersionT:
+        if isinstance(encoded, str):
+            try:
+                encoded_int = int(encoded)
+            except ValueError as exc:
+                raise ValueError(
+                    f"{cls.__name__}.from_encoded() expected an integer or decimal string, got {encoded!r}."
+                ) from exc
+        elif isinstance(encoded, int):
+            encoded_int = encoded
+        else:
+            raise TypeError(
+                f"{cls.__name__}.from_encoded() expected an integer or decimal string, got {type(encoded).__name__}."
+            )
+        if encoded_int < 0:
+            raise ValueError(
+                f"{cls.__name__}.from_encoded() expected a non-negative encoded CUDA version, got {encoded_int}."
+            )
+        # CUDA encodes versions as major * 1000 + minor * 10. The least-significant
+        # decimal is ignored here: it is 0 in all CUDA releases and is not a patch version.
+        return cls(
+            encoded=encoded_int,
+            major=encoded_int // 1000,
+            minor=(encoded_int % 1000) // 10,
+        )
 
 
 class ReadCudaHeaderVersionError(RuntimeError):
@@ -16,12 +54,8 @@ class ReadCudaHeaderVersionError(RuntimeError):
 
 
 @dataclass(frozen=True, slots=True)
-class CudaToolkitVersion:
+class CudaToolkitVersion(EncodedCudaVersion):
     """CUDA Toolkit version encoded by the ``CUDA_VERSION`` macro in ``cuda.h``."""
-
-    encoded: int
-    major: int
-    minor: int
 
 
 def parse_cuda_header_version(header_text: str) -> CudaToolkitVersion | None:
@@ -29,12 +63,7 @@ def parse_cuda_header_version(header_text: str) -> CudaToolkitVersion | None:
     match = _CUDA_VERSION_RE.search(header_text)
     if match is None:
         return None
-    encoded = int(match.group("encoded"))
-    return CudaToolkitVersion(
-        encoded=encoded,
-        major=encoded // 1000,
-        minor=(encoded % 1000) // 10,
-    )
+    return CudaToolkitVersion.from_encoded(match.group("encoded"))
 
 
 @functools.cache

--- a/cuda_pathfinder/tests/test_utils_driver_info.py
+++ b/cuda_pathfinder/tests/test_utils_driver_info.py
@@ -155,6 +155,36 @@ def test_query_driver_release_version_text_raises_when_nvml_call_fails(monkeypat
     assert fake_nvml_lib.shutdown_calls == 1
 
 
+def test_query_driver_release_version_text_raises_when_only_shutdown_fails(monkeypatch):
+    fake_nvml_lib = _FakeNvmlLib(shutdown_statuses=(2,))
+
+    monkeypatch.setattr(
+        driver_info,
+        "_load_nvidia_dynamic_lib",
+        lambda _libname: _loaded_nvml("/usr/lib/libnvidia-ml.so.1"),
+    )
+    monkeypatch.setattr(driver_info.ctypes, "CDLL", lambda _abs_path: fake_nvml_lib)
+
+    with pytest.raises(RuntimeError, match=r"nvmlShutdown\(\) \(status=2\)"):
+        driver_info._query_driver_release_version_text()
+    assert fake_nvml_lib.shutdown_calls == 1
+
+
+def test_query_driver_release_version_text_body_error_wins_when_both_fail(monkeypatch):
+    fake_nvml_lib = _FakeNvmlLib(query_status=1, shutdown_statuses=(2,))
+
+    monkeypatch.setattr(
+        driver_info,
+        "_load_nvidia_dynamic_lib",
+        lambda _libname: _loaded_nvml("/usr/lib/libnvidia-ml.so.1"),
+    )
+    monkeypatch.setattr(driver_info.ctypes, "CDLL", lambda _abs_path: fake_nvml_lib)
+
+    with pytest.raises(RuntimeError, match=r"nvmlSystemGetDriverVersion\(\) \(status=1\)"):
+        driver_info._query_driver_release_version_text()
+    assert fake_nvml_lib.shutdown_calls == 1
+
+
 def test_query_driver_cuda_version_uses_windll_on_windows(monkeypatch):
     fake_driver_lib = _FakeDriverLib(status=0, version=12080)
     loaded_paths: list[str] = []

--- a/cuda_pathfinder/tests/test_utils_driver_info.py
+++ b/cuda_pathfinder/tests/test_utils_driver_info.py
@@ -73,6 +73,17 @@ def test_query_driver_cuda_version_returns_parsed_dataclass(monkeypatch):
     )
 
 
+def test_driver_cuda_version_from_encoded_returns_subclass_instance():
+    version = driver_info.DriverCudaVersion.from_encoded(12080)
+
+    assert version == driver_info.DriverCudaVersion(
+        encoded=12080,
+        major=12,
+        minor=8,
+    )
+    assert type(version) is driver_info.DriverCudaVersion
+
+
 def test_query_driver_cuda_version_wraps_internal_failures(monkeypatch):
     root_cause = RuntimeError("low-level query failed")
 

--- a/cuda_pathfinder/tests/test_utils_driver_info.py
+++ b/cuda_pathfinder/tests/test_utils_driver_info.py
@@ -12,8 +12,10 @@ from cuda.pathfinder._utils import driver_info
 @pytest.fixture(autouse=True)
 def _clear_driver_cuda_version_query_cache():
     driver_info.query_driver_cuda_version.cache_clear()
+    driver_info.query_driver_release_version.cache_clear()
     yield
     driver_info.query_driver_cuda_version.cache_clear()
+    driver_info.query_driver_release_version.cache_clear()
 
 
 class _FakeCuDriverGetVersion:
@@ -33,6 +35,47 @@ class _FakeDriverLib:
         self.cuDriverGetVersion = _FakeCuDriverGetVersion(status=status, version=version)
 
 
+class _FakeNvmlFunction:
+    def __init__(self, func):
+        self.argtypes = None
+        self.restype = None
+        self._func = func
+
+    def __call__(self, *args):
+        return self._func(*args)
+
+
+class _FakeNvmlLib:
+    def __init__(
+        self,
+        *,
+        init_status: int = 0,
+        driver_release_version: str = "595.58.03",
+        query_status: int = 0,
+        shutdown_statuses: tuple[int, ...] = (0,),
+    ):
+        self.shutdown_calls = 0
+        remaining_shutdown_statuses = list(shutdown_statuses)
+
+        self.nvmlInit_v2 = _FakeNvmlFunction(lambda: init_status)
+
+        def nvml_system_get_driver_version(version_buffer, _buffer_length) -> int:
+            if query_status != 0:
+                return query_status
+            version_buffer.value = driver_release_version.encode()
+            return 0
+
+        self.nvmlSystemGetDriverVersion = _FakeNvmlFunction(nvml_system_get_driver_version)
+
+        def nvml_shutdown() -> int:
+            self.shutdown_calls += 1
+            if remaining_shutdown_statuses:
+                return remaining_shutdown_statuses.pop(0)
+            return 0
+
+        self.nvmlShutdown = _FakeNvmlFunction(nvml_shutdown)
+
+
 def _loaded_cuda(abs_path: str) -> LoadedDL:
     return LoadedDL(
         abs_path=abs_path,
@@ -40,6 +83,86 @@ def _loaded_cuda(abs_path: str) -> LoadedDL:
         _handle_uint=0xBEEF,
         found_via="system-search",
     )
+
+
+def _loaded_nvml(abs_path: str) -> LoadedDL:
+    return LoadedDL(
+        abs_path=abs_path,
+        was_already_loaded_from_elsewhere=False,
+        _handle_uint=0xCAFE,
+        found_via="system-search",
+    )
+
+
+def test_driver_release_version_from_text_parses_branch():
+    assert driver_info.DriverReleaseVersion.from_text("595.58.03") == driver_info.DriverReleaseVersion(
+        text="595.58.03",
+        components=(595, 58, 3),
+        branch=595,
+    )
+
+
+def test_query_driver_release_version_returns_parsed_dataclass(monkeypatch):
+    monkeypatch.setattr(driver_info, "_query_driver_release_version_text", lambda: "595.58.03")
+
+    assert driver_info.query_driver_release_version() == driver_info.DriverReleaseVersion(
+        text="595.58.03",
+        components=(595, 58, 3),
+        branch=595,
+    )
+
+
+def test_query_driver_release_version_wraps_internal_failures(monkeypatch):
+    root_cause = RuntimeError("low-level release query failed")
+
+    def fail_query_driver_release_version_text() -> str:
+        raise root_cause
+
+    monkeypatch.setattr(driver_info, "_query_driver_release_version_text", fail_query_driver_release_version_text)
+
+    with pytest.raises(
+        driver_info.QueryDriverReleaseVersionError,
+        match="Failed to query the display-driver release version",
+    ) as exc_info:
+        driver_info.query_driver_release_version()
+
+    assert exc_info.value.__cause__ is root_cause
+
+
+def test_query_driver_release_version_text_uses_nvml(monkeypatch):
+    fake_nvml_lib = _FakeNvmlLib(driver_release_version="595.58.03")
+    loaded_paths: list[str] = []
+
+    monkeypatch.setattr(
+        driver_info,
+        "_load_nvidia_dynamic_lib",
+        lambda _libname: _loaded_nvml("/usr/lib/libnvidia-ml.so.1"),
+    )
+
+    def fake_cdll(abs_path: str):
+        loaded_paths.append(abs_path)
+        return fake_nvml_lib
+
+    monkeypatch.setattr(driver_info.ctypes, "CDLL", fake_cdll)
+
+    assert driver_info._query_driver_release_version_text() == "595.58.03"
+    assert loaded_paths == ["/usr/lib/libnvidia-ml.so.1"]
+    assert fake_nvml_lib.shutdown_calls == 1
+
+
+def test_query_driver_release_version_text_raises_when_nvml_call_fails(monkeypatch):
+    fake_nvml_lib = _FakeNvmlLib(query_status=1)
+
+    monkeypatch.setattr(
+        driver_info,
+        "_load_nvidia_dynamic_lib",
+        lambda _libname: _loaded_nvml("/usr/lib/libnvidia-ml.so.1"),
+    )
+    monkeypatch.setattr(driver_info.ctypes, "CDLL", lambda _abs_path: fake_nvml_lib)
+
+    with pytest.raises(RuntimeError, match=r"nvmlSystemGetDriverVersion\(\) \(status=1\)"):
+        driver_info._query_driver_release_version_text()
+    assert fake_nvml_lib.shutdown_calls == 1
 
 
 def test_query_driver_cuda_version_uses_windll_on_windows(monkeypatch):

--- a/cuda_pathfinder/tests/test_utils_driver_info.py
+++ b/cuda_pathfinder/tests/test_utils_driver_info.py
@@ -102,16 +102,6 @@ def test_driver_release_version_from_text_parses_branch():
     )
 
 
-def test_query_driver_release_version_returns_parsed_dataclass(monkeypatch):
-    monkeypatch.setattr(driver_info, "_query_driver_release_version_text", lambda: "595.58.03")
-
-    assert driver_info.query_driver_release_version() == driver_info.DriverReleaseVersion(
-        text="595.58.03",
-        components=(595, 58, 3),
-        branch=595,
-    )
-
-
 def test_query_driver_release_version_wraps_internal_failures(monkeypatch):
     root_cause = RuntimeError("low-level release query failed")
 
@@ -184,16 +174,6 @@ def test_query_driver_cuda_version_uses_windll_on_windows(monkeypatch):
 
     assert driver_info._query_driver_cuda_version_int() == 12080
     assert loaded_paths == [r"C:\Windows\System32\nvcuda.dll"]
-
-
-def test_query_driver_cuda_version_returns_parsed_dataclass(monkeypatch):
-    monkeypatch.setattr(driver_info, "_query_driver_cuda_version_int", lambda: 12080)
-
-    assert driver_info.query_driver_cuda_version() == driver_info.DriverCudaVersion(
-        encoded=12080,
-        major=12,
-        minor=8,
-    )
 
 
 def test_driver_cuda_version_from_encoded_returns_subclass_instance():

--- a/cuda_pathfinder/tests/test_utils_toolkit_info.py
+++ b/cuda_pathfinder/tests/test_utils_toolkit_info.py
@@ -13,6 +13,39 @@ def _clear_cuda_header_version_cache():
     toolkit_info.read_cuda_header_version.cache_clear()
 
 
+def test_encoded_cuda_version_from_encoded_decodes_major_minor():
+    assert toolkit_info.EncodedCudaVersion.from_encoded(13020) == toolkit_info.EncodedCudaVersion(
+        encoded=13020,
+        major=13,
+        minor=2,
+    )
+
+
+def test_encoded_cuda_version_from_encoded_accepts_decimal_string():
+    assert toolkit_info.EncodedCudaVersion.from_encoded("13020") == toolkit_info.EncodedCudaVersion(
+        encoded=13020,
+        major=13,
+        minor=2,
+    )
+
+
+def test_encoded_cuda_version_from_encoded_raises_helpful_error_for_invalid_string():
+    with pytest.raises(
+        ValueError,
+        match=r"EncodedCudaVersion\.from_encoded\(\) expected an integer or decimal string, got '13\.2'",
+    ):
+        toolkit_info.EncodedCudaVersion.from_encoded("13.2")
+
+
+@pytest.mark.parametrize("encoded", [-1, "-1"])
+def test_encoded_cuda_version_from_encoded_rejects_negative_values(encoded):
+    with pytest.raises(
+        ValueError,
+        match=r"EncodedCudaVersion\.from_encoded\(\) expected a non-negative encoded CUDA version, got -1",
+    ):
+        toolkit_info.EncodedCudaVersion.from_encoded(encoded)
+
+
 def test_parse_cuda_header_version_returns_parsed_dataclass():
     header_text = """
     #ifndef CUDA_H
@@ -26,6 +59,17 @@ def test_parse_cuda_header_version_returns_parsed_dataclass():
         major=13,
         minor=2,
     )
+
+
+def test_cuda_toolkit_version_from_encoded_returns_subclass_instance():
+    version = toolkit_info.CudaToolkitVersion.from_encoded(12090)
+
+    assert version == toolkit_info.CudaToolkitVersion(
+        encoded=12090,
+        major=12,
+        minor=9,
+    )
+    assert type(version) is toolkit_info.CudaToolkitVersion
 
 
 def test_parse_cuda_header_version_returns_none_when_macro_is_missing():

--- a/cuda_pathfinder/tests/test_utils_toolkit_info.py
+++ b/cuda_pathfinder/tests/test_utils_toolkit_info.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from cuda.pathfinder._utils import toolkit_info
+
+
+@pytest.fixture(autouse=True)
+def _clear_cuda_header_version_cache():
+    toolkit_info.read_cuda_header_version.cache_clear()
+    yield
+    toolkit_info.read_cuda_header_version.cache_clear()
+
+
+def test_parse_cuda_header_version_returns_parsed_dataclass():
+    header_text = """
+    #ifndef CUDA_H
+    #define CUDA_H
+    #define CUDA_VERSION 13020
+    #endif
+    """
+
+    assert toolkit_info.parse_cuda_header_version(header_text) == toolkit_info.CudaToolkitVersion(
+        encoded=13020,
+        major=13,
+        minor=2,
+    )
+
+
+def test_parse_cuda_header_version_returns_none_when_macro_is_missing():
+    header_text = """
+    #ifndef CUDA_H
+    #define CUDA_H
+    #define CUDA_API_PER_THREAD_DEFAULT_STREAM 1
+    #endif
+    """
+
+    assert toolkit_info.parse_cuda_header_version(header_text) is None
+
+
+def test_read_cuda_header_version_reads_file_and_returns_parsed_dataclass(tmp_path):
+    cuda_h_path = tmp_path / "cuda.h"
+    cuda_h_path.write_text(
+        """
+        #ifndef CUDA_H
+        #define CUDA_H
+        #define CUDA_VERSION 12090 /* CUDA 12.9 */
+        #endif
+        """,
+        encoding="utf-8",
+    )
+
+    assert toolkit_info.read_cuda_header_version(str(cuda_h_path)) == toolkit_info.CudaToolkitVersion(
+        encoded=12090,
+        major=12,
+        minor=9,
+    )
+
+
+def test_read_cuda_header_version_tolerates_non_utf8_bytes(tmp_path):
+    cuda_h_path = tmp_path / "cuda.h"
+    cuda_h_path.write_bytes(
+        b"#ifndef CUDA_H\n"
+        b"#define CUDA_H\n"
+        b"\xff\xfe invalid bytes in comment or banner\n"
+        b"#define CUDA_VERSION 12080\n"
+        b"#endif\n"
+    )
+
+    assert toolkit_info.read_cuda_header_version(str(cuda_h_path)) == toolkit_info.CudaToolkitVersion(
+        encoded=12080,
+        major=12,
+        minor=8,
+    )
+
+
+def test_read_cuda_header_version_wraps_parse_failures(tmp_path):
+    cuda_h_path = tmp_path / "cuda.h"
+    cuda_h_path.write_text(
+        """
+        #ifndef CUDA_H
+        #define CUDA_H
+        #endif
+        """,
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        toolkit_info.ReadCudaHeaderVersionError,
+        match="Failed to read the CUDA Toolkit version from cuda.h",
+    ) as exc_info:
+        toolkit_info.read_cuda_header_version(str(cuda_h_path))
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert "does not define CUDA_VERSION" in str(exc_info.value.__cause__)


### PR DESCRIPTION
## Summary

Extracted from #1977 (xref #1038) so the underlying `cuda.pathfinder._utils` plumbing can be reviewed independently of the larger compatibility guard-rails work that consumes it. Five commits, scoped strictly to `cuda_pathfinder/cuda/pathfinder/_utils/{driver_info,toolkit_info}.py` and their unit tests; nothing else is touched.

## Changes

- **toolkit-info parser.** Add `cuda.pathfinder._utils.toolkit_info`, a small utility that reads the `CUDA_VERSION` macro from `cuda.h` so callers can infer CTK major.minor from toolkit headers without depending on `version.json`.

- **Shared encoded-CUDA-version decoding.** Centralize encoded CUDA version parsing and validation so toolkit and driver version helpers stay aligned and `cuda.h` parsing gets consistent string conversion and error reporting.

- **Display-driver release metadata.** Add `DriverReleaseVersion` and `query_driver_release_version()` in `cuda.pathfinder._utils.driver_info`. The helper queries `nvmlSystemGetDriverVersion()` via `ctypes` against the NVML library loaded through pathfinder's existing dynamic-lib loader, and parses the result into a frozen dataclass exposing both the raw text (e.g. `"595.58.03"`) and the branch number (e.g. `595`) used by NVIDIA's published minor-version compatibility tables.

- **`try`/`finally` around NVML init/shutdown.** The matched `nvmlInit_v2()` / `nvmlShutdown()` pair runs under a single `try`/`finally`, with `sys.exc_info()[1]` preserving the asymmetric error precedence: when both the body and shutdown fail, the body's error wins (Python keeps the shutdown error on `__context__` for debugging); when only shutdown fails, the shutdown error surfaces. Comments document that NVML's init/shutdown is reference-counted, so this balanced pair is safe even when the caller has already initialized NVML elsewhere in the process.

- **Tests.** Direct coverage of the dataclass parsers, the cache-clear lifecycle, the `QueryDriverReleaseVersionError` wrapping, the fake-NVML end-to-end path, and the full success/failure cleanup matrix (body-ok+shutdown-fail, body-fail+shutdown-ok, body-fail+shutdown-fail).
