### PR TITLE
nvbug-6193808: Work around mojibake in nvml.system_get_process_name on WSL

### DIFF
--- a/cuda_bindings/docs/source/release/13.2.0-notes.rst
+++ b/cuda_bindings/docs/source/release/13.2.0-notes.rst
@@ -80,3 +80,7 @@ Known issues
 ------------
 
 * Updating from older versions (v12.6.2.post1 and below) via ``pip install -U cuda-python`` might not work. Please do a clean re-installation by uninstalling ``pip uninstall -y cuda-python`` followed by installing ``pip install cuda-python``.
+* ``nvml.system_get_process_name`` on WSL can return incorrect values.  To work
+  around this, set the locale to "C" before calling
+  ``nvml.system_get_process_name``. ``cuda_core`` does this automatically, but
+  users of the raw NVML API will need to do this manually.

--- a/cuda_bindings/docs/source/release/13.2.0-notes.rst
+++ b/cuda_bindings/docs/source/release/13.2.0-notes.rst
@@ -80,7 +80,4 @@ Known issues
 ------------
 
 * Updating from older versions (v12.6.2.post1 and below) via ``pip install -U cuda-python`` might not work. Please do a clean re-installation by uninstalling ``pip uninstall -y cuda-python`` followed by installing ``pip install cuda-python``.
-* ``nvml.system_get_process_name`` on WSL can return incorrect values.  To work
-  around this, set the locale to "C" before calling
-  ``nvml.system_get_process_name``. ``cuda_core`` does this automatically, but
-  users of the raw NVML API will need to do this manually.
+* ``nvml.system_get_process_name`` on WSL can return incorrect values.  To work around this, set the locale to "C" before calling ``nvml.device_get_compute_running_processes_v3`` (which sets the process names) and before calling ``nvml.system_get_process_name``. ``cuda_core`` does this automatically, but users of the raw NVML API will need to do this manually.

--- a/cuda_bindings/docs/source/release/13.3.0-notes.rst
+++ b/cuda_bindings/docs/source/release/13.3.0-notes.rst
@@ -39,3 +39,7 @@ Known issues
 ------------
 
 * Updating from older versions (v12.6.2.post1 and below) via ``pip install -U cuda-python`` might not work. Please do a clean re-installation by uninstalling ``pip uninstall -y cuda-python`` followed by installing ``pip install cuda-python``.
+* ``nvml.system_get_process_name`` on WSL can return incorrect values.  To work
+  around this, set the locale to "C" before calling
+  ``nvml.system_get_process_name``. ``cuda_core`` does this automatically, but
+  users of the raw NVML API will need to do this manually.

--- a/cuda_bindings/docs/source/release/13.3.0-notes.rst
+++ b/cuda_bindings/docs/source/release/13.3.0-notes.rst
@@ -39,7 +39,4 @@ Known issues
 ------------
 
 * Updating from older versions (v12.6.2.post1 and below) via ``pip install -U cuda-python`` might not work. Please do a clean re-installation by uninstalling ``pip uninstall -y cuda-python`` followed by installing ``pip install cuda-python``.
-* ``nvml.system_get_process_name`` on WSL can return incorrect values.  To work
-  around this, set the locale to "C" before calling
-  ``nvml.system_get_process_name``. ``cuda_core`` does this automatically, but
-  users of the raw NVML API will need to do this manually.
+* ``nvml.system_get_process_name`` on WSL can return incorrect values.  To work around this, set the locale to "C" before calling ``nvml.device_get_compute_running_processes_v3`` (which sets the process names) and before calling ``nvml.system_get_process_name``. ``cuda_core`` does this automatically, but users of the raw NVML API will need to do this manually.

--- a/cuda_core/build_hooks.py
+++ b/cuda_core/build_hooks.py
@@ -143,12 +143,21 @@ def _build_cuda_core(debug=False):
         # cuda-bindings not available in editable mode, will use installed version
         pass
 
+    _posix_only_modules = frozenset(
+        {
+            "_utils/_wsl_locale",
+        }
+    )
+
     # It seems setuptools' wildcard support has problems for namespace packages,
     # so we explicitly spell out all Extension instances.
     def module_names():
         root_path = os.path.sep.join(["cuda", "core", ""])
         for filename in glob.glob(f"{root_path}/**/*.pyx", recursive=True):
