### PR TITLE
Harden pinned NUMA mempool tests against constructor OOM flakes

### DIFF
--- a/cuda_core/tests/test_memory.py
+++ b/cuda_core/tests/test_memory.py
@@ -1474,11 +1474,11 @@ def test_pinned_mr_numa_id_default_no_ipc(init_cuda):
     device = Device()
     skip_if_pinned_memory_unsupported(device)
 
-    mr = PinnedMemoryResource(PinnedMemoryResourceOptions())
+    mr = create_pinned_memory_resource_or_xfail(PinnedMemoryResourceOptions(), xfail_device=device)
     assert mr.numa_id == -1
     mr.close()
 
-    mr = PinnedMemoryResource(PinnedMemoryResourceOptions(ipc_enabled=False))
+    mr = create_pinned_memory_resource_or_xfail(PinnedMemoryResourceOptions(ipc_enabled=False), xfail_device=device)
     assert mr.numa_id == -1
     mr.close()
 
@@ -1497,7 +1497,9 @@ def test_pinned_mr_numa_id_default_with_ipc(init_cuda):
     if expected_numa_id < 0:
         pytest.skip("System does not support NUMA")
 
-    mr = PinnedMemoryResource(PinnedMemoryResourceOptions(ipc_enabled=True, max_size=POOL_SIZE))
+    mr = create_pinned_memory_resource_or_xfail(
+        PinnedMemoryResourceOptions(ipc_enabled=True, max_size=POOL_SIZE), xfail_device=device
+    )
     assert mr.numa_id == expected_numa_id
     mr.close()
 
@@ -1511,7 +1513,7 @@ def test_pinned_mr_numa_id_explicit(init_cuda):
     if host_numa_id < 0:
         pytest.skip("System does not support NUMA")
 
-    mr = PinnedMemoryResource(PinnedMemoryResourceOptions(numa_id=host_numa_id))
+    mr = create_pinned_memory_resource_or_xfail(PinnedMemoryResourceOptions(numa_id=host_numa_id), xfail_device=device)
     assert mr.numa_id == host_numa_id
     mr.close()
 
@@ -1520,7 +1522,10 @@ def test_pinned_mr_numa_id_explicit(init_cuda):
     if not supports_ipc_mempool(device):
         pytest.skip("Driver rejects IPC-enabled mempool creation on this platform")
 
-    mr = PinnedMemoryResource(PinnedMemoryResourceOptions(ipc_enabled=True, numa_id=host_numa_id, max_size=POOL_SIZE))
+    mr = create_pinned_memory_resource_or_xfail(
+        PinnedMemoryResourceOptions(ipc_enabled=True, numa_id=host_numa_id, max_size=POOL_SIZE),
+        xfail_device=device,
+    )
     assert mr.numa_id == host_numa_id
     mr.close()
 


### PR DESCRIPTION
This is a small follow-up to PR #2084.

The `cuda_core_5.15.log` attached to `nvbug 5815123` shows two remaining intermittent `cuda_core` failures after the PR #2084 patch:

- `tests/test_memory.py::test_pinned_mr_numa_id_default_no_ipc`
- `tests/test_memory.py::test_pinned_mr_numa_id_explicit`

Both tests are meant to validate `PinnedMemoryResource.numa_id` behavior, but they instantiate `PinnedMemoryResource(PinnedMemoryResourceOptions(...))` directly. Those constructor paths create a real pinned memory pool immediately, so they can still hit the same constructor-time `CUDA_ERROR_OUT_OF_MEMORY` failure mode that is already handled elsewhere in the Windows mempool workaround coverage.

This change routes those constructor sites through the existing `create_pinned_memory_resource_or_xfail(...)` helper. It also updates the nearby `test_pinned_mr_numa_id_default_with_ipc` case for consistency, since it exercises the same pool-creation path.

The goal is to keep these tests focused on NUMA-ID semantics instead of failing on the known Windows MCDM mempool-constructor flake.

___

xref: `nvbug 5815123`