### PR TITLE
Fix a double-free bug

### DIFF
--- a/cuda_bindings/cuda/bindings/driver.pyx.in
+++ b/cuda_bindings/cuda/bindings/driver.pyx.in
@@ -11148,6 +11148,7 @@ cdef class CUDA_BATCH_MEM_OP_NODE_PARAMS_v1_st:
     def paramArray(self, val):
         if len(val) == 0:
             free(self._paramArray)
+            self._paramArray = NULL
             self._paramArray_length = 0
             self._pvt_ptr[0].paramArray = NULL
         else:
@@ -11283,6 +11284,7 @@ cdef class CUDA_BATCH_MEM_OP_NODE_PARAMS_v2_st:
     def paramArray(self, val):
         if len(val) == 0:
             free(self._paramArray)
+            self._paramArray = NULL
             self._paramArray_length = 0
             self._pvt_ptr[0].paramArray = NULL
         else:
@@ -14774,6 +14776,7 @@ cdef class CUlaunchConfig_st:
     def attrs(self, val):
         if len(val) == 0:
             free(self._attrs)
+            self._attrs = NULL
             self._attrs_length = 0
             self._pvt_ptr[0].attrs = NULL
         else:
@@ -15124,6 +15127,7 @@ cdef class CUctxCreateParams_st:
     def execAffinityParams(self, val):
         if len(val) == 0:
             free(self._execAffinityParams)
+            self._execAffinityParams = NULL
             self._execAffinityParams_length = 0
             self._pvt_ptr[0].execAffinityParams = NULL
         else:
@@ -15155,6 +15159,7 @@ cdef class CUctxCreateParams_st:
     def cigParams(self, val):
         if len(val) == 0:
             free(self._cigParams)
+            self._cigParams = NULL
             self._cigParams_length = 0
             self._pvt_ptr[0].cigParams = NULL
         else:
@@ -15296,6 +15301,7 @@ cdef class CUstreamCigCaptureParams_st:
     def streamCigParams(self, val):
         if len(val) == 0:
             free(self._streamCigParams)
+            self._streamCigParams = NULL
             self._streamCigParams_length = 0
             self._pvt_ptr[0].streamCigParams = NULL
         else:
@@ -20525,6 +20531,7 @@ cdef class CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_st:
     def extSemArray(self, val):
         if len(val) == 0:
             free(self._extSemArray)
+            self._extSemArray = NULL
             self._extSemArray_length = 0
             self._pvt_ptr[0].extSemArray = NULL
         else:
@@ -20548,6 +20555,7 @@ cdef class CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_st:
     def paramsArray(self, val):
         if len(val) == 0:
             free(self._paramsArray)
+            self._paramsArray = NULL
             self._paramsArray_length = 0
             self._pvt_ptr[0].paramsArray = NULL
         else:
@@ -20650,6 +20658,7 @@ cdef class CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_v2_st:
     def extSemArray(self, val):
         if len(val) == 0:
             free(self._extSemArray)
+            self._extSemArray = NULL
             self._extSemArray_length = 0
             self._pvt_ptr[0].extSemArray = NULL
         else:
@@ -20673,6 +20682,7 @@ cdef class CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_v2_st:
     def paramsArray(self, val):
         if len(val) == 0:
             free(self._paramsArray)
+            self._paramsArray = NULL
             self._paramsArray_length = 0
             self._pvt_ptr[0].paramsArray = NULL
         else:
@@ -20775,6 +20785,7 @@ cdef class CUDA_EXT_SEM_WAIT_NODE_PARAMS_st:
     def extSemArray(self, val):
         if len(val) == 0:
             free(self._extSemArray)
+            self._extSemArray = NULL
             self._extSemArray_length = 0
             self._pvt_ptr[0].extSemArray = NULL
         else:
@@ -20798,6 +20809,7 @@ cdef class CUDA_EXT_SEM_WAIT_NODE_PARAMS_st:
     def paramsArray(self, val):
         if len(val) == 0:
             free(self._paramsArray)