-            yield filename[len(root_path) : -4]
+            mod = filename[len(root_path) : -4]
+            if sys.platform == "win32" and mod.replace(os.path.sep, "/") in _posix_only_modules:
+                continue
+            yield mod
 
     def get_sources(mod_name):
         """Get source files for a module, including any .cpp files."""

--- a/cuda_core/cuda/core/_utils/_wsl_locale.pyx
+++ b/cuda_core/cuda/core/_utils/_wsl_locale.pyx
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+# WSL-specific locale guard, used by cuda.core.system.get_process_name() to
+# work around a bug in NVML's WSL implementation where nvmlSystemGetProcessName
+# returns mojibake when the calling thread is in a non-"C" locale. See
+# get_process_name() for the full backstory.
+#
+# This module is only compiled on Linux (build_hooks.py excludes it on Windows)
+# because it uses the POSIX per-thread locale APIs (newlocale/uselocale/
+# freelocale), which are not available on MSVC. Callers must guard imports of
+# this module with try/except ImportError.
+
+
+cdef extern from "locale.h" nogil:
+    ctypedef void *locale_t
+    int LC_ALL_MASK
+    locale_t newlocale(int category_mask, const char *locale, locale_t base)
+    locale_t uselocale(locale_t newloc)
+    void freelocale(locale_t locobj)
+
+
+cdef class c_locale_guard:
+    """Context manager that pins the calling thread to the "C" locale.
+
+    Uses POSIX newlocale/uselocale/freelocale so other threads' view of the
+    locale is unaffected. Restores the previous thread locale on exit.
+    """
+    cdef locale_t _c_locale
+    cdef locale_t _prev_locale
+    cdef bint _active
+
+    def __cinit__(self):
+        self._c_locale = <locale_t>0
+        self._prev_locale = <locale_t>0
+        self._active = False
+
+    def __enter__(self):
+        self._c_locale = newlocale(LC_ALL_MASK, b"C", <locale_t>0)
+        if self._c_locale == <locale_t>0:
+            raise RuntimeError("Failed to create C locale")
+        self._prev_locale = uselocale(self._c_locale)
+        self._active = True
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._active:
+            uselocale(self._prev_locale)
+            freelocale(self._c_locale)
+            self._active = False
+        return False

--- a/cuda_core/cuda/core/system/_system.pyx
+++ b/cuda_core/cuda/core/system/_system.pyx
@@ -10,6 +10,30 @@
 
 CUDA_BINDINGS_NVML_IS_COMPATIBLE: bool
 
+
+# POSIX per-thread locale APIs. We use these (rather than setlocale(3))
+# so the WSL workaround in get_process_name() doesn't perturb the locale
+# observed by other threads. locale_t is an opaque pointer in glibc.
+cdef extern from "locale.h" nogil:
+    ctypedef void *locale_t
+    int LC_ALL_MASK
+    locale_t LC_GLOBAL_LOCALE
+    locale_t newlocale(int category_mask, const char *locale, locale_t base)
+    locale_t uselocale(locale_t newloc)
+    void freelocale(locale_t locobj)
+
+
+cdef bint _detect_wsl():
+    try:
+        with open("/proc/sys/kernel/osrelease") as f:
+            data = f.read().lower()
+    except OSError:
+        return False
+    return "microsoft" in data or "wsl" in data
+
+
+cdef bint _IS_WSL = _detect_wsl()
+
 try:
     from cuda.bindings._version import __version_tuple__ as _BINDINGS_VERSION
 except ImportError:
