### PR TITLE
[FIX]: pathfinder: Add missing static-lib CUDA 12 path for Windows conda  layouts.

### DIFF
--- a/cuda_pathfinder/cuda/pathfinder/_static_libs/find_static_lib.py
+++ b/cuda_pathfinder/cuda/pathfinder/_static_libs/find_static_lib.py
@@ -28,7 +28,7 @@ class LocatedStaticLib:
 class _StaticLibInfo(TypedDict):
     filename: str
     ctk_rel_paths: tuple[str, ...]
-    conda_rel_path: str
+    conda_rel_paths: tuple[str, ...]
     site_packages_dirs: tuple[str, ...]
 
 
@@ -36,7 +36,7 @@ _SUPPORTED_STATIC_LIBS_INFO: dict[str, _StaticLibInfo] = {
     "cudadevrt": {
         "filename": "cudadevrt.lib" if IS_WINDOWS else "libcudadevrt.a",
         "ctk_rel_paths": (os.path.join("lib", "x64"),) if IS_WINDOWS else ("lib64", "lib"),
-        "conda_rel_path": os.path.join("lib", "x64") if IS_WINDOWS else "lib",
+        "conda_rel_paths": ((os.path.join("lib", "x64"), "lib") if IS_WINDOWS else ("lib",)),
         "site_packages_dirs": (
             ("nvidia/cu13/lib/x64", "nvidia/cuda_runtime/lib/x64")
             if IS_WINDOWS
@@ -66,7 +66,7 @@ class _FindStaticLib:
         self.config: _StaticLibInfo = _SUPPORTED_STATIC_LIBS_INFO[name]
         self.filename: str = self.config["filename"]
         self.ctk_rel_paths: tuple[str, ...] = self.config["ctk_rel_paths"]
-        self.conda_rel_path: str = self.config["conda_rel_path"]
+        self.conda_rel_paths: tuple[str, ...] = self.config["conda_rel_paths"]
         self.site_packages_dirs: tuple[str, ...] = self.config["site_packages_dirs"]
         self.error_messages: list[str] = []
         self.attachments: list[str] = []
@@ -86,9 +86,10 @@ class _FindStaticLib:
             return None
 
         anchor = os.path.join(conda_prefix, "Library") if IS_WINDOWS else conda_prefix
-        file_path = os.path.join(anchor, self.conda_rel_path, self.filename)
-        if os.path.isfile(file_path):
-            return file_path
+        for rel_path in self.conda_rel_paths:
+            file_path = os.path.join(anchor, rel_path, self.filename)
+            if os.path.isfile(file_path):
+                return file_path
         return None
 
     def try_with_cuda_home(self) -> str | None:

--- a/cuda_pathfinder/tests/test_find_static_lib.py
+++ b/cuda_pathfinder/tests/test_find_static_lib.py
@@ -78,7 +78,7 @@ def test_locate_static_lib(info_summary_append, libname):
 @pytest.mark.usefixtures("clear_find_static_lib_cache")
 def test_locate_static_lib_search_order(monkeypatch, tmp_path):
     filename = CUDADEVRT_INFO["filename"]
-    conda_rel_path = CUDADEVRT_INFO["conda_rel_path"]
+    conda_rel_path = CUDADEVRT_INFO["conda_rel_paths"][0]
 
     site_pkg_rel = CUDADEVRT_INFO["site_packages_dirs"][0]
     site_packages_lib_dir = tmp_path / "site-packages" / Path(site_pkg_rel.replace("/", os.sep))
@@ -115,6 +115,32 @@ def test_locate_static_lib_search_order(monkeypatch, tmp_path):
     located_lib = locate_static_lib("cudadevrt")
     assert located_lib.abs_path == cuda_home_path
     assert located_lib.found_via == "CUDA_PATH"
+
+
+@pytest.mark.usefixtures("clear_find_static_lib_cache")
+def test_locate_static_lib_conda_rel_path_fallback(monkeypatch, tmp_path):
+    filename = CUDADEVRT_INFO["filename"]
+    conda_rel_paths = CUDADEVRT_INFO["conda_rel_paths"]
+    if len(conda_rel_paths) == 1:
+        monkeypatch.setitem(CUDADEVRT_INFO, "conda_rel_paths", ("missing-first", conda_rel_paths[0]))
+        conda_rel_paths = CUDADEVRT_INFO["conda_rel_paths"]
+
+    conda_prefix = tmp_path / "conda-prefix"
+    conda_lib_dir = _conda_anchor(conda_prefix) / Path(conda_rel_paths[1])
+    conda_path = _make_static_lib_file(conda_lib_dir, filename)
+
+    monkeypatch.setattr(
+        find_static_lib_module,
+        "find_sub_dirs_all_sitepackages",
+        lambda _sub_dir: [],
+    )
+    monkeypatch.setenv("CONDA_PREFIX", str(conda_prefix))
+    monkeypatch.delenv("CUDA_HOME", raising=False)
+    monkeypatch.delenv("CUDA_PATH", raising=False)
+
+    located_lib = locate_static_lib("cudadevrt")
+    assert located_lib.abs_path == conda_path
+    assert located_lib.found_via == "conda"
 
 
 @pytest.mark.usefixtures("clear_find_static_lib_cache")


### PR DESCRIPTION
Latent bug discovered while testing PR #1977 (xref issue #1038) with Windows Conda.

**Source change — `find_static_lib.py`**

- The `_StaticLibInfo` schema had a single conda lookup directory per library (`conda_rel_path: str`). On Windows that was hard-coded to `Library/lib/x64`, but only CUDA 13 conda environments lay `cudadevrt.lib` out that way; CUDA 12 conda environments put it in `Library/lib`. So on a Windows + CUDA 12 conda setup, pathfinder skipped the conda anchor entirely and fell through to `CUDA_PATH`, often producing a misleading "not found" error pointing at the wrong location.
- The fix changes the schema to a *tuple* of lookup paths (`conda_rel_paths: tuple[str, ...]`) so each lib can declare every layout it knows about. For `cudadevrt`:
  - Windows: `("lib/x64", "lib")` — try the CUDA 13 layout first, fall back to the CUDA 12 layout.
  - Linux: `("lib",)` — unchanged, single entry.
- `_FindStaticLib.try_with_conda_prefix` now loops through `self.conda_rel_paths` and returns the first hit instead of probing one fixed subdirectory.

**Test change — `test_find_static_lib.py`**

- Existing search-order test (`test_locate_static_lib_search_order`) is updated mechanically: `CUDADEVRT_INFO["conda_rel_path"]` → `CUDADEVRT_INFO["conda_rel_paths"][0]`.
- New test `test_locate_static_lib_conda_rel_path_fallback`:
  - Asserts the fallback semantic by injecting a deliberately-missing first entry (`"missing-first"`) when the platform only ships a single path. On Windows, where the tuple already has two entries, it uses them as-is.
  - Drops the file at the *second* listed path under the conda anchor and verifies `locate_static_lib("cudadevrt")` finds it with `found_via="conda"`.
  - Real coverage: confirms the loop tries entries in order and a missing first entry doesn't abort the search.

Real (not mock-based) testing was reported here:

* https://github.com/NVIDIA/cuda-python/pull/1977#issuecomment-4332733658 — **PR 1977 conda testing results analysis**
