### PR TITLE
[skip-ci] Add note about minimum cuda_bindings version

### DIFF
--- a/cuda_core/docs/source/api.rst
+++ b/cuda_core/docs/source/api.rst
@@ -245,6 +245,9 @@ execution.
 CUDA system information and NVIDIA Management Library (NVML)
 ------------------------------------------------------------
 
+.. note::
+   ``cuda.core.system`` support requires ``cuda_bindings`` 12.9.6 or later, or 13.2.0 or later.
+
 Basic functions
 ```````````````
 


### PR DESCRIPTION
This should hopefully avoid a little confusion about `cuda.core.system`.
