### PR TITLE
cuda.core: rename HostCallbackNode.callback_fn to callback

### DIFF
--- a/cuda_core/cuda/core/graph/_subclasses.pyx
+++ b/cuda_core/cuda/core/graph/_subclasses.pyx
@@ -573,7 +573,7 @@ cdef class HostCallbackNode(GraphNode):
 
     Properties
     ----------
-    callback_fn : callable or None
+    callback : callable or None
         The Python callable (None for ctypes function pointer callbacks).
     """
 
@@ -613,7 +613,7 @@ cdef class HostCallbackNode(GraphNode):
                 f" cfunc=0x{<uintptr_t>self._fn:x}>")
 
     @property
-    def callback_fn(self):
+    def callback(self):
         """The Python callable, or None for ctypes function pointer callbacks."""
         return self._callable
 

--- a/cuda_core/docs/source/release/1.0.0-notes.rst
+++ b/cuda_core/docs/source/release/1.0.0-notes.rst
@@ -87,6 +87,10 @@ Breaking changes
   - New: ``kernel.attributes.num_regs`` and
     ``kernel.attributes[some_dev].num_regs``
 
+- Renamed :attr:`graph.HostCallbackNode.callback_fn` to
+  :attr:`graph.HostCallbackNode.callback` to drop the redundant ``_fn`` suffix
+  (`#1945 <https://github.com/NVIDIA/cuda-python/issues/1945>`__).
+
 - Unified the conditional graph API on :class:`~graph.GraphCondition`
   and consistent verbs
   (`#1945 <https://github.com/NVIDIA/cuda-python/issues/1945>`__):

--- a/cuda_core/tests/graph/test_graph_definition.py
+++ b/cuda_core/tests/graph/test_graph_definition.py
@@ -386,7 +386,7 @@ def _build_host_callback_node(g):
 
     node = g.callback(my_callback)
     return node, {
-        "callback_fn": lambda v: v is my_callback,
+        "callback": lambda v: v is my_callback,
     }
 
 


### PR DESCRIPTION
## Summary

Renames `HostCallbackNode.callback_fn` to `callback`. This was missed during the earlier change addressing the naming audit (#1945).

## Changes

- `HostCallbackNode.callback_fn` -> `HostCallbackNode.callback` (property + docstring entry).
- Test assertion key in `test_graph_definition.py` updated.
- v1.0.0 release note added under "Breaking changes".