+            self._paramsArray = NULL
             self._paramsArray_length = 0
             self._pvt_ptr[0].paramsArray = NULL
         else:
@@ -20900,6 +20912,7 @@ cdef class CUDA_EXT_SEM_WAIT_NODE_PARAMS_v2_st:
     def extSemArray(self, val):
         if len(val) == 0:
             free(self._extSemArray)
+            self._extSemArray = NULL
             self._extSemArray_length = 0
             self._pvt_ptr[0].extSemArray = NULL
         else:
@@ -20923,6 +20936,7 @@ cdef class CUDA_EXT_SEM_WAIT_NODE_PARAMS_v2_st:
     def paramsArray(self, val):
         if len(val) == 0:
             free(self._paramsArray)
+            self._paramsArray = NULL
             self._paramsArray_length = 0
             self._pvt_ptr[0].paramsArray = NULL
         else:
@@ -23346,6 +23360,7 @@ cdef class CUDA_MEM_ALLOC_NODE_PARAMS_v1_st:
     def accessDescs(self, val):
         if len(val) == 0:
             free(self._accessDescs)
+            self._accessDescs = NULL
             self._accessDescs_length = 0
             self._pvt_ptr[0].accessDescs = NULL
         else:
@@ -23507,6 +23522,7 @@ cdef class CUDA_MEM_ALLOC_NODE_PARAMS_v2_st:
     def accessDescs(self, val):
         if len(val) == 0:
             free(self._accessDescs)
+            self._accessDescs = NULL
             self._accessDescs_length = 0
             self._pvt_ptr[0].accessDescs = NULL
         else:
@@ -24507,6 +24523,7 @@ cdef class CUcheckpointRestoreArgs_st:
     def gpuPairs(self, val):
         if len(val) == 0:
             free(self._gpuPairs)
+            self._gpuPairs = NULL
             self._gpuPairs_length = 0
             self._pvt_ptr[0].gpuPairs = NULL
         else:
@@ -25345,6 +25362,7 @@ cdef class CUdevResource_st:
     def nextResource(self, val):
         if len(val) == 0:
             free(self._nextResource)
+            self._nextResource = NULL
             self._nextResource_length = 0
             self._pvt_ptr[0].nextResource = NULL
         else:

--- a/cuda_bindings/cuda/bindings/driver.pyx.in
+++ b/cuda_bindings/cuda/bindings/driver.pyx.in
@@ -11081,6 +11081,7 @@ cdef class CUDA_BATCH_MEM_OP_NODE_PARAMS_v1_st:
         {{if 'CUDA_BATCH_MEM_OP_NODE_PARAMS_v1_st.paramArray' in found_struct}}
         if self._paramArray is not NULL:
             free(self._paramArray)
+            self._pvt_ptr[0].paramArray = NULL
         {{endif}}
     def getPtr(self):
         return <void_ptr>self._pvt_ptr
@@ -11217,6 +11218,7 @@ cdef class CUDA_BATCH_MEM_OP_NODE_PARAMS_v2_st:
         {{if 'CUDA_BATCH_MEM_OP_NODE_PARAMS_v2_st.paramArray' in found_struct}}
         if self._paramArray is not NULL:
             free(self._paramArray)
+            self._pvt_ptr[0].paramArray = NULL
         {{endif}}
     def getPtr(self):
         return <void_ptr>self._pvt_ptr
@@ -14625,6 +14627,7 @@ cdef class CUlaunchConfig_st:
         {{if 'CUlaunchConfig_st.attrs' in found_struct}}
         if self._attrs is not NULL:
             free(self._attrs)
+            self._pvt_ptr[0].attrs = NULL
         {{endif}}
     def getPtr(self):
         return <void_ptr>self._pvt_ptr
@@ -15087,10 +15090,12 @@ cdef class CUctxCreateParams_st:
         {{if 'CUctxCreateParams_st.execAffinityParams' in found_struct}}
         if self._execAffinityParams is not NULL:
             free(self._execAffinityParams)
