### PR TITLE
test: skip IPC peer access tests when IPC is unavailable

### DIFF
--- a/cuda_core/tests/conftest.py
+++ b/cuda_core/tests/conftest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import multiprocessing
@@ -284,6 +284,20 @@ def mempool_device_x2():
 def mempool_device_x3():
     """Fixture that provides three devices if available, otherwise skips test."""
     return _mempool_device_impl(3)
+
+
+@pytest.fixture
+def ipc_mempool_device_x2(mempool_device_x2):
+    """Fixture that provides two IPC-capable mempool devices, or skips."""
+    from helpers import IS_WSL, supports_ipc_mempool
+
+    if not all(device.properties.handle_type_posix_file_descriptor_supported for device in mempool_device_x2):
+        pytest.skip("Device does not support IPC")
+
+    if IS_WSL or not all(supports_ipc_mempool(device) for device in mempool_device_x2):
+        pytest.skip("Driver rejects IPC-enabled mempool creation on this platform")
+
+    return mempool_device_x2
 
 
 @pytest.fixture(

--- a/cuda_core/tests/conftest.py
+++ b/cuda_core/tests/conftest.py
@@ -133,6 +133,21 @@ def _device_id_from_resource_options(device, args, kwargs):
     return 0
 
 
+def _require_ipc_mempool_devices(devices):
+    """Return devices if they all support IPC-enabled mempools, otherwise skip."""
+    from helpers import IS_WSL, supports_ipc_mempool
+
+    checked_devices = tuple(devices)
+
+    if not all(device.properties.handle_type_posix_file_descriptor_supported for device in checked_devices):
+        pytest.skip("Device does not support IPC")
+
+    if IS_WSL or not all(supports_ipc_mempool(device) for device in checked_devices):
+        pytest.skip("Driver rejects IPC-enabled mempool creation on this platform")
+
+    return devices
+
+
 @pytest.fixture(scope="session", autouse=True)
 def session_setup():
     # Always init CUDA.
@@ -199,25 +214,13 @@ def deinit_all_contexts_function():
 @pytest.fixture
 def ipc_device():
     """Obtains a device suitable for IPC-enabled mempool tests, or skips."""
-    # Check if IPC is supported on this platform/device
     device = Device(0)
     device.set_current()
 
     if not device.properties.memory_pools_supported:
         pytest.skip("Device does not support mempool operations")
 
-    # Note: Linux specific. Once Windows support for IPC is implemented, this
-    # test should be updated.
-    if not device.properties.handle_type_posix_file_descriptor_supported:
-        pytest.skip("Device does not support IPC")
-
-    # Skip on WSL or if driver rejects IPC-enabled mempool creation on this platform/device
-    from helpers import IS_WSL, supports_ipc_mempool
-
-    if IS_WSL or not supports_ipc_mempool(device):
-        pytest.skip("Driver rejects IPC-enabled mempool creation on this platform")
-
-    return device
+    return _require_ipc_mempool_devices((device,))[0]
 
 
 @pytest.fixture(
@@ -289,15 +292,7 @@ def mempool_device_x3():
 @pytest.fixture
 def ipc_mempool_device_x2(mempool_device_x2):
     """Fixture that provides two IPC-capable mempool devices, or skips."""
-    from helpers import IS_WSL, supports_ipc_mempool
-
-    if not all(device.properties.handle_type_posix_file_descriptor_supported for device in mempool_device_x2):
-        pytest.skip("Device does not support IPC")
-
-    if IS_WSL or not all(supports_ipc_mempool(device) for device in mempool_device_x2):
-        pytest.skip("Driver rejects IPC-enabled mempool creation on this platform")
-
-    return mempool_device_x2
+    return _require_ipc_mempool_devices(mempool_device_x2)
 
 
 @pytest.fixture(

--- a/cuda_core/tests/memory_ipc/test_peer_access.py
+++ b/cuda_core/tests/memory_ipc/test_peer_access.py
@@ -21,8 +21,8 @@ class TestPeerAccessNotPreservedOnImport:
     """
 
     @pytest.mark.flaky(reruns=2)
-    def test_main(self, mempool_device_x2):
-        dev0, dev1 = mempool_device_x2
+    def test_main(self, ipc_mempool_device_x2):
+        dev0, dev1 = ipc_mempool_device_x2
 
         # Parent Process - Create and Configure MR
         dev1.set_current()
@@ -61,8 +61,8 @@ class TestBufferPeerAccessAfterImport:
 
     @pytest.mark.flaky(reruns=2)
     @pytest.mark.parametrize("grant_access_in_parent", [True, False])
-    def test_main(self, mempool_device_x2, grant_access_in_parent):
-        dev0, dev1 = mempool_device_x2
+    def test_main(self, ipc_mempool_device_x2, grant_access_in_parent):
+        dev0, dev1 = ipc_mempool_device_x2
 
         # Parent Process - Create MR and Buffer
         dev1.set_current()


### PR DESCRIPTION
nvbug 6176793

Problem:
FAILED memory_ipc\test_peer_access.py::TestPeerAccessNotPreservedOnImport::test_main - RuntimeError: IPC is not available on Windows
FAILED memory_ipc\test_peer_access.py::TestBufferPeerAccessAfterImport::test_main[True] - RuntimeError: IPC is not available on Windows
FAILED memory_ipc\test_peer_access.py::TestBufferPeerAccessAfterImport::test_main[False] - RuntimeError: IPC is not available on Windows

The three tests in `cuda_core/tests/memory_ipc/test_peer_access.py` depend on the `mempool_device_x2` fixture, which only checks for two GPUs with mutual peer access — it does not check for IPC support.

The fix is to add an `ipc_mempool_device_x2` fixture in `cuda_core/tests/conftest.py` that composes `mempool_device_x2` with the same IPC-capability checks already used by `ipc_device` . 

After the fix, the tests could be successfully skipped.
tests/memory_ipc/test_peer_access.py::TestPeerAccessNotPreservedOnImport::test_main SKIPPED (Device does not...)
tests/memory_ipc/test_peer_access.py::TestBufferPeerAccessAfterImport::test_main[True] SKIPPED (Device does ...)
tests/memory_ipc/test_peer_access.py::TestBufferPeerAccessAfterImport::test_main[False] SKIPPED (Device does...)
