### PR TITLE
Maintenance: small CI and test-helper cleanups

### DIFF
--- a/.github/workflows/test-sdist-linux.yml
+++ b/.github/workflows/test-sdist-linux.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   test-sdist:
     name: Test sdist builds
+    timeout-minutes: 60
     runs-on: linux-amd64-cpu8
     steps:
       - name: Checkout ${{ github.event.repository.name }}

--- a/.github/workflows/test-sdist-windows.yml
+++ b/.github/workflows/test-sdist-windows.yml
@@ -28,6 +28,7 @@ permissions:
 jobs:
   test-sdist:
     name: Test sdist builds
+    timeout-minutes: 60
     runs-on: windows-2022
     steps:
       - name: Checkout ${{ github.event.repository.name }}

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -96,6 +96,7 @@ jobs:
 
   test:
     name: Python ${{ matrix.PY_VER }}, CUDA ${{ matrix.CUDA_VER }} (${{ (matrix.LOCAL_CTK == '1' && 'local') || 'wheels' }}), GPU ${{ matrix.GPU }}${{ matrix.GPU_COUNT != '1' && format(' (x{0})', matrix.GPU_COUNT) || '' }}${{ matrix.FLAVOR && format(', {0}', matrix.FLAVOR) || '' }}${{ matrix.TORCH_VER && format(', {0}', matrix.TORCH_VER) || '' }}${{ matrix.MODE == 'nightly-numba-cuda' && ', latest' || '' }}
+    timeout-minutes: 60
     needs: compute-matrix
     strategy:
       fail-fast: false

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -88,6 +88,7 @@ jobs:
 
   test:
     name: Python ${{ matrix.PY_VER }}, CUDA ${{ matrix.CUDA_VER }} (${{ (matrix.LOCAL_CTK == '1' && 'local') || 'wheels' }}), GPU ${{ matrix.GPU }}${{ matrix.GPU_COUNT != '1' && format(' (x{0})', matrix.GPU_COUNT) || '' }} (${{ matrix.DRIVER_MODE }})${{ matrix.TORCH_VER && format(', {0}', matrix.TORCH_VER) || '' }}${{ matrix.MODE == 'nightly-numba-cuda' && ', latest' || '' }}
+    timeout-minutes: 60
     # The build stage could fail but we want the CI to keep moving.
     needs: compute-matrix
     strategy:

--- a/cuda_bindings/examples/2_Concepts_and_Techniques/stream_ordered_allocation.py
+++ b/cuda_bindings/examples/2_Concepts_and_Techniques/stream_ordered_allocation.py
@@ -137,7 +137,7 @@ def stream_ordered_allocation_post_sync(dev, nelem, a, b, c):
             threshold_val,
         )
     )
-    # Record teh start event
+    # Record the start event
     check_cuda_errors(cudart.cudaEventRecord(start, stream))
     for _i in range(MAX_ITER):
         d_a = check_cuda_errors(cudart.cudaMallocAsync(num_bytes, stream))

--- a/cuda_core/cuda/core/system/_system.pyx
+++ b/cuda_core/cuda/core/system/_system.pyx
@@ -11,6 +11,8 @@
 CUDA_BINDINGS_NVML_IS_COMPATIBLE: bool
 
 
+# Please keep in sync with the equivalent implementation in
+# cuda_python_test_helpers/cuda_python_test_helpers/__init__.py.
 cdef bint _detect_wsl():
     try:
         with open("/proc/sys/kernel/osrelease") as f:

--- a/cuda_core/tests/memory_ipc/test_leaks.py
+++ b/cuda_core/tests/memory_ipc/test_leaks.py
@@ -34,7 +34,7 @@ def test_alloc_handle(ipc_memory_resource):
 
 
 def exec_success(obj, number=1):
-    """Succesfully run a child process."""
+    """Successfully run a child process."""
     for _ in range(number):
         process = mp.Process(target=child_main, args=(obj,))
         process.start()
@@ -50,8 +50,8 @@ def child_main(obj, *args):
 
 def exec_launch_failure(obj, number=1):
     """
-    Unsuccesfully try to launch a child process. This fails when
-    after the child starts.
+    Unsuccessfully try to launch a child process. This fails after
+    the child starts.
     """
     for _ in range(number):
         process = mp.Process(target=child_main_bad, args=(obj,))
@@ -68,7 +68,7 @@ def child_main_bad():
 
 def exec_reduce_failure(obj, number=1):
     """
-    Unsuccesfully try to launch a child process. This fails before
+    Unsuccessfully try to launch a child process. This fails before
     the child starts but after the resource-owning object is serialized.
     """
     for _ in range(number):

--- a/cuda_python_test_helpers/cuda_python_test_helpers/__init__.py
+++ b/cuda_python_test_helpers/cuda_python_test_helpers/__init__.py
@@ -15,13 +15,13 @@ __all__ = [
 ]
 
 
+# Please keep in sync with the equivalent implementation in
+# cuda_core/cuda/core/system/_system.pyx.
 def _detect_wsl() -> bool:
     data = ""
     with suppress(Exception), open("/proc/sys/kernel/osrelease") as f:
         data = f.read().lower()
-    if "microsoft" in data or "wsl" in data:
-        return True
-    return any(os.environ.get(k) for k in ("WSL_DISTRO_NAME", "WSL_INTEROP"))
+    return "microsoft" in data or "wsl" in data
 
 
 IS_WSL: bool = _detect_wsl()


### PR DESCRIPTION
This housekeeping PR combines three unrelated small changes to make the best use of CI resources:
- commit 7bce5f4b05 — add 60-minute timeouts to reusable test jobs so hung test runs release runners promptly (xref: [issue #2004](https://github.com/NVIDIA/cuda-python/issues/2004)).
- commit b78cdb59d9 — fix trivial spelling errors in two files, including errors pointed out in [PR #2103](https://github.com/NVIDIA/cuda-python/pull/2103).
- commit 741f971786 — align duplicate WSL detection helpers by removing the env-var fallback from test helpers and adding sync comments (xref: [PR #2118](https://github.com/NVIDIA/cuda-python/pull/2118)).