+            self._pvt_ptr[0].execAffinityParams = NULL
         {{endif}}
         {{if 'CUctxCreateParams_st.cigParams' in found_struct}}
         if self._cigParams is not NULL:
             free(self._cigParams)
+            self._pvt_ptr[0].cigParams = NULL
         {{endif}}
     def getPtr(self):
         return <void_ptr>self._pvt_ptr
@@ -15277,6 +15282,7 @@ cdef class CUstreamCigCaptureParams_st:
         {{if 'CUstreamCigCaptureParams_st.streamCigParams' in found_struct}}
         if self._streamCigParams is not NULL:
             free(self._streamCigParams)
+            self._pvt_ptr[0].streamCigParams = NULL
         {{endif}}
     def getPtr(self):
         return <void_ptr>self._pvt_ptr
@@ -20491,10 +20497,12 @@ cdef class CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_st:
         {{if 'CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_st.extSemArray' in found_struct}}
         if self._extSemArray is not NULL:
             free(self._extSemArray)
+            self._pvt_ptr[0].extSemArray = NULL
         {{endif}}
         {{if 'CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_st.paramsArray' in found_struct}}
         if self._paramsArray is not NULL:
             free(self._paramsArray)
+            self._pvt_ptr[0].paramsArray = NULL
         {{endif}}
     def getPtr(self):
         return <void_ptr>self._pvt_ptr
@@ -20618,10 +20626,12 @@ cdef class CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_v2_st:
         {{if 'CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_v2_st.extSemArray' in found_struct}}
         if self._extSemArray is not NULL:
             free(self._extSemArray)
+            self._pvt_ptr[0].extSemArray = NULL
         {{endif}}
         {{if 'CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_v2_st.paramsArray' in found_struct}}
         if self._paramsArray is not NULL:
             free(self._paramsArray)
+            self._pvt_ptr[0].paramsArray = NULL
         {{endif}}
     def getPtr(self):
         return <void_ptr>self._pvt_ptr
@@ -20745,10 +20755,12 @@ cdef class CUDA_EXT_SEM_WAIT_NODE_PARAMS_st:
         {{if 'CUDA_EXT_SEM_WAIT_NODE_PARAMS_st.extSemArray' in found_struct}}
         if self._extSemArray is not NULL:
             free(self._extSemArray)
+            self._pvt_ptr[0].extSemArray = NULL
         {{endif}}
         {{if 'CUDA_EXT_SEM_WAIT_NODE_PARAMS_st.paramsArray' in found_struct}}
         if self._paramsArray is not NULL:
             free(self._paramsArray)
+            self._pvt_ptr[0].paramsArray = NULL
         {{endif}}
     def getPtr(self):
         return <void_ptr>self._pvt_ptr
@@ -20872,10 +20884,12 @@ cdef class CUDA_EXT_SEM_WAIT_NODE_PARAMS_v2_st:
         {{if 'CUDA_EXT_SEM_WAIT_NODE_PARAMS_v2_st.extSemArray' in found_struct}}
         if self._extSemArray is not NULL:
             free(self._extSemArray)
+            self._pvt_ptr[0].extSemArray = NULL
         {{endif}}
         {{if 'CUDA_EXT_SEM_WAIT_NODE_PARAMS_v2_st.paramsArray' in found_struct}}
         if self._paramsArray is not NULL:
             free(self._paramsArray)
+            self._pvt_ptr[0].paramsArray = NULL
         {{endif}}
     def getPtr(self):
         return <void_ptr>self._pvt_ptr
@@ -23304,6 +23318,7 @@ cdef class CUDA_MEM_ALLOC_NODE_PARAMS_v1_st:
         {{if 'CUDA_MEM_ALLOC_NODE_PARAMS_v1_st.accessDescs' in found_struct}}
         if self._accessDescs is not NULL:
             free(self._accessDescs)
+            self._pvt_ptr[0].accessDescs = NULL
         {{endif}}
     def getPtr(self):
         return <void_ptr>self._pvt_ptr
