### PR TITLE
[no-ci] CI: stop trusting public read permission in restricted paths guard

### DIFF
--- a/.github/workflows/restricted-paths-guard.yml
+++ b/.github/workflows/restricted-paths-guard.yml
@@ -6,8 +6,7 @@ name: "CI: Restricted Paths Guard"
 on:
   # Run on drafts too so maintainers get early awareness on WIP PRs.
   # Label updates on fork PRs require pull_request_target permissions.
-  # TEMPORARY: Using pull_request for testing; revert to pull_request_target before merge.
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize

--- a/.github/workflows/restricted-paths-guard.yml
+++ b/.github/workflows/restricted-paths-guard.yml
@@ -6,7 +6,8 @@ name: "CI: Restricted Paths Guard"
 on:
   # Run on drafts too so maintainers get early awareness on WIP PRs.
   # Label updates on fork PRs require pull_request_target permissions.
-  pull_request_target:
+  # TEMPORARY: Using pull_request for testing; revert to pull_request_target before merge.
+  pull_request:
     types:
       - opened
       - synchronize

--- a/.github/workflows/restricted-paths-guard.yml
+++ b/.github/workflows/restricted-paths-guard.yml
@@ -217,7 +217,7 @@ jobs:
               fi
 
               case "$COLLABORATOR_PERMISSION" in
-                admin|maintain|write|triage)
+                admin|maintain|triage)
                   HAS_TRUSTED_SIGNAL=true
                   LABEL_ACTION="not needed (collaborator permission is a trusted signal)"
                   TRUSTED_SIGNALS="collaborator_permission:$COLLABORATOR_PERMISSION"

--- a/.github/workflows/restricted-paths-guard.yml
+++ b/.github/workflows/restricted-paths-guard.yml
@@ -217,7 +217,7 @@ jobs:
               fi
 
               case "$COLLABORATOR_PERMISSION" in
-                admin|maintain|triage)
+                admin|maintain|write|triage)
                   HAS_TRUSTED_SIGNAL=true
                   LABEL_ACTION="not needed (collaborator permission is a trusted signal)"
                   TRUSTED_SIGNALS="collaborator_permission:$COLLABORATOR_PERMISSION"

--- a/.github/workflows/restricted-paths-guard.yml
+++ b/.github/workflows/restricted-paths-guard.yml
@@ -24,8 +24,8 @@ jobs:
     steps:
       - name: Inspect PR author signals for restricted paths
         env:
-          # PR metadata inputs (author_association from event payload is
-          # unreliable for fork PRs, so we query the collaborator API directly)
+          # PR metadata inputs (the event payload's author_association can be
+          # stale for fork PRs, so restricted-path PRs query the live PR API).
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -42,6 +42,8 @@ jobs:
 
           COLLABORATOR_PERMISSION="not checked"
           COLLABORATOR_PERMISSION_API_ERROR=""
+          AUTHOR_ASSOCIATION="not checked"
+          AUTHOR_ASSOCIATION_API_ERROR=""
 
           if ! MATCHING_RESTRICTED_PATHS=$(
             gh api \
@@ -68,6 +70,7 @@ jobs:
               echo ""
               echo "- **Error**: Failed to inspect the PR file list."
               echo "- **Author**: $PR_AUTHOR"
+              echo "- **Author association**: $AUTHOR_ASSOCIATION"
               echo "- **Collaborator permission**: $COLLABORATOR_PERMISSION"
               echo ""
               echo "Please update the PR at: $PR_URL"
@@ -88,6 +91,7 @@ jobs:
               echo ""
               echo "- **Error**: Failed to inspect the current PR labels."
               echo "- **Author**: $PR_AUTHOR"
+              echo "- **Author association**: $AUTHOR_ASSOCIATION"
               echo "- **Collaborator permission**: $COLLABORATOR_PERMISSION"
               echo ""
               echo "Please update the PR at: $PR_URL"
@@ -114,6 +118,13 @@ jobs:
             echo '```'
           }
 
