### PR TITLE
Skip JIT LTO example when PTX cannot load

### DIFF
--- a/cuda_core/tests/example_tests/test_basic_examples.py
+++ b/cuda_core/tests/example_tests/test_basic_examples.py
@@ -13,6 +13,7 @@ import warnings
 import pytest
 
 from cuda.core import Device, ManagedMemoryResource, system
+from cuda.core._program import _can_load_generated_ptx
 
 try:
     from cuda.bindings._test_helpers.pep723 import has_package_requirements_or_skip
@@ -82,6 +83,7 @@ def has_recent_memory_pool_support() -> bool:
 SYSTEM_REQUIREMENTS = {
     "memory_pool_resources.py": has_recent_memory_pool_support,
     "gl_interop_plasma.py": has_display,
+    "jit_lto_fractal.py": _can_load_generated_ptx,
     "pytorch_example.py": lambda: (
         has_compute_capability_9_or_higher() and is_x86_64()
     ),  # PyTorch only provides CUDA support for x86_64


### PR DESCRIPTION
Fixes #1851.

The `jit_lto_fractal.py` example compiles PTX before it runs the rest of the example. When the generated PTX is newer than the active driver can load, the broader test suite already treats that condition as a skip, but the example subprocess kept running and could fail with the Windows access-violation exit seen in the issue.

This adds `jit_lto_fractal.py` to the example system requirements using the existing `_can_load_generated_ptx()` helper, so the example is skipped under the same driver/backend mismatch instead of launching the subprocess.

Tested:
- `python -m compileall -q cuda_core/tests/example_tests/test_basic_examples.py`
- `python -m ruff check cuda_core/tests/example_tests/test_basic_examples.py`
- `git diff --check`