@@ -23466,6 +23481,7 @@ cdef class CUDA_MEM_ALLOC_NODE_PARAMS_v2_st:
         {{if 'CUDA_MEM_ALLOC_NODE_PARAMS_v2_st.accessDescs' in found_struct}}
         if self._accessDescs is not NULL:
             free(self._accessDescs)
+            self._pvt_ptr[0].accessDescs = NULL
         {{endif}}
     def getPtr(self):
         return <void_ptr>self._pvt_ptr
@@ -24481,6 +24497,7 @@ cdef class CUcheckpointRestoreArgs_st:
         {{if 'CUcheckpointRestoreArgs_st.gpuPairs' in found_struct}}
         if self._gpuPairs is not NULL:
             free(self._gpuPairs)
+            self._pvt_ptr[0].gpuPairs = NULL
         {{endif}}
     def getPtr(self):
         return <void_ptr>self._pvt_ptr
@@ -25248,6 +25265,7 @@ cdef class CUdevResource_st:
         {{if 'CUdevResource_st.nextResource' in found_struct}}
         if self._nextResource is not NULL:
             free(self._nextResource)
+            self._pvt_ptr[0].nextResource = NULL
         {{endif}}
     def getPtr(self):
         return <void_ptr>self._pvt_ptr

--- a/cuda_bindings/cuda/bindings/runtime.pyx.in
+++ b/cuda_bindings/cuda/bindings/runtime.pyx.in
@@ -11520,6 +11520,7 @@ cdef class cudaMemAllocNodeParams:
     def accessDescs(self, val):
         if len(val) == 0:
             free(self._accessDescs)
+            self._accessDescs = NULL
             self._accessDescs_length = 0
             self._pvt_ptr[0].accessDescs = NULL
         else:
@@ -11669,6 +11670,7 @@ cdef class cudaMemAllocNodeParamsV2:
     def accessDescs(self, val):
         if len(val) == 0:
             free(self._accessDescs)
+            self._accessDescs = NULL
             self._accessDescs_length = 0
             self._pvt_ptr[0].accessDescs = NULL
         else:
@@ -16489,6 +16491,7 @@ cdef class cudaDevResource_st:
     def nextResource(self, val):
         if len(val) == 0:
             free(self._nextResource)
+            self._nextResource = NULL
             self._nextResource_length = 0
             self._pvt_ptr[0].nextResource = NULL
         else:
@@ -17094,6 +17097,7 @@ cdef class cudaExternalSemaphoreSignalNodeParams:
     def extSemArray(self, val):
         if len(val) == 0:
             free(self._extSemArray)
+            self._extSemArray = NULL
             self._extSemArray_length = 0
             self._pvt_ptr[0].extSemArray = NULL
         else:
@@ -17117,6 +17121,7 @@ cdef class cudaExternalSemaphoreSignalNodeParams:
     def paramsArray(self, val):
         if len(val) == 0:
             free(self._paramsArray)
+            self._paramsArray = NULL
             self._paramsArray_length = 0
             self._pvt_ptr[0].paramsArray = NULL
         else:
@@ -17219,6 +17224,7 @@ cdef class cudaExternalSemaphoreSignalNodeParamsV2:
     def extSemArray(self, val):
         if len(val) == 0:
             free(self._extSemArray)
+            self._extSemArray = NULL
             self._extSemArray_length = 0
             self._pvt_ptr[0].extSemArray = NULL
         else:
@@ -17242,6 +17248,7 @@ cdef class cudaExternalSemaphoreSignalNodeParamsV2:
     def paramsArray(self, val):
         if len(val) == 0:
             free(self._paramsArray)
+            self._paramsArray = NULL
             self._paramsArray_length = 0
             self._pvt_ptr[0].paramsArray = NULL
         else:
@@ -17344,6 +17351,7 @@ cdef class cudaExternalSemaphoreWaitNodeParams:
     def extSemArray(self, val):
         if len(val) == 0:
             free(self._extSemArray)
+            self._extSemArray = NULL
             self._extSemArray_length = 0
             self._pvt_ptr[0].extSemArray = NULL
         else:
