### PR TITLE
[doc-only] cuda.core: add docstrings to Host properties and public StrEnum types

### DIFF
--- a/cuda_core/cuda/core/_host.py
+++ b/cuda_core/cuda/core/_host.py
@@ -62,10 +62,12 @@ class Host:
 
     @property
     def numa_id(self) -> int | None:
+        """NUMA node ID, or ``None`` if not pinned to a specific NUMA node."""
         return self._numa_id
 
     @property
     def is_numa_current(self) -> bool:
+        """Whether this ``Host`` represents the calling thread's NUMA node (constructed via :meth:`numa_current`)."""
         return self._is_numa_current
 
     @classmethod

--- a/cuda_core/cuda/core/_host.py
+++ b/cuda_core/cuda/core/_host.py
@@ -67,7 +67,7 @@ class Host:
 
     @property
     def is_numa_current(self) -> bool:
-        """Whether this ``Host`` represents the calling thread's NUMA node (constructed via :meth:`numa_current`)."""
+        """``True`` if this ``Host`` represents the calling thread's NUMA node (constructed via :meth:`numa_current`)."""
         return self._is_numa_current
 
     @classmethod

--- a/cuda_core/cuda/core/typing.py
+++ b/cuda_core/cuda/core/typing.py
@@ -43,12 +43,28 @@ ProcessStateType = _Literal["running", "locked", "checkpointed", "failed"]
 
 
 class SourceCodeType(StrEnum):
+    """Source language passed to :class:`~cuda.core.Program`.
+
+    ``CXX`` selects CUDA C++, ``PTX`` selects PTX assembly text, and
+    ``NVVM`` selects NVVM IR (LLVM bitcode).
+    """
+
     CXX = "c++"
     PTX = "ptx"
     NVVM = "nvvm"
 
 
 class ObjectCodeFormatType(StrEnum):
+    """Output format produced by :meth:`~cuda.core.Program.compile`.
+
+    ``PTX`` — PTX assembly text.
+    ``CUBIN`` — device-native CUDA binary.
+    ``LTOIR`` — LTO (link-time optimization) IR for later linking.
+    ``FATBIN`` — fat binary bundling multiple device images.
+    ``OBJECT`` — relocatable device object.
+    ``LIBRARY`` — device code library.
+    """
+
     PTX = "ptx"
     CUBIN = "cubin"
     LTOIR = "ltoir"
@@ -58,6 +74,14 @@ class ObjectCodeFormatType(StrEnum):
 
 
 class CompilerBackendType(StrEnum):
+    """Compiler backend selected via :class:`~cuda.core.ProgramOptions`.
+
+    ``NVRTC`` — NVIDIA Runtime Compilation.
+    ``NVVM`` — NVVM LLVM backend.
+    ``NVJITLINK`` — nvJitLink device-side linker.
+    ``DRIVER`` — CUDA driver PTX JIT compiler.
+    """
+
     NVRTC = "NVRTC"
     NVVM = "NVVM"
     NVJITLINK = "nvJitLink"
@@ -65,36 +89,80 @@ class CompilerBackendType(StrEnum):
 
 
 class PCHStatusType(StrEnum):
+    """Precompiled-header (PCH) outcome reported by :meth:`~cuda.core.Program.compile`.
+
+    ``CREATED`` — PCH was successfully written.
+    ``NOT_ATTEMPTED`` — PCH creation was skipped (backend does not support it or
+    the option was not requested).
+    ``FAILED`` — PCH creation was attempted but failed.
+    """
+
     CREATED = "created"
     NOT_ATTEMPTED = "not_attempted"
     FAILED = "failed"
 
 
 class GraphConditionalType(StrEnum):
+    """Conditional node flavor for :class:`~cuda.core.graph.GraphBuilder`.
+
+    ``IF`` — body graph executes at most once based on a condition.
+    ``WHILE`` — body graph loops while the condition is true.
+    ``SWITCH`` — selects one child graph by an integer index.
+    """
+
     IF = "if"
     WHILE = "while"
     SWITCH = "switch"
 
 
 class GraphMemoryType(StrEnum):
+    """Memory space for a graph memory-allocation or free node.
+
+    ``DEVICE`` — GPU device memory.
+    ``HOST`` — pinned host memory.
+    ``MANAGED`` — CUDA managed (unified) memory.
+    """
+
     DEVICE = "device"
     HOST = "host"
     MANAGED = "managed"
 
 
 class ManagedMemoryLocationType(StrEnum):