@@ -127,8 +151,43 @@ def get_process_name(pid: int) -> str:
     name: str
         The process name.
     """
+    def _get_process_name(pid) -> str:
+        # NVML caches process names on a per-PID basis when queried via
+        # nvmlSystemGetProcessName, and the cache is populated when enumerating
+        # running processes on devices. To ensure the name is cached for the
+        # requested PID, we walk all devices and query their running processes.
+        for i in range(nvml.device_get_count_v2()):
+            dev_h = nvml.device_get_handle_by_index_v2(i)
+            nvml.device_get_compute_running_processes_v3(dev_h)
+        return nvml.system_get_process_name(pid)
+
+    cdef locale_t c_locale
+    cdef locale_t prev_locale
+
     initialize()
-    return nvml.system_get_process_name(pid)
+    if not _IS_WSL:
+        return _get_process_name(pid)
+
+    # WSL workaround: nvmlSystemGetProcessName on WSL takes a wide-char
+    # conversion path when the process locale is non-"C". That path walks
+    # a UTF-16LE source buffer with a 4-byte stride (as if it were UTF-32LE)
+    # and emits 5-byte UTF-8 sequences that look like garbage preceding the
+    # trailing basename of /proc/<pid>/exe. CPython's startup unconditionally
+    # calls setlocale(LC_ALL, ""), so essentially every cuda.core caller hits
+    # this. The cached entry for the PID is set the first time NVML resolves
+    # it (typically inside nvmlDeviceGetComputeRunningProcesses_v3), so to
+    # recover a correct value we re-prime the cache under the "C" locale
+    # before reading the name. We use the POSIX per-thread locale APIs so
+    # other threads' view of the locale is unaffected.
+    c_locale = newlocale(LC_ALL_MASK, b"C", <locale_t>0)
+    if c_locale == <locale_t>0:
+        raise RuntimeError("Failed to create C locale")
+    prev_locale = uselocale(c_locale)
+    try:
+        return _get_process_name(pid)
+    finally:
+        uselocale(prev_locale)
+        freelocale(c_locale)
 
 
 __all__ = [

--- a/cuda_core/cuda/core/system/_system.pyx
+++ b/cuda_core/cuda/core/system/_system.pyx
@@ -157,8 +157,11 @@ def get_process_name(pid: int) -> str:
         # running processes on devices. To ensure the name is cached for the
         # requested PID, we walk all devices and query their running processes.
         for i in range(nvml.device_get_count_v2()):
-            dev_h = nvml.device_get_handle_by_index_v2(i)
-            nvml.device_get_compute_running_processes_v3(dev_h)
+            try:
+                dev_h = nvml.device_get_handle_by_index_v2(i)
+                nvml.device_get_compute_running_processes_v3(dev_h)
+            except nvml.NvmlError:
+                continue
         return nvml.system_get_process_name(pid)
 
     initialize()

--- a/cuda_core/cuda/core/system/_system.pyx
+++ b/cuda_core/cuda/core/system/_system.pyx
@@ -11,18 +11,6 @@
 CUDA_BINDINGS_NVML_IS_COMPATIBLE: bool
 
 
-# POSIX per-thread locale APIs. We use these (rather than setlocale(3))
-# so the WSL workaround in get_process_name() doesn't perturb the locale
-# observed by other threads. locale_t is an opaque pointer in glibc.
-cdef extern from "locale.h" nogil:
-    ctypedef void *locale_t
-    int LC_ALL_MASK
-    locale_t LC_GLOBAL_LOCALE
-    locale_t newlocale(int category_mask, const char *locale, locale_t base)
-    locale_t uselocale(locale_t newloc)
-    void freelocale(locale_t locobj)
-
-
 cdef bint _detect_wsl():
     try:
         with open("/proc/sys/kernel/osrelease") as f:
@@ -33,6 +21,18 @@ cdef bint _detect_wsl():
 
 
 cdef bint _IS_WSL = _detect_wsl()
+
+
+# The WSL locale guard lives in a separate module that is only compiled on
+# Linux (build_hooks.py excludes it on Windows), because it relies on POSIX
+# per-thread locale APIs that MSVC does not provide. On non-Linux platforms
+# the import fails and we fall back to a no-op guard; _IS_WSL is then False
+# so the guard is never entered anyway.
+if _IS_WSL:
+    from cuda.core._utils._wsl_locale import c_locale_guard
+else:
+    c_locale_guard = None
+
 
 try:
     from cuda.bindings._version import __version_tuple__ as _BINDINGS_VERSION
@@ -161,33 +161,24 @@ def get_process_name(pid: int) -> str:
             nvml.device_get_compute_running_processes_v3(dev_h)
         return nvml.system_get_process_name(pid)
 
-    cdef locale_t c_locale
-    cdef locale_t prev_locale
-
     initialize()
     if not _IS_WSL:
         return _get_process_name(pid)
 
     # WSL workaround: nvmlSystemGetProcessName on WSL takes a wide-char
-    # conversion path when the process locale is non-"C". That path walks
-    # a UTF-16LE source buffer with a 4-byte stride (as if it were UTF-32LE)
-    # and emits 5-byte UTF-8 sequences that look like garbage preceding the
-    # trailing basename of /proc/<pid>/exe. CPython's startup unconditionally
-    # calls setlocale(LC_ALL, ""), so essentially every cuda.core caller hits
-    # this. The cached entry for the PID is set the first time NVML resolves
-    # it (typically inside nvmlDeviceGetComputeRunningProcesses_v3), so to
-    # recover a correct value we re-prime the cache under the "C" locale
-    # before reading the name. We use the POSIX per-thread locale APIs so
-    # other threads' view of the locale is unaffected.
-    c_locale = newlocale(LC_ALL_MASK, b"C", <locale_t>0)
-    if c_locale == <locale_t>0:
-        raise RuntimeError("Failed to create C locale")
-    prev_locale = uselocale(c_locale)
-    try:
+    # conversion path when the calling thread's locale is non-"C". That path
+    # walks a UTF-16LE source buffer with a 4-byte stride (as if it were
+    # UTF-32LE) and emits 5-byte UTF-8 sequences that look like garbage
+    # preceding the trailing basename of /proc/<pid>/exe. CPython's startup
+    # unconditionally calls setlocale(LC_ALL, ""), so essentially every
+    # cuda.core caller hits this. The cached entry for the PID is set the
+    # first time NVML resolves it (typically inside
+    # nvmlDeviceGetComputeRunningProcesses_v3), so to recover a correct value
+    # we re-prime the cache under the "C" locale before reading the name.
+    # c_locale_guard uses POSIX per-thread locale APIs (see _wsl_locale.pyx)
+    # so other threads' view of the locale is unaffected.
+    with c_locale_guard():  # no-cython-lint
         return _get_process_name(pid)
-    finally:
-        uselocale(prev_locale)
-        freelocale(c_locale)
 
 
 __all__ = [

--- a/cuda_core/docs/source/release/1.1.0-notes.rst
+++ b/cuda_core/docs/source/release/1.1.0-notes.rst
@@ -48,8 +48,7 @@ Bug fixes
 ---------
 
 - On WSL, ``cuda.core.system.get_process_name`` would raise a
-  ``UnicodeDecodeError``.  It should now return the correct result.  Note it may
-  cause a performance issue as it holds a global lock.
+  ``UnicodeDecodeError``.  It should now return the correct result.
 - Calling ``cuda.core.system.get_process_name`` before querying any device's
   ``compute_running_processes`` would raise a ``NvmlNotFoundError``.  Now it will
   correctly return the process name, if it is a GPU-using process.

--- a/cuda_core/docs/source/release/1.1.0-notes.rst
+++ b/cuda_core/docs/source/release/1.1.0-notes.rst
@@ -43,3 +43,13 @@ New features
   :attr:`~ManagedBuffer.preferred_location`,
   :attr:`~ManagedBuffer.accessed_by`). Locations are expressed via
   :class:`Device` or :class:`Host`.
+
+Bug fixes
+---------
+
+- On WSL, ``cuda.core.system.get_process_name`` would raise a
+  ``UnicodeDecodeError``.  It should now return the correct result.  Note it may
+  cause a performance issue as it holds a global lock.
+- Calling ``cuda.core.system.get_process_name`` before querying any device's
+  ``compute_running_processes`` would raise a ``NvmlNotFoundError``.  Now it will
+  correctly return the process name, if it is a GPU-using process.

--- a/cuda_core/tests/system/test_system_system.py
+++ b/cuda_core/tests/system/test_system_system.py
@@ -12,8 +12,6 @@ try:
 except ImportError:
     from cuda import cuda as driver
 
-import helpers
-
 from cuda.core import system
 from cuda.core._utils.cuda_utils import handle_return
 
@@ -62,7 +60,6 @@ def test_nvml_version():
         assert 0 <= ver_patch[0] <= 99
 
 
-@pytest.mark.skipif(helpers.IS_WSL, reason="Process names may not be available on WSL")
 @skip_if_nvml_unsupported
 def test_get_process_name():
     try:

--- a/cuda_core/tests/system/test_system_system.py
+++ b/cuda_core/tests/system/test_system_system.py
@@ -62,6 +62,9 @@ def test_nvml_version():
 
 @skip_if_nvml_unsupported
 def test_get_process_name():
+    for device in system.Device.get_all_devices():
+        x = device.compute_running_processes
+
     try:
         process_name = system.get_process_name(os.getpid())
     except system.NotFoundError:


### PR DESCRIPTION
## Summary

`cuda.core.system.get_process_name(pid)` raises `UnicodeDecodeError` under
WSL whenever the calling process has a non-`C` locale (which is the default
state for any CPython process, since the interpreter calls
`setlocale(LC_ALL, "")` at startup). This is reproducible by running the
`cuda_core` test suite with any seed that schedules
`tests/system/test_system_device.py::test_compute_running_processes` before
`tests/system/test_system_system.py::test_get_process_name`.

The underlying defect is in NVML's WSL implementation (see *Root cause*
below). This PR adds a scoped, defensive workaround in `cuda_core` so the
public API returns a correct value on WSL. It also fixes a latent issue
where `get_process_name` was effectively unusable from a fresh process
because it never primed NVML's per-PID name cache.

## Root cause: the WSL mojibake

NVML's `nvmlSystemGetProcessName` on WSL takes a different code path
depending on the process's current locale. With the default `"C"` locale,
the function returns the basename portion of `/proc/<pid>/exe` correctly.
With any other locale (including the typical `en_US.UTF-8`), it instead
walks an internal UTF-16LE buffer holding the executable path but uses a
**4-byte stride** (as if the buffer were UTF-32LE). Each "code point" it
pulls is therefore two adjacent ASCII bytes packed into the low and
next-higher bytes of a single 24-bit value. That value is then emitted as
an extended 5-byte UTF-8 sequence (the `0xF8`-prefixed encoding used to
represent code points beyond U+10FFFF).

The net result for, say, a Python process whose `/proc/<pid>/exe` resolves
to:

```
/home/mdboom/.local/share/uv/python/cpython-3.14.0-linux-x86_64-gnu/bin/python3.14
```

is that the returned buffer looks like ~180 bytes of `f8 …` chunks
followed by the correctly-encoded trailing basename, e.g.:

```
f8 9a 80 80 af  f8 9b 90 81 af  f8 8b b0 81 a5  f8 99 80 81 ad  …  /python3.14\0
```

Decoding the first chunk illustrates the pattern:

- bytes `f8 9a 80 80 af` decode as the extended-UTF-8 code point `0x68002F`
- that 24-bit value packs `'h'` (`0x68`) in the high byte and `'/'` (`0x2F`)
  in the low byte — i.e. the source ASCII bytes `/h` read as a
  little-endian 32-bit value padded with zeros

Every chunk has this structure; together they spell out the prefix
`/home/mdboom/.local/share/uv/python/cpython-3.14.0-linux-x86_64-gnu/bin/`
two characters at a time. The trailing `/python3.14` is unaffected because
of where the buggy stride leaves the cursor.

### Why the workaround needs to "re-prime"

`nvmlSystemGetProcessName` is cache-driven: the per-PID name is populated
the first time NVML enumerates compute processes that include the PID
(typically via `nvmlDeviceGetComputeRunningProcesses_v3`). Critically:

- The mojibake is produced *during* the prime call, not during the read.
- Once a buggy entry is in NVML's cache, switching to the `"C"` locale and
  re-reading does **not** unscramble it — the cache survives the locale
  flip.
- Re-running the prime call under the `"C"` locale overwrites the cached
  entry with the correct UTF-8 string. Subsequent reads (in any locale)
  then return correctly.

So the workaround must do prime + read together under `"C"`.

## Behaviour after this PR

- **Native Linux / Windows**: behaviour is identical to before, except that
  `get_process_name` now primes the NVML cache automatically. This makes
  it usable from a fresh process (previously a caller had to have
  manually queried `device.compute_running_processes` first or accept
  `NotFoundError`).
- **WSL**: the locale flip is applied around the prime + read sequence,
  so the returned name is the correct UTF-8 string regardless of the
  caller's locale.

## Discussion

- Should we instead try to fix this at the ``cuda_bindings`` layer and fix it
  for all ``cuda_bindings`` users? In that case I guess ``cuda_core`` should raise
  an exception from ``get_process_name`` if on WSL and the ``cuda_bindings``
  installed is too old?
- I do plan to file the underlying bug with NVML. Locale-sensitive APIs should
  generally be avoided.