@@ -17367,6 +17375,7 @@ cdef class cudaExternalSemaphoreWaitNodeParams:
     def paramsArray(self, val):
         if len(val) == 0:
             free(self._paramsArray)
+            self._paramsArray = NULL
             self._paramsArray_length = 0
             self._pvt_ptr[0].paramsArray = NULL
         else:
@@ -17469,6 +17478,7 @@ cdef class cudaExternalSemaphoreWaitNodeParamsV2:
     def extSemArray(self, val):
         if len(val) == 0:
             free(self._extSemArray)
+            self._extSemArray = NULL
             self._extSemArray_length = 0
             self._pvt_ptr[0].extSemArray = NULL
         else:
@@ -17492,6 +17502,7 @@ cdef class cudaExternalSemaphoreWaitNodeParamsV2:
     def paramsArray(self, val):
         if len(val) == 0:
             free(self._paramsArray)
+            self._paramsArray = NULL
             self._paramsArray_length = 0
             self._pvt_ptr[0].paramsArray = NULL
         else:

--- a/cuda_bindings/cuda/bindings/runtime.pyx.in
+++ b/cuda_bindings/cuda/bindings/runtime.pyx.in
@@ -11464,6 +11464,7 @@ cdef class cudaMemAllocNodeParams:
         {{if 'cudaMemAllocNodeParams.accessDescs' in found_struct}}
         if self._accessDescs is not NULL:
             free(self._accessDescs)
+            self._pvt_ptr[0].accessDescs = NULL
         {{endif}}
     def getPtr(self):
         return <void_ptr>self._pvt_ptr
@@ -11614,6 +11615,7 @@ cdef class cudaMemAllocNodeParamsV2:
         {{if 'cudaMemAllocNodeParamsV2.accessDescs' in found_struct}}
         if self._accessDescs is not NULL:
             free(self._accessDescs)
+            self._pvt_ptr[0].accessDescs = NULL
         {{endif}}
     def getPtr(self):
         return <void_ptr>self._pvt_ptr
@@ -16377,6 +16379,7 @@ cdef class cudaDevResource_st:
         {{if 'cudaDevResource_st.nextResource' in found_struct}}
         if self._nextResource is not NULL:
             free(self._nextResource)
+            self._pvt_ptr[0].nextResource = NULL
         {{endif}}
     def getPtr(self):
         return <void_ptr>self._pvt_ptr
@@ -17057,10 +17060,12 @@ cdef class cudaExternalSemaphoreSignalNodeParams:
         {{if 'cudaExternalSemaphoreSignalNodeParams.extSemArray' in found_struct}}
         if self._extSemArray is not NULL:
             free(self._extSemArray)
+            self._pvt_ptr[0].extSemArray = NULL
         {{endif}}
         {{if 'cudaExternalSemaphoreSignalNodeParams.paramsArray' in found_struct}}
         if self._paramsArray is not NULL:
             free(self._paramsArray)
+            self._pvt_ptr[0].paramsArray = NULL
         {{endif}}
     def getPtr(self):
         return <void_ptr>self._pvt_ptr
@@ -17184,10 +17189,12 @@ cdef class cudaExternalSemaphoreSignalNodeParamsV2:
         {{if 'cudaExternalSemaphoreSignalNodeParamsV2.extSemArray' in found_struct}}
         if self._extSemArray is not NULL:
             free(self._extSemArray)
+            self._pvt_ptr[0].extSemArray = NULL
         {{endif}}
         {{if 'cudaExternalSemaphoreSignalNodeParamsV2.paramsArray' in found_struct}}
         if self._paramsArray is not NULL:
             free(self._paramsArray)
+            self._pvt_ptr[0].paramsArray = NULL
         {{endif}}
     def getPtr(self):
         return <void_ptr>self._pvt_ptr
@@ -17311,10 +17318,12 @@ cdef class cudaExternalSemaphoreWaitNodeParams:
         {{if 'cudaExternalSemaphoreWaitNodeParams.extSemArray' in found_struct}}
         if self._extSemArray is not NULL:
             free(self._extSemArray)
