### PR TITLE
docs: fix test and example typos

### DIFF
--- a/cuda_bindings/examples/2_Concepts_and_Techniques/stream_ordered_allocation.py
+++ b/cuda_bindings/examples/2_Concepts_and_Techniques/stream_ordered_allocation.py
@@ -137,7 +137,7 @@ def stream_ordered_allocation_post_sync(dev, nelem, a, b, c):
             threshold_val,
         )
     )
-    # Record teh start event
+    # Record the start event
     check_cuda_errors(cudart.cudaEventRecord(start, stream))
     for _i in range(MAX_ITER):
         d_a = check_cuda_errors(cudart.cudaMallocAsync(num_bytes, stream))

--- a/cuda_core/tests/memory_ipc/test_leaks.py
+++ b/cuda_core/tests/memory_ipc/test_leaks.py
@@ -33,7 +33,7 @@ def test_alloc_handle(ipc_memory_resource):
 
 
 def exec_success(obj, number=1):
-    """Succesfully run a child process."""
+    """Successfully run a child process."""
     for _ in range(number):
         process = mp.Process(target=child_main, args=(obj,))
         process.start()


### PR DESCRIPTION
## Summary

Fixes two spelling typos in a test docstring and CUDA bindings example comment.

## Files changed

- `cuda_core/tests/memory_ipc/test_leaks.py`: `Succesfully` -> `Successfully`
- `cuda_bindings/examples/2_Concepts_and_Techniques/stream_ordered_allocation.py`: `teh` -> `the`

## Before / after

Before, a test helper docstring and example comment contained spelling typos. After, the text is corrected with no behavior change.

## Verification

- Inspected the diff to confirm these are docstring/comment-only changes.
- Ran `rg "Succesfully run a child process|Record teh start event" cuda_core/tests/memory_ipc/test_leaks.py cuda_bindings/examples/2_Concepts_and_Techniques/stream_ordered_allocation.py` and confirmed no matches.
- Did not run CUDA-dependent tests/examples locally because the change does not affect executable behavior and requires CUDA runtime coverage.

## Competing PR check

Checked for existing PRs with:

- `gh pr list --repo NVIDIA/cuda-python --search "Succesfully run a child process" --state all --limit 10`
- `gh pr list --repo NVIDIA/cuda-python --search "Record teh start event" --state all --limit 10`

No matching PRs were returned.