+    """Destination type for managed-memory prefetch and advise operations.
+
+    ``DEVICE`` — target a GPU device.
+    ``HOST`` — target the CPU host (any NUMA node).
+    ``HOST_NUMA`` — target a specific host NUMA node (CUDA 13+ only).
+    """
+
     DEVICE = "device"
     HOST = "host"
     HOST_NUMA = "host_numa"
 
 
 class VirtualMemoryHandleType(StrEnum):
+    """OS handle type for exporting virtual memory allocations across processes.
+
+    ``POSIX_FD`` — POSIX file descriptor (Linux).
+    ``WIN32_KMT`` — Win32 D3DKMT handle (Windows).
+    ``FABRIC`` — NVLink/NVSwitch fabric handle for multi-node topologies.
+    """
+
     POSIX_FD = "posix_fd"
     WIN32_KMT = "win32_kmt"
     FABRIC = "fabric"
 
 
 class VirtualMemoryLocationType(StrEnum):
+    """Physical backing location for a virtual memory allocation.
+
+    ``DEVICE`` — GPU device memory.
+    ``HOST`` — pinned host memory.
+    ``HOST_NUMA`` — host memory pinned to a specific NUMA node.
+    ``HOST_NUMA_CURRENT`` — host memory on the calling thread's NUMA node.
+    """
+
     DEVICE = "device"
     HOST = "host"
     HOST_NUMA = "host_numa"
@@ -102,16 +170,34 @@ class VirtualMemoryLocationType(StrEnum):
 
 
 class VirtualMemoryGranularityType(StrEnum):
+    """Granularity query type for virtual memory allocations.
+
+    ``MINIMUM`` — smallest allocation size supported by the device.
+    ``RECOMMENDED`` — granularity that yields best performance on the device.
+    """
+
     MINIMUM = "minimum"
     RECOMMENDED = "recommended"
 
 
 class VirtualMemoryAccessType(StrEnum):
+    """Access permissions for a virtual memory mapping.
+
+    ``READ_WRITE`` — both read and write access.
+    ``READ`` — read-only access.
+    """
+
     READ_WRITE = "rw"
     READ = "r"
 
 
 class VirtualMemoryAllocationType(StrEnum):
+    """Physical memory type for a virtual memory backing allocation.
+
+    ``PINNED`` — page-locked (pinned) host memory.
+    ``MANAGED`` — CUDA managed (unified) memory.
+    """
+
     PINNED = "pinned"
     MANAGED = "managed"
 

--- a/cuda_core/cuda/core/typing.py
+++ b/cuda_core/cuda/core/typing.py
@@ -45,8 +45,9 @@ ProcessStateType = _Literal["running", "locked", "checkpointed", "failed"]
 class SourceCodeType(StrEnum):
     """Source language passed to :class:`~cuda.core.Program`.
 
-    ``CXX`` selects CUDA C++, ``PTX`` selects PTX assembly text, and
-    ``NVVM`` selects NVVM IR (LLVM bitcode).
+    * ``CXX`` — CUDA C++ source.
+    * ``PTX`` — PTX assembly text.
+    * ``NVVM`` — NVVM IR (LLVM bitcode).
     """
 
     CXX = "c++"
@@ -55,14 +56,14 @@ class SourceCodeType(StrEnum):
 
 
 class ObjectCodeFormatType(StrEnum):
-    """Output format produced by :meth:`~cuda.core.Program.compile`.
+    """Output format for :meth:`~cuda.core.Program.compile`, :meth:`~cuda.core.Linker.link`, and :meth:`~cuda.core.Program.as_bytes`.
 
