### PR TITLE
cuda.core: add host_launch for direct stream callbacks

### DIFF
--- a/cuda_core/cuda/core/__init__.py
+++ b/cuda_core/cuda/core/__init__.py
@@ -82,7 +82,7 @@ from cuda.core._event import Event, EventOptions
 from cuda.core._graphics import GraphicsResource
 from cuda.core._host import Host
 from cuda.core._launch_config import LaunchConfig
-from cuda.core._launcher import launch
+from cuda.core._launcher import host_launch, launch
 from cuda.core._linker import Linker, LinkerOptions
 from cuda.core._memory import (
     Buffer,

--- a/cuda_core/cuda/core/_launcher.pyx
+++ b/cuda_core/cuda/core/_launcher.pyx
@@ -2,11 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import ctypes
-import itertools
-import threading
+from cpython.ref cimport Py_INCREF
 
 from libc.stdint cimport uintptr_t
+from libc.stdlib cimport malloc, free
+from libc.string cimport memcpy as c_memcpy
 
 from cuda.bindings cimport cydriver
 
@@ -24,68 +24,104 @@ from cuda.core._stream import Stream
 from math import prod
 
 
-class _PendingHostLaunch:
-    __slots__ = ("_fn", "_payload", "_stream")
-
-    def __init__(self, stream, fn, payload):
-        self._fn = fn
-        self._payload = payload
-        self._stream = stream
-
-    def invoke(self):
-        if isinstance(self._fn, ctypes._CFuncPtr):
-            if self._payload is None:
-                self._fn(None)
-            elif isinstance(self._payload, int):
-                self._fn(ctypes.c_void_p(self._payload))
-            else:
-                self._fn(ctypes.c_void_p(ctypes.addressof(self._payload)))
-            return
-
-        self._fn()
+cdef extern from "Python.h":
+    void _py_decref "Py_DECREF" (void*)
 
 
-_pending_host_launches = {}
-_pending_host_launches_lock = threading.Lock()
-_pending_host_launch_tokens = itertools.count(1)
+cdef struct _HostLaunchCFuncState:
+    cydriver.CUhostFn fn
+    void* user_data
+    bint owns_user_data
+    void* fn_pyobj
 
 
-cdef void _host_launch_trampoline(void* data) noexcept with gil:
-    cdef object pending
+cdef void _py_host_launch_trampoline(void* data) noexcept with gil:
+    try:
+        (<object>data)()
+    finally:
+        _py_decref(data)
 
-    with _pending_host_launches_lock:
-        pending = _pending_host_launches.pop(<uintptr_t>data, None)
-    if pending is None:
+
+cdef void _ctypes_host_launch_trampoline(void* data) noexcept with gil:
+    cdef _HostLaunchCFuncState* state = <_HostLaunchCFuncState*>data
+
+    try:
+        state.fn(state.user_data)
+    finally:
+        if state.fn_pyobj != NULL:
+            _py_decref(state.fn_pyobj)
+        if state.owns_user_data and state.user_data != NULL:
+            free(state.user_data)
+        free(state)
+
+
+cdef void _cleanup_host_launch(
+        cydriver.CUhostFn fn, void* user_data) except *:
+    cdef _HostLaunchCFuncState* state
+
+    if fn == <cydriver.CUhostFn>_py_host_launch_trampoline:
+        if user_data != NULL:
+            _py_decref(user_data)
         return
 
-    pending.invoke()
+    if fn == <cydriver.CUhostFn>_ctypes_host_launch_trampoline:
+        state = <_HostLaunchCFuncState*>user_data
+        if state != NULL:
+            if state.fn_pyobj != NULL:
+                _py_decref(state.fn_pyobj)
+            if state.owns_user_data and state.user_data != NULL:
+                free(state.user_data)
+            free(state)
 
 
-def _register_host_launch(stream, fn, user_data):
-    if isinstance(fn, ctypes._CFuncPtr):
+cdef void _prepare_host_launch(
+        object fn, object user_data,
+        cydriver.CUhostFn* out_fn, void** out_user_data) except *:
+    import ctypes as ct
+
+    cdef void* fn_pyobj = NULL
+    cdef _HostLaunchCFuncState* state = NULL
+    cdef bytes buf
+
+    if isinstance(fn, ct._CFuncPtr):
+        state = <_HostLaunchCFuncState*>malloc(sizeof(_HostLaunchCFuncState))
+        if state == NULL:
+            raise MemoryError("failed to allocate host callback state")
+
+        state.fn = <cydriver.CUhostFn><uintptr_t>ct.cast(fn, ct.c_void_p).value
+        state.user_data = NULL
+        state.owns_user_data = False
+        state.fn_pyobj = NULL
+
+        Py_INCREF(fn)
+        fn_pyobj = <void*>fn
+        state.fn_pyobj = fn_pyobj
+
+        out_fn[0] = <cydriver.CUhostFn>_ctypes_host_launch_trampoline
+
         if user_data is None:
-            payload = None
+            pass
         elif isinstance(user_data, int):
-            payload = user_data
+            state.user_data = <void*><uintptr_t>user_data
         else:
-            payload = ctypes.create_string_buffer(bytes(user_data))
+            buf = bytes(user_data)
+            state.user_data = malloc(len(buf))
+            if state.user_data == NULL:
+                _py_decref(fn_pyobj)
+                free(state)
+                raise MemoryError("failed to allocate user_data buffer")
+            c_memcpy(state.user_data, <const char*>buf, len(buf))
+            state.owns_user_data = True
+        out_user_data[0] = <void*>state
     else:
         if user_data is not None:
             raise ValueError("user_data is only supported with ctypes function pointers")
         if not callable(fn):
             raise TypeError("fn must be callable")
-        payload = None
-
-    pending = _PendingHostLaunch(stream, fn, payload)
-    token = next(_pending_host_launch_tokens)
-    with _pending_host_launches_lock:
-        _pending_host_launches[token] = pending
-    return token
-
-
-def _discard_host_launch(token):
-    with _pending_host_launches_lock:
-        _pending_host_launches.pop(token, None)
+        Py_INCREF(fn)
+        fn_pyobj = <void*>fn
+        out_fn[0] = <cydriver.CUhostFn>_py_host_launch_trampoline
+        out_user_data[0] = fn_pyobj
 
 
 def launch(stream: Stream | GraphBuilder | IsStreamType, config: LaunchConfig, kernel: Kernel, *kernel_args):
@@ -162,17 +198,16 @@ def host_launch(stream: Stream | IsStreamType, fn, *, user_data=None):
         pointer to the copied buffer.
     """
     cdef Stream s = Stream_accept(stream, allow_stream_protocol=True)
-    cdef uintptr_t token = _register_host_launch(s, fn, user_data)
+    cdef cydriver.CUhostFn c_fn
+    cdef void* c_user_data = NULL
 
+    _prepare_host_launch(fn, user_data, &c_fn, &c_user_data)
     try:
         with nogil:
             HANDLE_RETURN(cydriver.cuLaunchHostFunc(
-                as_cu(s._h_stream),
-                <cydriver.CUhostFn>_host_launch_trampoline,
-                <void*>token,
-            ))
+                as_cu(s._h_stream), c_fn, c_user_data))
     except Exception:
-        _discard_host_launch(token)
+        _cleanup_host_launch(c_fn, c_user_data)
         raise
 
 

--- a/cuda_core/cuda/core/_launcher.pyx
+++ b/cuda_core/cuda/core/_launcher.pyx
@@ -93,6 +93,7 @@ cdef void _prepare_host_launch(
         state.owns_user_data = False
         state.fn_pyobj = NULL
 
+        # Keep the ctypes wrapper alive until the driver invokes the callback.
         Py_INCREF(fn)
         fn_pyobj = <void*>fn
         state.fn_pyobj = fn_pyobj
@@ -118,6 +119,8 @@ cdef void _prepare_host_launch(
             raise ValueError("user_data is only supported with ctypes function pointers")
         if not callable(fn):
             raise TypeError("fn must be callable")
+        # The driver only sees a void* payload, so we transfer the Python
+        # callable itself as callback state and release it in the trampoline.
         Py_INCREF(fn)
         fn_pyobj = <void*>fn
         out_fn[0] = <cydriver.CUhostFn>_py_host_launch_trampoline

--- a/cuda_core/cuda/core/_launcher.pyx
+++ b/cuda_core/cuda/core/_launcher.pyx
@@ -2,6 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import ctypes
+import itertools
+import threading
+
 from libc.stdint cimport uintptr_t
 
 from cuda.bindings cimport cydriver
@@ -18,6 +22,70 @@ from cuda.core._utils.cuda_utils cimport (
 from cuda.core._module import Kernel
 from cuda.core._stream import Stream
 from math import prod
+
+
+class _PendingHostLaunch:
+    __slots__ = ("_fn", "_payload", "_stream")
+
+    def __init__(self, stream, fn, payload):
+        self._fn = fn
+        self._payload = payload
+        self._stream = stream
+
+    def invoke(self):
+        if isinstance(self._fn, ctypes._CFuncPtr):
+            if self._payload is None:
+                self._fn(None)
+            elif isinstance(self._payload, int):
+                self._fn(ctypes.c_void_p(self._payload))
+            else:
+                self._fn(ctypes.c_void_p(ctypes.addressof(self._payload)))
+            return
+
+        self._fn()
+
+
+_pending_host_launches = {}
+_pending_host_launches_lock = threading.Lock()
+_pending_host_launch_tokens = itertools.count(1)
+
+
+cdef void _host_launch_trampoline(void* data) noexcept with gil:
+    cdef object pending
+
+    with _pending_host_launches_lock:
+        pending = _pending_host_launches.pop(<uintptr_t>data, None)
+    if pending is None:
+        return
+
+    pending.invoke()
+
+
+def _register_host_launch(stream, fn, user_data):
+    if isinstance(fn, ctypes._CFuncPtr):
+        if user_data is None:
+            payload = None
+        elif isinstance(user_data, int):
+            payload = user_data
+        else:
+            payload = ctypes.create_string_buffer(bytes(user_data))
+    else:
+        if user_data is not None:
+            raise ValueError("user_data is only supported with ctypes function pointers")
+        if not callable(fn):
+            raise TypeError("fn must be callable")
+        payload = None
+
+    pending = _PendingHostLaunch(stream, fn, payload)
+    token = next(_pending_host_launch_tokens)
+    with _pending_host_launches_lock:
+        _pending_host_launches[token] = pending
+    return token
+
+
+def _discard_host_launch(token):
+    with _pending_host_launches_lock:
+        _pending_host_launches.pop(token, None)
 
 
 def launch(stream: Stream | GraphBuilder | IsStreamType, config: LaunchConfig, kernel: Kernel, *kernel_args):
@@ -56,6 +124,52 @@ def launch(stream: Stream | GraphBuilder | IsStreamType, config: LaunchConfig, k
         _check_cooperative_launch(kernel, conf, s)
     with nogil:
         HANDLE_RETURN(cydriver.cuLaunchKernelEx(&drv_cfg, func_handle, args_ptr, NULL))
+
+
+def host_launch(stream: Stream | IsStreamType, fn, *, user_data=None):
+    """Enqueue a host callback onto a CUDA stream.
+
+    The callback runs on a host thread after all previously enqueued work on
+    ``stream`` completes. Future work added to the same stream will not begin
+    until the callback returns.
+
+    Two callback forms are supported:
+
+    - **Python callable**: pass any callable that takes no arguments.
+    - **ctypes function pointer**: pass a ``ctypes.CFUNCTYPE``-style callable.
+      The callback receives a single ``void*`` argument. ``user_data`` may be
+      an ``int`` pointer value or bytes-like object.
+
+    .. warning::
+
+        Host callbacks must not call CUDA APIs directly or indirectly. CUDA
+        driver callbacks run on an internal host thread, so re-entering CUDA
+        from the callback can deadlock.
+
+    Parameters
+    ----------
+    stream : :obj:`~_stream.Stream`
+        The stream that establishes the callback ordering.
+    fn : callable or ctypes function pointer
+        The callback function.
+    user_data : int or bytes-like, optional
+        Only for ctypes function pointers. If ``int``, passed as a raw pointer
+        value. If bytes-like, the payload is copied and passed as a ``void*``
+        pointer to the copied buffer.
+    """
+    cdef Stream s = Stream_accept(stream, allow_stream_protocol=True)
+    cdef uintptr_t token = _register_host_launch(s, fn, user_data)
+
+    try:
+        with nogil:
+            HANDLE_RETURN(cydriver.cuLaunchHostFunc(
+                as_cu(s._h_stream),
+                <cydriver.CUhostFn>_host_launch_trampoline,
+                <void*>token,
+            ))
+    except Exception:
+        _discard_host_launch(token)
+        raise
 
 
 cdef _check_cooperative_launch(kernel: Kernel, config: LaunchConfig, stream: Stream):

--- a/cuda_core/cuda/core/_launcher.pyx
+++ b/cuda_core/cuda/core/_launcher.pyx
@@ -143,8 +143,12 @@ def host_launch(stream: Stream | IsStreamType, fn, *, user_data=None):
     .. warning::
 
         Host callbacks must not call CUDA APIs directly or indirectly. CUDA
-        driver callbacks run on an internal host thread, so re-entering CUDA
-        from the callback can deadlock.
+        driver callbacks run on an internal host thread. If that thread blocks
+        waiting for the GIL while another Python thread holds the GIL and is
+        blocked in a CUDA call, the process can deadlock through CUDA-driver /
+        GIL lock-order inversion. CUDA-using Python libraries should release
+        the GIL around CUDA calls, and host callbacks must avoid re-entering
+        CUDA from Python.
 
     Parameters
     ----------

--- a/cuda_core/docs/source/api.rst
+++ b/cuda_core/docs/source/api.rst
@@ -20,6 +20,7 @@ Devices and execution
 
    Device
    Host
+   host_launch
    launch
 
    :template: autosummary/cyclass.rst

--- a/cuda_core/docs/source/release/1.1.0-notes.rst
+++ b/cuda_core/docs/source/release/1.1.0-notes.rst
@@ -44,6 +44,11 @@ New features
   :attr:`~ManagedBuffer.accessed_by`). Locations are expressed via
   :class:`Device` or :class:`Host`.
 
+- Added :func:`host_launch` for enqueueing host callbacks directly onto a
+  :class:`Stream`, including ``ctypes`` callbacks with optional ``user_data``.
+  This complements the existing graph-side
+  :class:`graph.HostCallbackNode` support for host work ordering.
+
 Bug fixes
 ---------
 

--- a/cuda_core/examples/host_launch.py
+++ b/cuda_core/examples/host_launch.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# ################################################################################
+#
+# This example demonstrates scheduling host work on a CUDA stream with
+# cuda.core.host_launch(). A kernel updates pinned host memory, a host callback
+# observes that intermediate state and updates it on the CPU, and a second
+# kernel runs afterward on the same stream.
+#
+# ################################################################################
+
+# /// script
+# dependencies = ["cuda_bindings", "cuda_core", "nvidia-cuda-nvrtc", "numpy>=2.1"]
+# ///
+
+import numpy as np
+
+from cuda.core import Device, LaunchConfig, LegacyPinnedMemoryResource, Program, ProgramOptions, host_launch, launch
+
+code = r"""
+extern "C" __global__ void increment_index(int* values, unsigned long long index) {
+    values[index] += 1;
+}
+"""
+
+
+def main():
+    dev = Device()
+    dev.set_current()
+    stream = dev.create_stream()
+    pinned_mr = LegacyPinnedMemoryResource()
+    pinned_buffer = None
+
+    try:
+        program_options = ProgramOptions(std="c++17", arch=f"sm_{dev.arch}")
+        prog = Program(code, code_type="c++", options=program_options)
+        mod = prog.compile("cubin")
+        kernel = mod.get_kernel("increment_index")
+
+        pinned_buffer = pinned_mr.allocate(2 * np.dtype(np.int32).itemsize)
+        values = np.from_dlpack(pinned_buffer).view(np.int32)
+        values[:] = 0
+
+        config = LaunchConfig(grid=1, block=1)
+
+        launch(stream, config, kernel, pinned_buffer, np.uint64(0))
+
+        def capture_progress():
+            assert values[0] == 1
+            assert values[1] == 0
+            values[1] += 1
+
+        host_launch(stream, capture_progress)
+        launch(stream, config, kernel, pinned_buffer, np.uint64(1))
+        stream.sync()
+
+        np.testing.assert_array_equal(values, np.array([1, 2], dtype=np.int32))
+    finally:
+        if pinned_buffer is not None:
+            pinned_buffer.close(stream)
+        stream.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/cuda_core/tests/test_launcher.py
+++ b/cuda_core/tests/test_launcher.py
@@ -22,6 +22,7 @@ from cuda.core import (
     LegacyPinnedMemoryResource,
     Program,
     ProgramOptions,
+    host_launch,
     launch,
 )
 from cuda.core._memory._legacy import _SynchronousMemoryResource
@@ -153,6 +154,39 @@ def test_launch_invalid_values(init_cuda):
 
     launch(stream, config, ker)
     stream.sync()  # TODO(#1539)
+
+
+def test_host_launch_python(init_cuda):
+    stream = Device().create_stream()
+    results = []
+
+    host_launch(stream, lambda: results.append(1))
+    host_launch(stream, lambda: results.append(2))
+    stream.sync()
+
+    assert results == [1, 2]
+
+
+def test_host_launch_ctypes_with_user_data(init_cuda):
+    CALLBACK = ctypes.CFUNCTYPE(None, ctypes.c_void_p)
+    result = [0]
+
+    @CALLBACK
+    def read_byte(data):
+        result[0] = ctypes.cast(data, ctypes.POINTER(ctypes.c_uint8))[0]
+
+    stream = Device().create_stream()
+    host_launch(stream, read_byte, user_data=bytes([0xAB]))
+    stream.sync()
+
+    assert result[0] == 0xAB
+
+
+def test_host_launch_rejects_user_data_for_python_callable(init_cuda):
+    stream = Device().create_stream()
+
+    with pytest.raises(ValueError, match="user_data is only supported"):
+        host_launch(stream, lambda: None, user_data=b"hello")
 
 
 # Parametrize: (python_type, cpp_type, init_value)

--- a/cuda_core/tests/test_launcher.py
+++ b/cuda_core/tests/test_launcher.py
@@ -160,8 +160,14 @@ def test_host_launch_python(init_cuda):
     stream = Device().create_stream()
     results = []
 
-    host_launch(stream, lambda: results.append(1))
-    host_launch(stream, lambda: results.append(2))
+    def capture_one():
+        results.append(1)
+
+    def capture_two():
+        results.append(2)
+
+    host_launch(stream, capture_one)
+    host_launch(stream, capture_two)
     stream.sync()
 
     assert results == [1, 2]
@@ -185,8 +191,11 @@ def test_host_launch_ctypes_with_user_data(init_cuda):
 def test_host_launch_rejects_user_data_for_python_callable(init_cuda):
     stream = Device().create_stream()
 
+    def noop():
+        pass
+
     with pytest.raises(ValueError, match="user_data is only supported"):
-        host_launch(stream, lambda: None, user_data=b"hello")
+        host_launch(stream, noop, user_data=b"hello")
 
 
 # Parametrize: (python_type, cpp_type, init_value)


### PR DESCRIPTION
## Summary

- add `cuda.core.host_launch(stream, fn, *, user_data=None)` as the direct stream-side host callback API
- keep Python callbacks, ctypes callbacks, copied payload buffers, and the stream callback state alive until the driver invokes the callback
- document the CUDA-driver/GIL lock-order inversion risk raised in issue discussion
- add a small `cuda_core/examples/host_launch.py` example showing host work ordered between two kernels
- add repo-native `cuda_core/tests/test_launcher.py` coverage for Python callbacks, ctypes payloads, and `user_data` validation

## Context

Fixes #2058.

`cuda.core` already had graph-side host callback support through `graph.HostCallbackNode` and the existing `cuGraphAddHostNode` plumbing. The missing gap called out in the issue was the direct stream-side host callback surface, which previously forced users down to `cuda.bindings`.

This PR adds that missing `host_launch(...)` API without widening the graph abstraction or introducing a separate callback framework.

## Validation

- `ruff check /Users/srini/cuda-python-pr-host-launch/cuda_core/tests/test_launcher.py`
- `ruff check /Users/srini/cuda-python-pr-host-launch/cuda_core/examples/host_launch.py`
- `python3 -m py_compile /Users/srini/cuda-python-pr-host-launch/cuda_core/tests/test_launcher.py /Users/srini/cuda-python-pr-host-launch/cuda_core/examples/host_launch.py /Users/srini/cuda-python-pr-host-launch/cuda_core/cuda/core/__init__.py`

