### PR TITLE
Fix CUDA checkpoint restore args and generated API docs

### DIFF
--- a/cuda_bindings/build_hooks.py
+++ b/cuda_bindings/build_hooks.py
@@ -109,13 +109,32 @@ class _Struct:
         self._name = name
         self._member_names = []
         self._member_types = []
+        self._member_declarators = []
         for var_name, var_type, _ in members:
-            var_type = var_type[0]
-            var_type = var_type.removeprefix("struct ")
-            var_type = var_type.removeprefix("union ")
+            base_type = var_type[0]
+            base_type = base_type.removeprefix("struct ")
+            base_type = base_type.removeprefix("union ")
 
             self._member_names += [var_name]
-            self._member_types += [var_type]
+            self._member_types += [base_type]
+            self._member_declarators += [tuple(var_type[1:])]
+
+    def member_type(self, member_name):
+        try:
+            return self._member_types[self._member_names.index(member_name)]
+        except ValueError:
+            return None
+
+    def member_array_length(self, member_name):
+        try:
+            declarators = self._member_declarators[self._member_names.index(member_name)]
+        except ValueError:
+            return None
+
+        for declarator in declarators:
+            if isinstance(declarator, list) and len(declarator) == 1:
+                return declarator[0]
+        return None
 
     def discoverMembers(self, memberDict, prefix, seen=None):
         if seen is None:
@@ -192,6 +211,7 @@ def _parse_headers(header_dict, include_path_list, parser_caching):
         # Since we only support 64 bit architectures, we can inline the sizeof(T*) to 8 and then compute the
         # result in Python. The arithmetic expression is preserved to help with clarity and understanding
         r"char reserved\[52 - sizeof\(CUcheckpointGpuPair \*\)\];": rf"char reserved[{52 - 8}];",
+        r"char reserved\[64 - sizeof\(CUcheckpointGpuPair \*\) - sizeof\(unsigned int\)\];": rf"char reserved[{64 - 8 - 4}];",
     }
 
     print(f'Parsing headers in "{include_path_list}" (Caching = {parser_caching})', flush=True)
@@ -341,6 +361,13 @@ def _build_cuda_bindings(debug=False):
     found_types, found_functions, found_values, found_struct, struct_list = _parse_headers(
         header_dict, include_path_list, parser_caching
     )
