### PR TITLE
Add Python 3.15 to the build/test matrix (12.9.x backport)

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -257,6 +257,23 @@ jobs:
             mv "/c/Program Files/Git/usr/bin/link.exe" "/c/Program Files/Git/usr/bin/link.exe.bak"
           fi
 
+      - name: Build numpy wheel (pre-release Python)
+        if: ${{ startsWith(matrix.python-version, '3.15') }}
+        run: |
+          pip wheel "numpy>=1.21.1" --no-binary numpy -w numpy-wheel/
+
+      - name: Upload numpy wheel
+        if: ${{ startsWith(matrix.python-version, '3.15') }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: numpy-python${{ env.PYTHON_VERSION_FORMATTED }}-${{ inputs.host-platform }}
+          path: numpy-wheel/*.whl
+          if-no-files-found: error
+
+      - name: Install numpy wheel
+        if: ${{ startsWith(matrix.python-version, '3.15') }}
+        run: pip install numpy-wheel/*.whl
+
       - name: Build cuda.bindings Cython tests
         run: |
           pip install $(ls ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}/*.whl)[test]

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -257,8 +257,27 @@ jobs:
             mv "/c/Program Files/Git/usr/bin/link.exe" "/c/Program Files/Git/usr/bin/link.exe.bak"
           fi
 
-      - name: Build numpy wheel (pre-release Python)
-        if: ${{ startsWith(matrix.python-version, '3.15') }}
+      - name: Download numpy sdist (pre-release Python)
+        if: ${{ startsWith(matrix.python-version, '3.15') && startsWith(inputs.host-platform, 'linux') }}
+        run: |
+          pip download --no-binary numpy --no-deps "numpy>=1.21.1" -d numpy-sdist/
+          cd numpy-sdist && tar xf numpy-*.tar.gz && rm numpy-*.tar.gz
+          echo "NUMPY_SRC_DIR=$(pwd)/$(ls -d numpy-*/)" >> $GITHUB_ENV
+
+      - name: Build numpy wheel (pre-release Python, Linux)
+        if: ${{ startsWith(matrix.python-version, '3.15') && startsWith(inputs.host-platform, 'linux') }}
+        uses: pypa/cibuildwheel@54327ab9d35de03b359ac25c97de9417d94639c0  # v4.0.0rc1
+        env:
+          CIBW_BUILD: ${{ env.CIBW_BUILD }}
+          CIBW_ARCHS_LINUX: "native"
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_ENABLE: "cpython-prerelease"
+        with:
+          package-dir: ${{ env.NUMPY_SRC_DIR }}
+          output-dir: numpy-wheel/
+
+      - name: Build numpy wheel (pre-release Python, Windows)
+        if: ${{ startsWith(matrix.python-version, '3.15') && startsWith(inputs.host-platform, 'win') }}
         run: |
           pip wheel "numpy>=1.21.1" --no-binary numpy -w numpy-wheel/
 

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -122,7 +122,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --namespace-pkg cuda -w {dest_dir} {wheel}"
           CIBW_ENVIRONMENT: >
             CUDA_PYTHON_PARALLEL_LEVEL=${{ env.CUDA_PYTHON_PARALLEL_LEVEL }}
-          CIBW_ENABLE: "cpython-freethreading cpython-prerelease"
+          CIBW_ENABLE: "cpython-prerelease"
         with:
           package-dir: ./cuda_core/
           output-dir: ${{ env.CUDA_CORE_ARTIFACTS_DIR }}
@@ -170,7 +170,7 @@ jobs:
             CUDA_PYTHON_PARALLEL_LEVEL=${{ env.CUDA_PYTHON_PARALLEL_LEVEL }}
           CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --namespace-pkg cuda -w {dest_dir} {wheel}"