+          write_author_association_api_error() {
+            echo "- **Author association API error**:"
+            echo '```text'
+            printf '%s\n' "$AUTHOR_ASSOCIATION_API_ERROR"
+            echo '```'
+          }
+
           post_review_label_comment() {
             local comment_body
             printf -v comment_body '%s\n\n%s\n' \
@@ -135,46 +146,87 @@ jobs:
           COMMENT_ACTION="not needed"
 
           if [ "$TOUCHES_RESTRICTED_PATHS" = "true" ]; then
-            # Distinguish a legitimate 404 "not a collaborator" response from
-            # actual API failures. The former is an expected untrusted case;
-            # the latter fails the workflow so it can be rerun later.
-            if COLLABORATOR_PERMISSION_RESPONSE=$(
-              gh api "repos/$REPO/collaborators/$PR_AUTHOR/permission" \
-                --jq '.permission' 2>&1
+            if AUTHOR_ASSOCIATION_RESPONSE=$(
+              gh api "repos/$REPO/pulls/$PR_NUMBER" \
+                --jq '.author_association // "NONE"' 2>&1
             ); then
-              COLLABORATOR_PERMISSION="$COLLABORATOR_PERMISSION_RESPONSE"
-            elif [[ "$COLLABORATOR_PERMISSION_RESPONSE" == *"(HTTP 404)"* ]]; then
-              COLLABORATOR_PERMISSION="none"
+              AUTHOR_ASSOCIATION="$AUTHOR_ASSOCIATION_RESPONSE"
             else
-              COLLABORATOR_PERMISSION="unknown"
-              COLLABORATOR_PERMISSION_API_ERROR="$COLLABORATOR_PERMISSION_RESPONSE"
-              echo "::error::Failed to inspect collaborator permission for $PR_AUTHOR."
+              AUTHOR_ASSOCIATION="unknown"
+              AUTHOR_ASSOCIATION_API_ERROR="$AUTHOR_ASSOCIATION_RESPONSE"
+              echo "::error::Failed to inspect live author association for PR #$PR_NUMBER."
               {
                 echo "## Restricted Paths Guard Failed"
                 echo ""
-                echo "- **Error**: Failed to inspect collaborator permission."
+                echo "- **Error**: Failed to inspect live author association."
                 echo "- **Author**: $PR_AUTHOR"
-                echo "- **Collaborator permission**: $COLLABORATOR_PERMISSION"
+                echo "- **Author association**: $AUTHOR_ASSOCIATION"
                 echo ""
                 write_matching_restricted_paths
                 echo ""
-                write_collaborator_permission_api_error
+                write_author_association_api_error
                 echo ""
-                echo "Please retry this workflow. If the failure persists, inspect the collaborator permission API error above."
+                echo "Please retry this workflow. If the failure persists, inspect the author association API error above."
               } >> "$GITHUB_STEP_SUMMARY"
               exit 1
             fi
 
-            case "$COLLABORATOR_PERMISSION" in
-              admin|maintain|write|triage|read)
+            case "$AUTHOR_ASSOCIATION" in
+              MEMBER|OWNER)
                 HAS_TRUSTED_SIGNAL=true
-                LABEL_ACTION="not needed (collaborator permission is a trusted signal)"
-                TRUSTED_SIGNALS="collaborator_permission:$COLLABORATOR_PERMISSION"
+                LABEL_ACTION="not needed (live author association is a trusted signal)"
+                TRUSTED_SIGNALS="author_association:$AUTHOR_ASSOCIATION"
                 ;;
               *)
-                # none: not a trusted signal
+                # COLLABORATOR can still be too broad for this policy; use the
+                # collaborator permission API below for repo-level trust.
                 ;;
             esac
