### PR TITLE
test fix: Skip NVLink version checks for inactive links

### DIFF
--- a/cuda_core/tests/system/test_system_device.py
+++ b/cuda_core/tests/system/test_system_device.py
@@ -771,14 +771,17 @@ def test_nvlink():
             assert isinstance(nvlink_info, _device.NvlinkInfo)
 
             with unsupported_before(device, None):
+                state = nvlink_info.state
+            assert isinstance(state, bool)
+
+            if not state:
+                continue
+
+            with unsupported_before(device, None):
                 version = nvlink_info.version
             assert isinstance(version, tuple)
             assert len(version) == 2
             assert all(isinstance(i, int) for i in version)
-
-            with unsupported_before(device, None):
-                state = nvlink_info.state
-            assert isinstance(state, bool)
 
 
 def test_utilization():


### PR DESCRIPTION
## Context

This PR fixes a `cuda.core` system-test failure that was first observed while reviewing PR 2130:

- Workflow run: https://github.com/NVIDIA/cuda-python/actions/runs/26611106556?pr=2130
- Failed job: `Test win-64 / Python 3.14, CUDA 13.3.0 (wheels), GPU h100 (x2) (MCDM)`
- Failed test: `tests/system/test_system_device.py::test_nvlink`
- Error: `RuntimeError: Invalid NvLink version returned for device`

The failure was seen in the original CI attempt for PR #2130. PR 2130 itself was adding coverage-oriented tests in other areas and did not modify `tests/system/test_system_device.py`, so the failing test was an existing system-test fragility rather than a regression introduced by that PR.

CI log with full failure details:
* [pr2130_h100_win_py314_cuda133_attempt1_job78418596734.log](https://github.com/user-attachments/files/28401818/pr2130_h100_win_py314_cuda133_attempt1_job78418596734.log)


## What Failed

The failing traceback showed that `test_nvlink` queried `nvlink_info.version` for link `0` and received `NvlinkVersion.VERSION_INVALID` from NVML:

```text
tests\system\test_system_device.py:774:
>   version = nvlink_info.version

cuda\core\system\_nvlink.pxi:46:
>   raise RuntimeError("Invalid NvLink version returned for device")
E   RuntimeError: Invalid NvLink version returned for device
```

The relevant local values in the failure were:

```text
link       = 0
max_links  = 18
```

The old test iterated over every index in `range(NvlinkInfo.max_links)` and queried the version before checking whether the link was active. On the failing H100 PCIe/MCDM runner, NVML reported an invalid version for at least one link slot. That is consistent with an inactive or unavailable NVLink slot, and the test should not assume that every slot up to `max_links` has a valid version.

## Fix

This PR changes `test_nvlink` to query `nvlink_info.state` before querying `nvlink_info.version`.

The updated test now:

- Retrieves the `NvlinkInfo` object for each possible link index.
- Queries and validates `nvlink_info.state`.
- Skips version validation for inactive links.
- Keeps the existing version validation for active links.

This preserves the useful test invariant: if a link is active, its version should be available and well-formed. It avoids treating inactive link slots as failures.