-          CIBW_ENABLE: "cpython-freethreading cpython-prerelease"
+          CIBW_ENABLE: "cpython-prerelease"
         with:
           package-dir: ./cuda_bindings/
           output-dir: ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -262,10 +262,17 @@ jobs:
         run: |
           pip download --no-binary numpy --no-deps "numpy>=1.21.1" -d numpy-sdist/
           cd numpy-sdist && tar xf numpy-*.tar.gz && rm numpy-*.tar.gz
-          # WAR: numpy 2.4.x ships enable=["cpython-freethreading", ...] which
-          # is invalid in cibuildwheel v4.0 (freethreading is now on by default).
-          # Fixed on numpy main (a5df4859) but not yet released.
-          sed -i 's/"cpython-freethreading", //' numpy-*/pyproject.toml
+          # WAR: numpy 2.4.x ships [tool.cibuildwheel] config that is
+          # incompatible with cibuildwheel v4.0 (cpython-freethreading enable
+          # group, OpenBLAS before-build scripts, etc.). Strip the entire
+          # section — we only need a basic numpy wheel for testing.
+          python -c "
+          import glob, re
+          for f in glob.glob('numpy-*/pyproject.toml'):
+              txt = open(f).read()
+              txt = re.sub(r'\n\[tool\.cibuildwheel\].*', '', txt, flags=re.DOTALL)
+              open(f, 'w').write(txt)
+          "
           echo "NUMPY_SRC_DIR=$(pwd)/$(ls -d numpy-*/)" >> $GITHUB_ENV
 
       - name: Build numpy wheel (pre-release Python)
@@ -275,6 +282,8 @@ jobs:
           CIBW_BUILD: ${{ env.CIBW_BUILD }}
           CIBW_ARCHS_LINUX: "native"
           CIBW_BUILD_VERBOSITY: 1
+          CIBW_CONFIG_SETTINGS: "setup-args=-Dallow-noblas=true"
+          CIBW_CONFIG_SETTINGS_WINDOWS: "setup-args=--vsenv setup-args=-Dallow-noblas=true"
           CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
           CIBW_ENABLE: "cpython-prerelease"

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -257,29 +257,30 @@ jobs:
             mv "/c/Program Files/Git/usr/bin/link.exe" "/c/Program Files/Git/usr/bin/link.exe.bak"
           fi
 
-      - name: Download numpy sdist (pre-release Python)
-        if: ${{ startsWith(matrix.python-version, '3.15') && startsWith(inputs.host-platform, 'linux') }}
+      - name: Download and patch numpy sdist (pre-release Python)
+        if: ${{ startsWith(matrix.python-version, '3.15') }}
         run: |
           pip download --no-binary numpy --no-deps "numpy>=1.21.1" -d numpy-sdist/
           cd numpy-sdist && tar xf numpy-*.tar.gz && rm numpy-*.tar.gz
+          # WAR: numpy 2.4.x ships enable=["cpython-freethreading", ...] which
+          # is invalid in cibuildwheel v4.0 (freethreading is now on by default).
+          # Fixed on numpy main (a5df4859) but not yet released.
+          sed -i 's/"cpython-freethreading", //' numpy-*/pyproject.toml
           echo "NUMPY_SRC_DIR=$(pwd)/$(ls -d numpy-*/)" >> $GITHUB_ENV
 
-      - name: Build numpy wheel (pre-release Python, Linux)
-        if: ${{ startsWith(matrix.python-version, '3.15') && startsWith(inputs.host-platform, 'linux') }}
+      - name: Build numpy wheel (pre-release Python)
+        if: ${{ startsWith(matrix.python-version, '3.15') }}
         uses: pypa/cibuildwheel@54327ab9d35de03b359ac25c97de9417d94639c0  # v4.0.0rc1
         env:
           CIBW_BUILD: ${{ env.CIBW_BUILD }}
           CIBW_ARCHS_LINUX: "native"
           CIBW_BUILD_VERBOSITY: 1