+    struct_field_types = {}
+    struct_field_array_lengths = {}
+    for struct_name, struct in struct_list.items():
+        for member_name in struct._member_names:
+            key = f"{struct_name}.{member_name}"
+            struct_field_types[key] = struct.member_type(member_name)
+            struct_field_array_lengths[key] = struct.member_array_length(member_name)
 
     # Generate code from .in templates
     path_list = [
@@ -363,6 +390,8 @@ def _build_cuda_bindings(debug=False):
         "found_values": found_values,
         "found_struct": found_struct,
         "struct_list": struct_list,
+        "struct_field_types": struct_field_types,
+        "struct_field_array_lengths": struct_field_array_lengths,
         "os": os,
         "sys": sys,
         "platform": platform,

--- a/cuda_bindings/cuda/bindings/_bindings/cydriver.pxd.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cydriver.pxd.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.3.0, generator version 0.3.1.dev1719+g565f73f4e. Do not modify it directly.
+# This code was automatically generated with version 13.3.0, generator version 0.3.1.dev1711+g875fec45. Do not modify it directly.
 from cuda.bindings.cydriver cimport *
 
 {{if 'cuGetErrorString' in found_functions}}

--- a/cuda_bindings/cuda/bindings/_bindings/cydriver.pyx.in
+++ b/cuda_bindings/cuda/bindings/_bindings/cydriver.pyx.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.3.0, generator version 0.3.1.dev1719+g565f73f4e. Do not modify it directly.
+# This code was automatically generated with version 13.3.0, generator version 0.3.1.dev1711+g875fec45. Do not modify it directly.
 {{if 'Windows' == platform.system()}}
 import os
 cimport cuda.bindings._lib.windll as windll

--- a/cuda_bindings/cuda/bindings/cydriver.pxd.in
+++ b/cuda_bindings/cuda/bindings/cydriver.pxd.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.3.0, generator version 0.3.1.dev1719+g565f73f4e. Do not modify it directly.
+# This code was automatically generated with version 13.3.0, generator version 0.3.1.dev1711+g875fec45. Do not modify it directly.
 
 from libc.stdint cimport uint32_t, uint64_t
 
@@ -2458,9 +2458,21 @@ cdef extern from "cuda.h":
     ctypedef CUcheckpointGpuPair_st CUcheckpointGpuPair
 
     cdef struct CUcheckpointRestoreArgs_st:
+        {{if 'CUcheckpointRestoreArgs_st.gpuPairs' in found_struct}}
         CUcheckpointGpuPair* gpuPairs
+        {{endif}}
+        {{if 'CUcheckpointRestoreArgs_st.gpuPairsCount' in found_struct}}
         unsigned int gpuPairsCount
-        char reserved[52]
+        {{endif}}
+        {{if struct_field_types.get('CUcheckpointRestoreArgs_st.reserved') == 'char'}}
+        char reserved[{{struct_field_array_lengths['CUcheckpointRestoreArgs_st.reserved']}}]
+        {{endif}}
+        {{if struct_field_types.get('CUcheckpointRestoreArgs_st.reserved') == 'cuuint64_t'}}
+        cuuint64_t reserved[{{struct_field_array_lengths['CUcheckpointRestoreArgs_st.reserved']}}]
+        {{endif}}
+        {{if 'CUcheckpointRestoreArgs_st.reserved1' in found_struct}}
+        cuuint64_t reserved1
+        {{endif}}
 
     ctypedef CUcheckpointRestoreArgs_st CUcheckpointRestoreArgs
 

--- a/cuda_bindings/cuda/bindings/cydriver.pyx.in
+++ b/cuda_bindings/cuda/bindings/cydriver.pyx.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.3.0, generator version 0.3.1.dev1719+g565f73f4e. Do not modify it directly.
+# This code was automatically generated with version 13.3.0, generator version 0.3.1.dev1711+g875fec45. Do not modify it directly.
 cimport cuda.bindings._bindings.cydriver as cydriver
 
 {{if 'cuGetErrorString' in found_functions}}

--- a/cuda_bindings/cuda/bindings/driver.pxd.in
+++ b/cuda_bindings/cuda/bindings/driver.pxd.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.3.0, generator version 0.3.1.dev1719+g565f73f4e. Do not modify it directly.
+# This code was automatically generated with version 13.3.0, generator version 0.3.1.dev1711+g875fec45. Do not modify it directly.
 cimport cuda.bindings.cydriver as cydriver
 
 include "_lib/utils.pxd"
@@ -5335,8 +5335,16 @@ cdef class CUcheckpointRestoreArgs_st:
     gpuPairsCount : unsigned int
         Number of gpu pairs to remap
     {{endif}}
-    {{if 'CUcheckpointRestoreArgs_st.reserved' in found_struct}}
+    {{if struct_field_types.get('CUcheckpointRestoreArgs_st.reserved') == 'char'}}
     reserved : bytes
+        Reserved for future use, must be zeroed
+    {{endif}}
+    {{if struct_field_types.get('CUcheckpointRestoreArgs_st.reserved') == 'cuuint64_t'}}
+    reserved : list[cuuint64_t]
+        Reserved for future use, must be zeroed
+    {{endif}}
+    {{if 'CUcheckpointRestoreArgs_st.reserved1' in found_struct}}
+    reserved1 : cuuint64_t
         Reserved for future use, must be zeroed
     {{endif}}
 
@@ -5350,6 +5358,9 @@ cdef class CUcheckpointRestoreArgs_st:
     {{if 'CUcheckpointRestoreArgs_st.gpuPairs' in found_struct}}
     cdef size_t _gpuPairs_length
     cdef cydriver.CUcheckpointGpuPair* _gpuPairs
+    {{endif}}
+    {{if 'CUcheckpointRestoreArgs_st.reserved1' in found_struct}}
+    cdef cuuint64_t _reserved1
     {{endif}}
 {{endif}}
 {{if 'CUcheckpointUnlockArgs_st' in found_struct}}
@@ -11226,8 +11237,16 @@ cdef class CUcheckpointRestoreArgs(CUcheckpointRestoreArgs_st):
     gpuPairsCount : unsigned int
         Number of gpu pairs to remap
     {{endif}}
-    {{if 'CUcheckpointRestoreArgs_st.reserved' in found_struct}}
+    {{if struct_field_types.get('CUcheckpointRestoreArgs_st.reserved') == 'char'}}
     reserved : bytes
+        Reserved for future use, must be zeroed
+    {{endif}}
+    {{if struct_field_types.get('CUcheckpointRestoreArgs_st.reserved') == 'cuuint64_t'}}
+    reserved : list[cuuint64_t]
+        Reserved for future use, must be zeroed
+    {{endif}}
+    {{if 'CUcheckpointRestoreArgs_st.reserved1' in found_struct}}
+    reserved1 : cuuint64_t
         Reserved for future use, must be zeroed
     {{endif}}
 

--- a/cuda_bindings/cuda/bindings/driver.pyx.in
+++ b/cuda_bindings/cuda/bindings/driver.pyx.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.3.0, generator version 0.3.1.dev1719+g565f73f4e. Do not modify it directly.
+# This code was automatically generated with version 13.3.0, generator version 0.3.1.dev1711+g875fec45. Do not modify it directly.
 from typing import Any, Optional
 import cython
 import ctypes
@@ -879,7 +879,7 @@ class CUstreamMemoryBarrier_flags(_FastEnum):
 class CUstreamAtomicReductionOpType(_FastEnum):
     """
     Atomic reduction operation types for
-    :py:obj:`~.CUstreamBatchMemOpParams`::atomicReduction::reductionOp
+    :py:obj:`~.CUstreamBatchMemOpParams.atomicReduction.reductionOp`
     """
     {{if 'CU_STREAM_ATOMIC_REDUCTION_OP_ADD' in found_values}}
 
@@ -906,7 +906,7 @@ class CUstreamAtomicReductionOpType(_FastEnum):
 class CUstreamAtomicReductionDataType(_FastEnum):
     """
     Atomic reduction data types for
-    :py:obj:`~.CUstreamBatchMemOpParams`::atomicReduction::dataType
+    :py:obj:`~.CUstreamBatchMemOpParams.atomicReduction.dataType`
     """
     {{if 'CU_STREAM_ATOMIC_REDUCTION_UNSIGNED_32' in found_values}}
     CU_STREAM_ATOMIC_REDUCTION_UNSIGNED_32 = cydriver.CUstreamAtomicReductionDataType_enum.CU_STREAM_ATOMIC_REDUCTION_UNSIGNED_32{{endif}}
@@ -24699,8 +24699,16 @@ cdef class CUcheckpointRestoreArgs_st:
     gpuPairsCount : unsigned int
         Number of gpu pairs to remap
     {{endif}}
-    {{if 'CUcheckpointRestoreArgs_st.reserved' in found_struct}}
+    {{if struct_field_types.get('CUcheckpointRestoreArgs_st.reserved') == 'char'}}
     reserved : bytes
+        Reserved for future use, must be zeroed
+    {{endif}}
+    {{if struct_field_types.get('CUcheckpointRestoreArgs_st.reserved') == 'cuuint64_t'}}
+    reserved : list[cuuint64_t]
+        Reserved for future use, must be zeroed
+    {{endif}}
+    {{if 'CUcheckpointRestoreArgs_st.reserved1' in found_struct}}
+    reserved1 : cuuint64_t
         Reserved for future use, must be zeroed
     {{endif}}
 
@@ -24716,6 +24724,9 @@ cdef class CUcheckpointRestoreArgs_st:
             self._pvt_ptr = <cydriver.CUcheckpointRestoreArgs_st *>_ptr
     def __init__(self, void_ptr _ptr = 0):
         pass
+        {{if 'CUcheckpointRestoreArgs_st.reserved1' in found_struct}}
+        self._reserved1 = cuuint64_t(_ptr=<void_ptr>&self._pvt_ptr[0].reserved1)
+        {{endif}}
     def __dealloc__(self):
         pass
         {{if 'CUcheckpointRestoreArgs_st.gpuPairs' in found_struct}}
@@ -24745,6 +24756,12 @@ cdef class CUcheckpointRestoreArgs_st:
                 str_list += ['reserved : ' + str(self.reserved)]
             except ValueError:
                 str_list += ['reserved : <ValueError>']
+            {{endif}}
+            {{if 'CUcheckpointRestoreArgs_st.reserved1' in found_struct}}
+            try:
+                str_list += ['reserved1 : ' + str(self.reserved1)]
+            except ValueError:
+                str_list += ['reserved1 : <ValueError>']
             {{endif}}
             return '\n'.join(str_list)
         else:
@@ -24781,14 +24798,14 @@ cdef class CUcheckpointRestoreArgs_st:
     def gpuPairsCount(self, unsigned int gpuPairsCount):
         self._pvt_ptr[0].gpuPairsCount = gpuPairsCount
     {{endif}}
-    {{if 'CUcheckpointRestoreArgs_st.reserved' in found_struct}}
+    {{if struct_field_types.get('CUcheckpointRestoreArgs_st.reserved') == 'char'}}
     @property
     def reserved(self):
-        return PyBytes_FromStringAndSize(self._pvt_ptr[0].reserved, 52)
+        return PyBytes_FromStringAndSize(self._pvt_ptr[0].reserved, {{struct_field_array_lengths['CUcheckpointRestoreArgs_st.reserved']}})
     @reserved.setter
     def reserved(self, reserved):
-        if len(reserved) != 52:
-            raise ValueError("reserved length must be 52, is " + str(len(reserved)))
+        if len(reserved) != {{struct_field_array_lengths['CUcheckpointRestoreArgs_st.reserved']}}:
+            raise ValueError("reserved length must be {{struct_field_array_lengths['CUcheckpointRestoreArgs_st.reserved']}}, is " + str(len(reserved)))
         if CHAR_MIN == 0:
             for i, b in enumerate(reserved):
                 if b < 0 and b > -129:
@@ -24799,6 +24816,33 @@ cdef class CUcheckpointRestoreArgs_st:
                 if b > 127 and b < 256:
                     b = b - 256
                 self._pvt_ptr[0].reserved[i] = b
+    {{endif}}
+    {{if struct_field_types.get('CUcheckpointRestoreArgs_st.reserved') == 'cuuint64_t'}}
+    @property
+    def reserved(self):
+        return [cuuint64_t(init_value=_reserved) for _reserved in self._pvt_ptr[0].reserved]
+    @reserved.setter
+    def reserved(self, reserved):
+        self._pvt_ptr[0].reserved = reserved
+
+    {{endif}}
+    {{if 'CUcheckpointRestoreArgs_st.reserved1' in found_struct}}
+    @property
+    def reserved1(self):
+        return self._reserved1
+    @reserved1.setter
+    def reserved1(self, reserved1):
+        cdef cydriver.cuuint64_t cyreserved1
+        if reserved1 is None:
+            cyreserved1 = <cydriver.cuuint64_t><void_ptr>0
+        elif isinstance(reserved1, (cuuint64_t)):
+            preserved1 = int(reserved1)
+            cyreserved1 = <cydriver.cuuint64_t><void_ptr>preserved1
+        else:
+            preserved1 = int(cuuint64_t(reserved1))
+            cyreserved1 = <cydriver.cuuint64_t><void_ptr>preserved1
+        self._reserved1._pvt_ptr[0] = cyreserved1
+
     {{endif}}
 {{endif}}
 {{if 'CUcheckpointUnlockArgs_st' in found_struct}}
@@ -34422,16 +34466,15 @@ def cuMemcpy3DBatchAsync(size_t numOps, opList : Optional[tuple[CUDA_MEMCPY3D_BA
     :py:obj:`~.CUmemcpy3DOperand.op.ptr.rowLength` field specifies the
     length of each row in elements and must either be zero or be greater
     than or equal to the width of the copy specified in
-    :py:obj:`~.CUDA_MEMCPY3D_BATCH_OP`::extent::width. The
+    :py:obj:`~.CUDA_MEMCPY3D_BATCH_OP.extent.width`. The
     :py:obj:`~.CUmemcpy3DOperand.op.ptr.layerHeight` field specifies the
     height of each layer and must either be zero or be greater than or
     equal to the height of the copy specified in
-    :py:obj:`~.CUDA_MEMCPY3D_BATCH_OP`::extent::height. When either of
-    these values is zero, that aspect of the operand is considered to be
-    tightly packed according to the copy extent. For managed memory
-    pointers on devices where
-    :py:obj:`~.CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS` is true or
-    system-allocated pageable memory on devices where
+    :py:obj:`~.CUDA_MEMCPY3D_BATCH_OP.extent.height`. When either of these
+    values is zero, that aspect of the operand is considered to be tightly
+    packed according to the copy extent. For managed memory pointers on
+    devices where :py:obj:`~.CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS`
+    is true or system-allocated pageable memory on devices where
     :py:obj:`~.CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS` is true, the
     :py:obj:`~.CUmemcpy3DOperand.op.ptr.locHint` field can be used to hint
     the location of the operand.
@@ -36334,7 +36377,7 @@ def cuMemCreate(size_t size, prop : Optional[CUmemAllocationProp], unsigned long
     allocation that doesn't target any specific NUMA nodes, applications
     must set :py:obj:`~.CUmemAllocationProp.CUmemLocation.type` to
     :py:obj:`~.CU_MEM_LOCATION_TYPE_HOST`.
-    :py:obj:`~.CUmemAllocationProp`::CUmemLocation::id is ignored for HOST
+    :py:obj:`~.CUmemAllocationProp.CUmemLocation.id` is ignored for HOST
     allocations. HOST allocations are not IPC capable and
     :py:obj:`~.CUmemAllocationProp.requestedHandleTypes` must be 0, any
     other value will result in :py:obj:`~.CUDA_ERROR_INVALID_VALUE`. To
@@ -36342,9 +36385,9 @@ def cuMemCreate(size_t size, prop : Optional[CUmemAllocationProp], unsigned long
     applications must set
     :py:obj:`~.CUmemAllocationProp.CUmemLocation.type` to
     :py:obj:`~.CU_MEM_LOCATION_TYPE_HOST_NUMA` and
-    :py:obj:`~.CUmemAllocationProp`::CUmemLocation::id must specify the
-    NUMA ID of the CPU. On systems where NUMA is not available
-    :py:obj:`~.CUmemAllocationProp`::CUmemLocation::id must be set to 0.
+    :py:obj:`~.CUmemAllocationProp.CUmemLocation.id` must specify the NUMA
+    ID of the CPU. On systems where NUMA is not available
+    :py:obj:`~.CUmemAllocationProp.CUmemLocation.id` must be set to 0.
     Specifying :py:obj:`~.CU_MEM_LOCATION_TYPE_HOST_NUMA_CURRENT` as the
     :py:obj:`~.CUmemLocation.type` will result in
     :py:obj:`~.CUDA_ERROR_INVALID_VALUE`.
@@ -36547,7 +36590,7 @@ def cuMemMapArrayAsync(mapInfoList : Optional[tuple[CUarrayMapInfo] | list[CUarr
 
     where :py:obj:`~.CUarrayMapInfo.resourceType` specifies the type of
     resource to be operated on. If :py:obj:`~.CUarrayMapInfo.resourceType`
-    is set to :py:obj:`~.CUresourcetype`::CU_RESOURCE_TYPE_ARRAY then
+    is set to :py:obj:`~.CUresourcetype.CU_RESOURCE_TYPE_ARRAY` then
     :py:obj:`~.CUarrayMapInfo.resource.array` must be set to a valid sparse
     CUDA array handle. The CUDA array must be either a 2D, 2D layered or 3D
     CUDA array and must have been allocated using :py:obj:`~.cuArrayCreate`
@@ -36557,7 +36600,7 @@ def cuMemMapArrayAsync(mapInfoList : Optional[tuple[CUarrayMapInfo] | list[CUarr
     using :py:obj:`~.cuMipmappedArrayGetLevel`,
     :py:obj:`~.CUDA_ERROR_INVALID_VALUE` will be returned. If
     :py:obj:`~.CUarrayMapInfo.resourceType` is set to
-    :py:obj:`~.CUresourcetype`::CU_RESOURCE_TYPE_MIPMAPPED_ARRAY then
+    :py:obj:`~.CUresourcetype.CU_RESOURCE_TYPE_MIPMAPPED_ARRAY` then
     :py:obj:`~.CUarrayMapInfo.resource.mipmap` must be set to a valid
     sparse CUDA mipmapped array handle. The CUDA mipmapped array must be
     either a 2D, 2D layered or 3D CUDA mipmapped array and must have been
@@ -36572,16 +36615,16 @@ def cuMemMapArrayAsync(mapInfoList : Optional[tuple[CUarrayMapInfo] | list[CUarr
     **View CUDA Toolkit Documentation for a C++ code example**
 
     where
-    :py:obj:`~.CUarraySparseSubresourceType`::CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_SPARSE_LEVEL
+    :py:obj:`~.CUarraySparseSubresourceType.CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_SPARSE_LEVEL`
     indicates a sparse-miplevel which spans at least one tile in every
     dimension. The remaining miplevels which are too small to span at least
     one tile in any dimension constitute the mip tail region as indicated
     by
-    :py:obj:`~.CUarraySparseSubresourceType`::CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_MIPTAIL
+    :py:obj:`~.CUarraySparseSubresourceType.CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_MIPTAIL`
     subresource type.
 
     If :py:obj:`~.CUarrayMapInfo.subresourceType` is set to
-    :py:obj:`~.CUarraySparseSubresourceType`::CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_SPARSE_LEVEL
+    :py:obj:`~.CUarraySparseSubresourceType.CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_SPARSE_LEVEL`
     then :py:obj:`~.CUarrayMapInfo.subresource.sparseLevel` struct must
     contain valid array subregion offsets and extents. The
     :py:obj:`~.CUarrayMapInfo.subresource.sparseLevel.offsetX`,
@@ -36607,7 +36650,7 @@ def cuMemMapArrayAsync(mapInfoList : Optional[tuple[CUarrayMapInfo] | list[CUarr
     :py:obj:`~.cuMipmappedArrayGetSparseProperties`
 
     If :py:obj:`~.CUarrayMapInfo.subresourceType` is set to
-    :py:obj:`~.CUarraySparseSubresourceType`::CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_MIPTAIL
+    :py:obj:`~.CUarraySparseSubresourceType.CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_MIPTAIL`
     then :py:obj:`~.CUarrayMapInfo.subresource.miptail` struct must contain
     valid mip tail offset in
     :py:obj:`~.CUarrayMapInfo.subresource.miptail.offset` and size in
@@ -36632,17 +36675,17 @@ def cuMemMapArrayAsync(mapInfoList : Optional[tuple[CUarrayMapInfo] | list[CUarr
     **View CUDA Toolkit Documentation for a C++ code example**
 
     If :py:obj:`~.CUarrayMapInfo.memOperationType` is set to
-    :py:obj:`~.CUmemOperationType`::CU_MEM_OPERATION_TYPE_MAP then the
+    :py:obj:`~.CUmemOperationType.CU_MEM_OPERATION_TYPE_MAP` then the
     subresource will be mapped onto the tile pool memory specified by
     :py:obj:`~.CUarrayMapInfo.memHandle` at offset
     :py:obj:`~.CUarrayMapInfo.offset`. The tile pool allocation has to be
     created by specifying the :py:obj:`~.CU_MEM_CREATE_USAGE_TILE_POOL`
     flag when calling :py:obj:`~.cuMemCreate`. Also,
     :py:obj:`~.CUarrayMapInfo.memHandleType` must be set to
-    :py:obj:`~.CUmemHandleType`::CU_MEM_HANDLE_TYPE_GENERIC.
+    :py:obj:`~.CUmemHandleType.CU_MEM_HANDLE_TYPE_GENERIC`.
 
     If :py:obj:`~.CUarrayMapInfo.memOperationType` is set to
-    :py:obj:`~.CUmemOperationType`::CU_MEM_OPERATION_TYPE_UNMAP then an
+    :py:obj:`~.CUmemOperationType.CU_MEM_OPERATION_TYPE_UNMAP` then an
     unmapping operation is performed. :py:obj:`~.CUarrayMapInfo.memHandle`
     must be NULL.
 
@@ -36651,7 +36694,7 @@ def cuMemMapArrayAsync(mapInfoList : Optional[tuple[CUarrayMapInfo] | list[CUarr
     exactly one bit set, and the corresponding device must match the device
     associated with the stream. If
     :py:obj:`~.CUarrayMapInfo.memOperationType` is set to
-    :py:obj:`~.CUmemOperationType`::CU_MEM_OPERATION_TYPE_MAP, the device
+    :py:obj:`~.CUmemOperationType.CU_MEM_OPERATION_TYPE_MAP`, the device
     must also match the device associated with the tile pool memory
     allocation as specified by :py:obj:`~.CUarrayMapInfo.memHandle`.
 
@@ -36766,9 +36809,9 @@ def cuMemSetAccess(ptr, size_t size, desc : Optional[tuple[CUmemAccessDesc] | li
     :py:obj:`~.cuMemCreate`. Users cannot specify
     :py:obj:`~.CU_MEM_LOCATION_TYPE_HOST_NUMA` accessibility for
     allocations created on with other location types. Note: When
-    :py:obj:`~.CUmemAccessDesc`::CUmemLocation::type is
+    :py:obj:`~.CUmemAccessDesc.CUmemLocation.type` is
     :py:obj:`~.CU_MEM_LOCATION_TYPE_HOST_NUMA`,
-    :py:obj:`~.CUmemAccessDesc`::CUmemLocation::id is ignored. When setting
+    :py:obj:`~.CUmemAccessDesc.CUmemLocation.id` is ignored. When setting
     the access flags for a virtual address range mapping a multicast
     object, `ptr` and `size` must be aligned to the value returned by
     :py:obj:`~.cuMulticastGetGranularity` with the flag
@@ -37545,20 +37588,19 @@ def cuMemPoolCreate(poolProps : Optional[CUmemPoolProps]):
 
     To create a memory pool for HOST memory not targeting a specific NUMA
     node, applications must set set
-    :py:obj:`~.CUmemPoolProps`::CUmemLocation::type to
+    :py:obj:`~.CUmemPoolProps.CUmemLocation.type` to
     :py:obj:`~.CU_MEM_LOCATION_TYPE_HOST`.
-    :py:obj:`~.CUmemPoolProps`::CUmemLocation::id is ignored for such
-    pools. Pools created with the type
-    :py:obj:`~.CU_MEM_LOCATION_TYPE_HOST` are not IPC capable and
-    :py:obj:`~.CUmemPoolProps.handleTypes` must be 0, any other values will
-    result in :py:obj:`~.CUDA_ERROR_INVALID_VALUE`. To create a memory pool
-    targeting a specific host NUMA node, applications must set
-    :py:obj:`~.CUmemPoolProps`::CUmemLocation::type to
+    :py:obj:`~.CUmemPoolProps.CUmemLocation.id` is ignored for such pools.
+    Pools created with the type :py:obj:`~.CU_MEM_LOCATION_TYPE_HOST` are
+    not IPC capable and :py:obj:`~.CUmemPoolProps.handleTypes` must be 0,
+    any other values will result in :py:obj:`~.CUDA_ERROR_INVALID_VALUE`.
+    To create a memory pool targeting a specific host NUMA node,
+    applications must set :py:obj:`~.CUmemPoolProps.CUmemLocation.type` to
     :py:obj:`~.CU_MEM_LOCATION_TYPE_HOST_NUMA` and
-    :py:obj:`~.CUmemPoolProps`::CUmemLocation::id must specify the NUMA ID
-    of the host memory node. Specifying
+    :py:obj:`~.CUmemPoolProps.CUmemLocation.id` must specify the NUMA ID of
+    the host memory node. Specifying
     :py:obj:`~.CU_MEM_LOCATION_TYPE_HOST_NUMA_CURRENT` as the
-    :py:obj:`~.CUmemPoolProps`::CUmemLocation::type will result in
+    :py:obj:`~.CUmemPoolProps.CUmemLocation.type` will result in
     :py:obj:`~.CUDA_ERROR_INVALID_VALUE`.
 
     By default, the pool's memory will be accessible from the device it is
@@ -37591,11 +37633,11 @@ def cuMemPoolCreate(poolProps : Optional[CUmemPoolProps]):
     /dev/nvidia-caps-imex-channels/channel0 c <major number> 0`
 
     To create a managed memory pool, applications must set
-    :py:obj:`~.CUmemPoolProps`::CUmemAllocationType to
+    :py:obj:`~.CUmemPoolProps.CUmemAllocationType` to
     CU_MEM_ALLOCATION_TYPE_MANAGED.
-    :py:obj:`~.CUmemPoolProps`::CUmemAllocationHandleType must also be set
+    :py:obj:`~.CUmemPoolProps.CUmemAllocationHandleType` must also be set
     to CU_MEM_HANDLE_TYPE_NONE since IPC is not supported. For managed
-    memory pools, :py:obj:`~.CUmemPoolProps`::CUmemLocation will be treated
+    memory pools, :py:obj:`~.CUmemPoolProps.CUmemLocation` will be treated
     as the preferred location for all allocations created from the pool. An
     application can also set CU_MEM_LOCATION_TYPE_NONE to indicate no
     preferred location. :py:obj:`~.CUmemPoolProps.maxSize` must be set to
@@ -38866,7 +38908,7 @@ def cuLogicalEndpointAddDevice(leId, dev):
     Associates a device to a logical endpoint. The type of the logical
     endpoint must be :py:obj:`~.CU_LOGICAL_ENDPOINT_TYPE_MULTICAST`. The
     added device will be a part of the multicast team of size specified by
-    :py:obj:`~.CUlogicalEndpointProp.multicast.numDevices` during
+    CUlogicalEndpointProp::multicast::numDevices during
     :py:obj:`~.cuLogicalEndpointCreate`. The association of the device to
     the multicast logical endpoint is permanent during the life time of the
     multicast logical endpoint. All devices must be added to the multicast
@@ -43122,7 +43164,7 @@ def cuExternalMemoryGetMappedMipmappedArray(extMem, mipmapDesc : Optional[CUDA_E
     the mipmapped array is bound as a color target in the graphics API,
     then the flag :py:obj:`~.CUDA_ARRAY3D_COLOR_ATTACHMENT` must be
     specified in
-    :py:obj:`~.CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC`::arrayDesc::Flags.
+    :py:obj:`~.CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC.arrayDesc.Flags`.
     :py:obj:`~.CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC.numLevels`
     specifies the total number of levels in the mipmap chain.
 
@@ -43445,7 +43487,7 @@ def cuSignalExternalSemaphoresAsync(extSemArray : Optional[tuple[CUexternalSemap
     :py:obj:`~.CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D11_KEYED_MUTEX`,
     :py:obj:`~.CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D11_KEYED_MUTEX_KMT`
     then the keyed mutex will be released with the key specified in
-    :py:obj:`~.CUDA_EXTERNAL_SEMAPHORE_PARAMS`::params::keyedmutex::key.
+    :py:obj:`~.CUDA_EXTERNAL_SEMAPHORE_PARAMS.params.keyedmutex.key`.
 
     Parameters
     ----------
@@ -45676,7 +45718,7 @@ def cuLaunchGridAsync(f, int grid_width, int grid_height, hStream):
 
     Notes
     -----
-    In certain cases where cubins are created with no ABI (i.e., using `ptxas` `--abi-compile` `no`), this function may serialize kernel launches. The CUDA driver retains asynchronous behavior by growing the per-thread stack as needed per launch and not shrinking it afterwards.
+    In certain cases where cubins are created with no ABI (i.e., using `ptxas`  `no`), this function may serialize kernel launches. The CUDA driver retains asynchronous behavior by growing the per-thread stack as needed per launch and not shrinking it afterwards.
     """
     cdef cydriver.CUstream cyhStream
     if hStream is None:

--- a/cuda_bindings/docs/source/conf.py
+++ b/cuda_bindings/docs/source/conf.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2012-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2012-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 # Configuration file for the Sphinx documentation builder.
@@ -9,7 +9,6 @@
 
 # -- Path setup --------------------------------------------------------------
 
-import inspect
 import os
 import sys
 from pathlib import Path
@@ -122,29 +121,6 @@ intersphinx_mapping = {
 }
 
 
-def _sanitize_generated_docstring(lines):
-    doc_lines = inspect.cleandoc("\n".join(lines)).splitlines()
-    if not doc_lines:
-        return
-
-    if "(" in doc_lines[0] and ")" in doc_lines[0]:
-        doc_lines = doc_lines[1:]
-        while doc_lines and not doc_lines[0].strip():
-            doc_lines.pop(0)
-
-    if not doc_lines:
-        lines[:] = []
-        return
-
-    lines[:] = [".. code-block:: text", ""]
-    lines.extend(f"   {line}" if line else "   " for line in doc_lines)
-
-
-def autodoc_process_docstring(app, what, name, obj, options, lines):
-    if name.startswith("cuda.bindings."):
-        _sanitize_generated_docstring(lines)
-
-
 def rewrite_source(app, docname, source):
     text = source[0]
 
@@ -161,5 +137,4 @@ suppress_warnings = [
 
 
 def setup(app):
-    app.connect("autodoc-process-docstring", autodoc_process_docstring)
     app.connect("source-read", rewrite_source)

--- a/cuda_bindings/docs/source/module/driver.rst
+++ b/cuda_bindings/docs/source/module/driver.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 .. SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 ------


### PR DESCRIPTION
## Summary
- Fix CUDA checkpoint restore argument generation across the CUDA 12.9, 13.2, and 13.3 header layouts, including the CUDA 13.3 `sizeof(...)` reserved-field spelling that caused `CUcheckpointRestoreArgs` to disappear.
- Carry parsed struct member type and array-length metadata into the generated driver templates so `CUcheckpointRestoreArgs_st` and related checkpoint structs are emitted with the correct fields.
- Regenerate CUDA 13.3 bindings from the updated cybind legacy cython generator (`0.3.1.dev1711+g9f37ce73`) so the generated files capture the fixed generator commit for traceability.
- Refresh the generated `cuda.bindings` API docs and remove the temporary `conf.py` docstring sanitizer now that cybind emits docstrings that Sphinx can parse directly.

## Validation
- Parsed/rendered CUDA header snapshots for CUDA 12.9, 13.2, and 13.3; `CUcheckpointRestoreArgs` is present in all three and the generated layouts match the corresponding headers.
- Checked the CUDA 13.2 vs 13.3 `cuda.h` checkpoint structs, `sizeof(...)` array expressions, and empty named structs; no additional checkpoint struct breakages were found.
- Confirmed the generated CUDA 13.3 code matches regeneration from the updated cybind generator.
- `python -m py_compile cuda_bindings/docs/source/conf.py`
- Pre-commit hooks passed during commit.
- PR docs job completed successfully and deployed the preview. The live driver docs render `CUcheckpointRestoreArgs`, its fields, and `cuCheckpointProcessRestore` links as API objects, with no raw `.. attribute::`, `.. method::`, `:param`, `:rtype`, or `code-block:: text` artifacts in the generated module pages.

## Notes
- The docs build still has pre-existing/generated-doc warnings unrelated to the restored API rendering. The warning spike is from Sphinx now parsing generated docstrings as RST rather than displaying them as literal blocks; follow-up cleanup should happen in cybind generation rather than reintroducing the `conf.py` sanitizer.

## Related

* Issue #2149