### PR TITLE
Simplify `.gitattributes` handling for C/C++ headers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,15 +1,8 @@
 * text eol=lf
 *.cmd text eol=crlf
 
-# we do not own any headers checked in, don't touch them
-*.h binary
-*.hpp binary
-# Exception: headers we own
-benchmarks/cuda_bindings/benchmarks/cpp/*.hpp -binary text diff
-cuda_bindings/cuda/bindings/_bindings/*.h -binary text diff
-cuda_bindings/cuda/bindings/_lib/*.h -binary text diff
-cuda_core/cuda/core/_cpp/*.h -binary text diff
-cuda_core/cuda/core/_cpp/*.hpp -binary text diff
+# Keep the vendored DLPack header byte-for-byte, but still show text diffs.
+cuda_core/cuda/core/_include/dlpack.h -text !eol diff
 # git should not convert line endings in PNG files
 *.png binary
 *.svg binary


### PR DESCRIPTION
## Summary

This simplifies the `.gitattributes` handling for checked-in `.h` and `.hpp` files.

Plain `git diff` now works intuitively across the tracked source headers, so changes in these files appear as normal text diffs without requiring `git diff -a`. This should also make future header additions less surprising. A newly added `.h` or `.hpp` file will behave like normal source by default, instead of silently becoming binary-classified unless someone remembers to add a matching exception rule.

The old attributes treated every C/C++ header as binary, then carved out path-specific exceptions for headers maintained in this repository. That was based on an outdated assumption that checked-in headers were broadly generated or hands-off inputs.

The tracked header set is much smaller and clearer: the only header that needs Git-level byte preservation is the vendored DLPack header. This change keeps `cuda_core/cuda/core/_include/dlpack.h` opted out of Git text normalization with `-text` and an explicit `!eol` reset, while forcing text diffs so review output stays readable.

All other tracked headers now inherit the repository default `text eol=lf` behavior, consistent with Python files and other normal source. This includes repo-owned C++ helpers as well as the AOTI shim adaptation, which is third-party-derived but maintained here rather than a byte-for-byte vendored header.

## Fresh Clone Behavior

For a fresh clone, this should not change the bytes of the nine existing tracked headers on Linux or Windows. The blobs are already stored with LF line endings.

On `main`, exception headers checked out as LF via `text eol=lf`, while the remaining binary-classified headers were written as raw LF blob bytes. After this change, ordinary headers still check out as LF via `text eol=lf`, and DLPack remains raw LF.

For a fresh clone, the only observable change is Git behavior: ordinary headers stop being binary-classified, and DLPack remains no-normalization but becomes text-diffable.

## Pre-commit

Pre-commit behavior is unchanged and still governed by hook-specific matching.

## Validation

Checked the effective attributes with `git check-attr` and verified the tracked header line-ending state with `git ls-files --eol`.

## Details

This change affects the attributes for the nine tracked `.h` and `.hpp` files.

These five files were already treated as text on `main` by path-specific exception rules that overrode the broad `binary` header rule with `-binary text diff`:

```
benchmarks/cuda_bindings/benchmarks/cpp/bench_support.hpp
cuda_bindings/cuda/bindings/_bindings/loader.h
cuda_bindings/cuda/bindings/_lib/param_packer.h
cuda_core/cuda/core/_cpp/resource_handles.hpp
cuda_core/cuda/core/_cpp/tensor_map_cccl.h
```

These three files were binary-classified on `main`, but are maintained source in this repository and should inherit the same `text eol=lf` behavior as other normal source files:

```
cuda_core/cuda/core/_include/aoti_shim.h
cuda_core/cuda/core/_include/layout.hpp
cuda_core/cuda/core/_include/utility.hpp
```

This one file remains special-cased because it is the byte-for-byte vendored header that should not be normalized by Git:

```
cuda_core/cuda/core/_include/dlpack.h
```
