### PR TITLE
BUG: Handle CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM correctly

### DIFF
--- a/cuda_bindings/cuda/bindings/_bindings/cydriver.pyx.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cydriver.pyx.in
@@ -519,7 +519,7 @@ cdef int _cuPythonInit() except -1 nogil:
     cdef char libPath[260]
 
     with gil, __symbol_lock:
-        usePTDS = os.getenv('CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM', default=0)
+        usePTDS = bool(int(os.getenv('CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM', default=0)))
 
         # Load library
         libPath[0] = 0

--- a/cuda_bindings/cuda/bindings/_bindings/cyruntime.pyx.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cyruntime.pyx.in
@@ -15,7 +15,7 @@ cdef int _cudaPythonInit() except -1 nogil:
         global __usePTDS
 
         with gil:
-            __usePTDS = os.getenv('CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM', default=False)
+            __usePTDS = bool(int(os.getenv('CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM', default=0)))
         __cudaPythonInit = True
         return __usePTDS
 

--- a/cuda_bindings/docs/source/release/13.2.1-notes.rst
+++ b/cuda_bindings/docs/source/release/13.2.1-notes.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 .. SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 .. module:: cuda.bindings

--- a/cuda_bindings/docs/source/release/13.2.1-notes.rst
+++ b/cuda_bindings/docs/source/release/13.2.1-notes.rst
@@ -1,0 +1,14 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
+
+.. module:: cuda.bindings
+
+``cuda-bindings`` 13.2.1 Release notes
+======================================
+
+Bugfixes
+--------
+
+* Per-thread default stream mode would be used whenever the
+  ``CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM`` environment variable was set,
+  even if it was set to ``0``.

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -133,7 +133,7 @@ status_from_rc() {
 run_pytest() {
   # Run pytest safely under set -e and return its exit code
   set +e
-  python -m pytest "${PYTEST_FLAGS[@]}" "$@"
+  CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM=0 python -m pytest "${PYTEST_FLAGS[@]}" "$@"
   local rc=$?
   set -e
   return ${rc}


### PR DESCRIPTION
As @leofang pointed out [here](https://github.com/NVIDIA/cuda-python/pull/1972/files/9bb9f5a62a625d0fe117349b67de10d9c62d43c3#diff-05f9f01058c2371b760076824cb01359afd9373333cbd2c480815ce2bf385974)...

Per-thread default stream would be enabled if `CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM` was set to any value, including '0'.