+          CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
           CIBW_ENABLE: "cpython-prerelease"
         with:
           package-dir: ${{ env.NUMPY_SRC_DIR }}
           output-dir: numpy-wheel/
-
-      - name: Build numpy wheel (pre-release Python, Windows)
-        if: ${{ startsWith(matrix.python-version, '3.15') && startsWith(inputs.host-platform, 'win') }}
-        run: |
-          pip wheel "numpy>=1.21.1" --no-binary numpy -w numpy-wheel/
 
       - name: Upload numpy wheel
         if: ${{ startsWith(matrix.python-version, '3.15') }}

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -264,14 +264,23 @@ jobs:
           cd numpy-sdist && tar xf numpy-*.tar.gz && rm numpy-*.tar.gz
           # WAR: numpy 2.4.x ships [tool.cibuildwheel] config that is
           # incompatible with cibuildwheel v4.0 (cpython-freethreading enable
-          # group, OpenBLAS before-build scripts, etc.). Strip the entire
-          # section — we only need a basic numpy wheel for testing.
+          # group, OpenBLAS before-build scripts, etc.). Strip the cibuildwheel
+          # sections but preserve [tool.meson-python] (vendored meson path).
           python -c "
-          import glob, re
+          import glob
           for f in glob.glob('numpy-*/pyproject.toml'):
-              txt = open(f).read()
-              txt = re.sub(r'\n\[tool\.cibuildwheel\].*', '', txt, flags=re.DOTALL)
-              open(f, 'w').write(txt)
+              lines, skip = open(f).readlines(), False
+              out = []
+              for line in lines:
+                  hdr = line.strip()
+                  if hdr.startswith('[tool.cibuildwheel') or hdr.startswith('[[tool.cibuildwheel'):
+                      skip = True
+                      continue
+                  if skip and hdr.startswith('[') and 'cibuildwheel' not in hdr:
+                      skip = False
+                  if not skip:
+                      out.append(line)
+              open(f, 'w').writelines(out)
           "
           echo "NUMPY_SRC_DIR=$(pwd)/$(ls -d numpy-*/)" >> $GITHUB_ENV
 

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -29,7 +29,6 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
-          - "3.13t"
           - "3.14"
           - "3.14t"
           - "3.15"