+            self._pvt_ptr[0].extSemArray = NULL
         {{endif}}
         {{if 'cudaExternalSemaphoreWaitNodeParams.paramsArray' in found_struct}}
         if self._paramsArray is not NULL:
             free(self._paramsArray)
+            self._pvt_ptr[0].paramsArray = NULL
         {{endif}}
     def getPtr(self):
         return <void_ptr>self._pvt_ptr
@@ -17438,10 +17447,12 @@ cdef class cudaExternalSemaphoreWaitNodeParamsV2:
         {{if 'cudaExternalSemaphoreWaitNodeParamsV2.extSemArray' in found_struct}}
         if self._extSemArray is not NULL:
             free(self._extSemArray)
+            self._pvt_ptr[0].extSemArray = NULL
         {{endif}}
         {{if 'cudaExternalSemaphoreWaitNodeParamsV2.paramsArray' in found_struct}}
         if self._paramsArray is not NULL:
             free(self._paramsArray)
+            self._pvt_ptr[0].paramsArray = NULL
         {{endif}}
     def getPtr(self):
         return <void_ptr>self._pvt_ptr

--- a/cuda_bindings/docs/source/release/13.3.0-notes.rst
+++ b/cuda_bindings/docs/source/release/13.3.0-notes.rst
@@ -23,6 +23,13 @@ Bugfixes
   data.
   (`Issue #1804 <https://github.com/NVIDIA/cuda-python/issues/1804>`_)
 
+* Fixed a double-free in the generated setters for list-valued struct members
+  (e.g. ``CUlaunchConfig.attrs``, ``CUDA_MEM_ALLOC_NODE_PARAMS.accessDescs``,
+  external-semaphore and batch-mem-op node parameter arrays, and their runtime
+  counterparts). Assigning an empty list freed the internal buffer but left
+  the cached pointer non-NULL, so a subsequent assignment or ``__dealloc__``
+  would call ``free()`` again on the dangling pointer.
+
 
 Miscellaneous
 -------------

--- a/cuda_bindings/tests/test_cuda.py
+++ b/cuda_bindings/tests/test_cuda.py
@@ -3,6 +3,8 @@
 
 import ctypes
 import shutil
+import subprocess
+import sys
 import textwrap
 
 import numpy as np
@@ -1270,3 +1272,37 @@ def test_buffer_reference():
     ptr = ctypes.cast(memcpyParams.memcpy.copyParams.dstHost, ctypes.POINTER(ctypes.c_uint8))
     x = np.ctypeslib.as_array(ptr, shape=(size,))
     assert np.all(x == 2)
+
+
+def test_array_setter_no_double_free_after_clearing_with_empty_list():
+    # Regression test for a double-free in the generated setters for
+    # list-valued struct members (e.g. CUlaunchConfig.attrs,
+    # CUDA_MEM_ALLOC_NODE_PARAMS.accessDescs, ...). Assigning an empty list
+    # used to free the internal buffer but leave the cached pointer non-NULL;
+    # the next assignment (or __dealloc__) would call free() on that dangling
+    # pointer, causing a double-free that glibc aborts via SIGABRT.
+    #
+    # CUlaunchConfig.attrs is exercised here as one representative instance;
+    # the same pattern was applied across many setters in driver.pyx.in and
+    # runtime.pyx.in.
+    #
+    # The reproducer runs in a subprocess so that a glibc abort surfaces as
+    # a non-zero return code instead of tearing down the pytest process.
+    code = textwrap.dedent(
+        """
+        import cuda.bindings.driver as cuda
+
+        params = cuda.CUlaunchConfig()
+        # Allocate the internal buffer.
+        params.attrs = [cuda.CUlaunchAttribute() for _ in range(4)]
+        # Free it. Pre-fix, self._attrs is left pointing at freed memory.
+        params.attrs = []
+        # Length mismatch (0 vs 8) takes the else branch and calls free()
+        # again on the dangling pointer.
+        params.attrs = [cuda.CUlaunchAttribute() for _ in range(8)]
+        """
+    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True)  # noqa: S603
+    assert proc.returncode == 0, (
+        f"reproducer subprocess exited with code {proc.returncode}; stderr: {proc.stderr.decode(errors='replace')}"
+    )

