### PR TITLE
cuda.core: bump tensor bridge PyTorch upper-bound to 2.12

### DIFF
--- a/cuda_core/cuda/core/_memoryview.pyx
+++ b/cuda_core/cuda/core/_memoryview.pyx
@@ -43,7 +43,7 @@ cdef dict _torch_type_cache = {}
 cdef object _torch_version_ok = None
 
 cdef inline bint _torch_version_check():
-    """Return True if 2.3 <= torch <= 2.11 (known AOTI ABI range). Memoized.
+    """Return True if 2.3 <= torch <= 2.12 (known AOTI ABI range). Memoized.
 
     Lower bound: AOTI functions we use were introduced in PyTorch 2.3.
     Upper bound: the ``pyobj_to_aten_handle`` trick relies on the
@@ -64,7 +64,7 @@ cdef inline bint _torch_version_check():
     try:
         major, minor = int(torch.__version__.split(".")[0]), \
                        int(torch.__version__.split(".")[1])
-        _torch_version_ok = (2, 3) <= (major, minor) <= (2, 11)
+        _torch_version_ok = (2, 3) <= (major, minor) <= (2, 12)
     except (ValueError, IndexError):
         _torch_version_ok = False
     return <bint>_torch_version_ok


### PR DESCRIPTION
Closes #2089.

## Problem

PyTorch 2.12 was released on ~May 14 2026. The version guard in `_torch_version_check()` (`cuda_core/cuda/core/_memoryview.pyx`) capped the AOTI tensor bridge at `(2, 11)`, so `_is_torch_tensor()` returned `False` for any torch tensor under 2.12.

As a result, torch tensors fell through to the generic CAI/DLPack paths and raised:

```
BufferError: only CUDA Array Interface v3 or above is supported
```

## Fix

Extend the upper bound from `(2, 11)` to `(2, 12)`. The `THPVariable` struct layout (`PyObject_HEAD` followed by `at::Tensor cdata`) and the `AtenTensorHandle == at::Tensor*` identity are stable across PyTorch 2.x minor releases, as they have been across 2.3–2.11.

```diff
-    _torch_version_ok = (2, 3) <= (major, minor) <= (2, 11)
+    _torch_version_ok = (2, 3) <= (major, minor) <= (2, 12)
```

## Testing

This change cannot be exercised without a PyTorch 2.12 build in CI. The existing tensor bridge tests (`cuda_core/tests/`) cover the code path; they will validate correctness once a 2.12 runner is available. The nightly CI matrix already references a `latest` PyTorch entry (see `nightly.yml`) which should pick up 2.12.