@@ -250,6 +249,13 @@ jobs:
       - name: Install cuda.pathfinder (required for next step)
         run: |
           pip install cuda_pathfinder/*.whl
+
+      - name: Hide GNU link.exe so Meson finds MSVC link.exe
+        if: ${{ startsWith(inputs.host-platform, 'win') }}
+        run: |
+          if [ -f "/c/Program Files/Git/usr/bin/link.exe" ]; then
+            mv "/c/Program Files/Git/usr/bin/link.exe" "/c/Program Files/Git/usr/bin/link.exe.bak"
+          fi
 
       - name: Build cuda.bindings Cython tests
         run: |

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -32,6 +32,8 @@ jobs:
           - "3.13t"
           - "3.14"
           - "3.14t"
+          - "3.15"
+          - "3.15t"
     name: py${{ matrix.python-version }}
     runs-on: ${{ (inputs.host-platform == 'linux-64' && 'linux-amd64-cpu8') ||
                  (inputs.host-platform == 'linux-aarch64' && 'linux-arm64-cpu8') ||
@@ -111,7 +113,7 @@ jobs:
           if-no-files-found: error
 
       - name: Build cuda.core wheel
-        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084  # v3.4.1
+        uses: pypa/cibuildwheel@54327ab9d35de03b359ac25c97de9417d94639c0  # v4.0.0rc1
         env:
           CIBW_BUILD: ${{ env.CIBW_BUILD }}
           CIBW_ARCHS_LINUX: "native"
@@ -120,7 +122,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --namespace-pkg cuda -w {dest_dir} {wheel}"
           CIBW_ENVIRONMENT: >
             CUDA_PYTHON_PARALLEL_LEVEL=${{ env.CUDA_PYTHON_PARALLEL_LEVEL }}
-          CIBW_ENABLE: "cpython-freethreading"
+          CIBW_ENABLE: "cpython-freethreading cpython-prerelease"
         with:
           package-dir: ./cuda_core/
           output-dir: ${{ env.CUDA_CORE_ARTIFACTS_DIR }}
@@ -154,7 +156,7 @@ jobs:
           cuda-version: ${{ inputs.cuda-version }}
 
       - name: Build cuda.bindings wheel
-        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084  # v3.4.1
+        uses: pypa/cibuildwheel@54327ab9d35de03b359ac25c97de9417d94639c0  # v4.0.0rc1
         env:
           CIBW_BUILD: ${{ env.CIBW_BUILD }}
           CIBW_ARCHS_LINUX: "native"
@@ -168,7 +170,7 @@ jobs:
             CUDA_PYTHON_PARALLEL_LEVEL=${{ env.CUDA_PYTHON_PARALLEL_LEVEL }}
           CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --namespace-pkg cuda -w {dest_dir} {wheel}"
-          CIBW_ENABLE: "cpython-freethreading"
+          CIBW_ENABLE: "cpython-freethreading cpython-prerelease"
         with:
           package-dir: ./cuda_bindings/
           output-dir: ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,10 @@ jobs:
             if [[ "${p}" == *-tests ]]; then
               continue
             fi
+            # exclude pre-release Python (3.15) wheels from publishing
+            if [[ "${p}" == *python315* ]]; then
+              continue
+            fi
             mv ${p}/*.whl dist/
           done
           rm -rf ${{ inputs.component }}*

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -240,6 +240,17 @@ jobs:
       - name: Set up compute-sanitizer
         run: setup-sanitizer
 
+      - name: Download numpy wheel (pre-release Python)
+        if: ${{ startsWith(matrix.PY_VER, '3.15') }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: numpy-python${{ env.PYTHON_VERSION_FORMATTED }}-${{ inputs.host-platform }}
+          path: numpy-wheel
+
+      - name: Install numpy wheel (pre-release Python)
+        if: ${{ startsWith(matrix.PY_VER, '3.15') }}
+        run: pip install numpy-wheel/*.whl
+
       - name: Run cuda.bindings tests
         if: ${{ env.SKIP_CUDA_BINDINGS_TEST == '0' }}
         env:

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -215,6 +215,17 @@ jobs:
           host-platform: ${{ inputs.host-platform }}
           cuda-version: ${{ matrix.CUDA_VER }}
 
+      - name: Download numpy wheel (pre-release Python)
+        if: ${{ startsWith(matrix.PY_VER, '3.15') }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: numpy-python${{ env.PYTHON_VERSION_FORMATTED }}-${{ inputs.host-platform }}
+          path: numpy-wheel
+
+      - name: Install numpy wheel (pre-release Python)
+        if: ${{ startsWith(matrix.PY_VER, '3.15') }}
+        run: pip install numpy-wheel/*.whl
+
       - name: Run cuda.bindings tests
         if: ${{ env.SKIP_CUDA_BINDINGS_TEST == '0' }}
         env:

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -224,6 +224,7 @@ jobs:
 
       - name: Install numpy wheel (pre-release Python)
         if: ${{ startsWith(matrix.PY_VER, '3.15') }}
+        shell: bash --noprofile --norc -xeuo pipefail {0}
         run: pip install numpy-wheel/*.whl
 
       - name: Run cuda.bindings tests

--- a/ci/test-matrix.json
+++ b/ci/test-matrix.json
@@ -15,6 +15,8 @@
       { "ARCH": "amd64", "PY_VER": "3.13t", "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.14", "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.14t", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.15",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.15t", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "arm64", "PY_VER": "3.10", "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "a100", "DRIVER": "latest" },
       { "ARCH": "arm64", "PY_VER": "3.10", "CUDA_VER": "13.0.1", "LOCAL_CTK": "0", "GPU": "a100", "DRIVER": "latest" },
       { "ARCH": "arm64", "PY_VER": "3.11", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "a100", "DRIVER": "latest" },

--- a/ci/test-matrix.json
+++ b/ci/test-matrix.json
@@ -25,7 +25,9 @@
       { "ARCH": "arm64", "PY_VER": "3.13", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "a100", "DRIVER": "latest" },
       { "ARCH": "arm64", "PY_VER": "3.13", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "a100", "DRIVER": "latest" },
       { "ARCH": "arm64", "PY_VER": "3.14", "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "a100", "DRIVER": "latest" },
-      { "ARCH": "arm64", "PY_VER": "3.14t", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "a100", "DRIVER": "latest" }
+      { "ARCH": "arm64", "PY_VER": "3.14t", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "a100", "DRIVER": "latest" },
+      { "ARCH": "arm64", "PY_VER": "3.15",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "a100", "DRIVER": "latest" },
+      { "ARCH": "arm64", "PY_VER": "3.15t", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "a100", "DRIVER": "latest" }
     ],
     "nightly": [
       { "ARCH": "amd64", "PY_VER": "3.10", "CUDA_VER": "11.8.0", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "earliest" },
@@ -77,10 +79,16 @@
   },
   "windows": {
     "pull-request": [
-      { "ARCH": "amd64", "PY_VER": "3.12", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.12", "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "t4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.13", "CUDA_VER": "13.0.1", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.13", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" }
+      { "ARCH": "amd64", "PY_VER": "3.10",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.11",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "t4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.12",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.12",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "t4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.13",  "CUDA_VER": "13.0.1", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.13",  "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.14",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.14t", "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.15",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.15t", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" }
     ],
     "nightly": [
       { "ARCH": "amd64", "PY_VER": "3.12", "CUDA_VER": "11.8.0", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },

--- a/ci/test-matrix.json
+++ b/ci/test-matrix.json
@@ -80,11 +80,13 @@
   "windows": {
     "pull-request": [
       { "ARCH": "amd64", "PY_VER": "3.10",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.11",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "t4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.10",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "t4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.11",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.11",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.12",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.12",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "t4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.13",  "CUDA_VER": "13.0.1", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.13",  "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.13",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
+      { "ARCH": "amd64", "PY_VER": "3.13",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.14",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.14t", "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.15",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },

--- a/ci/test-matrix.json
+++ b/ci/test-matrix.json
@@ -12,7 +12,6 @@
       { "ARCH": "amd64", "PY_VER": "3.12", "CUDA_VER": "13.0.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.13", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.13", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.13t", "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.14", "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.14t", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.15",  "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
@@ -25,7 +24,6 @@
       { "ARCH": "arm64", "PY_VER": "3.12", "CUDA_VER": "13.0.1", "LOCAL_CTK": "0", "GPU": "a100", "DRIVER": "latest" },
       { "ARCH": "arm64", "PY_VER": "3.13", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "a100", "DRIVER": "latest" },
       { "ARCH": "arm64", "PY_VER": "3.13", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "a100", "DRIVER": "latest" },
-      { "ARCH": "arm64", "PY_VER": "3.13t", "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "a100", "DRIVER": "latest" },
       { "ARCH": "arm64", "PY_VER": "3.14", "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "a100", "DRIVER": "latest" },
       { "ARCH": "arm64", "PY_VER": "3.14t", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "a100", "DRIVER": "latest" }
     ],
@@ -82,17 +80,13 @@
       { "ARCH": "amd64", "PY_VER": "3.12", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.12", "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "t4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.13", "CUDA_VER": "13.0.1", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.13", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.13t", "CUDA_VER": "13.0.1", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.13t", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" }
+      { "ARCH": "amd64", "PY_VER": "3.13", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" }
     ],
     "nightly": [
       { "ARCH": "amd64", "PY_VER": "3.12", "CUDA_VER": "11.8.0", "LOCAL_CTK": "0", "GPU": "l4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.12", "CUDA_VER": "11.8.0", "LOCAL_CTK": "1", "GPU": "t4", "DRIVER": "latest" },
       { "ARCH": "amd64", "PY_VER": "3.12", "CUDA_VER": "12.9.1", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.12", "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.13t", "CUDA_VER": "13.0.1", "LOCAL_CTK": "0", "GPU": "t4", "DRIVER": "latest" },
-      { "ARCH": "amd64", "PY_VER": "3.13t", "CUDA_VER": "13.0.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" }
+      { "ARCH": "amd64", "PY_VER": "3.12", "CUDA_VER": "12.9.1", "LOCAL_CTK": "1", "GPU": "l4", "DRIVER": "latest" }
     ]
   }
 }

--- a/ci/tools/download-wheels
+++ b/ci/tools/download-wheels
@@ -56,6 +56,12 @@ do
         continue
     fi
 
+    # exclude pre-release Python (3.15) wheels from releasing
+    if [[ "${p}" == *python315* ]]; then
+        echo "Skipping pre-release Python artifact: $p"
+        continue
+    fi
+
     # If we're not downloading "all", only process matching component
     if [[ "$COMPONENT" != "all" && "$p" != ${COMPONENT}* ]]; then
         continue

--- a/cuda_bindings/tests/test_graphics_apis.py
+++ b/cuda_bindings/tests/test_graphics_apis.py
@@ -12,7 +12,7 @@ def test_graphics_api_smoketest():
         import pyglet
 
         tex = pyglet.image.Texture.create(512, 512)
-    except (ImportError, AttributeError):
+    except (ImportError, AttributeError, OSError):
         pytest.skip("pyglet not available or could not create GL context")
         # return to make linters happy
         return


### PR DESCRIPTION
Part of #2163.

Backport of #2108 to the `12.9.x` branch so that `cuda-bindings` 12.9.x wheels are available for Python 3.15, which the `main` branch needs in order to build `cuda-core`.

## Changes

- Add `3.15` / `3.15t` to the build matrix in `build-wheel.yml`
- Upgrade cibuildwheel from v3.4.1 to v4.0.0rc1 (required for `cpython-prerelease` support)
- Add `cpython-prerelease` to `CIBW_ENABLE` (v4.0 enables free-threading by default, so `cpython-freethreading` was dropped)
- Drop `3.13t` from build and test matrices (already removed on `main`)
- Work around GNU `link.exe` (Git for Windows) shadowing MSVC `link.exe` — only affects pre-release Python on Windows where numpy must build from source
- Add test entries for 3.15 / 3.15t on all platforms (linux amd64, linux arm64, win-64)
- Add missing Windows pull-request entries for 3.10, 3.11, 3.14, 3.14t to sync with main
- Pre-build numpy wheel for Python 3.15 via cibuildwheel (no pre-built wheel available yet). numpy 2.4.x's `[tool.cibuildwheel]` config is incompatible with cibuildwheel v4.0, so we strip it and build with `-Dallow-noblas=true`
- Fix `test_graphics_api_smoketest` on py3.10/3.11 Windows: catch `OSError` (pyglet raises `FileNotFoundError` when `opengl32.dll` is missing on older Python)
- Exclude Python 3.15 wheels from release publishing (`release.yml`) and release upload (`ci/tools/download-wheels`) — 3.15 is pre-release and not ready for PyPI

## Adaptation notes

The following changes from #2108 were **not needed** on `12.9.x`:

- `test-wheel-linux.yml` — already has `allow-prereleases: true`
- `cuda_bindings/pyproject.toml` — `matplotlib` was already absent from test deps
- `cuda_core/pyproject.toml` — `cffi` was already absent from test deps
- `CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: ""` — not needed because 12.9.x already sets an explicit delvewheel command that overrides the v4.0 default