-    ``PTX`` — PTX assembly text.
-    ``CUBIN`` — device-native CUDA binary.
-    ``LTOIR`` — LTO (link-time optimization) IR for later linking.
-    ``FATBIN`` — fat binary bundling multiple device images.
-    ``OBJECT`` — relocatable device object.
-    ``LIBRARY`` — device code library.
+    * ``PTX`` — PTX assembly text.
+    * ``CUBIN`` — device-native CUDA binary.
+    * ``LTOIR`` — LTO (link-time optimization) IR for later linking.
+    * ``FATBIN`` — fat binary bundling multiple device images.
+    * ``OBJECT`` — relocatable device object.
+    * ``LIBRARY`` — device code library.
     """
 
     PTX = "ptx"
@@ -74,12 +75,12 @@ class ObjectCodeFormatType(StrEnum):
 
 
 class CompilerBackendType(StrEnum):
-    """Compiler backend selected via :class:`~cuda.core.ProgramOptions`.
+    """Compiler backend inferred from the program's code type and exposed on :attr:`~cuda.core.Program.backend`.
 
-    ``NVRTC`` — NVIDIA Runtime Compilation.
-    ``NVVM`` — NVVM LLVM backend.
-    ``NVJITLINK`` — nvJitLink device-side linker.
-    ``DRIVER`` — CUDA driver PTX JIT compiler.
+    * ``NVRTC`` — NVIDIA Runtime Compilation.
+    * ``NVVM`` — NVVM LLVM backend.
+    * ``NVJITLINK`` — nvJitLink device-side linker.
+    * ``DRIVER`` — CUDA driver PTX JIT compiler.
     """
 
     NVRTC = "NVRTC"
@@ -91,10 +92,9 @@ class CompilerBackendType(StrEnum):
 class PCHStatusType(StrEnum):
     """Precompiled-header (PCH) outcome reported by :meth:`~cuda.core.Program.compile`.
 
-    ``CREATED`` — PCH was successfully written.
-    ``NOT_ATTEMPTED`` — PCH creation was skipped (backend does not support it or
-    the option was not requested).
-    ``FAILED`` — PCH creation was attempted but failed.
+    * ``CREATED`` — PCH was successfully written.
+    * ``NOT_ATTEMPTED`` — PCH creation was skipped (backend does not support it or the option was not requested).
+    * ``FAILED`` — PCH creation was attempted but failed.
     """
 
     CREATED = "created"
@@ -105,9 +105,9 @@ class PCHStatusType(StrEnum):
 class GraphConditionalType(StrEnum):
     """Conditional node flavor for :class:`~cuda.core.graph.GraphBuilder`.
 
-    ``IF`` — body graph executes at most once based on a condition.
-    ``WHILE`` — body graph loops while the condition is true.
-    ``SWITCH`` — selects one child graph by an integer index.
+    * ``IF`` — body graph executes at most once based on a condition.
+    * ``WHILE`` — body graph loops while the condition is true.
+    * ``SWITCH`` — selects one child graph by an integer index.
     """
 
     IF = "if"
@@ -118,9 +118,9 @@ class GraphConditionalType(StrEnum):
 class GraphMemoryType(StrEnum):
     """Memory space for a graph memory-allocation or free node.
 
-    ``DEVICE`` — GPU device memory.
-    ``HOST`` — pinned host memory.
-    ``MANAGED`` — CUDA managed (unified) memory.
+    * ``DEVICE`` — GPU device memory.
+    * ``HOST`` — pinned host memory.
+    * ``MANAGED`` — CUDA managed (unified) memory.
     """
 
     DEVICE = "device"
@@ -131,9 +131,9 @@ class GraphMemoryType(StrEnum):
 class ManagedMemoryLocationType(StrEnum):
     """Destination type for managed-memory prefetch and advise operations.
 
-    ``DEVICE`` — target a GPU device.
-    ``HOST`` — target the CPU host (any NUMA node).
-    ``HOST_NUMA`` — target a specific host NUMA node (CUDA 13+ only).
+    * ``DEVICE`` — target a GPU device.
+    * ``HOST`` — target the CPU host (any NUMA node).
+    * ``HOST_NUMA`` — target a specific host NUMA node.
     """
 
     DEVICE = "device"
@@ -144,9 +144,9 @@ class ManagedMemoryLocationType(StrEnum):
 class VirtualMemoryHandleType(StrEnum):
     """OS handle type for exporting virtual memory allocations across processes.
 
-    ``POSIX_FD`` — POSIX file descriptor (Linux).
-    ``WIN32_KMT`` — Win32 kernel-mode handle (Windows).
-    ``FABRIC`` — NVLink/NVSwitch fabric handle for multi-node topologies.
+    * ``POSIX_FD`` — POSIX file descriptor (Linux).
+    * ``WIN32_KMT`` — Win32 kernel-mode handle (Windows).
+    * ``FABRIC`` — NVLink/NVSwitch fabric handle for multi-node topologies.
     """
 
     POSIX_FD = "posix_fd"
