### PR TITLE
[doc-only] Release notes for CUDA Python 13.3.1

### DIFF
--- a/cuda_bindings/docs/nv-versions.json
+++ b/cuda_bindings/docs/nv-versions.json
@@ -4,6 +4,10 @@
         "url": "https://nvidia.github.io/cuda-python/cuda-bindings/latest/"
     },
     {
+        "version": "13.3.1",
+        "url": "https://nvidia.github.io/cuda-python/cuda-bindings/13.3.1/"
+    },
+    {
         "version": "13.3.0",
         "url": "https://nvidia.github.io/cuda-python/cuda-bindings/13.3.0/"
     },

--- a/cuda_bindings/docs/source/release/13.3.1-notes.rst
+++ b/cuda_bindings/docs/source/release/13.3.1-notes.rst
@@ -1,0 +1,26 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
+
+.. module:: cuda.bindings
+
+``cuda-bindings`` 13.3.1 Release notes
+======================================
+
+Bugfixes
+--------
+
+* Restored the ``CUcheckpointRestoreArgs`` and ``CUcheckpointRestoreArgs_st``
+  driver bindings for CUDA 13.3. CUDA 13.3 changed the checkpoint restore
+  argument layout in a way that caused header parsing to omit the restore
+  argument struct and typedef during generation.
+  (`PR #2144 <https://github.com/NVIDIA/cuda-python/pull/2144>`_)
+
+* Fixed generated CUDA 13.3 driver API documentation for checkpoint restore
+  arguments and related references.
+  (`PR #2144 <https://github.com/NVIDIA/cuda-python/pull/2144>`_)
+
+Known issues
+------------
+
+* Updating from older versions (v12.6.2.post1 and below) via ``pip install -U cuda-python`` might not work. Please do a clean re-installation by uninstalling ``pip uninstall -y cuda-python`` followed by installing ``pip install cuda-python``.
+* ``nvml.system_get_process_name`` on WSL can return incorrect values.  To work around this, set the locale to "C" before calling ``nvml.device_get_compute_running_processes_v3`` (which sets the process names) and before calling ``nvml.system_get_process_name``. ``cuda_core`` does this automatically, but users of the raw NVML API will need to do this manually.

--- a/cuda_python/docs/nv-versions.json
+++ b/cuda_python/docs/nv-versions.json
@@ -4,6 +4,10 @@
         "url": "https://nvidia.github.io/cuda-python/latest/"
     },
     {
+        "version": "13.3.1",
+        "url": "https://nvidia.github.io/cuda-python/13.3.1/"
+    },
+    {
         "version": "13.3.0",
         "url": "https://nvidia.github.io/cuda-python/13.3.0/"
     },

--- a/cuda_python/docs/source/release/13.3.0-notes.rst
+++ b/cuda_python/docs/source/release/13.3.0-notes.rst
@@ -8,6 +8,7 @@ Included components
 -------------------
 
 * `cuda.bindings 13.3.0 <https://nvidia.github.io/cuda-python/cuda-bindings/13.3.0/release/13.3.0-notes.html>`_
+* `cuda.core 1.0.1 <https://nvidia.github.io/cuda-python/cuda-core/1.0.1/release/1.0.1-notes.html>`_
 * `cuda.pathfinder 1.5.5 <https://nvidia.github.io/cuda-python/cuda-pathfinder/1.5.5/release/1.5.5-notes.html>`_
 
 Known issues

--- a/cuda_python/docs/source/release/13.3.1-notes.rst
+++ b/cuda_python/docs/source/release/13.3.1-notes.rst
@@ -1,0 +1,15 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
+
+CUDA Python 13.3.1 Release notes
+================================
+
+Included components
+-------------------
+
+* `cuda.bindings 13.3.1 <https://nvidia.github.io/cuda-python/cuda-bindings/13.3.1/release/13.3.1-notes.html>`_
+
+Known issues
+------------
+
+* Updating from older versions (v12.6.2.post1 and below) via ``pip install -U cuda-python`` might not work. Please do a clean re-installation by uninstalling ``pip uninstall -y cuda-python`` followed by installing ``pip install cuda-python``.

--- a/cuda_python/docs/source/release/13.3.1-notes.rst
+++ b/cuda_python/docs/source/release/13.3.1-notes.rst
@@ -8,6 +8,8 @@ Included components
 -------------------
 
 * `cuda.bindings 13.3.1 <https://nvidia.github.io/cuda-python/cuda-bindings/13.3.1/release/13.3.1-notes.html>`_
+* `cuda.core 1.0.1 <https://nvidia.github.io/cuda-python/cuda-core/1.0.1/release/1.0.1-notes.html>`_
+* `cuda.pathfinder 1.5.5 <https://nvidia.github.io/cuda-python/cuda-pathfinder/1.5.5/release/1.5.5-notes.html>`_
 
 Known issues
 ------------


### PR DESCRIPTION
## Description

Add release notes for the CUDA Python 13.3.1 patch release.

This release is scoped to the CUDA 13.3 checkpoint restore-argument binding fix from #2144:

- Add `cuda-bindings` 13.3.1 release notes documenting the restored `CUcheckpointRestoreArgs` / `CUcheckpointRestoreArgs_st` driver bindings and generated documentation fix.
- Add top-level CUDA Python 13.3.1 release notes listing the included component versions.
- Add 13.3.1 entries to the `cuda-bindings` and CUDA Python documentation version selectors.