+
+            # Distinguish a legitimate 404 "not a collaborator" response from
+            # actual API failures. The former is an expected untrusted case;
+            # the latter fails the workflow so it can be rerun later.
+            if [ "$HAS_TRUSTED_SIGNAL" = "false" ]; then
+              if COLLABORATOR_PERMISSION_RESPONSE=$(
+                gh api "repos/$REPO/collaborators/$PR_AUTHOR/permission" \
+                  --jq '.permission' 2>&1
+              ); then
+                COLLABORATOR_PERMISSION="$COLLABORATOR_PERMISSION_RESPONSE"
+              elif [[ "$COLLABORATOR_PERMISSION_RESPONSE" == *"(HTTP 404)"* ]]; then
+                COLLABORATOR_PERMISSION="none"
+              else
+                COLLABORATOR_PERMISSION="unknown"
+                COLLABORATOR_PERMISSION_API_ERROR="$COLLABORATOR_PERMISSION_RESPONSE"
+                echo "::error::Failed to inspect collaborator permission for $PR_AUTHOR."
+                {
+                  echo "## Restricted Paths Guard Failed"
+                  echo ""
+                  echo "- **Error**: Failed to inspect collaborator permission."
+                  echo "- **Author**: $PR_AUTHOR"
+                  echo "- **Author association**: $AUTHOR_ASSOCIATION"
+                  echo "- **Collaborator permission**: $COLLABORATOR_PERMISSION"
+                  echo ""
+                  write_matching_restricted_paths
+                  echo ""
+                  write_collaborator_permission_api_error
+                  echo ""
+                  echo "Please retry this workflow. If the failure persists, inspect the collaborator permission API error above."
+                } >> "$GITHUB_STEP_SUMMARY"
+                exit 1
+              fi
+
+              case "$COLLABORATOR_PERMISSION" in
+                admin|maintain|write|triage)
+                  HAS_TRUSTED_SIGNAL=true
+                  LABEL_ACTION="not needed (collaborator permission is a trusted signal)"
+                  TRUSTED_SIGNALS="collaborator_permission:$COLLABORATOR_PERMISSION"
+                  ;;
+                *)
+                  # read or none: not a trusted signal. In a public repo, read
+                  # can be the effective permission for any GitHub user.
+                  ;;
+              esac
+            fi
           fi
 
           NEEDS_REVIEW_LABEL=false
@@ -197,6 +249,7 @@ jobs:
                 echo ""
                 echo "- **Error**: Failed to add the \`$REVIEW_LABEL\` label."
                 echo "- **Author**: $PR_AUTHOR"
+                echo "- **Author association**: $AUTHOR_ASSOCIATION"
                 echo "- **Collaborator permission**: $COLLABORATOR_PERMISSION"
                 echo ""
                 write_matching_restricted_paths
@@ -216,6 +269,7 @@ jobs:
             echo "## Restricted Paths Guard Completed"
             echo ""
             echo "- **Author**: $PR_AUTHOR"
+            echo "- **Author association**: $AUTHOR_ASSOCIATION"
             echo "- **Collaborator permission**: $COLLABORATOR_PERMISSION"
             echo "- **Touches restricted paths**: $TOUCHES_RESTRICTED_PATHS"
             echo "- **Restricted paths**: \`cuda_bindings/\`, \`cuda_python/\`"

--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
-# XXX DUMMY CHANGE FOR TESTING restricted-paths-guard.yml - REMOVE BEFORE MERGE XXX
 [build-system]
 requires = [
     "setuptools>=80.0.0",

--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
+# XXX DUMMY CHANGE FOR TESTING restricted-paths-guard.yml - REMOVE BEFORE MERGE XXX
 [build-system]
 requires = [
     "setuptools>=80.0.0",


### PR DESCRIPTION
Reference: #2104

## Summary

This PR fixes the restricted-paths guard trust check so public repository `read` permission is no longer treated as a collaborator/trust signal.

The guard now:

- queries the live pull request API for `author_association` on restricted-path PRs
- trusts live `MEMBER` and `OWNER` author associations
- falls back to the collaborator permission API only when the live author association is not trusted
- trusts collaborator permissions `triage`, `write`, `maintain`, and `admin`
- treats collaborator permission `read` as untrusted, because public repositories can report `read` for any GitHub user

## Background

Earlier versions of `restricted-paths-guard.yml` used `github.event.pull_request.author_association` from the workflow event payload. That value turned out to be stale or unreliable for some fork PRs, so PR #1930 switched the workflow to the collaborator permission API.

PR #2010 later expanded the trusted collaborator permissions to include `read`, after seeing a false positive for an internal/collaborator author whose permission was reported as `read`.

Issue #2104 captures the follow-up discovery: on a public repository, the collaborator permission API can return `read` for users who are not repository collaborators. For example, a first-time external contributor can get effective `read` access simply because the repository is public.

This PR keeps the useful part of the previous workaround, but tightens the trust model:

- live `author_association` is queried from `GET /repos/{owner}/{repo}/pulls/{pull_number}` instead of using the event payload
- `read` from `GET /repos/{owner}/{repo}/collaborators/{username}/permission` is no longer trusted

## Testing via reverted temporary commits

- 5ede77269f — TEMPORARY: Switch to pull_request trigger for testing
- 5226846b47 — TEMPORARY: Exclude write permission from trusted collaborators