@@ -157,10 +157,10 @@ class VirtualMemoryHandleType(StrEnum):
 class VirtualMemoryLocationType(StrEnum):
     """Physical backing location for a virtual memory allocation.
 
-    ``DEVICE`` — GPU device memory.
-    ``HOST`` — pinned host memory.
-    ``HOST_NUMA`` — host memory pinned to a specific NUMA node.
-    ``HOST_NUMA_CURRENT`` — host memory on the calling thread's NUMA node.
+    * ``DEVICE`` — GPU device memory.
+    * ``HOST`` — pinned host memory.
+    * ``HOST_NUMA`` — host memory pinned to a specific NUMA node.
+    * ``HOST_NUMA_CURRENT`` — host memory on the calling thread's NUMA node.
     """
 
     DEVICE = "device"
@@ -172,8 +172,8 @@ class VirtualMemoryLocationType(StrEnum):
 class VirtualMemoryGranularityType(StrEnum):
     """Granularity query type for virtual memory allocations.
 
-    ``MINIMUM`` — smallest allocation size supported by the device.
-    ``RECOMMENDED`` — granularity that yields best performance on the device.
+    * ``MINIMUM`` — smallest allocation size supported by the device.
+    * ``RECOMMENDED`` — granularity that yields best performance on the device.
     """
 
     MINIMUM = "minimum"
@@ -183,8 +183,8 @@ class VirtualMemoryGranularityType(StrEnum):
 class VirtualMemoryAccessType(StrEnum):
     """Access permissions for a virtual memory mapping.
 
-    ``READ_WRITE`` — both read and write access.
-    ``READ`` — read-only access.
+    * ``READ_WRITE`` — both read and write access.
+    * ``READ`` — read-only access.
     """
 
     READ_WRITE = "rw"
@@ -194,8 +194,8 @@ class VirtualMemoryAccessType(StrEnum):
 class VirtualMemoryAllocationType(StrEnum):
     """Physical memory type for a virtual memory backing allocation.
 
-    ``PINNED`` — page-locked (pinned) host memory.
-    ``MANAGED`` — CUDA managed (unified) memory.
+    * ``PINNED`` — pinned/non-migratable physical allocation (placement via :class:`VirtualMemoryLocationType`).
+    * ``MANAGED`` — CUDA managed (unified) memory (CUDA 13+ only).
     """
 
     PINNED = "pinned"

--- a/cuda_core/cuda/core/typing.py
+++ b/cuda_core/cuda/core/typing.py
@@ -145,7 +145,7 @@ class VirtualMemoryHandleType(StrEnum):
     """OS handle type for exporting virtual memory allocations across processes.
 
     ``POSIX_FD`` — POSIX file descriptor (Linux).
-    ``WIN32_KMT`` — Win32 D3DKMT handle (Windows).
+    ``WIN32_KMT`` — Win32 kernel-mode handle (Windows).
     ``FABRIC`` — NVLink/NVSwitch fabric handle for multi-node topologies.
     """
 


### PR DESCRIPTION
## Summary

Contributes to the doc-finalization step of #2131.

Two doc-only changes to `cuda.core`, touching no logic:

### `cuda/core/_host.py` — Host property docstrings

`Host` is a new 1.1.0 API (release notes: #2131 checklist item "Finalize the doc update"). The class-level docstring is already complete, but `numa_id` and `is_numa_current` had no docstrings, leaving them blank in generated API docs and `help()`:

```python
@property
def numa_id(self) -> int | None:
    """NUMA node ID, or ``None`` if not pinned to a specific NUMA node."""

@property
def is_numa_current(self) -> bool:
    """``True`` if this ``Host`` represents the calling thread's NUMA node (constructed via :meth:`numa_current`)."""
```

### `cuda/core/typing.py` — StrEnum class docstrings

All 12 public `StrEnum` subclasses (`SourceCodeType`, `ObjectCodeFormatType`, `CompilerBackendType`, `PCHStatusType`, `GraphConditionalType`, `GraphMemoryType`, `ManagedMemoryLocationType`, `VirtualMemoryHandleType`, `VirtualMemoryLocationType`, `VirtualMemoryGranularityType`, `VirtualMemoryAccessType`, `VirtualMemoryAllocationType`) previously had zero class-level docstrings. Each now has a short description and a one-liner per member so `help()` and Sphinx show meaningful output.

## Checklist

- [x] `cuda.core` only — no `cuda.bindings` files touched
- [x] No logic changes — docstrings only
- [x] Consistent with existing single-line property docstring style (`Host.numa_current`, `ManagedBuffer` methods)