### PR TITLE
Re-wrap most of the enums in cuda.bindings.nvml for cuda.core.system.

### DIFF
--- a/cuda_core/cuda/core/system/_clock.pxi
+++ b/cuda_core/cuda/core/system/_clock.pxi
@@ -16,7 +16,7 @@ Current actual clock value.
 ClockId.CUSTOMER_BOOST_MAX.__doc__ = """
 OEM-defined maximum clock rate
 """
-cdef dict _CLOCK_ID_MAPPING = {
+_CLOCK_ID_MAPPING = {
     ClockId.CURRENT: nvml.ClockId.CURRENT,
     ClockId.CUSTOMER_BOOST_MAX: nvml.ClockId.CUSTOMER_BOOST_MAX,
 }
@@ -36,7 +36,7 @@ class ClocksEventReasons(StrEnum):
     HW_THERMAL_SLOWDOWN = "hw_thermal_slowdown"
     HW_POWER_BRAKE_SLOWDOWN = "hw_power_brake_slowdown"
     DISPLAY_CLOCK_SETTING = "display_clock_setting"
-cdef dict _CLOCKS_EVENT_REASONS_MAPPING = {
+_CLOCKS_EVENT_REASONS_MAPPING = {
     nvml.ClocksEventReasons.EVENT_REASON_NONE: ClocksEventReasons.NONE,
     nvml.ClocksEventReasons.EVENT_REASON_GPU_IDLE: ClocksEventReasons.GPU_IDLE,
     nvml.ClocksEventReasons.EVENT_REASON_APPLICATIONS_CLOCKS_SETTING: ClocksEventReasons.APPLICATIONS_CLOCKS_SETTING,
@@ -58,7 +58,7 @@ class ClockType(StrEnum):
     SM = "sm"
     MEMORY = "memory"
     VIDEO = "video"
-cdef dict _CLOCK_TYPE_MAPPING = {
+_CLOCK_TYPE_MAPPING = {
     ClockType.GRAPHICS: nvml.ClockType.CLOCK_GRAPHICS,
     ClockType.SM: nvml.ClockType.CLOCK_SM,
     ClockType.MEMORY: nvml.ClockType.CLOCK_MEM,

--- a/cuda_core/cuda/core/system/_clock.pxi
+++ b/cuda_core/cuda/core/system/_clock.pxi
@@ -3,9 +3,67 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-ClockId = nvml.ClockId
-ClocksEventReasons = nvml.ClocksEventReasons
-ClockType = nvml.ClockType
+class ClockId(StrEnum):
+    """
+    Clock Ids. These are used in combination with :class:`ClockType` to specify a single clock value.
+    """
+    CURRENT = "current"
+    CUSTOMER_BOOST_MAX = "customer_boost_max"
+    # APP_CLOCK_TARGET and APP_CLOCK_DEFAULT are deprecated so not included here
+ClockId.CURRENT.__doc__ = """
+Current actual clock value.
+"""
+ClockId.CUSTOMER_BOOST_MAX.__doc__ = """
+OEM-defined maximum clock rate
+"""
+cdef dict _CLOCK_ID_MAPPING = {
+    ClockId.CURRENT: nvml.ClockId.CURRENT,
+    ClockId.CUSTOMER_BOOST_MAX: nvml.ClockId.CUSTOMER_BOOST_MAX,
+}
+
+
+class ClocksEventReasons(StrEnum):
+    """
+    Reasons for a clocks event.  These are used in combination with :class:`ClockType` to specify the reason for a clocks event.
+    """
+    NONE = "none"
+    GPU_IDLE = "gpu_idle"
+    APPLICATIONS_CLOCKS_SETTING = "applications_clocks_setting"
+    SW_POWER_CAP = "sw_power_cap"
+    HW_SLOWDOWN = "hw_slowdown"
+    SYNC_BOOST = "sync_boost"
+    SW_THERMAL_SLOWDOWN = "sw_thermal_slowdown"
+    HW_THERMAL_SLOWDOWN = "hw_thermal_slowdown"
+    HW_POWER_BRAKE_SLOWDOWN = "hw_power_brake_slowdown"
+    DISPLAY_CLOCK_SETTING = "display_clock_setting"
+cdef dict _CLOCKS_EVENT_REASONS_MAPPING = {
+    nvml.ClocksEventReasons.EVENT_REASON_NONE: ClocksEventReasons.NONE,
+    nvml.ClocksEventReasons.EVENT_REASON_GPU_IDLE: ClocksEventReasons.GPU_IDLE,
+    nvml.ClocksEventReasons.EVENT_REASON_APPLICATIONS_CLOCKS_SETTING: ClocksEventReasons.APPLICATIONS_CLOCKS_SETTING,
+    nvml.ClocksEventReasons.EVENT_REASON_SW_POWER_CAP: ClocksEventReasons.SW_POWER_CAP,
+    nvml.ClocksEventReasons.THROTTLE_REASON_HW_SLOWDOWN: ClocksEventReasons.HW_SLOWDOWN,
+    nvml.ClocksEventReasons.EVENT_REASON_SYNC_BOOST: ClocksEventReasons.SYNC_BOOST,
+    nvml.ClocksEventReasons.EVENT_REASON_SW_THERMAL_SLOWDOWN: ClocksEventReasons.SW_THERMAL_SLOWDOWN,
+    nvml.ClocksEventReasons.THROTTLE_REASON_HW_THERMAL_SLOWDOWN: ClocksEventReasons.HW_THERMAL_SLOWDOWN,
+    nvml.ClocksEventReasons.THROTTLE_REASON_HW_POWER_BRAKE_SLOWDOWN: ClocksEventReasons.HW_POWER_BRAKE_SLOWDOWN,
+    nvml.ClocksEventReasons.EVENT_REASON_DISPLAY_CLOCK_SETTING: ClocksEventReasons.DISPLAY_CLOCK_SETTING,
+}
+
+
+class ClockType(StrEnum):
+    """
+    Clock types. All speeds are in Mhz.
+    """
+    GRAPHICS = "graphics"
+    SM = "sm"
+    MEMORY = "memory"
+    VIDEO = "video"
+cdef dict _CLOCK_TYPE_MAPPING = {
+    ClockType.GRAPHICS: nvml.ClockType.CLOCK_GRAPHICS,
+    ClockType.SM: nvml.ClockType.CLOCK_SM,
+    ClockType.MEMORY: nvml.ClockType.CLOCK_MEM,
+    ClockType.VIDEO: nvml.ClockType.CLOCK_VIDEO,
+}
 
 
 cdef class ClockOffsets:
@@ -48,11 +106,18 @@ cdef class ClockInfo:
     cdef intptr_t _handle
     cdef int _clock_type
 
-    def __init__(self, handle, clock_type: ClockType):
+    def __init__(self, handle, clock_type: ClockType | str):
         self._handle = handle
+        try:
+            clock_type = _CLOCK_TYPE_MAPPING[clock_type]
+        except KeyError:
+            raise ValueError(
+                f"Invalid clock type: {clock_type}. "
+                f"Must be one of {list(ClockType.__members__.values())}"
+            ) from None
         self._clock_type = int(clock_type)
 
-    def get_current_mhz(self, clock_id: ClockId = ClockId.CURRENT) -> int:
+    def get_current_mhz(self, clock_id: ClockId | str = ClockId.CURRENT) -> int:
         """
         Get the current clock speed of a specific clock domain, in MHz.
 
@@ -60,14 +125,21 @@ cdef class ClockInfo:
 
         Parameters
         ----------
-        clock_id: :class:`ClockId`
-            The clock ID to query.
+        clock_id: :class:`ClockId` | str
+            The clock ID to query.  Defaults to the current clock value.
 
         Returns
         -------
         int
             The clock speed in MHz.
         """
+        try:
+            clock_id = _CLOCK_ID_MAPPING[clock_id]
+        except KeyError:
+            raise ValueError(
+                f"Invalid clock ID: {clock_id}. "
+                f"Must be one of {list(ClockId.__members__.values())}"
+            ) from None
         return nvml.device_get_clock(self._handle, self._clock_type, clock_id)
 
     def get_max_mhz(self) -> int:
@@ -99,24 +171,26 @@ cdef class ClockInfo:
         """
         return nvml.device_get_max_customer_boost_clock(self._handle, self._clock_type)
 
-    def get_min_max_clock_of_pstate_mhz(self, pstate: Pstates) -> tuple[int, int]:
+    def get_min_max_clock_of_pstate_mhz(self, pstate: int) -> tuple[int, int]:
         """
         Get the minimum and maximum clock speeds for this clock domain
         at a given performance state (Pstate), in MHz.
 
         Parameters
         ----------
-        pstate: :class:`Pstates`
-            The performance state to query.
+        pstate: int
+            The performance state to query.  Must be an int between 0 and 15,
+            where 0 is the highest performance state (P0) and 15 is the lowest
+            (P15).
 
         Returns
         -------
         tuple[int, int]
             A tuple containing the minimum and maximum clock speeds in MHz.
         """
-        return nvml.device_get_min_max_clock_of_p_state(self._handle, self._clock_type, pstate)
+        return nvml.device_get_min_max_clock_of_p_state(self._handle, self._clock_type, _pstate_to_enum(pstate))
 
-    def get_offsets(self, pstate: Pstates) -> ClockOffsets:
+    def get_offsets(self, pstate: int) -> ClockOffsets:
         """
         Retrieve min, max and current clock offset of some clock domain for a given Pstate.
 
@@ -124,12 +198,14 @@ cdef class ClockInfo:
 
         Parameters
         ----------
-        pstate: :class:`Pstates`
-            The performance state to query.
+        pstate: int
+            The performance state to query.  Must be an int between 0 and 15,
+            where 0 is the highest performance state (P0) and 15 is the lowest
+            (P15).
 
         Returns
         -------
         :obj:`~_device.ClockOffsets`
             An object with the min, max and current clock offset.
         """
-        return ClockOffsets(nvml.device_get_clock_offsets(self._handle, self._clock_type, pstate))
+        return ClockOffsets(nvml.device_get_clock_offsets(self._handle, self._clock_type, _pstate_to_enum(pstate)))

--- a/cuda_core/cuda/core/system/_clock.pxi
+++ b/cuda_core/cuda/core/system/_clock.pxi
@@ -10,12 +10,12 @@ class ClockId(StrEnum):
     CURRENT = "current"
     CUSTOMER_BOOST_MAX = "customer_boost_max"
     # APP_CLOCK_TARGET and APP_CLOCK_DEFAULT are deprecated so not included here
-ClockId.CURRENT.__doc__ = """
-Current actual clock value.
-"""
-ClockId.CUSTOMER_BOOST_MAX.__doc__ = """
-OEM-defined maximum clock rate
-"""
+
+
+ClockId.CURRENT.__doc__ = "Current actual clock value."
+ClockId.CUSTOMER_BOOST_MAX.__doc__ = "OEM-defined maximum clock rate"
+
+
 _CLOCK_ID_MAPPING = {
     ClockId.CURRENT: nvml.ClockId.CURRENT,
     ClockId.CUSTOMER_BOOST_MAX: nvml.ClockId.CUSTOMER_BOOST_MAX,
@@ -36,6 +36,8 @@ class ClocksEventReasons(StrEnum):
     HW_THERMAL_SLOWDOWN = "hw_thermal_slowdown"
     HW_POWER_BRAKE_SLOWDOWN = "hw_power_brake_slowdown"
     DISPLAY_CLOCK_SETTING = "display_clock_setting"
+
+
 _CLOCKS_EVENT_REASONS_MAPPING = {
     nvml.ClocksEventReasons.EVENT_REASON_NONE: ClocksEventReasons.NONE,
     nvml.ClocksEventReasons.EVENT_REASON_GPU_IDLE: ClocksEventReasons.GPU_IDLE,
@@ -58,6 +60,8 @@ class ClockType(StrEnum):
     SM = "sm"
     MEMORY = "memory"
     VIDEO = "video"
+
+
 _CLOCK_TYPE_MAPPING = {
     ClockType.GRAPHICS: nvml.ClockType.CLOCK_GRAPHICS,
     ClockType.SM: nvml.ClockType.CLOCK_SM,

--- a/cuda_core/cuda/core/system/_cooler.pxi
+++ b/cuda_core/cuda/core/system/_cooler.pxi
@@ -3,8 +3,50 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-CoolerControl = nvml.CoolerControl
-CoolerTarget = nvml.CoolerTarget
+class CoolerControl(StrEnum):
+    """
+    Cooler control type.
+    """
+    TOGGLE = "toggle"
+    VARIABLE = "variable"
+CoolerControl.TOGGLE.__doc__ = """
+This cooler can only be toggled either ON or OFF (e.g. a switch).
+"""
+CoolerControl.VARIABLE.__doc__ = """
+This cooler's level can be adjusted from some minimum to some maximum (e.g. a knob).
+"""
+cdef dict _COOLER_CONTROL_MAPPING = {
+    nvml.CoolerControl.THERMAL_COOLER_SIGNAL_TOGGLE: CoolerControl.TOGGLE,
+    nvml.CoolerControl.THERMAL_COOLER_SIGNAL_VARIABLE: CoolerControl.VARIABLE,
+}
+
+
+class CoolerTarget(StrEnum):
+    """
+    Cooler target.
+    """
+    NONE = "none"
+    GPU = "gpu"
+    MEMORY = "memory"
+    POWER_SUPPLY = "power_supply"
+CoolerTarget.NONE.__doc__ = """
+This cooler controls nothing.
+"""
+CoolerTarget.GPU.__doc__ = """
+This cooler can cool the GPU.
+"""
+CoolerTarget.MEMORY.__doc__ = """
+This cooler can cool the memory.
+"""
+CoolerTarget.POWER_SUPPLY.__doc__ = """
+This cooler can cool the power supply.
+"""
+cdef dict _COOLER_TARGET_MAPPING = {
+    nvml.CoolerTarget.THERMAL_NONE: CoolerTarget.NONE,
+    nvml.CoolerTarget.THERMAL_GPU: CoolerTarget.GPU,
+    nvml.CoolerTarget.THERMAL_MEMORY: CoolerTarget.MEMORY,
+    nvml.CoolerTarget.THERMAL_POWER_SUPPLY: CoolerTarget.POWER_SUPPLY,
+}
 
 
 cdef class CoolerInfo:
@@ -14,14 +56,13 @@ cdef class CoolerInfo:
         self._cooler_info = cooler_info
 
     @property
-    def signal_type(self) -> CoolerControl:
+    def signal_type(self) -> CoolerControl | None:
         """
         The cooler's control signal characteristics.
 
-        The possible types are restricted, variable and toggle.  See
-        :class:`CoolerControl` for details.
+        The possible types are variable and toggle.
         """
-        return CoolerControl(self._cooler_info.signal_type)
+        return _COOLER_CONTROL_MAPPING.get(self._cooler_info.signal_type, None)
 
     @property
     def target(self) -> list[CoolerTarget]:
@@ -32,4 +73,11 @@ cdef class CoolerInfo:
         :class:`CoolerTarget` for details.
         """
         cdef uint64_t[1] targets = [self._cooler_info.target]
-        return [CoolerTarget(1 << ev) for ev in _unpack_bitmask(targets)]
+        output_targets = []
+        for target in _unpack_bitmask(targets):
+            try:
+                output_target = _COOLER_TARGET_MAPPING[1 << target]
+            except KeyError:
+                raise ValueError(f"Unknown cooler target bit: {1 << target}")
+            output_targets.append(output_target)
+        return output_targets

--- a/cuda_core/cuda/core/system/_cooler.pxi
+++ b/cuda_core/cuda/core/system/_cooler.pxi
@@ -29,6 +29,8 @@ class CoolerTarget(StrEnum):
     GPU = "gpu"
     MEMORY = "memory"
     POWER_SUPPLY = "power_supply"
+    # THERMAL_GPU_RELATED is a composite target, so it is omitted here and will
+    # get returned as 3 separate targets: GPU, MEMORY, and POWER_SUPPLY.
 CoolerTarget.NONE.__doc__ = """
 This cooler controls nothing.
 """

--- a/cuda_core/cuda/core/system/_cooler.pxi
+++ b/cuda_core/cuda/core/system/_cooler.pxi
@@ -9,12 +9,16 @@ class CoolerControl(StrEnum):
     """
     TOGGLE = "toggle"
     VARIABLE = "variable"
+
+
 CoolerControl.TOGGLE.__doc__ = """
 This cooler can only be toggled either ON or OFF (e.g. a switch).
 """
 CoolerControl.VARIABLE.__doc__ = """
 This cooler's level can be adjusted from some minimum to some maximum (e.g. a knob).
 """
+
+
 _COOLER_CONTROL_MAPPING = {
     nvml.CoolerControl.THERMAL_COOLER_SIGNAL_TOGGLE: CoolerControl.TOGGLE,
     nvml.CoolerControl.THERMAL_COOLER_SIGNAL_VARIABLE: CoolerControl.VARIABLE,
@@ -31,18 +35,14 @@ class CoolerTarget(StrEnum):
     POWER_SUPPLY = "power_supply"
     # THERMAL_GPU_RELATED is a composite target, so it is omitted here and will
     # get returned as 3 separate targets: GPU, MEMORY, and POWER_SUPPLY.
-CoolerTarget.NONE.__doc__ = """
-This cooler controls nothing.
-"""
-CoolerTarget.GPU.__doc__ = """
-This cooler can cool the GPU.
-"""
-CoolerTarget.MEMORY.__doc__ = """
-This cooler can cool the memory.
-"""
-CoolerTarget.POWER_SUPPLY.__doc__ = """
-This cooler can cool the power supply.
-"""
+
+
+CoolerTarget.NONE.__doc__ = "This cooler controls nothing."
+CoolerTarget.GPU.__doc__ = "This cooler can cool the GPU."
+CoolerTarget.MEMORY.__doc__ = "This cooler can cool the memory."
+CoolerTarget.POWER_SUPPLY.__doc__ = "This cooler can cool the power supply."
+
+
 _COOLER_TARGET_MAPPING = {
     nvml.CoolerTarget.THERMAL_NONE: CoolerTarget.NONE,
     nvml.CoolerTarget.THERMAL_GPU: CoolerTarget.GPU,

--- a/cuda_core/cuda/core/system/_cooler.pxi
+++ b/cuda_core/cuda/core/system/_cooler.pxi
@@ -15,7 +15,7 @@ This cooler can only be toggled either ON or OFF (e.g. a switch).
 CoolerControl.VARIABLE.__doc__ = """
 This cooler's level can be adjusted from some minimum to some maximum (e.g. a knob).
 """
-cdef dict _COOLER_CONTROL_MAPPING = {
+_COOLER_CONTROL_MAPPING = {
     nvml.CoolerControl.THERMAL_COOLER_SIGNAL_TOGGLE: CoolerControl.TOGGLE,
     nvml.CoolerControl.THERMAL_COOLER_SIGNAL_VARIABLE: CoolerControl.VARIABLE,
 }
@@ -43,7 +43,7 @@ This cooler can cool the memory.
 CoolerTarget.POWER_SUPPLY.__doc__ = """
 This cooler can cool the power supply.
 """
-cdef dict _COOLER_TARGET_MAPPING = {
+_COOLER_TARGET_MAPPING = {
     nvml.CoolerTarget.THERMAL_NONE: CoolerTarget.NONE,
     nvml.CoolerTarget.THERMAL_GPU: CoolerTarget.GPU,
     nvml.CoolerTarget.THERMAL_MEMORY: CoolerTarget.MEMORY,

--- a/cuda_core/cuda/core/system/_device.pyx
+++ b/cuda_core/cuda/core/system/_device.pyx
@@ -5,22 +5,27 @@
 from libc.stdint cimport intptr_t, uint64_t
 from libc.math cimport ceil
 
+from enum import StrEnum
 from multiprocessing import cpu_count
 from typing import Iterable
+import warnings
 
 from cuda.bindings import nvml
+from cuda.bindings._internal._fast_enum import FastEnum
 
 from ._nvml_context cimport initialize
 
 
-AddressingMode = nvml.DeviceAddressingModeType
-AffinityScope = nvml.AffinityScope
-BrandType = nvml.BrandType
-DeviceArch = nvml.DeviceArch
-GpuP2PCapsIndex = nvml.GpuP2PCapsIndex
-GpuP2PStatus = nvml.GpuP2PStatus
-GpuTopologyLevel = nvml.GpuTopologyLevel
-Pstates = nvml.Pstates
+cdef object _pstate_to_int(object pstate):
+    if pstate == nvml.Pstates.PSTATE_UNKNOWN:
+        return None
+    return int(pstate) - int(nvml.Pstates.PSTATE_0)
+
+
+cdef int _pstate_to_enum(int pstate):
+    if pstate < 0 or pstate > 15:
+        raise ValueError(f"Invalid P-state: {pstate}. Must be between 0 and 15 inclusive.")
+    return int(pstate) + int(nvml.Pstates.PSTATE_0)
 
 
 include "_clock.pxi"
@@ -40,6 +45,151 @@ include "_process.pxi"
 include "_repair_status.pxi"
 include "_temperature.pxi"
 include "_utilization.pxi"
+
+
+class AddressingMode(StrEnum):
+    """
+    Addressing mode of a device.
+
+    For Kepler™ or newer fully supported devices.
+    """
+    HMM = "hmm"
+    ATS = "ats"
+AddressingMode.HMM.__doc__ = """
+    System allocated memory (``malloc``, ``mmap``) is addressable from the device
+    (GPU), via software-based mirroring of the CPU's page tables, on the GPU.
+"""
+AddressingMode.ATS.__doc__ = """
+    System allocated memory (``malloc``, ``mmap``) is addressable from the device
+    (GPU), via Address Translation Services. This means that there is (effectively)
+    a single set of page tables, and the CPU and GPU both use them.
+"""
+cdef dict _ADDRESSING_MODE_MAPPING = {
+    nvml.DeviceAddressingModeType.DEVICE_ADDRESSING_MODE_HMM: AddressingMode.HMM,
+    nvml.DeviceAddressingModeType.DEVICE_ADDRESSING_MODE_ATS: AddressingMode.ATS,
+}
+
+
+class AffinityScope(StrEnum):
+    """
+    Scope for affinity queries.
+    """
+    NODE = "node"
+    SOCKET = "socket"
+AffinityScope.NODE.__doc__ = """
+    The NUMA node is the scope of the affinity query.  This is the default scope.
+"""
+AffinityScope.SOCKET.__doc__ = """
+    The CPU socket is the scope of the affinity query.
+"""
+cdef dict _AFFINITY_SCOPE_MAPPING = {
+    AffinityScope.NODE: nvml.AffinityScope.NODE,
+    AffinityScope.SOCKET: nvml.AffinityScope.SOCKET,
+}
+
+
+cdef dict _BRAND_TYPE_MAPPING = {
+    nvml.BrandType.BRAND_UNKNOWN: "Unknown",
+    nvml.BrandType.BRAND_QUADRO: "Quadro",
+    nvml.BrandType.BRAND_TESLA: "Tesla",
+    nvml.BrandType.BRAND_NVS: "NVS",
+    nvml.BrandType.BRAND_GRID: "GRID",
+    nvml.BrandType.BRAND_GEFORCE: "GeForce",
+    nvml.BrandType.BRAND_TITAN: "Titan",
+    nvml.BrandType.BRAND_NVIDIA_VAPPS: "NVIDIA vApps",
+    nvml.BrandType.BRAND_NVIDIA_VPC: "NVIDIA VPC",
+    nvml.BrandType.BRAND_NVIDIA_VCS: "NVIDIA VCS",
+    nvml.BrandType.BRAND_NVIDIA_VWS: "NVIDIA VWS",
+    nvml.BrandType.BRAND_NVIDIA_CLOUD_GAMING: "NVIDIA Cloud Gaming",
+    nvml.BrandType.BRAND_NVIDIA_VGAMING: "NVIDIA vGaming",
+    nvml.BrandType.BRAND_GEFORCE_RTX: "GeForce RTX",
+    nvml.BrandType.BRAND_TITAN_RTX: "Titan RTX",
+}
+
+
+# This uses FastEnum instead of StrEnum because the ordering of the values is
+# meaningful, e.g. Kepler "or later"
+class DeviceArch(FastEnum):
+    """
+    Device architecture.
+    """
+    KEPLER = int(nvml.DeviceArch.KEPLER)
+    MAXWELL = int(nvml.DeviceArch.MAXWELL)
+    PASCAL = int(nvml.DeviceArch.PASCAL)
+    VOLTA = int(nvml.DeviceArch.VOLTA)
+    TURING = int(nvml.DeviceArch.TURING)
+    AMPERE = int(nvml.DeviceArch.AMPERE)
+    ADA = int(nvml.DeviceArch.ADA)
+    HOPPER = int(nvml.DeviceArch.HOPPER)
+    BLACKWELL = int(nvml.DeviceArch.BLACKWELL)
+    UNKNOWN = int(nvml.DeviceArch.UNKNOWN)
+
+
+class GpuP2PCapsIndex(StrEnum):
+    """
+    GPU peer-to-peer capabilities index.
+    """
+    READ = "read"
+    WRITE = "write"
+    NVLINK = "nvlink"
+    ATOMICS = "atomics"
+    PCI = "pci"
+    PROP = "prop"
+    UNKNOWN = "unknown"
+cdef dict _GPU_P2P_CAPS_INDEX_MAPPING = {
+    GpuP2PCapsIndex.READ: nvml.GpuP2PCapsIndex.P2P_CAPS_INDEX_READ,
+    GpuP2PCapsIndex.WRITE: nvml.GpuP2PCapsIndex.P2P_CAPS_INDEX_WRITE,
+    GpuP2PCapsIndex.NVLINK: nvml.GpuP2PCapsIndex.P2P_CAPS_INDEX_NVLINK,
+    GpuP2PCapsIndex.ATOMICS: nvml.GpuP2PCapsIndex.P2P_CAPS_INDEX_ATOMICS,
+    GpuP2PCapsIndex.PCI: nvml.GpuP2PCapsIndex.P2P_CAPS_INDEX_PCI,
+    GpuP2PCapsIndex.PROP: nvml.GpuP2PCapsIndex.P2P_CAPS_INDEX_PROP,
+}
+
+
+class GpuP2PStatus(StrEnum):
+    """
+    GPU peer-to-peer status.
+    """
+    OK = "ok"
+    CHIPSET_NOT_SUPPORTED = "chipset not supported"
+    GPU_NOT_SUPPORTED = "GPU not supported"
+    IOH_TOPOLOGY_NOT_SUPPORTED = "IOH topology not supported"
+    DISABLED_BY_REGKEY = "disabled by regkey"
+    NOT_SUPPORTED = "not supported"
+    UNKNOWN = "unknown"
+cdef dict _GPU_P2P_STATUS_MAPPING = {
+    nvml.GpuP2PStatus.P2P_STATUS_OK: GpuP2PStatus.OK,
+    # Typo in upstream library
+    nvml.GpuP2PStatus.P2P_STATUS_CHIPSET_NOT_SUPPORED: GpuP2PStatus.CHIPSET_NOT_SUPPORTED,
+    nvml.GpuP2PStatus.P2P_STATUS_CHIPSET_NOT_SUPPORTED: GpuP2PStatus.CHIPSET_NOT_SUPPORTED,
+    nvml.GpuP2PStatus.P2P_STATUS_GPU_NOT_SUPPORTED: GpuP2PStatus.GPU_NOT_SUPPORTED,
+    nvml.GpuP2PStatus.P2P_STATUS_IOH_TOPOLOGY_NOT_SUPPORTED: GpuP2PStatus.IOH_TOPOLOGY_NOT_SUPPORTED,
+    nvml.GpuP2PStatus.P2P_STATUS_DISABLED_BY_REGKEY: GpuP2PStatus.DISABLED_BY_REGKEY,
+    nvml.GpuP2PStatus.P2P_STATUS_NOT_SUPPORTED: GpuP2PStatus.NOT_SUPPORTED,
+    nvml.GpuP2PStatus.P2P_STATUS_UNKNOWN: GpuP2PStatus.UNKNOWN,
+}
+
+
+class GpuTopologyLevel(StrEnum):
+    """
+    Represents level relationships within a system between two GPUs.
+    """
+    INTERNAL = "internal"
+    SINGLE = "single"
+    MULTIPLE = "multiple"
+    HOSTBRIDGE = "hostbridge"
+    NODE = "node"
+    SYSTEM = "system"
+cdef dict _GPU_TOPOLOGY_LEVEL_MAPPING = {
+    GpuTopologyLevel.INTERNAL: nvml.GpuTopologyLevel.TOPOLOGY_INTERNAL,
+    GpuTopologyLevel.SINGLE: nvml.GpuTopologyLevel.TOPOLOGY_SINGLE,
+    GpuTopologyLevel.MULTIPLE: nvml.GpuTopologyLevel.TOPOLOGY_MULTIPLE,
+    GpuTopologyLevel.HOSTBRIDGE: nvml.GpuTopologyLevel.TOPOLOGY_HOSTBRIDGE,
+    GpuTopologyLevel.NODE: nvml.GpuTopologyLevel.TOPOLOGY_NODE,
+    GpuTopologyLevel.SYSTEM: nvml.GpuTopologyLevel.TOPOLOGY_SYSTEM,
+}
+cdef dict _GPU_TOPOLOGY_LEVEL_INV_MAPPING = {v: k for k, v in _GPU_TOPOLOGY_LEVEL_MAPPING.items()}
+
 
 
 cdef class Device:
@@ -184,7 +334,7 @@ cdef class Device:
         try:
             return DeviceArch(arch)
         except ValueError:
-            return nvml.DeviceArch.UNKNOWN
+            return DeviceArch.UNKNOWN
 
     @property
     def name(self) -> str:
@@ -194,11 +344,13 @@ cdef class Device:
         return nvml.device_get_name(self._handle)
 
     @property
-    def brand(self) -> BrandType:
+    def brand(self) -> str:
         """
-        :obj:`~BrandType` brand of the device
+        The brand of the device.
+
+        Returns "Unknown" if the brand is unknown.
         """
-        return BrandType(nvml.device_get_brand(self._handle))
+        return _BRAND_TYPE_MAPPING.get(nvml.device_get_brand(self._handle), "Unknown")
 
     @property
     def serial(self) -> str:
@@ -322,23 +474,11 @@ cdef class Device:
     # ADDRESSING MODE
 
     @property
-    def addressing_mode(self) -> AddressingMode:
+    def addressing_mode(self) -> AddressingMode | None:
         """
         Get the :obj:`~AddressingMode` of the device.
-
-        Addressing modes can be one of:
-
-        - :attr:`AddressingMode.DEVICE_ADDRESSING_MODE_HMM`: System allocated
-          memory (``malloc``, ``mmap``) is addressable from the device (GPU), via
-          software-based mirroring of the CPU's page tables, on the GPU.
-        - :attr:`AddressingMode.DEVICE_ADDRESSING_MODE_ATS`: System allocated
-          memory (``malloc``, ``mmap``) is addressable from the device (GPU), via
-          Address Translation Services. This means that there is (effectively) a
-          single set of page tables, and the CPU and GPU both use them.
-        - :attr:`AddressingMode.DEVICE_ADDRESSING_MODE_NONE`: Neither HMM nor ATS
-          is active.
         """
-        return AddressingMode(nvml.device_get_addressing_mode(self._handle).value)
+        return _ADDRESSING_MODE_MAPPING.get(nvml.device_get_addressing_mode(self._handle).value, None)
 
     #########################################################################
     # MIG (MULTI-INSTANCE GPU) DEVICES
@@ -378,7 +518,7 @@ cdef class Device:
             device._handle = handle
             yield device
 
-    def get_memory_affinity(self, scope: AffinityScope=AffinityScope.NODE) -> list[int]:
+    def get_memory_affinity(self, scope: AffinityScope | str=AffinityScope.NODE) -> list[int]:
         """
         Retrieves a list of indices of NUMA nodes or CPU sockets with the ideal
         memory affinity for the device.
@@ -390,16 +530,35 @@ cdef class Device:
         If requested scope is not applicable to the target topology, the API
         will fall back to reporting the memory affinity for the immediate non-I/O
         ancestor of the device.
+
+        Parameters
+        ----------
+        scope: AffinityScope | str, optional
+            The scope of the affinity query.  Must be one of the values of
+            :class:`AffinityScope`.  Default is :attr:`AffinityScope.NODE`.
+
+        Returns
+        -------
+        list[int]
+            A list of indices of NUMA nodes or CPU sockets with the ideal memory
+            affinity for the device.
         """
+        try:
+            scope = _AFFINITY_SCOPE_MAPPING[scope]
+        except KeyError:
+            raise ValueError(
+                f"Invalid affinity scope: {scope}. "
+                f"Must be one of {list(AffinityScope.__members__.values())}"
+            ) from None
         return _unpack_bitmask(
             nvml.device_get_memory_affinity(
                 self._handle,
                 <unsigned int>ceil(cpu_count() / 64),
-                scope
+                scope,
             )
         )
 
-    def get_cpu_affinity(self, scope: AffinityScope=AffinityScope.NODE) -> list[int]:
+    def get_cpu_affinity(self, scope: AffinityScope | str=AffinityScope.NODE) -> list[int]:
         """
         Retrieves a list of indices of NUMA nodes or CPU sockets with the ideal
         CPU affinity for the device.
@@ -411,7 +570,26 @@ cdef class Device:
         If requested scope is not applicable to the target topology, the API
         will fall back to reporting the memory affinity for the immediate non-I/O
         ancestor of the device.
+
+        Parameters
+        ----------
+        scope: AffinityScope | str, optional
+            The scope of the affinity query.  Must be one of the values of
+            :class:`AffinityScope`.  Default is :attr:`AffinityScope.NODE`.
+
+        Returns
+        -------
+        list[int]
+            A list of indices of NUMA nodes or CPU sockets with the ideal memory
+            affinity for the device.
         """
+        try:
+            scope = _AFFINITY_SCOPE_MAPPING[scope]
+        except KeyError:
+            raise ValueError(
+                f"Invalid affinity scope: {scope}. "
+                f"Must be one of {list(AffinityScope.__members__.values())}"
+            ) from None
         return _unpack_bitmask(
             nvml.device_get_cpu_affinity_within_scope(
                 self._handle,
@@ -444,7 +622,7 @@ cdef class Device:
     # CLOCK
     # See external class definitions in _clock.pxi
 
-    def get_clock(self, clock_type: ClockType) -> ClockInfo:
+    def get_clock(self, clock_type: ClockType | str) -> ClockInfo:
         """
         :obj:`~_device.ClockInfo` object to get information about and manage a specific clock on a device.
         """
@@ -485,7 +663,14 @@ cdef class Device:
         """
         cdef uint64_t[1] reasons
         reasons[0] = nvml.device_get_current_clocks_event_reasons(self._handle)
-        return [ClocksEventReasons(1 << reason) for reason in _unpack_bitmask(reasons)]
+        output_reasons = []
+        for reason in _unpack_bitmask(reasons):
+            try:
+                output_reason = _CLOCKS_EVENT_REASONS_MAPPING[1 << reason]
+            except KeyError:
+                raise ValueError(f"Unknown clock event reason bit: {reason}")
+            output_reasons.append(output_reason)
+        return output_reasons
 
     @property
     def supported_clock_event_reasons(self) -> list[ClocksEventReasons]:
@@ -499,7 +684,14 @@ cdef class Device:
         """
         cdef uint64_t[1] reasons
         reasons[0] = nvml.device_get_supported_clocks_event_reasons(self._handle)
-        return [ClocksEventReasons(1 << reason) for reason in _unpack_bitmask(reasons)]
+        output_reasons = []
+        for reason in _unpack_bitmask(reasons):
+            try:
+                output_reason = _CLOCKS_EVENT_REASONS_MAPPING[1 << reason]
+            except KeyError:
+                raise ValueError(f"Unknown clock event reason bit: {reason}")
+            output_reasons.append(output_reason)
+        return output_reasons
 
     ##########################################################################
     # COOLER
@@ -556,7 +748,7 @@ cdef class Device:
     # EVENTS
     # See external class definitions in _event.pxi
 
-    def register_events(self, events: EventType | int | list[EventType | int]) -> DeviceEvents:
+    def register_events(self, events: EventType | str | list[EventType | str]) -> DeviceEvents:
         """
         Starts recording events on this device.
 
@@ -575,14 +767,14 @@ cdef class Device:
         --------
         >>> device = Device(index=0)
         >>> events = device.register_events([
-        ...     EventType.EVENT_TYPE_XID_CRITICAL_ERROR,
+        ...     EventType.XID_CRITICAL_ERROR,
         ... ])
         >>> while event := events.wait(timeout_ms=10000):
         ...     print(f"Event {event.event_type} occurred on device {event.device.uuid}")
 
         Parameters
         ----------
-        events: EventType, int, or list of EventType or int
+        events: EventType, str, or list of EventType or str
             The event type or list of event types to register for this device.
 
         Returns
@@ -612,7 +804,14 @@ cdef class Device:
         """
         cdef uint64_t[1] bitmask
         bitmask[0] = nvml.device_get_supported_event_types(self._handle)
-        return [EventType(1 << ev) for ev in _unpack_bitmask(bitmask)]
+        events = []
+        for ev in _unpack_bitmask(bitmask):
+            try:
+                ev_enum = _EVENT_TYPE_MAPPING[1 << ev]
+            except KeyError:
+                raise ValueError(f"Unknown event type bit: {1 << ev}")
+            events.append(ev_enum)
+        return events
 
     ##########################################################################
     # FAN
@@ -752,15 +951,20 @@ cdef class Device:
     # See external class definitions in _performance.pxi
 
     @property
-    def performance_state(self) -> Pstates:
+    def performance_state(self) -> int | None:
         """
         The current performance state of the device.
 
         For Fermi™ or newer fully supported devices.
 
-        See :class:`Pstates` for possible performance states.
+        Returns
+        -------
+        int | None
+            The current performance state of the device, as an integer between 0 and 15,
+            where 0 is maximum performance and higher numbers are lower performance.
+            Returns `None` if the performance state is unknown.
         """
-        return Pstates(nvml.device_get_performance_state(self._handle))
+        return _pstate_to_int(nvml.device_get_performance_state(self._handle))
 
     @property
     def dynamic_pstates_info(self) -> GpuDynamicPstatesInfo:
@@ -770,7 +974,7 @@ cdef class Device:
         return GpuDynamicPstatesInfo(nvml.device_get_dynamic_pstates_info(self._handle))
 
     @property
-    def supported_pstates(self) -> list[Pstates]:
+    def supported_pstates(self) -> list[int]:
         """
         Get all supported Performance States (P-States) for the device.
 
@@ -779,10 +983,23 @@ cdef class Device:
 
         Return
         ------
-        list[Pstates]
-            A list of supported P-States for the device.
+        list[int]
+            A list of supported performance state of the device, as an integer
+            between 0 and 15, where 0 is maximum performance and higher numbers
+            are lower performance.
         """
-        return [Pstates(x) for x in nvml.device_get_supported_performance_states(self._handle)]
+        # From nvml.h:
+        # The returned array would contain a contiguous list of valid P-States
+        # supported by the device. If the number of supported P-States is fewer
+        # than the size of the array supplied missing elements would contain \a
+        # NVML_PSTATE_UNKNOWN.
+
+        pstates = []
+        for pstate in nvml.device_get_supported_performance_states(self._handle):
+            pstate_value = _pstate_to_int(pstate)
+            if pstate_value is not None:
+                pstates.append(pstate_value)
+        return pstates
 
     ##########################################################################
     # PROCESS
@@ -838,7 +1055,7 @@ cdef class Device:
     #######################################################################
     # TOPOLOGY
 
-    def get_topology_nearest_gpus(self, level: GpuTopologyLevel) -> Iterable[Device]:
+    def get_topology_nearest_gpus(self, level: GpuTopologyLevel | str) -> Iterable[Device]:
         """
         Retrieve the GPUs that are nearest to this device at a specific interconnectivity level.
 
@@ -855,6 +1072,13 @@ cdef class Device:
             The nearest devices at the given topology level.
         """
         cdef Device device
+        try:
+            level = _GPU_TOPOLOGY_LEVEL_MAPPING[level]
+        except KeyError:
+            raise ValueError(
+                f"Invalid topology level: {level}. "
+                f"Must be one of {list(GpuTopologyLevel.__members__.values())}"
+            ) from None
         for handle in nvml.device_get_topology_nearest_gpus(self._handle, level):
             device = Device.__new__(Device)
             device._handle = handle
@@ -904,15 +1128,15 @@ def get_topology_common_ancestor(device1: Device, device2: Device) -> GpuTopolog
     :class:`GpuTopologyLevel`
         The common ancestor level of the two devices.
     """
-    return GpuTopologyLevel(
+    return _GPU_TOPOLOGY_LEVEL_INV_MAPPING[
         nvml.device_get_topology_common_ancestor(
             device1._handle,
             device2._handle,
         )
-    )
+    ]
 
 
-def get_p2p_status(device1: Device, device2: Device, index: GpuP2PCapsIndex) -> GpuP2PStatus:
+def get_p2p_status(device1: Device, device2: Device, index: GpuP2PCapsIndex | str) -> GpuP2PStatus:
     """
     Retrieve the P2P status between two devices.
 
@@ -922,7 +1146,7 @@ def get_p2p_status(device1: Device, device2: Device, index: GpuP2PCapsIndex) -> 
         The first device.
     device2: :class:`Device`
         The second device.
-    index: :class:`GpuP2PCapsIndex`
+    index: :class:`GpuP2PCapsIndex` | str
         The P2P capability index being looked for between ``device1`` and ``device2``.
 
     Returns
@@ -930,19 +1154,26 @@ def get_p2p_status(device1: Device, device2: Device, index: GpuP2PCapsIndex) -> 
     :class:`GpuP2PStatus`
         The P2P status between the two devices.
     """
-    return GpuP2PStatus(
+    try:
+        index_enum = _GPU_P2P_CAPS_INDEX_MAPPING[index]
+    except KeyError:
+        raise ValueError(
+            f"Invalid P2P caps index: {index}. "
+            f"Must be one of {list(GpuP2PCapsIndex.__members__.values())}"
+        ) from None
+    return _GPU_P2P_STATUS_MAPPING.get(
         nvml.device_get_p2p_status(
             device1._handle,
             device2._handle,
-            index,
-        )
+            index_enum,
+        ),
+        GpuP2PStatus.UNKNOWN
     )
 
 
 __all__ = [
     "AddressingMode",
     "AffinityScope",
-    "BrandType",
     "ClockId",
     "ClocksEventReasons",
     "ClockType",
@@ -959,10 +1190,7 @@ __all__ = [
     "GpuP2PStatus",
     "GpuTopologyLevel",
     "InforomObject",
-    "NvlinkVersion",
-    "PcieUtilCounter",
-    "Pstates",
-    "TemperatureSensors",
+    "NvlinkInfo",
     "TemperatureThresholds",
     "ThermalController",
     "ThermalTarget",

--- a/cuda_core/cuda/core/system/_device.pyx
+++ b/cuda_core/cuda/core/system/_device.pyx
@@ -5,7 +5,11 @@
 from libc.stdint cimport intptr_t, uint64_t
 from libc.math cimport ceil
 
-from enum import StrEnum
+import sys
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from backports.strenum import StrEnum
 from multiprocessing import cpu_count
 from typing import Iterable
 import warnings

--- a/cuda_core/cuda/core/system/_device.pyx
+++ b/cuda_core/cuda/core/system/_device.pyx
@@ -71,7 +71,7 @@ AddressingMode.ATS.__doc__ = """
     (GPU), via Address Translation Services. This means that there is (effectively)
     a single set of page tables, and the CPU and GPU both use them.
 """
-cdef dict _ADDRESSING_MODE_MAPPING = {
+_ADDRESSING_MODE_MAPPING = {
     nvml.DeviceAddressingModeType.DEVICE_ADDRESSING_MODE_HMM: AddressingMode.HMM,
     nvml.DeviceAddressingModeType.DEVICE_ADDRESSING_MODE_ATS: AddressingMode.ATS,
 }
@@ -89,13 +89,13 @@ AffinityScope.NODE.__doc__ = """
 AffinityScope.SOCKET.__doc__ = """
     The CPU socket is the scope of the affinity query.
 """
-cdef dict _AFFINITY_SCOPE_MAPPING = {
+_AFFINITY_SCOPE_MAPPING = {
     AffinityScope.NODE: nvml.AffinityScope.NODE,
     AffinityScope.SOCKET: nvml.AffinityScope.SOCKET,
 }
 
 
-cdef dict _BRAND_TYPE_MAPPING = {
+_BRAND_TYPE_MAPPING = {
     nvml.BrandType.BRAND_UNKNOWN: "Unknown",
     nvml.BrandType.BRAND_QUADRO: "Quadro",
     nvml.BrandType.BRAND_TESLA: "Tesla",
@@ -146,7 +146,7 @@ class GpuP2PCapsIndex(StrEnum):
     PCI = "pci"
     PROP = "prop"
     UNKNOWN = "unknown"
-cdef dict _GPU_P2P_CAPS_INDEX_MAPPING = {
+_GPU_P2P_CAPS_INDEX_MAPPING = {
     GpuP2PCapsIndex.READ: nvml.GpuP2PCapsIndex.P2P_CAPS_INDEX_READ,
     GpuP2PCapsIndex.WRITE: nvml.GpuP2PCapsIndex.P2P_CAPS_INDEX_WRITE,
     GpuP2PCapsIndex.NVLINK: nvml.GpuP2PCapsIndex.P2P_CAPS_INDEX_NVLINK,
@@ -167,7 +167,7 @@ class GpuP2PStatus(StrEnum):
     DISABLED_BY_REGKEY = "disabled by regkey"
     NOT_SUPPORTED = "not supported"
     UNKNOWN = "unknown"
-cdef dict _GPU_P2P_STATUS_MAPPING = {
+_GPU_P2P_STATUS_MAPPING = {
     nvml.GpuP2PStatus.P2P_STATUS_OK: GpuP2PStatus.OK,
     # Typo in upstream library
     nvml.GpuP2PStatus.P2P_STATUS_CHIPSET_NOT_SUPPORED: GpuP2PStatus.CHIPSET_NOT_SUPPORTED,
@@ -190,7 +190,7 @@ class GpuTopologyLevel(StrEnum):
     HOSTBRIDGE = "hostbridge"
     NODE = "node"
     SYSTEM = "system"
-cdef dict _GPU_TOPOLOGY_LEVEL_MAPPING = {
+_GPU_TOPOLOGY_LEVEL_MAPPING = {
     GpuTopologyLevel.INTERNAL: nvml.GpuTopologyLevel.TOPOLOGY_INTERNAL,
     GpuTopologyLevel.SINGLE: nvml.GpuTopologyLevel.TOPOLOGY_SINGLE,
     GpuTopologyLevel.MULTIPLE: nvml.GpuTopologyLevel.TOPOLOGY_MULTIPLE,
@@ -198,7 +198,7 @@ cdef dict _GPU_TOPOLOGY_LEVEL_MAPPING = {
     GpuTopologyLevel.NODE: nvml.GpuTopologyLevel.TOPOLOGY_NODE,
     GpuTopologyLevel.SYSTEM: nvml.GpuTopologyLevel.TOPOLOGY_SYSTEM,
 }
-cdef dict _GPU_TOPOLOGY_LEVEL_INV_MAPPING = {v: k for k, v in _GPU_TOPOLOGY_LEVEL_MAPPING.items()}
+_GPU_TOPOLOGY_LEVEL_INV_MAPPING = {v: k for k, v in _GPU_TOPOLOGY_LEVEL_MAPPING.items()}
 
 
 

--- a/cuda_core/cuda/core/system/_device.pyx
+++ b/cuda_core/cuda/core/system/_device.pyx
@@ -106,6 +106,9 @@ cdef dict _BRAND_TYPE_MAPPING = {
     nvml.BrandType.BRAND_NVIDIA_VWS: "NVIDIA VWS",
     nvml.BrandType.BRAND_NVIDIA_CLOUD_GAMING: "NVIDIA Cloud Gaming",
     nvml.BrandType.BRAND_NVIDIA_VGAMING: "NVIDIA vGaming",
+    nvml.BrandType.BRAND_QUADRO_RTX: "Quadro RTX",
+    nvml.BrandType.BRAND_NVIDIA_RTX: "NVIDIA RTX",
+    nvml.BrandType.BRAND_NVIDIA: "NVIDIA",
     nvml.BrandType.BRAND_GEFORCE_RTX: "GeForce RTX",
     nvml.BrandType.BRAND_TITAN_RTX: "Titan RTX",
 }
@@ -672,7 +675,7 @@ cdef class Device:
             try:
                 output_reason = _CLOCKS_EVENT_REASONS_MAPPING[1 << reason]
             except KeyError:
-                raise ValueError(f"Unknown clock event reason bit: {reason}")
+                raise ValueError(f"Unknown clock event reason bit: {1 << reason}")
             output_reasons.append(output_reason)
         return output_reasons
 
@@ -693,7 +696,7 @@ cdef class Device:
             try:
                 output_reason = _CLOCKS_EVENT_REASONS_MAPPING[1 << reason]
             except KeyError:
-                raise ValueError(f"Unknown clock event reason bit: {reason}")
+                raise ValueError(f"Unknown clock event reason bit: {1 << reason}")
             output_reasons.append(output_reason)
         return output_reasons
 

--- a/cuda_core/cuda/core/system/_device.pyx
+++ b/cuda_core/cuda/core/system/_device.pyx
@@ -23,6 +23,9 @@ from ._nvml_context cimport initialize
 cdef object _pstate_to_int(object pstate):
     if pstate == nvml.Pstates.PSTATE_UNKNOWN:
         return None
+    assert (
+        int(pstate) >= 0 and int(pstate) <= 15
+    ), f"Invalid P-state: {pstate}. Must be between 0 and 15 inclusive, or PSTATE_UNKNOWN."
     return int(pstate) - int(nvml.Pstates.PSTATE_0)
 
 

--- a/cuda_core/cuda/core/system/_device.pyx
+++ b/cuda_core/cuda/core/system/_device.pyx
@@ -15,7 +15,10 @@ from typing import Iterable
 import warnings
 
 from cuda.bindings import nvml
-from cuda.bindings._internal._fast_enum import FastEnum
+try:
+    from cuda.bindings._internal._fast_enum import FastEnum
+except ImportError:
+    from enum import IntEnum as FastEnum
 
 from ._nvml_context cimport initialize
 
@@ -62,15 +65,21 @@ class AddressingMode(StrEnum):
     """
     HMM = "hmm"
     ATS = "ats"
+
+
 AddressingMode.HMM.__doc__ = """
     System allocated memory (``malloc``, ``mmap``) is addressable from the device
     (GPU), via software-based mirroring of the CPU's page tables, on the GPU.
 """
+
+
 AddressingMode.ATS.__doc__ = """
     System allocated memory (``malloc``, ``mmap``) is addressable from the device
     (GPU), via Address Translation Services. This means that there is (effectively)
     a single set of page tables, and the CPU and GPU both use them.
 """
+
+
 _ADDRESSING_MODE_MAPPING = {
     nvml.DeviceAddressingModeType.DEVICE_ADDRESSING_MODE_HMM: AddressingMode.HMM,
     nvml.DeviceAddressingModeType.DEVICE_ADDRESSING_MODE_ATS: AddressingMode.ATS,
@@ -83,12 +92,18 @@ class AffinityScope(StrEnum):
     """
     NODE = "node"
     SOCKET = "socket"
+
+
 AffinityScope.NODE.__doc__ = """
-    The NUMA node is the scope of the affinity query.  This is the default scope.
+The NUMA node is the scope of the affinity query.  This is the default scope.
 """
+
+
 AffinityScope.SOCKET.__doc__ = """
-    The CPU socket is the scope of the affinity query.
+The CPU socket is the scope of the affinity query.
 """
+
+
 _AFFINITY_SCOPE_MAPPING = {
     AffinityScope.NODE: nvml.AffinityScope.NODE,
     AffinityScope.SOCKET: nvml.AffinityScope.SOCKET,
@@ -146,6 +161,8 @@ class GpuP2PCapsIndex(StrEnum):
     PCI = "pci"
     PROP = "prop"
     UNKNOWN = "unknown"
+
+
 _GPU_P2P_CAPS_INDEX_MAPPING = {
     GpuP2PCapsIndex.READ: nvml.GpuP2PCapsIndex.P2P_CAPS_INDEX_READ,
     GpuP2PCapsIndex.WRITE: nvml.GpuP2PCapsIndex.P2P_CAPS_INDEX_WRITE,
@@ -167,6 +184,8 @@ class GpuP2PStatus(StrEnum):
     DISABLED_BY_REGKEY = "disabled by regkey"
     NOT_SUPPORTED = "not supported"
     UNKNOWN = "unknown"
+
+
 _GPU_P2P_STATUS_MAPPING = {
     nvml.GpuP2PStatus.P2P_STATUS_OK: GpuP2PStatus.OK,
     # Typo in upstream library
@@ -190,6 +209,8 @@ class GpuTopologyLevel(StrEnum):
     HOSTBRIDGE = "hostbridge"
     NODE = "node"
     SYSTEM = "system"
+
+
 _GPU_TOPOLOGY_LEVEL_MAPPING = {
     GpuTopologyLevel.INTERNAL: nvml.GpuTopologyLevel.TOPOLOGY_INTERNAL,
     GpuTopologyLevel.SINGLE: nvml.GpuTopologyLevel.TOPOLOGY_SINGLE,
@@ -198,6 +219,8 @@ _GPU_TOPOLOGY_LEVEL_MAPPING = {
     GpuTopologyLevel.NODE: nvml.GpuTopologyLevel.TOPOLOGY_NODE,
     GpuTopologyLevel.SYSTEM: nvml.GpuTopologyLevel.TOPOLOGY_SYSTEM,
 }
+
+
 _GPU_TOPOLOGY_LEVEL_INV_MAPPING = {v: k for k, v in _GPU_TOPOLOGY_LEVEL_MAPPING.items()}
 
 

--- a/cuda_core/cuda/core/system/_event.pxi
+++ b/cuda_core/cuda/core/system/_event.pxi
@@ -3,7 +3,50 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-EventType = nvml.EventType
+class EventType(StrEnum):
+    """
+    Event types that can be waited on with :class:`DeviceEvents`.
+    """
+    NONE = "none"
+    SINGLE_BIT_ECC_ERROR = "single_bit_ecc_error"
+    DOUBLE_BIT_ECC_ERROR = "double_bit_ecc_error"
+    PSTATE = "pstate"
+    XID_CRITICAL_ERROR = "xid_critical_error"
+    CLOCK = "clock"
+    POWER_SOURCE_CHANGE = "power_source_change"
+    MIG_CONFIG_CHANGE = "mig_config_change"
+    SINGLE_BIT_ECC_ERROR_STORM = "single_bit_ecc_error_storm"
+    DRAM_RETIREMENT_EVENT = "dram_retirement_event"
+    DRAM_RETIREMENT_FAILURE = "dram_retirement_failure"
+    NON_FATAL_POISON_ERROR = "non_fatal_poison_error"
+    FATAL_POISON_ERROR = "fatal_poison_error"
+    GPU_UNAVAILABLE_ERROR = "gpu_unavailable_error"
+    GPU_RECOVERY_ACTION = "gpu_recovery_action"
+EventType.PSTATE.__doc__ = """
+Event about PState changes
+
+On Fermi™ architecture, PState changes are also an indicator that GPU is throttling down due to
+no work being executed on the GPU, power capping or thermal capping. In a typical situation,
+Fermi-based GPU should stay in P0 for the duration of the execution of the compute process.
+"""
+cdef dict _EVENT_TYPE_MAPPING = {
+    nvml.EventType.NONE: EventType.NONE,
+    nvml.EventType.SINGLE_BIT_ECC_ERROR: EventType.SINGLE_BIT_ECC_ERROR,
+    nvml.EventType.DOUBLE_BIT_ECC_ERROR: EventType.DOUBLE_BIT_ECC_ERROR,
+    nvml.EventType.PSTATE: EventType.PSTATE,
+    nvml.EventType.XID_CRITICAL_ERROR: EventType.XID_CRITICAL_ERROR,
+    nvml.EventType.CLOCK: EventType.CLOCK,
+    nvml.EventType.POWER_SOURCE_CHANGE: EventType.POWER_SOURCE_CHANGE,
+    nvml.EventType.MIG_CONFIG_CHANGE: EventType.MIG_CONFIG_CHANGE,
+    nvml.EventType.SINGLE_BIT_ECC_ERROR_STORM: EventType.SINGLE_BIT_ECC_ERROR_STORM,
+    nvml.EventType.DRAM_RETIREMENT_EVENT: EventType.DRAM_RETIREMENT_EVENT,
+    nvml.EventType.DRAM_RETIREMENT_FAILURE: EventType.DRAM_RETIREMENT_FAILURE,
+    nvml.EventType.NON_FATAL_POISON_ERROR: EventType.NON_FATAL_POISON_ERROR,
+    nvml.EventType.FATAL_POISON_ERROR: EventType.FATAL_POISON_ERROR,
+    nvml.EventType.GPU_UNAVAILABLE_ERROR: EventType.GPU_UNAVAILABLE_ERROR,
+    nvml.EventType.GPU_RECOVERY_ACTION: EventType.GPU_RECOVERY_ACTION,
+}
+cdef dict _EVENT_TYPE_INV_MAPPING = {v: k for k, v in _EVENT_TYPE_MAPPING.items()}
 
 
 cdef class EventData:
@@ -27,7 +70,7 @@ cdef class EventData:
         """
         The type of event that was triggered.
         """
-        return EventType(self._event_data.event_type)
+        return _EVENT_TYPE_MAPPING[self._event_data.event_type]
 
     @property
     def event_data(self) -> int:
@@ -37,7 +80,7 @@ cdef class EventData:
 
         Raises :class:`ValueError` for other event types.
         """
-        if self.event_type != EventType.EVENT_TYPE_XID_CRITICAL_ERROR:
+        if self._event_data.event_type != nvml.EventType.XID_CRITICAL_ERROR:
             raise ValueError("event_data is only available for Xid critical error events.")
         return self._event_data.event_data
 
@@ -50,7 +93,7 @@ cdef class EventData:
 
         Raises :class:`ValueError` for other event types.
         """
-        if self.event_type != EventType.EVENT_TYPE_XID_CRITICAL_ERROR:
+        if self._event_data.event_type != nvml.EventType.XID_CRITICAL_ERROR:
             raise ValueError("gpu_instance_id is only available for Xid critical error events.")
         return self._event_data.gpu_instance_id
 
@@ -63,7 +106,7 @@ cdef class EventData:
 
         Raises :class:`ValueError` for other event types.
         """
-        if self.event_type != EventType.EVENT_TYPE_XID_CRITICAL_ERROR:
+        if self._event_data.event_type != nvml.EventType.XID_CRITICAL_ERROR:
             raise ValueError("compute_instance_id is only available for Xid critical error events.")
         return self._event_data.compute_instance_id
 
@@ -75,16 +118,24 @@ cdef class DeviceEvents:
     cdef intptr_t _event_set
     cdef intptr_t _device_handle
 
-    def __init__(self, device_handle: intptr_t, events: EventType | int | list[EventType | int]):
+    def __init__(self, device_handle: intptr_t, events: EventType | str | list[EventType | str]):
         cdef unsigned long long event_bitmask
-        if isinstance(events, (int, EventType)):
-            event_bitmask = <unsigned long long>int(events)
-        elif isinstance(events, list):
+        if isinstance(events, (str, EventType)):
+            events = [events]
+
+        if isinstance(events, list):
             event_bitmask = 0
             for ev in events:
-                event_bitmask |= <unsigned long long>int(ev)
+                try:
+                    ev_enum = _EVENT_TYPE_INV_MAPPING[ev]
+                except KeyError:
+                    raise ValueError(
+                        f"Invalid event type: {ev}. "
+                        f"Must be one of {list(EventType.__members__.values())}"
+                    ) from None
+                event_bitmask |= <unsigned long long>int(ev_enum)
         else:
-            raise TypeError("events must be an EventType, int, or list of EventType or int")
+            raise TypeError("events must be an EventType, str, or list of EventType or str")
 
         self._device_handle = device_handle
         self._event_set = nvml.event_set_create()

--- a/cuda_core/cuda/core/system/_event.pxi
+++ b/cuda_core/cuda/core/system/_event.pxi
@@ -29,7 +29,7 @@ On Fermi™ architecture, PState changes are also an indicator that GPU is throt
 no work being executed on the GPU, power capping or thermal capping. In a typical situation,
 Fermi-based GPU should stay in P0 for the duration of the execution of the compute process.
 """
-cdef dict _EVENT_TYPE_MAPPING = {
+_EVENT_TYPE_MAPPING = {
     nvml.EventType.NONE: EventType.NONE,
     nvml.EventType.SINGLE_BIT_ECC_ERROR: EventType.SINGLE_BIT_ECC_ERROR,
     nvml.EventType.DOUBLE_BIT_ECC_ERROR: EventType.DOUBLE_BIT_ECC_ERROR,
@@ -46,7 +46,7 @@ cdef dict _EVENT_TYPE_MAPPING = {
     nvml.EventType.GPU_UNAVAILABLE_ERROR: EventType.GPU_UNAVAILABLE_ERROR,
     nvml.EventType.GPU_RECOVERY_ACTION: EventType.GPU_RECOVERY_ACTION,
 }
-cdef dict _EVENT_TYPE_INV_MAPPING = {v: k for k, v in _EVENT_TYPE_MAPPING.items()}
+_EVENT_TYPE_INV_MAPPING = {v: k for k, v in _EVENT_TYPE_MAPPING.items()}
 
 
 cdef class EventData:

--- a/cuda_core/cuda/core/system/_event.pxi
+++ b/cuda_core/cuda/core/system/_event.pxi
@@ -61,7 +61,7 @@ cdef class EventData:
         """
         The device on which the event occurred.
         """
-        device = Device.__new__()
+        device = Device.__new__(Device)
         device._handle = self._event_data.device
         return device
 
@@ -76,7 +76,7 @@ cdef class EventData:
     def event_data(self) -> int:
         """
         Returns Xid error for the device in the event of
-        :attr:`~cuda.core.system.EventType.EVENT_TYPE_XID_CRITICAL_ERROR`.
+        :attr:`~cuda.core.system.EventType.XID_CRITICAL_ERROR`.
 
         Raises :class:`ValueError` for other event types.
         """
@@ -89,7 +89,7 @@ cdef class EventData:
         """
         The GPU instance ID for MIG devices.
 
-        Only valid for events of type :attr:`EventType.EVENT_TYPE_XID_CRITICAL_ERROR`.
+        Only valid for events of type :attr:`EventType.XID_CRITICAL_ERROR`.
 
         Raises :class:`ValueError` for other event types.
         """
@@ -102,7 +102,7 @@ cdef class EventData:
         """
         The Compute instance ID for MIG devices.
 
-        Only valid for events of type :attr:`EventType.EVENT_TYPE_XID_CRITICAL_ERROR`.
+        Only valid for events of type :attr:`EventType.XID_CRITICAL_ERROR`.
 
         Raises :class:`ValueError` for other event types.
         """

--- a/cuda_core/cuda/core/system/_event.pxi
+++ b/cuda_core/cuda/core/system/_event.pxi
@@ -22,6 +22,8 @@ class EventType(StrEnum):
     FATAL_POISON_ERROR = "fatal_poison_error"
     GPU_UNAVAILABLE_ERROR = "gpu_unavailable_error"
     GPU_RECOVERY_ACTION = "gpu_recovery_action"
+
+
 EventType.PSTATE.__doc__ = """
 Event about PState changes
 
@@ -29,6 +31,8 @@ On Fermi™ architecture, PState changes are also an indicator that GPU is throt
 no work being executed on the GPU, power capping or thermal capping. In a typical situation,
 Fermi-based GPU should stay in P0 for the duration of the execution of the compute process.
 """
+
+
 _EVENT_TYPE_MAPPING = {
     nvml.EventType.NONE: EventType.NONE,
     nvml.EventType.SINGLE_BIT_ECC_ERROR: EventType.SINGLE_BIT_ECC_ERROR,
@@ -46,6 +50,8 @@ _EVENT_TYPE_MAPPING = {
     nvml.EventType.GPU_UNAVAILABLE_ERROR: EventType.GPU_UNAVAILABLE_ERROR,
     nvml.EventType.GPU_RECOVERY_ACTION: EventType.GPU_RECOVERY_ACTION,
 }
+
+
 _EVENT_TYPE_INV_MAPPING = {v: k for k, v in _EVENT_TYPE_MAPPING.items()}
 
 

--- a/cuda_core/cuda/core/system/_fan.pxi
+++ b/cuda_core/cuda/core/system/_fan.pxi
@@ -9,6 +9,8 @@ class FanControlPolicy(StrEnum):
     """
     TEMPERATURE_CONTROLLED = "temperature_controlled"
     MANUAL = "manual"
+
+
 _FAN_CONTROL_POLICY_MAPPING = {
     nvml.FanControlPolicy.TEMPERATURE_CONTINUOUS_SW: FanControlPolicy.TEMPERATURE_CONTROLLED,
     nvml.FanControlPolicy.MANUAL: FanControlPolicy.MANUAL,

--- a/cuda_core/cuda/core/system/_fan.pxi
+++ b/cuda_core/cuda/core/system/_fan.pxi
@@ -9,7 +9,7 @@ class FanControlPolicy(StrEnum):
     """
     TEMPERATURE_CONTROLLED = "temperature_controlled"
     MANUAL = "manual"
-cdef dict _FAN_CONTROL_POLICY_MAPPING = {
+_FAN_CONTROL_POLICY_MAPPING = {
     nvml.FanControlPolicy.TEMPERATURE_CONTINUOUS_SW: FanControlPolicy.TEMPERATURE_CONTROLLED,
     nvml.FanControlPolicy.MANUAL: FanControlPolicy.MANUAL,
 }

--- a/cuda_core/cuda/core/system/_fan.pxi
+++ b/cuda_core/cuda/core/system/_fan.pxi
@@ -3,7 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-FanControlPolicy = nvml.FanControlPolicy
+class FanControlPolicy(StrEnum):
+    """
+    Fan control policies.
+    """
+    TEMPERATURE_CONTROLLED = "temperature_controlled"
+    MANUAL = "manual"
+cdef dict _FAN_CONTROL_POLICY_MAPPING = {
+    nvml.FanControlPolicy.TEMPERATURE_CONTINUOUS_SW: FanControlPolicy.TEMPERATURE_CONTROLLED,
+    nvml.FanControlPolicy.MANUAL: FanControlPolicy.MANUAL,
+}
 
 
 cdef class FanInfo:
@@ -94,7 +103,7 @@ cdef class FanInfo:
 
         For all CUDA-capable discrete products with fans.
         """
-        return FanControlPolicy(nvml.device_get_fan_control_policy_v2(self._handle, self._fan))
+        return _FAN_CONTROL_POLICY_MAPPING[nvml.device_get_fan_control_policy_v2(self._handle, self._fan)]
 
     def set_default_speed(self):
         """

--- a/cuda_core/cuda/core/system/_inforom.pxi
+++ b/cuda_core/cuda/core/system/_inforom.pxi
@@ -23,7 +23,7 @@ The power management object.
 InforomObject.DEN.__doc__ = """
 DRAM Encryption object.
 """
-cdef dict _INFOROM_OBJECT_MAPPING = {
+_INFOROM_OBJECT_MAPPING = {
     InforomObject.OEM: nvml.InforomObject.INFOROM_OEM,
     InforomObject.ECC: nvml.InforomObject.INFOROM_ECC,
     InforomObject.POWER: nvml.InforomObject.INFOROM_POWER,

--- a/cuda_core/cuda/core/system/_inforom.pxi
+++ b/cuda_core/cuda/core/system/_inforom.pxi
@@ -3,7 +3,32 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-InforomObject = nvml.InforomObject
+class InforomObject(StrEnum):
+    """
+    InfoROM objects types.
+    """
+    OEM = "oem"
+    ECC = "ecc"
+    POWER = "power"
+    DEN = "den"
+InforomObject.OEM.__doc__ = """
+An object defined by OEM.
+"""
+InforomObject.ECC.__doc__ = """
+The ECC object determining the level of ECC support.
+"""
+InforomObject.POWER.__doc__ = """
+The power management object.
+"""
+InforomObject.DEN.__doc__ = """
+DRAM Encryption object.
+"""
+cdef dict _INFOROM_OBJECT_MAPPING = {
+    InforomObject.OEM: nvml.InforomObject.INFOROM_OEM,
+    InforomObject.ECC: nvml.InforomObject.INFOROM_ECC,
+    InforomObject.POWER: nvml.InforomObject.INFOROM_POWER,
+    InforomObject.DEN: nvml.InforomObject.INFOROM_DEN,
+}
 
 
 cdef class InforomInfo:
@@ -12,7 +37,7 @@ cdef class InforomInfo:
     def __init__(self, device: Device):
         self._device = device
 
-    def get_version(self, inforom: InforomObject) -> str:
+    def get_version(self, inforom: InforomObject | str) -> str:
         """
         Retrieves the InfoROM version for a given InfoROM object.
 
@@ -31,7 +56,14 @@ cdef class InforomInfo:
         str
             The InfoROM version.
         """
-        return nvml.device_get_inforom_version(self._device._handle, inforom)
+        try:
+            inforom_enum = _INFOROM_OBJECT_MAPPING[inforom]
+        except KeyError:
+            raise ValueError(
+                f"Invalid InfoROM object: {inforom}. "
+                f"Must be one of {list(InforomObject.__members__.values())}"
+            ) from None
+        return nvml.device_get_inforom_version(self._device._handle, inforom_enum)
 
     @property
     def image_version(self) -> str:

--- a/cuda_core/cuda/core/system/_inforom.pxi
+++ b/cuda_core/cuda/core/system/_inforom.pxi
@@ -11,18 +11,14 @@ class InforomObject(StrEnum):
     ECC = "ecc"
     POWER = "power"
     DEN = "den"
-InforomObject.OEM.__doc__ = """
-An object defined by OEM.
-"""
-InforomObject.ECC.__doc__ = """
-The ECC object determining the level of ECC support.
-"""
-InforomObject.POWER.__doc__ = """
-The power management object.
-"""
-InforomObject.DEN.__doc__ = """
-DRAM Encryption object.
-"""
+
+
+InforomObject.OEM.__doc__ = "An object defined by OEM."
+InforomObject.ECC.__doc__ = "The ECC object determining the level of ECC support."
+InforomObject.POWER.__doc__ = "The power management object."
+InforomObject.DEN.__doc__ = "DRAM Encryption object."
+
+
 _INFOROM_OBJECT_MAPPING = {
     InforomObject.OEM: nvml.InforomObject.INFOROM_OEM,
     InforomObject.ECC: nvml.InforomObject.INFOROM_ECC,

--- a/cuda_core/cuda/core/system/_nvlink.pxi
+++ b/cuda_core/cuda/core/system/_nvlink.pxi
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-cdef dict _NVLINK_VERSION_MAPPING = {
+_NVLINK_VERSION_MAPPING = {
     nvml.NvlinkVersion.VERSION_1_0: (1, 0),
     nvml.NvlinkVersion.VERSION_2_0: (2, 0),
     nvml.NvlinkVersion.VERSION_2_2: (2, 2),

--- a/cuda_core/cuda/core/system/_nvlink.pxi
+++ b/cuda_core/cuda/core/system/_nvlink.pxi
@@ -3,7 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-NvlinkVersion = nvml.NvlinkVersion
+cdef dict _NVLINK_VERSION_MAPPING = {
+    nvml.NvlinkVersion.VERSION_1_0: (1, 0),
+    nvml.NvlinkVersion.VERSION_2_0: (2, 0),
+    nvml.NvlinkVersion.VERSION_2_2: (2, 2),
+    nvml.NvlinkVersion.VERSION_3_0: (3, 0),
+    nvml.NvlinkVersion.VERSION_3_1: (3, 1),
+    nvml.NvlinkVersion.VERSION_4_0: (4, 0),
+    nvml.NvlinkVersion.VERSION_5_0: (5, 0),
+}
 
 
 cdef class NvlinkInfo:
@@ -18,18 +26,24 @@ cdef class NvlinkInfo:
         self._link = link
 
     @property
-    def version(self) -> NvlinkVersion:
+    def version(self) -> tuple[int, int]:
         """
-        Retrieves the :obj:`~NvlinkVersion` for the device and link.
+        Retrieves the NvLink version for the device and link.
 
         For all products with NvLink support.
 
         Returns
         -------
-        NvlinkVersion
-            The Nvlink version.
+        tuple[int, int]
+            The Nvlink version as a tuple of (major, minor).
         """
-        return NvlinkVersion(nvml.device_get_nvlink_version(self._device._handle, self._link))
+        version = nvml.device_get_nvlink_version(self._device._handle, self._link)
+        if version == nvml.NvlinkVersion.VERSION_INVALID:
+            raise RuntimeError(f"Invalid NvLink version returned for device")
+        try:
+            return _NVLINK_VERSION_MAPPING[version]
+        except KeyError:
+            raise RuntimeError(f"Unknown NvLink version {version} returned for device") from None
 
     @property
     def state(self) -> bool:

--- a/cuda_core/cuda/core/system/_pci_info.pxi
+++ b/cuda_core/cuda/core/system/_pci_info.pxi
@@ -3,9 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-PcieUtilCounter = nvml.PcieUtilCounter
-
-
 cdef class PciInfo:
     """
     PCI information about a GPU device.
@@ -134,9 +131,10 @@ cdef class PciInfo:
         """
         return nvml.device_get_curr_pcie_link_width(self._handle)
 
-    def get_throughput(self, counter: PcieUtilCounter) -> int:
+    @property
+    def rx_throughput(self) -> int:
         """
-        Retrieve PCIe utilization information, in KB/s.
+        Retrieve PCIe reception throughput, in KB/s.
 
         This function is querying a byte counter over a 20ms interval, and thus
         is the PCIe throughput over that interval.
@@ -146,7 +144,22 @@ cdef class PciInfo:
         This method is not supported in virtual machines running virtual GPU
         (vGPU).
         """
-        return nvml.device_get_pcie_throughput(self._handle, counter)
+        return nvml.device_get_pcie_throughput(self._handle, nvml.PcieUtilCounter.PCIE_UTIL_RX_BYTES)
+
+    @property
+    def tx_throughput(self) -> int:
+        """
+        Retrieve PCIe transmission throughput, in KB/s.
+
+        This function is querying a byte counter over a 20ms interval, and thus
+        is the PCIe throughput over that interval.
+
+        For Maxwell™ or newer fully supported devices.
+
+        This method is not supported in virtual machines running virtual GPU
+        (vGPU).
+        """
+        return nvml.device_get_pcie_throughput(self._handle, nvml.PcieUtilCounter.PCIE_UTIL_TX_BYTES)
 
     @property
     def replay_counter(self) -> int:

--- a/cuda_core/cuda/core/system/_system_events.pyx
+++ b/cuda_core/cuda/core/system/_system_events.pyx
@@ -24,10 +24,14 @@ class SystemEventType(StrEnum):
     """
     UNBIND = "unbind"
     BIND = "bind"
+
+
 _SYSTEM_EVENT_TYPE_MAPPING = {
     nvml.SystemEventType.GPU_DRIVER_UNBIND: SystemEventType.UNBIND,
     nvml.SystemEventType.GPU_DRIVER_BIND: SystemEventType.BIND,
 }
+
+
 _SYSTEM_EVENT_TYPE_INV_MAPPING = {v: k for k, v in _SYSTEM_EVENT_TYPE_MAPPING.items()}
 
 

--- a/cuda_core/cuda/core/system/_system_events.pyx
+++ b/cuda_core/cuda/core/system/_system_events.pyx
@@ -5,6 +5,8 @@
 
 from libc.stdint cimport intptr_t
 
+from enum import StrEnum
+
 from cuda.bindings import nvml
 
 from ._nvml_context cimport initialize
@@ -12,7 +14,17 @@ from ._nvml_context cimport initialize
 from . import _device
 
 
-SystemEventType = nvml.SystemEventType
+class SystemEventType(StrEnum):
+    """
+    System event types.
+    """
+    UNBIND = "unbind"
+    BIND = "bind"
+cdef dict _SYSTEM_EVENT_TYPE_MAPPING = {
+    nvml.SystemEventType.GPU_DRIVER_UNBIND: SystemEventType.UNBIND,
+    nvml.SystemEventType.GPU_DRIVER_BIND: SystemEventType.BIND,
+}
+cdef dict _SYSTEM_EVENT_TYPE_INV_MAPPING = {v: k for k, v in _SYSTEM_EVENT_TYPE_MAPPING.items()}
 
 
 cdef class SystemEvent:
@@ -28,7 +40,7 @@ cdef class SystemEvent:
         """
         The :obj:`~SystemEventType` that was triggered.
         """
-        return SystemEventType(self._event_data.event_type)
+        return _SYSTEM_EVENT_TYPE_MAPPING[self._event_data.event_type]
 
     @property
     def gpu_id(self) -> int:
@@ -68,16 +80,24 @@ cdef class RegisteredSystemEvents:
     """
     cdef intptr_t _event_set
 
-    def __init__(self, events: SystemEventType | int | list[SystemEventType | int]):
+    def __init__(self, events: SystemEventType | str | list[SystemEventType | str]):
         cdef unsigned long long event_bitmask
-        if isinstance(events, (int, SystemEventType)):
-            event_bitmask = <unsigned long long>int(events)
-        elif isinstance(events, list):
+        if isinstance(events, (str, SystemEventType)):
+            events = [events]
+
+        if isinstance(events, list):
             event_bitmask = 0
             for ev in events:
-                event_bitmask |= <unsigned long long>int(ev)
+                try:
+                    ev_enum = _SYSTEM_EVENT_TYPE_INV_MAPPING[ev]
+                except KeyError:
+                    raise ValueError(
+                        f"Invalid event type: {ev}. "
+                        f"Must be one of {list(SystemEventType.__members__.values())}"
+                    ) from None
+                event_bitmask |= <unsigned long long>int(ev_enum)
         else:
-            raise TypeError("events must be an SystemEventType, int, or list of SystemEventType or int")
+            raise TypeError("events must be an SystemEventType, str, or list of SystemEventType or str")
 
         initialize()
 
@@ -128,7 +148,7 @@ cdef class RegisteredSystemEvents:
         return SystemEvents(nvml.system_event_set_wait(self._event_set, timeout_ms, buffer_size))
 
 
-def register_events(events: SystemEventType | int | list[SystemEventType | int]) -> RegisteredSystemEvents:
+def register_events(events: SystemEventType | str | list[SystemEventType | str]) -> RegisteredSystemEvents:
     """
     Starts recording of events on test system.
 
@@ -148,7 +168,7 @@ def register_events(events: SystemEventType | int | list[SystemEventType | int])
 
     Parameters
     ----------
-    events: SystemEventType, int, or list of SystemEventType or int
+    events: SystemEventType, str, or list of SystemEventType or str
         The event type or list of event types to register for this device.
 
     Returns

--- a/cuda_core/cuda/core/system/_system_events.pyx
+++ b/cuda_core/cuda/core/system/_system_events.pyx
@@ -5,7 +5,11 @@
 
 from libc.stdint cimport intptr_t
 
-from enum import StrEnum
+import sys
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from backports.strenum import StrEnum
 
 from cuda.bindings import nvml
 

--- a/cuda_core/cuda/core/system/_system_events.pyx
+++ b/cuda_core/cuda/core/system/_system_events.pyx
@@ -164,9 +164,7 @@ def register_events(events: SystemEventType | str | list[SystemEventType | str])
     Examples
     --------
     >>> from cuda.core import system
-    >>> events = system.register_events([
-    ...     SystemEventType.SYSTEM_EVENT_TYPE_GPU_DRIVER_UNBIND,
-    ... ])
+    >>> events = system.register_events([SystemEventType.UNBIND])
     >>> while event := events.wait(timeout_ms=10000):
     ...     print(f"Event {event.event_type} occurred.")
 

--- a/cuda_core/cuda/core/system/_system_events.pyx
+++ b/cuda_core/cuda/core/system/_system_events.pyx
@@ -24,11 +24,11 @@ class SystemEventType(StrEnum):
     """
     UNBIND = "unbind"
     BIND = "bind"
-cdef dict _SYSTEM_EVENT_TYPE_MAPPING = {
+_SYSTEM_EVENT_TYPE_MAPPING = {
     nvml.SystemEventType.GPU_DRIVER_UNBIND: SystemEventType.UNBIND,
     nvml.SystemEventType.GPU_DRIVER_BIND: SystemEventType.BIND,
 }
-cdef dict _SYSTEM_EVENT_TYPE_INV_MAPPING = {v: k for k, v in _SYSTEM_EVENT_TYPE_MAPPING.items()}
+_SYSTEM_EVENT_TYPE_INV_MAPPING = {v: k for k, v in _SYSTEM_EVENT_TYPE_MAPPING.items()}
 
 
 cdef class SystemEvent:

--- a/cuda_core/cuda/core/system/_temperature.pxi
+++ b/cuda_core/cuda/core/system/_temperature.pxi
@@ -186,7 +186,7 @@ cdef class Temperature:
         """
         # NOTE: nvml.device_get_temperature_v takes a sensor type from the
         # TemperatorSensors enum, but there is only one value in that enum.  For
-        # future compatibility if there are other values for that enum, this if
+        # future compatibility if there are other values for that enum, this is
         # a method, not a property
         return nvml.device_get_temperature_v(self._handle, nvml.TemperatureSensors.TEMPERATURE_GPU)
 

--- a/cuda_core/cuda/core/system/_temperature.pxi
+++ b/cuda_core/cuda/core/system/_temperature.pxi
@@ -15,6 +15,8 @@ class TemperatureThresholds(StrEnum):
     ACOUSTIC_CURR = "acoustic_curr"
     ACOUSTIC_MAX = "acoustic_max"
     GPS_CURR = "gps_curr"
+
+
 _TEMPERATURE_THRESHOLD_MAPPING = {
     TemperatureThresholds.SHUTDOWN: nvml.TemperatureThresholds.TEMPERATURE_THRESHOLD_SHUTDOWN,
     TemperatureThresholds.SLOWDOWN: nvml.TemperatureThresholds.TEMPERATURE_THRESHOLD_SLOWDOWN,
@@ -49,6 +51,8 @@ class ThermalController(StrEnum):
     MAX6649R = "max6649r"
     ADT7473S = "adt7473s"
     UNKNOWN = "unknown"
+
+
 _THERMAL_CONTROLLER_MAPPING = {
     nvml.ThermalController.GPU_INTERNAL: ThermalController.GPU_INTERNAL,
     nvml.ThermalController.ADM1032: ThermalController.ADM1032,
@@ -83,6 +87,8 @@ class ThermalTarget(StrEnum):
     VCD_INLET = "vcd_inlet"
     VCD_OUTLET = "vcd_outlet"
     ALL = "all"
+
+
 ThermalTarget.GPU.__doc__ = "GPU core temperature requires physical GPU handle."
 ThermalTarget.MEMORY.__doc__ = "GPU memory temperature requires physical GPU handle."
 ThermalTarget.POWER_SUPPLY.__doc__ = "GPU power supply temperature requires physical GPU handle."
@@ -90,6 +96,8 @@ ThermalTarget.BOARD.__doc__ = "GPU board ambient temperature requires physical G
 ThermalTarget.VCD_BOARD.__doc__ = "Visual Computing Device Board temperature requires visual computing device handle."
 ThermalTarget.VCD_INLET.__doc__ = "Visual Computing Device Inlet temperature requires visual computing device handle."
 ThermalTarget.VCD_OUTLET.__doc__ = "Visual Computing Device Outlet temperature requires visual computing device handle."
+
+
 _THERMAL_TARGET_MAPPING = {
     nvml.ThermalTarget.NONE: ThermalTarget.NONE,
     nvml.ThermalTarget.GPU: ThermalTarget.GPU,
@@ -101,6 +109,8 @@ _THERMAL_TARGET_MAPPING = {
     nvml.ThermalTarget.VCD_OUTLET: ThermalTarget.VCD_OUTLET,
     nvml.ThermalTarget.ALL: ThermalTarget.ALL,
 }
+
+
 _THERMAL_TARGET_INV_MAPPING = {v: k for k, v in _THERMAL_TARGET_MAPPING.items()}
 
 

--- a/cuda_core/cuda/core/system/_temperature.pxi
+++ b/cuda_core/cuda/core/system/_temperature.pxi
@@ -15,7 +15,7 @@ class TemperatureThresholds(StrEnum):
     ACOUSTIC_CURR = "acoustic_curr"
     ACOUSTIC_MAX = "acoustic_max"
     GPS_CURR = "gps_curr"
-cdef dict _TEMPERATURE_THRESHOLD_MAPPING = {
+_TEMPERATURE_THRESHOLD_MAPPING = {
     TemperatureThresholds.SHUTDOWN: nvml.TemperatureThresholds.TEMPERATURE_THRESHOLD_SHUTDOWN,
     TemperatureThresholds.SLOWDOWN: nvml.TemperatureThresholds.TEMPERATURE_THRESHOLD_SLOWDOWN,
     TemperatureThresholds.MEM_MAX: nvml.TemperatureThresholds.TEMPERATURE_THRESHOLD_MEM_MAX,
@@ -49,7 +49,7 @@ class ThermalController(StrEnum):
     MAX6649R = "max6649r"
     ADT7473S = "adt7473s"
     UNKNOWN = "unknown"
-cdef dict _THERMAL_CONTROLLER_MAPPING = {
+_THERMAL_CONTROLLER_MAPPING = {
     nvml.ThermalController.GPU_INTERNAL: ThermalController.GPU_INTERNAL,
     nvml.ThermalController.ADM1032: ThermalController.ADM1032,
     nvml.ThermalController.ADT7461: ThermalController.ADT7461,
@@ -90,7 +90,7 @@ ThermalTarget.BOARD.__doc__ = "GPU board ambient temperature requires physical G
 ThermalTarget.VCD_BOARD.__doc__ = "Visual Computing Device Board temperature requires visual computing device handle."
 ThermalTarget.VCD_INLET.__doc__ = "Visual Computing Device Inlet temperature requires visual computing device handle."
 ThermalTarget.VCD_OUTLET.__doc__ = "Visual Computing Device Outlet temperature requires visual computing device handle."
-cdef dict _THERMAL_TARGET_MAPPING = {
+_THERMAL_TARGET_MAPPING = {
     nvml.ThermalTarget.NONE: ThermalTarget.NONE,
     nvml.ThermalTarget.GPU: ThermalTarget.GPU,
     nvml.ThermalTarget.MEMORY: ThermalTarget.MEMORY,
@@ -101,7 +101,7 @@ cdef dict _THERMAL_TARGET_MAPPING = {
     nvml.ThermalTarget.VCD_OUTLET: ThermalTarget.VCD_OUTLET,
     nvml.ThermalTarget.ALL: ThermalTarget.ALL,
 }
-cdef dict _THERMAL_TARGET_INV_MAPPING = {v: k for k, v in _THERMAL_TARGET_MAPPING.items()}
+_THERMAL_TARGET_INV_MAPPING = {v: k for k, v in _THERMAL_TARGET_MAPPING.items()}
 
 
 # In cuda.bindings.nvml, this is an anonymous struct inside nvmlThermalSettings_t.

--- a/cuda_core/cuda/core/system/_temperature.pxi
+++ b/cuda_core/cuda/core/system/_temperature.pxi
@@ -3,10 +3,105 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-TemperatureSensors = nvml.TemperatureSensors
-TemperatureThresholds = nvml.TemperatureThresholds
-ThermalController = nvml.ThermalController
-ThermalTarget = nvml.ThermalTarget
+class TemperatureThresholds(StrEnum):
+    """
+    Temperature threshold types.
+    """
+    SHUTDOWN = "shutdown"
+    SLOWDOWN = "slowdown"
+    MEM_MAX = "mem_max"
+    GPU_MAX = "gpu_max"
+    ACOUSTIC_MIN = "acoustic_min"
+    ACOUSTIC_CURR = "acoustic_curr"
+    ACOUSTIC_MAX = "acoustic_max"
+    GPS_CURR = "gps_curr"
+cdef dict _TEMPERATURE_THRESHOLD_MAPPING = {
+    TemperatureThresholds.SHUTDOWN: nvml.TemperatureThresholds.TEMPERATURE_THRESHOLD_SHUTDOWN,
+    TemperatureThresholds.SLOWDOWN: nvml.TemperatureThresholds.TEMPERATURE_THRESHOLD_SLOWDOWN,
+    TemperatureThresholds.MEM_MAX: nvml.TemperatureThresholds.TEMPERATURE_THRESHOLD_MEM_MAX,
+    TemperatureThresholds.GPU_MAX: nvml.TemperatureThresholds.TEMPERATURE_THRESHOLD_GPU_MAX,
+    TemperatureThresholds.ACOUSTIC_MIN: nvml.TemperatureThresholds.TEMPERATURE_THRESHOLD_ACOUSTIC_MIN,
+    TemperatureThresholds.ACOUSTIC_CURR: nvml.TemperatureThresholds.TEMPERATURE_THRESHOLD_ACOUSTIC_CURR,
+    TemperatureThresholds.ACOUSTIC_MAX: nvml.TemperatureThresholds.TEMPERATURE_THRESHOLD_ACOUSTIC_MAX,
+    TemperatureThresholds.GPS_CURR: nvml.TemperatureThresholds.TEMPERATURE_THRESHOLD_GPS_CURR,
+}
+
+
+class ThermalController(StrEnum):
+    """
+    Thermal controller types.
+    """
+    GPU_INTERNAL = "gpu_internal"
+    ADM1032 = "adm1032"
+    ADT7461 = "adt7461"
+    MAX6649 = "max6649"
+    MAX1617 = "max1617"
+    LM99 = "lm99"
+    LM89 = "lm89"
+    LM64 = "lm64"
+    G781 = "g781"
+    ADT7473 = "adt7473"
+    SBMAX6649 = "sbmax6649"
+    VBIOSEVT = "vbiosevt"
+    OS = "os"
+    NVSYSCON_CANOAS = "nvsyscon_canoas"
+    NVSYSCON_E551 = "nvsyscon_e551"
+    MAX6649R = "max6649r"
+    ADT7473S = "adt7473s"
+    UNKNOWN = "unknown"
+cdef dict _THERMAL_CONTROLLER_MAPPING = {
+    nvml.ThermalController.GPU_INTERNAL: ThermalController.GPU_INTERNAL,
+    nvml.ThermalController.ADM1032: ThermalController.ADM1032,
+    nvml.ThermalController.ADT7461: ThermalController.ADT7461,
+    nvml.ThermalController.MAX6649: ThermalController.MAX6649,
+    nvml.ThermalController.MAX1617: ThermalController.MAX1617,
+    nvml.ThermalController.LM99: ThermalController.LM99,
+    nvml.ThermalController.LM89: ThermalController.LM89,
+    nvml.ThermalController.LM64: ThermalController.LM64,
+    nvml.ThermalController.G781: ThermalController.G781,
+    nvml.ThermalController.ADT7473: ThermalController.ADT7473,
+    nvml.ThermalController.SBMAX6649: ThermalController.SBMAX6649,
+    nvml.ThermalController.VBIOSEVT: ThermalController.VBIOSEVT,
+    nvml.ThermalController.OS: ThermalController.OS,
+    nvml.ThermalController.NVSYSCON_CANOAS: ThermalController.NVSYSCON_CANOAS,
+    nvml.ThermalController.NVSYSCON_E551: ThermalController.NVSYSCON_E551,
+    nvml.ThermalController.MAX6649R: ThermalController.MAX6649R,
+    nvml.ThermalController.ADT7473S: ThermalController.ADT7473S,
+}
+
+
+class ThermalTarget(StrEnum):
+    """
+    Thermal sensor targets.
+    """
+    NONE = "none"
+    GPU = "gpu"
+    MEMORY = "memory"
+    POWER_SUPPLY = "power_supply"
+    BOARD = "board"
+    VCD_BOARD = "vcd_board"
+    VCD_INLET = "vcd_inlet"
+    VCD_OUTLET = "vcd_outlet"
+    ALL = "all"
+ThermalTarget.GPU.__doc__ = "GPU core temperature requires physical GPU handle."
+ThermalTarget.MEMORY.__doc__ = "GPU memory temperature requires physical GPU handle."
+ThermalTarget.POWER_SUPPLY.__doc__ = "GPU power supply temperature requires physical GPU handle."
+ThermalTarget.BOARD.__doc__ = "GPU board ambient temperature requires physical GPU handle."
+ThermalTarget.VCD_BOARD.__doc__ = "Visual Computing Device Board temperature requires visual computing device handle."
+ThermalTarget.VCD_INLET.__doc__ = "Visual Computing Device Inlet temperature requires visual computing device handle."
+ThermalTarget.VCD_OUTLET.__doc__ = "Visual Computing Device Outlet temperature requires visual computing device handle."
+cdef dict _THERMAL_TARGET_MAPPING = {
+    nvml.ThermalTarget.NONE: ThermalTarget.NONE,
+    nvml.ThermalTarget.GPU: ThermalTarget.GPU,
+    nvml.ThermalTarget.MEMORY: ThermalTarget.MEMORY,
+    nvml.ThermalTarget.POWER_SUPPLY: ThermalTarget.POWER_SUPPLY,
+    nvml.ThermalTarget.BOARD: ThermalTarget.BOARD,
+    nvml.ThermalTarget.VCD_BOARD: ThermalTarget.VCD_BOARD,
+    nvml.ThermalTarget.VCD_INLET: ThermalTarget.VCD_INLET,
+    nvml.ThermalTarget.VCD_OUTLET: ThermalTarget.VCD_OUTLET,
+    nvml.ThermalTarget.ALL: ThermalTarget.ALL,
+}
+cdef dict _THERMAL_TARGET_INV_MAPPING = {v: k for k, v in _THERMAL_TARGET_MAPPING.items()}
 
 
 # In cuda.bindings.nvml, this is an anonymous struct inside nvmlThermalSettings_t.
@@ -33,7 +128,7 @@ cdef class ThermalSensor:
 
     @property
     def controller(self) -> ThermalController:
-        return ThermalController(self._ptr[0].controller)
+        return _THERMAL_CONTROLLER_MAPPING.get(self._ptr[0].controller, ThermalController.UNKNOWN)
 
     @property
     def default_min_temp(self) -> int:
@@ -49,7 +144,7 @@ cdef class ThermalSensor:
 
     @property
     def target(self) -> ThermalTarget:
-        return ThermalTarget(self._ptr[0].target)
+        return _THERMAL_TARGET_MAPPING.get(self._ptr[0].target, ThermalTarget.NONE)
 
 
 cdef class ThermalSettings:
@@ -77,27 +172,25 @@ cdef class Temperature:
     def __init__(self, handle: int):
         self._handle = handle
 
-    def get_sensor(
-        self,
-        sensor: TemperatureSensors = TemperatureSensors.TEMPERATURE_GPU
-    ) -> int:
+    def get_sensor(self) -> int:
         """
         Get the temperature reading from a specific sensor on the device, in
         degrees Celsius.
 
-        Parameters
-        ----------
-        sensor: :class:`TemperatureSensors`, optional
-            The temperature sensor to query.
+        The only sensor currently supported is the GPU temperature sensor.
 
         Returns
         -------
         int
             The temperature in degrees Celsius.
         """
-        return nvml.device_get_temperature_v(self._handle, sensor)
+        # NOTE: nvml.device_get_temperature_v takes a sensor type from the
+        # TemperatorSensors enum, but there is only one value in that enum.  For
+        # future compatibility if there are other values for that enum, this if
+        # a method, not a property
+        return nvml.device_get_temperature_v(self._handle, nvml.TemperatureSensors.TEMPERATURE_GPU)
 
-    def get_threshold(self, threshold_type: TemperatureThresholds) -> int:
+    def get_threshold(self, threshold_type: TemperatureThresholds | str) -> int:
         """
         Retrieves the temperature threshold for this GPU with the specified
         threshold type, in degrees Celsius.
@@ -118,7 +211,27 @@ cdef class Temperature:
         use :meth:`get_field_values` with ``NVML_FI_DEV_TEMPERATURE_*`` fields
         to retrieve temperature thresholds on these architectures.
         """
-        return nvml.device_get_temperature_threshold(self._handle, threshold_type)
+        try:
+            threshold_type_enum = _TEMPERATURE_THRESHOLD_MAPPING[threshold_type]
+        except KeyError:
+            raise ValueError(
+                f"Invalid temperature threshold type: {threshold_type}. "
+                f"Must be one of {list(TemperatureThresholds.__members__.values())}"
+            ) from None
+        if threshold_type_enum in (
+            nvml.TemperatureThresholds.TEMPERATURE_THRESHOLD_SHUTDOWN,
+            nvml.TemperatureThresholds.TEMPERATURE_THRESHOLD_SLOWDOWN,
+            nvml.TemperatureThresholds.TEMPERATURE_THRESHOLD_MEM_MAX,
+            nvml.TemperatureThresholds.TEMPERATURE_THRESHOLD_GPU_MAX
+        ):
+            device_arch = nvml.DeviceArch(nvml.device_get_architecture(self._handle))
+            if device_arch >= nvml.DeviceArch.ADA:
+                warnings.warn(
+                    f"{threshold_type} is no longer recommended for Ada and later architectures.  Use get_field_values with NVML_FI_DEV_TEMPERATURE_* fields to retrieve this threshold on these architectures.",
+                    DeprecationWarning,
+                    stacklevel=2
+                )
+        return nvml.device_get_temperature_threshold(self._handle, threshold_type_enum)
 
     @property
     def margin(self) -> int:
@@ -127,11 +240,9 @@ cdef class Temperature:
         """
         return nvml.device_get_margin_temperature(self._handle)
 
-    def get_thermal_settings(self, sensor_index: ThermalTarget) -> ThermalSettings:
+    def get_thermal_settings(self, sensor_index: ThermalTarget | str) -> ThermalSettings:
         """
         Used to execute a list of thermal system instructions.
-
-        TODO: The above docstring is from the NVML header, but it doesn't seem to make sense.
 
         Parameters
         ----------
@@ -143,4 +254,13 @@ cdef class Temperature:
         :obj:`~_device.ThermalSettings`
             The thermal settings for the specified sensor.
         """
-        return ThermalSettings(nvml.device_get_thermal_settings(self._handle, sensor_index))
+        # TODO: The above docstring is from the NVML header, but it doesn't seem to make sense.
+        try:
+            sensor_index_enum = _THERMAL_TARGET_INV_MAPPING[sensor_index]
+        except KeyError:
+            raise ValueError(
+                f"Invalid thermal sensor index: {sensor_index}. "
+                f"Must be one of {list(ThermalTarget.__members__.values())}"
+            ) from None
+
+        return ThermalSettings(nvml.device_get_thermal_settings(self._handle, sensor_index_enum))

--- a/cuda_core/cuda/core/system/_temperature.pxi
+++ b/cuda_core/cuda/core/system/_temperature.pxi
@@ -227,7 +227,9 @@ cdef class Temperature:
             device_arch = nvml.DeviceArch(nvml.device_get_architecture(self._handle))
             if device_arch >= nvml.DeviceArch.ADA:
                 warnings.warn(
-                    f"{threshold_type} is no longer recommended for Ada and later architectures.  Use get_field_values with NVML_FI_DEV_TEMPERATURE_* fields to retrieve this threshold on these architectures.",
+                    f"{threshold_type} is no longer recommended for Ada and later architectures. "
+                    "Use get_field_values with NVML_FI_DEV_TEMPERATURE_* fields to retrieve this "
+                    "threshold on these architectures.",
                     DeprecationWarning,
                     stacklevel=2
                 )

--- a/cuda_core/docs/source/api.rst
+++ b/cuda_core/docs/source/api.rst
@@ -201,33 +201,6 @@ Events
    system.register_events
    system.SystemEventType
 
-Enums
-`````
-
-.. autosummary::
-   :toctree: generated/
-
-   system.AddressingMode
-   system.AffinityScope
-   system.BrandType
-   system.ClockId
-   system.ClocksEventReasons
-   system.ClockType
-   system.CoolerControl
-   system.CoolerTarget
-   system.DeviceArch
-   system.EventType
-   system.FanControlPolicy
-   system.FieldId
-   system.InforomObject
-   system.NvlinkVersion
-   system.PcieUtilCounter
-   system.Pstates
-   system.TemperatureSensors
-   system.TemperatureThresholds
-   system.ThermalController
-   system.ThermalTarget
-
 Types
 `````
 
@@ -237,6 +210,7 @@ Types
    :template: autosummary/cyclass.rst
 
    system.Device
+   system.NvlinkInfo
 
 .. module:: cuda.core.utils
 

--- a/cuda_core/docs/source/api_private.rst
+++ b/cuda_core/docs/source/api_private.rst
@@ -71,9 +71,6 @@ NVML
    system._device.FieldValues
    system._device.GpuDynamicPstatesInfo
    system._device.GpuDynamicPstatesUtilization
-   system._device.GpuP2PCapsIndex
-   system._device.GpuP2PStatus
-   system._device.GpuTopologyLevel
    system._device.InforomInfo
    system._device.MemoryInfo
    system._device.MigInfo
@@ -103,6 +100,9 @@ NVML
    system.EventType
    system.FanControlPolicy
    system.FieldId
+   system.GpuP2PCapsIndex
+   system.GpuP2PStatus
+   system.GpuTopologyLevel
    system.InforomObject
    system.TemperatureThresholds
    system.ThermalController

--- a/cuda_core/docs/source/api_private.rst
+++ b/cuda_core/docs/source/api_private.rst
@@ -77,7 +77,6 @@ NVML
    system._device.InforomInfo
    system._device.MemoryInfo
    system._device.MigInfo
-   system._device.NvlinkInfo
    system._device.PciInfo
    system._device.ProcessInfo
    system._device.RepairStatus
@@ -87,3 +86,25 @@ NVML
    system._system_events.RegisteredSystemEvents
    system._system_events.SystemEvent
    system._system_events.SystemEvents
+
+.. These are not technically private, but are included here to avoid cluttering the main API reference.
+
+.. autosummary::
+   :toctree: generated/
+
+   system.AddressingMode
+   system.AffinityScope
+   system.ClockId
+   system.ClocksEventReasons
+   system.ClockType
+   system.CoolerControl
+   system.CoolerTarget
+   system.DeviceArch
+   system.EventType
+   system.FanControlPolicy
+   system.FieldId
+   system.InforomObject
+   system.TemperatureThresholds
+   system.ThermalController
+   system.ThermalTarget
+   system.SystemEventType

--- a/cuda_core/pixi.toml
+++ b/cuda_core/pixi.toml
@@ -186,6 +186,9 @@ numpy = "*"
 cuda-bindings = "*"
 cuda-pathfinder = "*"
 
+[package.target.'python_version < "3.11"'.run-dependencies]
+"backports.strenum" = "*"
+
 [target.linux.tasks.build-cython-tests]
 cmd = ["$PIXI_PROJECT_ROOT/tests/cython/build_tests.sh"]
 

--- a/cuda_core/pyproject.toml
+++ b/cuda_core/pyproject.toml
@@ -50,6 +50,7 @@ classifiers = [
 dependencies = [
     "cuda-pathfinder >=1.4.2",
     "numpy",
+    "backports.strenum; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]

--- a/cuda_core/tests/system/test_system_device.py
+++ b/cuda_core/tests/system/test_system_device.py
@@ -20,7 +20,8 @@ from cuda.core import system
 
 if system.CUDA_BINDINGS_NVML_IS_COMPATIBLE:
     from cuda.bindings import nvml
-    from cuda.core.system import DeviceArch, _device
+    from cuda.bindings.nvml import DeviceArch
+    from cuda.core.system import _device
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -107,7 +108,7 @@ def test_device_cpu_affinity():
 @pytest.mark.skipif(helpers.IS_WSL or helpers.IS_WINDOWS, reason="Device attributes not supported on WSL or Windows")
 def test_affinity():
     for device in system.Device.get_all_devices():
-        for scope in (system.AffinityScope.NODE, system.AffinityScope.SOCKET):
+        for scope in system.AffinityScope.__members__.values():
             with unsupported_before(device, DeviceArch.KEPLER):
                 affinity = device.get_cpu_affinity(scope)
             assert isinstance(affinity, list)
@@ -214,7 +215,8 @@ def test_device_pci_info():
         assert 0 <= pci_info.current_link_width <= 0xFF
 
         with unsupported_before(device, None):
-            assert isinstance(pci_info.get_throughput(system.PcieUtilCounter.PCIE_UTIL_TX_BYTES), int)
+            assert isinstance(pci_info.tx_throughput, int)
+            assert isinstance(pci_info.rx_throughput, int)
 
         assert isinstance(pci_info.replay_counter, int)
 
@@ -280,25 +282,14 @@ def test_register_events():
             events.wait(timeout_ms=500)
 
     for device in system.Device.get_all_devices():
-        events = device.register_events(0)
-        with pytest.raises(system.TimeoutError):
-            events.wait(timeout_ms=500)
-
-
-def test_event_type_parsing():
-    events = [system.EventType(1 << ev) for ev in _device._unpack_bitmask(array.array("Q", [3]))]
-    assert events == [
-        system.EventType.SINGLE_BIT_ECC_ERROR,
-        system.EventType.DOUBLE_BIT_ECC_ERROR,
-    ]
+        with pytest.raises(TypeError):
+            events = device.register_events(0)
 
 
 def test_device_brand():
     for device in system.Device.get_all_devices():
         brand = device.brand
-        assert isinstance(brand, system.BrandType)
-        assert isinstance(brand.name, str)
-        assert isinstance(brand.value, int)
+        assert isinstance(brand, str)
 
 
 def test_device_pci_bus_id():
@@ -437,7 +428,7 @@ def test_addressing_mode():
         # is also unsupported on other hardware.
         with unsupported_before(device, None):
             addressing_mode = device.addressing_mode
-        assert isinstance(addressing_mode, system.AddressingMode)
+        assert addressing_mode is None or addressing_mode in system.AddressingMode.__members__.values()
 
 
 def test_display_mode():
@@ -487,7 +478,7 @@ def test_get_p2p_status():
 
     devices = list(system.Device.get_all_devices())
 
-    status = system.get_p2p_status(devices[0], devices[1], system.GpuP2PCapsIndex.P2P_CAPS_INDEX_READ)
+    status = system.get_p2p_status(devices[0], devices[1], system.GpuP2PCapsIndex.READ)
     assert isinstance(status, system.GpuP2PStatus)
 
 
@@ -497,7 +488,7 @@ def test_get_nearest_gpus():
     # in practice on our CI.
 
     for device in system.Device.get_all_devices():
-        for near_device in device.get_topology_nearest_gpus(system.GpuTopologyLevel.TOPOLOGY_SINGLE):
+        for near_device in device.get_topology_nearest_gpus(system.GpuTopologyLevel.SINGLE):
             assert isinstance(near_device, system.Device)
 
 
@@ -519,7 +510,7 @@ def test_get_inforom_version():
         assert isinstance(inforom_image_version, str)
         assert len(inforom_image_version) > 0
 
-        inforom_version = inforom.get_version(system.InforomObject.INFOROM_OEM)
+        inforom_version = inforom.get_version(system.InforomObject.OEM)
         assert isinstance(inforom_version, str)
         assert len(inforom_version) > 0
 
@@ -668,7 +659,7 @@ def test_cooler():
         assert isinstance(cooler_info, _device.CoolerInfo)
 
         signal_type = cooler_info.signal_type
-        assert isinstance(signal_type, system.CoolerControl)
+        assert isinstance(signal_type, (system.CoolerControl, type(None)))
 
         target = cooler_info.target
         assert all(isinstance(t, system.CoolerTarget) for t in target)
@@ -716,10 +707,10 @@ def test_pstates():
     for device in system.Device.get_all_devices():
         with unsupported_before(device, None):
             pstate = device.performance_state
-        assert isinstance(pstate, system.Pstates)
+        assert isinstance(pstate, int)
 
         pstates = device.supported_pstates
-        assert all(isinstance(p, system.Pstates) for p in pstates)
+        assert all(isinstance(p, int) for p in pstates)
 
         dynamic_pstates_info = device.dynamic_pstates_info
         assert isinstance(dynamic_pstates_info, _device.GpuDynamicPstatesInfo)

--- a/cuda_core/tests/system/test_system_device.py
+++ b/cuda_core/tests/system/test_system_device.py
@@ -277,6 +277,16 @@ def test_register_events():
         assert all(isinstance(ev, system.EventType) for ev in supported_events)
 
     for device in system.Device.get_all_devices():
+        events = device.register_events(["xid_critical_error"])
+        with pytest.raises(system.TimeoutError):
+            events.wait(timeout_ms=500)
+
+    for device in system.Device.get_all_devices():
+        events = device.register_events([system.EventType.XID_CRITICAL_ERROR])
+        with pytest.raises(system.TimeoutError):
+            events.wait(timeout_ms=500)
+
+    for device in system.Device.get_all_devices():
         events = device.register_events([])
         with pytest.raises(system.TimeoutError):
             events.wait(timeout_ms=500)
@@ -677,7 +687,7 @@ def test_temperature():
         # By docs, should be supported on KEPLER or newer, but experimentally,
         # is also unsupported on other hardware.
         with unsupported_before(device, None):
-            for threshold in list(system.TemperatureThresholds)[:-1]:
+            for threshold in list(system.TemperatureThresholds):
                 t = temperature.get_threshold(threshold)
                 assert isinstance(t, int)
                 assert t >= 0

--- a/cuda_core/tests/system/test_system_device.py
+++ b/cuda_core/tests/system/test_system_device.py
@@ -756,7 +756,9 @@ def test_nvlink():
 
             with unsupported_before(device, None):
                 version = nvlink_info.version
-            assert isinstance(version, system.NvlinkVersion)
+            assert isinstance(version, tuple)
+            assert len(version) == 2
+            assert all(isinstance(i, int) for i in version)
 
             with unsupported_before(device, None):
                 state = nvlink_info.state

--- a/cuda_core/tests/system/test_system_events.py
+++ b/cuda_core/tests/system/test_system_events.py
@@ -23,7 +23,7 @@ def test_register_events():
     # Also, some hardware doesn't support any event types.
 
     try:
-        events = system.register_events([system.SystemEventType.GPU_DRIVER_UNBIND])
+        events = system.register_events([system.SystemEventType.UNBIND])
     except system.UnknownError:
         pytest.skip("system events may only be registered once per process")
 

--- a/cuda_core/tests/test_enum_coverage.py
+++ b/cuda_core/tests/test_enum_coverage.py
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify that every NVML enum member has a corresponding entry in the
+# cuda_core wrapper mappings.  No GPU required; the test only inspects
+# mapping dicts at import time, so it runs on any CI host that has a
+# compatible cuda.bindings version.
+
+import importlib
+import inspect
+import pkgutil
+import sys
+
+import pytest
+
+import cuda.core
+from cuda.core import system
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from backports.strenum import StrEnum
+
+# Each entry is:
+#   (mapping_dict, cuda_binding_enum, binding_unmapped, str_enum_unmapped)
+#
+# binding_unmapped: cuda_binding_enum member names intentionally absent from the mapping
+#   (sentinels, deprecated aliases, etc.)
+# str_enum_unmapped: StrEnum member names intentionally absent from the mapping
+#   (fallback sentinels returned by the wrapper via .get(value, default))
+#
+# The first test checks that every member of cuda_binding_enum whose name is NOT
+# in binding_unmapped appears as either a key or a value of the mapping dict,
+# and conversely that every StrEnum member not in str_enum_unmapped also
+# appears.
+_CASES = []
+
+if system.CUDA_BINDINGS_NVML_IS_COMPATIBLE:
+    # Populated below only when NVML bindings are compatible, so that importing
+    # this module on an incompatible host does not raise ImportError.
+    from cuda.bindings import nvml
+    from cuda.core.system import _device, _system_events
+
+    _CASES.extend(
+        [
+            (
+                _device._ADDRESSING_MODE_MAPPING,
+                nvml.DeviceAddressingModeType,
+                # NONE means "no special addressing mode is active"; not a valid target
+                {"DEVICE_ADDRESSING_MODE_NONE"},
+                set(),
+            ),
+            (
+                _device._BRAND_TYPE_MAPPING,
+                nvml.BrandType,
+                # COUNT is a sentinel, not a real brand
+                {"BRAND_COUNT"},
+                set(),  # maps to str, not StrEnum; reverse check is a no-op
+            ),
+            (
+                _device._GPU_P2P_STATUS_MAPPING,
+                nvml.GpuP2PStatus,
+                # Both the typo'd (SUPPORED) and corrected (SUPPORTED) spellings
+                # share the same integer value; the mapping covers both via aliases
+                set(),
+                set(),
+            ),
+            (
+                _device._CLOCKS_EVENT_REASONS_MAPPING,
+                nvml.ClocksEventReasons,
+                set(),
+                set(),
+            ),
+            (
+                _device._EVENT_TYPE_MAPPING,
+                nvml.EventType,
+                set(),
+                set(),
+            ),
+            (
+                _device._FAN_CONTROL_POLICY_MAPPING,
+                nvml.FanControlPolicy,
+                set(),
+                set(),
+            ),
+            (
+                _device._COOLER_CONTROL_MAPPING,
+                nvml.CoolerControl,
+                # NONE means no signal; COUNT is a sentinel
+                {"THERMAL_COOLER_SIGNAL_NONE", "THERMAL_COOLER_SIGNAL_COUNT"},
+                set(),
+            ),
+            (
+                _device._COOLER_TARGET_MAPPING,
+                nvml.CoolerTarget,
+                # GPU_RELATED is a composite bitmask (GPU | MEMORY | POWER_SUPPLY);
+                # the wrapper expands it into individual targets instead of mapping
+                # it as a single entry
+                {"THERMAL_GPU_RELATED"},
+                set(),
+            ),
+            (
+                _device._THERMAL_CONTROLLER_MAPPING,
+                nvml.ThermalController,
+                # NONE and UNKNOWN are both handled by the .get() fallback that
+                # returns ThermalController.UNKNOWN when the value is not in the mapping
+                {"NONE", "UNKNOWN"},
+                # UNKNOWN is the default returned by .get() for unrecognised controllers
+                {"UNKNOWN"},
+            ),
+            (
+                _device._THERMAL_TARGET_MAPPING,
+                nvml.ThermalTarget,
+                # UNKNOWN is a fallback sentinel; handled by .get()
+                {"UNKNOWN"},
+                set(),
+            ),
+            (
+                _device._NVLINK_VERSION_MAPPING,
+                nvml.NvlinkVersion,
+                # VERSION_INVALID is a sentinel for "no NvLink present"
+                {"VERSION_INVALID"},
+                set(),  # maps to tuple, not StrEnum; reverse check is a no-op
+            ),
+            (
+                _system_events._SYSTEM_EVENT_TYPE_MAPPING,
+                nvml.SystemEventType,
+                set(),
+                set(),
+            ),
+            (
+                _device._AFFINITY_SCOPE_MAPPING,
+                nvml.AffinityScope,
+                set(),
+                set(),
+            ),
+            (
+                _device._GPU_P2P_CAPS_INDEX_MAPPING,
+                nvml.GpuP2PCapsIndex,
+                # UNKNOWN is returned by the driver when an index is unrecognised;
+                # it is not a capability the caller selects
+                {"P2P_CAPS_INDEX_UNKNOWN"},
+                # UNKNOWN is a driver-side fallback, not a caller-selectable index
+                {"UNKNOWN"},
+            ),
+            (
+                _device._GPU_TOPOLOGY_LEVEL_MAPPING,
+                nvml.GpuTopologyLevel,
+                set(),
+                set(),
+            ),
+            (
+                _device._CLOCK_ID_MAPPING,
+                nvml.ClockId,
+                # APP_CLOCK_TARGET and APP_CLOCK_DEFAULT are deprecated; COUNT is a sentinel
+                {"APP_CLOCK_TARGET", "APP_CLOCK_DEFAULT", "COUNT"},
+                set(),
+            ),
+            (
+                _device._CLOCK_TYPE_MAPPING,
+                nvml.ClockType,
+                # COUNT is a sentinel
+                {"CLOCK_COUNT"},
+                set(),
+            ),
+            (
+                _device._INFOROM_OBJECT_MAPPING,
+                nvml.InforomObject,
+                # COUNT is a sentinel
+                {"INFOROM_COUNT"},
+                set(),
+            ),
+            (
+                _device._TEMPERATURE_THRESHOLD_MAPPING,
+                nvml.TemperatureThresholds,
+                # COUNT is a sentinel
+                {"TEMPERATURE_THRESHOLD_COUNT"},
+                set(),
+            ),
+        ]
+    )
+
+
+# StrEnum subclasses that intentionally have no associated cuda_binding.
+# Add classes here (with a comment explaining why) when a new StrEnum is
+# introduced that wraps something other than a cuda_binding enum.
+_UNBOUND_STR_ENUMS: frozenset[type] = frozenset()
+
+
+@pytest.mark.parametrize(
+    "mapping, binding, binding_unmapped, str_enum_unmapped",
+    _CASES,
+    ids=[x[1].__name__ for x in _CASES],
+)
+def test_wrapper_covers_all_binding_members(mapping, binding, binding_unmapped, str_enum_unmapped):
+    """Every cuda_binding enum member must appear in the wrapper mapping (or be allow-listed).
+
+    Also checks the reverse: every StrEnum wrapper member must appear in the
+    mapping (or be listed in the per-entry str_enum_unmapped set).
+    """
+    required = set(binding.__members__) - binding_unmapped
+    # Compare by integer value so that enum aliases (two names, one integer)
+    # are treated as covered when the canonical member appears in the mapping.
+    covered_values = frozenset(int(m) for m in (*mapping.keys(), *mapping.values()) if isinstance(m, binding))
+    missing = {name for name in required if int(binding.__members__[name]) not in covered_values}
+    assert not missing, f"{binding.__name__} has members not covered by the wrapper mapping: {missing}"
+
+    # Reverse check: every StrEnum member must also appear in the mapping.
+    str_enum_instances = [m for m in (*mapping.keys(), *mapping.values()) if isinstance(m, StrEnum)]
+    if str_enum_instances:
+        str_enum_cls = type(str_enum_instances[0])
+        required_str = set(str_enum_cls.__members__) - str_enum_unmapped
+        covered_str = {m.name for m in str_enum_instances}
+        missing_str = required_str - covered_str
+        assert not missing_str, f"{str_enum_cls.__name__} has members not covered by the wrapper mapping: {missing_str}"
+
+
+def test_all_str_enums_in_cases():
+    """Every StrEnum subclass in cuda.core must appear in _CASES or _UNBOUND_STR_ENUMS.
+
+    This ensures that when a new StrEnum wrapper is added to cuda.core, the
+    author is prompted to add a binding-coverage entry to _CASES (or explicitly
+    declare it as unbound in _UNBOUND_STR_ENUMS).
+    """
+
+    def discover_str_enums() -> set[type]:
+        """Walk all submodules of cuda.core and return every StrEnum subclass found."""
+        found: set[type] = set()
+        for _, modname, _ in pkgutil.walk_packages(
+            path=cuda.core.__path__,
+            prefix=cuda.core.__name__ + ".",
+            onerror=lambda _: None,
+        ):
+            try:
+                mod = importlib.import_module(modname)
+            except Exception:  # noqa
+                continue
+            try:
+                members = inspect.getmembers(mod, inspect.isclass)
+            except Exception:  # noqa
+                continue
+            for _, obj in members:
+                if obj is not StrEnum and issubclass(obj, StrEnum):
+                    found.add(obj)
+        return found
+
+    covered = {
+        type(obj)
+        for mapping, _, _, _ in _CASES
+        for obj in (*mapping.keys(), *mapping.values())
+        if isinstance(obj, StrEnum)
+    }
+    uncovered = discover_str_enums() - covered - _UNBOUND_STR_ENUMS
+    assert not uncovered, (
+        f"StrEnum subclasses in cuda.core not covered by _CASES: "
+        f"{sorted(c.__qualname__ for c in uncovered)}\n"
+        "Add a _CASES entry for each, or add to _UNBOUND_STR_ENUMS if it does not wrap a cuda_binding enum."
+    )

--- a/cuda_core/tests/test_enum_coverage.py
+++ b/cuda_core/tests/test_enum_coverage.py
@@ -23,8 +23,12 @@ else:
     from backports.strenum import StrEnum
 
 # Each entry is:
-#   (mapping_dict, cuda_binding_enum, binding_unmapped, str_enum_unmapped)
+#   (cuda_binding_enum, str_enum, mapping_dict, binding_unmapped, str_enum_unmapped)
 #
+# cuda_binding_enum: the cuda.bindings NVML enum class
+# str_enum: the cuda_core StrEnum wrapper class, or None if the mapping does
+#   not use a StrEnum (e.g. maps to plain str or tuple)
+# mapping_dict: the dict that maps between the two enum types
 # binding_unmapped: cuda_binding_enum member names intentionally absent from the mapping
 #   (sentinels, deprecated aliases, etc.)
 # str_enum_unmapped: StrEnum member names intentionally absent from the mapping
@@ -32,7 +36,7 @@ else:
 #
 # The first test checks that every member of cuda_binding_enum whose name is NOT
 # in binding_unmapped appears as either a key or a value of the mapping dict,
-# and conversely that every StrEnum member not in str_enum_unmapped also
+# and conversely that every str_enum member not in str_enum_unmapped also
 # appears.
 _CASES = []
 
@@ -45,55 +49,63 @@ if system.CUDA_BINDINGS_NVML_IS_COMPATIBLE:
     _CASES.extend(
         [
             (
-                _device._ADDRESSING_MODE_MAPPING,
                 nvml.DeviceAddressingModeType,
+                _device.AddressingMode,
+                _device._ADDRESSING_MODE_MAPPING,
                 # NONE means "no special addressing mode is active"; not a valid target
                 {"DEVICE_ADDRESSING_MODE_NONE"},
                 set(),
             ),
             (
-                _device._BRAND_TYPE_MAPPING,
                 nvml.BrandType,
+                None,  # maps to plain str, not a StrEnum
+                _device._BRAND_TYPE_MAPPING,
                 # COUNT is a sentinel, not a real brand
                 {"BRAND_COUNT"},
-                set(),  # maps to str, not StrEnum; reverse check is a no-op
+                set(),
             ),
             (
-                _device._GPU_P2P_STATUS_MAPPING,
                 nvml.GpuP2PStatus,
+                _device.GpuP2PStatus,
+                _device._GPU_P2P_STATUS_MAPPING,
                 # Both the typo'd (SUPPORED) and corrected (SUPPORTED) spellings
                 # share the same integer value; the mapping covers both via aliases
                 set(),
                 set(),
             ),
             (
-                _device._CLOCKS_EVENT_REASONS_MAPPING,
                 nvml.ClocksEventReasons,
+                _device.ClocksEventReasons,
+                _device._CLOCKS_EVENT_REASONS_MAPPING,
                 set(),
                 set(),
             ),
             (
-                _device._EVENT_TYPE_MAPPING,
                 nvml.EventType,
+                _device.EventType,
+                _device._EVENT_TYPE_MAPPING,
                 set(),
                 set(),
             ),
             (
-                _device._FAN_CONTROL_POLICY_MAPPING,
                 nvml.FanControlPolicy,
+                _device.FanControlPolicy,
+                _device._FAN_CONTROL_POLICY_MAPPING,
                 set(),
                 set(),
             ),
             (
-                _device._COOLER_CONTROL_MAPPING,
                 nvml.CoolerControl,
+                _device.CoolerControl,
+                _device._COOLER_CONTROL_MAPPING,
                 # NONE means no signal; COUNT is a sentinel
                 {"THERMAL_COOLER_SIGNAL_NONE", "THERMAL_COOLER_SIGNAL_COUNT"},
                 set(),
             ),
             (
-                _device._COOLER_TARGET_MAPPING,
                 nvml.CoolerTarget,
+                _device.CoolerTarget,
+                _device._COOLER_TARGET_MAPPING,
                 # GPU_RELATED is a composite bitmask (GPU | MEMORY | POWER_SUPPLY);
                 # the wrapper expands it into individual targets instead of mapping
                 # it as a single entry
@@ -101,8 +113,9 @@ if system.CUDA_BINDINGS_NVML_IS_COMPATIBLE:
                 set(),
             ),
             (
-                _device._THERMAL_CONTROLLER_MAPPING,
                 nvml.ThermalController,
+                _device.ThermalController,
+                _device._THERMAL_CONTROLLER_MAPPING,
                 # NONE and UNKNOWN are both handled by the .get() fallback that
                 # returns ThermalController.UNKNOWN when the value is not in the mapping
                 {"NONE", "UNKNOWN"},
@@ -110,34 +123,39 @@ if system.CUDA_BINDINGS_NVML_IS_COMPATIBLE:
                 {"UNKNOWN"},
             ),
             (
-                _device._THERMAL_TARGET_MAPPING,
                 nvml.ThermalTarget,
+                _device.ThermalTarget,
+                _device._THERMAL_TARGET_MAPPING,
                 # UNKNOWN is a fallback sentinel; handled by .get()
                 {"UNKNOWN"},
                 set(),
             ),
             (
-                _device._NVLINK_VERSION_MAPPING,
                 nvml.NvlinkVersion,
+                None,  # maps to tuple, not a StrEnum
+                _device._NVLINK_VERSION_MAPPING,
                 # VERSION_INVALID is a sentinel for "no NvLink present"
                 {"VERSION_INVALID"},
-                set(),  # maps to tuple, not StrEnum; reverse check is a no-op
+                set(),
             ),
             (
-                _system_events._SYSTEM_EVENT_TYPE_MAPPING,
                 nvml.SystemEventType,
+                _system_events.SystemEventType,
+                _system_events._SYSTEM_EVENT_TYPE_MAPPING,
                 set(),
                 set(),
             ),
             (
-                _device._AFFINITY_SCOPE_MAPPING,
                 nvml.AffinityScope,
+                _device.AffinityScope,
+                _device._AFFINITY_SCOPE_MAPPING,
                 set(),
                 set(),
             ),
             (
-                _device._GPU_P2P_CAPS_INDEX_MAPPING,
                 nvml.GpuP2PCapsIndex,
+                _device.GpuP2PCapsIndex,
+                _device._GPU_P2P_CAPS_INDEX_MAPPING,
                 # UNKNOWN is returned by the driver when an index is unrecognised;
                 # it is not a capability the caller selects
                 {"P2P_CAPS_INDEX_UNKNOWN"},
@@ -145,35 +163,40 @@ if system.CUDA_BINDINGS_NVML_IS_COMPATIBLE:
                 {"UNKNOWN"},
             ),
             (
-                _device._GPU_TOPOLOGY_LEVEL_MAPPING,
                 nvml.GpuTopologyLevel,
+                _device.GpuTopologyLevel,
+                _device._GPU_TOPOLOGY_LEVEL_MAPPING,
                 set(),
                 set(),
             ),
             (
-                _device._CLOCK_ID_MAPPING,
                 nvml.ClockId,
+                _device.ClockId,
+                _device._CLOCK_ID_MAPPING,
                 # APP_CLOCK_TARGET and APP_CLOCK_DEFAULT are deprecated; COUNT is a sentinel
                 {"APP_CLOCK_TARGET", "APP_CLOCK_DEFAULT", "COUNT"},
                 set(),
             ),
             (
-                _device._CLOCK_TYPE_MAPPING,
                 nvml.ClockType,
+                _device.ClockType,
+                _device._CLOCK_TYPE_MAPPING,
                 # COUNT is a sentinel
                 {"CLOCK_COUNT"},
                 set(),
             ),
             (
-                _device._INFOROM_OBJECT_MAPPING,
                 nvml.InforomObject,
+                _device.InforomObject,
+                _device._INFOROM_OBJECT_MAPPING,
                 # COUNT is a sentinel
                 {"INFOROM_COUNT"},
                 set(),
             ),
             (
-                _device._TEMPERATURE_THRESHOLD_MAPPING,
                 nvml.TemperatureThresholds,
+                _device.TemperatureThresholds,
+                _device._TEMPERATURE_THRESHOLD_MAPPING,
                 # COUNT is a sentinel
                 {"TEMPERATURE_THRESHOLD_COUNT"},
                 set(),
@@ -189,11 +212,11 @@ _UNBOUND_STR_ENUMS: frozenset[type] = frozenset()
 
 
 @pytest.mark.parametrize(
-    "mapping, binding, binding_unmapped, str_enum_unmapped",
+    "binding, str_enum, mapping, binding_unmapped, str_enum_unmapped",
     _CASES,
-    ids=[x[1].__name__ for x in _CASES],
+    ids=[x[0].__name__ for x in _CASES],
 )
-def test_wrapper_covers_all_binding_members(mapping, binding, binding_unmapped, str_enum_unmapped):
+def test_wrapper_covers_all_binding_members(binding, str_enum, mapping, binding_unmapped, str_enum_unmapped):
     """Every cuda_binding enum member must appear in the wrapper mapping (or be allow-listed).
 
     Also checks the reverse: every StrEnum wrapper member must appear in the
@@ -207,13 +230,11 @@ def test_wrapper_covers_all_binding_members(mapping, binding, binding_unmapped, 
     assert not missing, f"{binding.__name__} has members not covered by the wrapper mapping: {missing}"
 
     # Reverse check: every StrEnum member must also appear in the mapping.
-    str_enum_instances = [m for m in (*mapping.keys(), *mapping.values()) if isinstance(m, StrEnum)]
-    if str_enum_instances:
-        str_enum_cls = type(str_enum_instances[0])
-        required_str = set(str_enum_cls.__members__) - str_enum_unmapped
-        covered_str = {m.name for m in str_enum_instances}
+    if str_enum is not None:
+        required_str = set(str_enum.__members__) - str_enum_unmapped
+        covered_str = {m.name for m in (*mapping.keys(), *mapping.values()) if isinstance(m, str_enum)}
         missing_str = required_str - covered_str
-        assert not missing_str, f"{str_enum_cls.__name__} has members not covered by the wrapper mapping: {missing_str}"
+        assert not missing_str, f"{str_enum.__name__} has members not covered by the wrapper mapping: {missing_str}"
 
 
 def test_all_str_enums_in_cases():
@@ -245,12 +266,7 @@ def test_all_str_enums_in_cases():
                     found.add(obj)
         return found
 
-    covered = {
-        type(obj)
-        for mapping, _, _, _ in _CASES
-        for obj in (*mapping.keys(), *mapping.values())
-        if isinstance(obj, StrEnum)
-    }
+    covered = {x[1] for x in _CASES if x[1] is not None}
     uncovered = discover_str_enums() - covered - _UNBOUND_STR_ENUMS
     assert not uncovered, (
         f"StrEnum subclasses in cuda.core not covered by _CASES: "

--- a/cuda_core/tests/test_enum_coverage.py
+++ b/cuda_core/tests/test_enum_coverage.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Verify that every NVML enum member has a corresponding entry in the
+# Verify that every cuda_binding enum member has a corresponding entry in the
 # cuda_core wrapper mappings.  No GPU required; the test only inspects
 # mapping dicts at import time, so it runs on any CI host that has a
 # compatible cuda.bindings version.
@@ -25,7 +25,7 @@ else:
 # Each entry is:
 #   (cuda_binding_enum, str_enum, mapping_dict, binding_unmapped, str_enum_unmapped)
 #
-# cuda_binding_enum: the cuda.bindings NVML enum class
+# cuda_binding_enum: the cuda.bindings enum class
 # str_enum: the cuda_core StrEnum wrapper class, or None if the mapping does
 #   not use a StrEnum (e.g. maps to plain str or tuple)
 # mapping_dict: the dict that maps between the two enum types


### PR DESCRIPTION
This rewraps most of the enums (except the extremely large and unorganized `FieldId`) for `cuda.core.system` rather than passing them directly through.  This also creates an optional string interface for all of these enum values.
