### PR TITLE
Fix missing binding version checks alongside driver version checks

### DIFF
--- a/cuda_core/cuda/core/_module.pyx
+++ b/cuda_core/cuda/core/_module.pyx
@@ -32,7 +32,7 @@ from cuda.core._utils.clear_error_support import (
     raise_code_path_meant_to_be_unreachable,
 )
 from cuda.core._utils.cuda_utils cimport HANDLE_RETURN
-from cuda.core._utils.version cimport cy_driver_version
+from cuda.core._utils.version cimport cy_binding_version, cy_driver_version
 from cuda.core._utils.cuda_utils import driver
 from cuda.bindings cimport cydriver
 
@@ -462,6 +462,11 @@ cdef class Kernel:
             raise NotImplementedError(
                 "Driver version 12.4 or newer is required for this function. "
                 f"Using driver version {'.'.join(map(str, cy_driver_version()))}"
+            )
+        if cy_binding_version() < (12, 4, 0):
+            raise NotImplementedError(
+                "cuda.bindings 12.4 or newer is required for this function. "
+                f"Using binding version {'.'.join(map(str, cy_binding_version()))}"
             )
         cdef size_t arg_pos = 0
         cdef list param_info_data = []

--- a/cuda_core/cuda/core/graph/_subclasses.pyx
+++ b/cuda_core/cuda/core/graph/_subclasses.pyx
@@ -60,8 +60,10 @@ cdef bint _version_checked = False
 cdef bint _check_node_get_params():
     global _has_cuGraphNodeGetParams, _version_checked
     if not _version_checked:
-        from cuda.core._utils.version import driver_version
-        _has_cuGraphNodeGetParams = driver_version() >= (13, 2, 0)
+        from cuda.core._utils.version import binding_version, driver_version
+        _has_cuGraphNodeGetParams = (
+            driver_version() >= (13, 2, 0) and binding_version() >= (13, 2, 0)
+        )
         _version_checked = True
     return _has_cuGraphNodeGetParams
 

--- a/cuda_core/tests/graph/test_graph_definition.py
+++ b/cuda_core/tests/graph/test_graph_definition.py
@@ -48,13 +48,13 @@ def _skip_if_no_managed_mempool():
         pytest.skip("Device does not support managed memory pool operations")
 
 
-def _driver_has_node_get_params():
-    from cuda.core._utils.version import driver_version
+def _has_node_get_params():
+    from cuda.core._utils.version import binding_version, driver_version
 
-    return driver_version() >= (13, 2, 0)
+    return driver_version() >= (13, 2, 0) and binding_version() >= (13, 2, 0)
 
 
-_HAS_NODE_GET_PARAMS = _driver_has_node_get_params()
+_HAS_NODE_GET_PARAMS = _has_node_get_params()
 
 
 def _bindings_major_version():


### PR DESCRIPTION
## Summary

Fixes #2052. Audited all version checks introduced by #1825 and found two additional source-level instances (plus one test helper) where only the driver version was checked but the binding version was not.

When `cuda-bindings` is older than the CUDA driver, the driver version gate passes but the corresponding binding attribute/symbol is absent, causing `AttributeError` (Python-level) or similar failures (Cython-level).

- `graph/_subclasses.pyx`: `_check_node_get_params()` now also checks `binding_version() >= (13, 2, 0)` (the bug reported in #2052)
- `_module.pyx`: `_get_arguments_info()` now also checks `cy_binding_version() >= (12, 4, 0)` (gates `cuKernelGetParamInfo`, exposed via `Kernel.num_arguments` / `Kernel.arguments_info`)
- `tests/graph/test_graph_definition.py`: `_driver_has_node_get_params()` renamed to `_has_node_get_params()` and checks both versions

## Test plan

- [ ] Verify existing tests pass (no functional change when driver and bindings are at the same version)
- [ ] With bindings 13.1 + driver 13.2: conditional node reconstruction should gracefully fall back to `ConditionalNode` instead of crashing
- [ ] With bindings < 12.4 + driver >= 12.4: `Kernel.num_arguments` should raise `NotImplementedError` instead of crashing