--- a/cuda_bindings/tests/test_cuda.py
+++ b/cuda_bindings/tests/test_cuda.py
@@ -1306,3 +1306,45 @@ def test_array_setter_no_double_free_after_clearing_with_empty_list():
     assert proc.returncode == 0, (
         f"reproducer subprocess exited with code {proc.returncode}; stderr: {proc.stderr.decode(errors='replace')}"
     )
+
+
+def test_dealloc_clears_array_field_in_external_struct():
+    # Regression test for the externally-owned-memory case of the same bug.
+    #
+    # When a wrapper aliases an externally-owned struct (constructed with
+    # `_ptr=...`), `__dealloc__` used to free its internal buffer but leave
+    # `self._pvt_ptr[0].<field>` pointing at the freed memory. Anyone still
+    # holding the external struct (the owning wrapper, a parent struct, or
+    # the CUDA driver itself) would see a dangling pointer.
+    #
+    # CUlaunchConfig.attrs is exercised here as one representative instance;
+    # the same pattern was applied across the `__dealloc__` methods in
+    # driver.pyx.in and runtime.pyx.in.
+    outer = cuda.CUlaunchConfig()
+    # `inner` aliases the same underlying struct as `outer`.
+    inner = cuda.CUlaunchConfig(_ptr=outer.getPtr())
+    # Allocates a buffer and writes its pointer into the shared struct's
+    # `attrs` field.
+    inner.attrs = [cuda.CUlaunchAttribute() for _ in range(4)]
+
+    # Locate `attrs` in the C struct by scanning for the just-written
+    # pointer. The struct is small and only `attrs` is non-NULL.
+    struct_addr = outer.getPtr()
+    word_size = ctypes.sizeof(ctypes.c_void_p)
+    scan_words = 128 // word_size
+    words = (ctypes.c_void_p * scan_words).from_address(struct_addr)
+    attrs_offset = next(
+        (i * word_size for i, p in enumerate(words) if p),
+        None,
+    )
+    assert attrs_offset is not None, "attrs pointer was not written into the C struct"
+
+    # Destroy the wrapper. With the fix, __dealloc__ also clears the field
+    # in the externally-owned struct; without it, the field remains dangling.
+    del inner
+
+    attrs_after = ctypes.c_void_p.from_address(struct_addr + attrs_offset).value
+    assert attrs_after is None, (
+        f"external struct still holds a dangling pointer ({attrs_after:#x}) "
+        "where attrs was, after the aliasing wrapper was destroyed"
+    )

--- a/cuda_bindings/tests/test_cuda.py
+++ b/cuda_bindings/tests/test_cuda.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 import ctypes
+import os.path
 import shutil
 import subprocess
 import sys
@@ -1302,7 +1303,7 @@ def test_array_setter_no_double_free_after_clearing_with_empty_list():
         params.attrs = [cuda.CUlaunchAttribute() for _ in range(8)]
         """
     )
-    proc = subprocess.run([sys.executable, "-c", code], capture_output=True)  # noqa: S603
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, cwd=os.path.dirname(__file__))  # noqa: S603
     assert proc.returncode == 0, (
         f"reproducer subprocess exited with code {proc.returncode}; stderr: {proc.stderr.decode(errors='replace')}"
     )


### PR DESCRIPTION
This is part of my experimentation with using an LLM agent for static analysis.

Fixes a double-free in the generated setters for list-valued struct members
(e.g. `CUlaunchConfig.attrs`, `CUDA_MEM_ALLOC_NODE_PARAMS.accessDescs`,
external-semaphore and batch-mem-op node parameter arrays, and their runtime
counterparts). Assigning an empty list freed the internal buffer but left
the cached pointer non-NULL, so a subsequent assignment or `__dealloc__`
would call `free()` again on the dangling pointer.