### PR TITLE
[no-ci] CI: clarify restricted paths review guidance

### DIFF
--- a/.github/workflows/restricted-paths-guard.yml
+++ b/.github/workflows/restricted-paths-guard.yml
@@ -33,6 +33,7 @@ jobs:
 
           # Workflow policy inputs
           REVIEW_LABEL: Needs-Restricted-Paths-Review
+          DRY_RUN_REVIEW_LABEL_WRITES: false
 
           # API request context/auth
           GH_TOKEN: ${{ github.token }}
@@ -125,14 +126,25 @@ jobs:
             echo '```'
           }
 
-          post_review_label_comment() {
-            local comment_body
-            printf -v comment_body '%s\n\n%s\n\n%s\n\n%s\n\n%s\n' \
+          build_review_label_comment() {
+            printf '%s\n\n%s\n\n%s\n\n%s\n\n%s\n' \
               "\`$REVIEW_LABEL\` was assigned by \`CI: Restricted Paths Guard\`." \
               "For details, open [this workflow run]($RUN_URL) and click **Summary**." \
               "For external contributors: thank you for your interest in improving CUDA Python. The \`cuda_bindings/\` package is distributed under the [NVIDIA Software License](https://github.com/NVIDIA/cuda-python/blob/main/cuda_bindings/LICENSE), which does not allow us to accept external contributions to files under \`cuda_bindings/\` in this repository." \
               "Please close this PR. If your changes also include updates outside \`cuda_bindings/\`, please open a new PR containing only those changes so we can review them separately under the applicable license." \
               "If you are an NVIDIA employee and believe this label was applied in error, no action is needed; a maintainer will review and remove the label if appropriate."
+          }
+
+          write_review_label_comment_dry_run() {
+            echo "- **Dry-run comment body**:"
+            echo '```markdown'
+            build_review_label_comment
+            echo '```'
+          }
+
+          post_review_label_comment() {
+            local comment_body
+            comment_body=$(build_review_label_comment)
 
             if gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
               -f body="$comment_body" >/dev/null; then
@@ -245,6 +257,16 @@ jobs:
           if [ "$NEEDS_REVIEW_LABEL" = "true" ]; then
             if [ "$LABEL_ALREADY_PRESENT" = "true" ]; then
               LABEL_ACTION="already present"
+            elif [ "$DRY_RUN_REVIEW_LABEL_WRITES" = "true" ]; then
+              LABEL_ACTION="would add (dry run)"
+              COMMENT_ACTION="would post (dry run)"
+              {
+                echo "## Restricted Paths Guard Dry Run"
+                echo ""
+                echo "- **Would add label**: \`$REVIEW_LABEL\`"
+                echo ""
+                write_review_label_comment_dry_run
+              } >> "$GITHUB_STEP_SUMMARY"
             elif ! gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$REVIEW_LABEL"; then
               echo "::error::Failed to add the $REVIEW_LABEL label."
               {

--- a/.github/workflows/restricted-paths-guard.yml
+++ b/.github/workflows/restricted-paths-guard.yml
@@ -6,7 +6,7 @@ name: "CI: Restricted Paths Guard"
 on:
   # Run on drafts too so maintainers get early awareness on WIP PRs.
   # Label updates on fork PRs require pull_request_target permissions.
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize
@@ -44,7 +44,7 @@ jobs:
           #    MEMBER|OWNER and admin|maintain|write|triage.
           # 5. Commit these changes as a temporary dry-run test commit and revert
           #    that commit before merge.
-          DRY_RUN_REVIEW_LABEL_WRITES: true
+          DRY_RUN_REVIEW_LABEL_WRITES: false
 
           # API request context/auth
           GH_TOKEN: ${{ github.token }}
@@ -198,7 +198,7 @@ jobs:
             fi
 
             case "$AUTHOR_ASSOCIATION" in
-              DRY_RUN_NEVER_MATCH)
+              MEMBER|OWNER)
                 HAS_TRUSTED_SIGNAL=true
                 LABEL_ACTION="not needed (live author association is a trusted signal)"
                 TRUSTED_SIGNALS="author_association:$AUTHOR_ASSOCIATION"
@@ -242,7 +242,7 @@ jobs:
               fi
 
               case "$COLLABORATOR_PERMISSION" in
-                DRY_RUN_NEVER_MATCH)
+                admin|maintain|write|triage)
                   HAS_TRUSTED_SIGNAL=true
                   LABEL_ACTION="not needed (collaborator permission is a trusted signal)"
                   TRUSTED_SIGNALS="collaborator_permission:$COLLABORATOR_PERMISSION"

--- a/.github/workflows/restricted-paths-guard.yml
+++ b/.github/workflows/restricted-paths-guard.yml
@@ -127,9 +127,12 @@ jobs:
 
           post_review_label_comment() {
             local comment_body
-            printf -v comment_body '%s\n\n%s\n' \
+            printf -v comment_body '%s\n\n%s\n\n%s\n\n%s\n\n%s\n' \
               "\`$REVIEW_LABEL\` was assigned by \`CI: Restricted Paths Guard\`." \
-              "For details, open [this workflow run]($RUN_URL) and click **Summary**."
+              "For details, open [this workflow run]($RUN_URL) and click **Summary**." \
+              "For external contributors: thank you for your interest in improving CUDA Python. The \`cuda_bindings/\` package is distributed under the [NVIDIA Software License](https://github.com/NVIDIA/cuda-python/blob/main/cuda_bindings/LICENSE), which does not allow us to accept external contributions to files under \`cuda_bindings/\` in this repository." \
+              "Please close this PR. If your changes also include updates outside \`cuda_bindings/\`, please open a new PR containing only those changes so we can review them separately under the applicable license." \
+              "If you are an NVIDIA employee and believe this label was applied in error, no action is needed; a maintainer will review and remove the label if appropriate."
 
             if gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
               -f body="$comment_body" >/dev/null; then

--- a/.github/workflows/restricted-paths-guard.yml
+++ b/.github/workflows/restricted-paths-guard.yml
@@ -6,7 +6,7 @@ name: "CI: Restricted Paths Guard"
 on:
   # Run on drafts too so maintainers get early awareness on WIP PRs.
   # Label updates on fork PRs require pull_request_target permissions.
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize
@@ -44,7 +44,7 @@ jobs:
           #    MEMBER|OWNER and admin|maintain|write|triage.
           # 5. Commit these changes as a temporary dry-run test commit and revert
           #    that commit before merge.
-          DRY_RUN_REVIEW_LABEL_WRITES: false
+          DRY_RUN_REVIEW_LABEL_WRITES: true
 
           # API request context/auth
           GH_TOKEN: ${{ github.token }}
@@ -198,7 +198,7 @@ jobs:
             fi
 
             case "$AUTHOR_ASSOCIATION" in
-              MEMBER|OWNER)
+              DRY_RUN_NEVER_MATCH)
                 HAS_TRUSTED_SIGNAL=true
                 LABEL_ACTION="not needed (live author association is a trusted signal)"
                 TRUSTED_SIGNALS="author_association:$AUTHOR_ASSOCIATION"
@@ -242,7 +242,7 @@ jobs:
               fi
 
               case "$COLLABORATOR_PERMISSION" in
-                admin|maintain|write|triage)
+                DRY_RUN_NEVER_MATCH)
                   HAS_TRUSTED_SIGNAL=true
                   LABEL_ACTION="not needed (collaborator permission is a trusted signal)"
                   TRUSTED_SIGNALS="collaborator_permission:$COLLABORATOR_PERMISSION"

--- a/.github/workflows/restricted-paths-guard.yml
+++ b/.github/workflows/restricted-paths-guard.yml
@@ -33,6 +33,17 @@ jobs:
 
           # Workflow policy inputs
           REVIEW_LABEL: Needs-Restricted-Paths-Review
+          # Temporary testing recipe for agents:
+          # 1. Change pull_request_target to pull_request.
+          # 2. Set DRY_RUN_REVIEW_LABEL_WRITES to true.
+          # 3. Add a dummy comment or whitespace-only change in
+          #    cuda_bindings/README.md to trigger restricted-path detection
+          #    without affecting build/package behavior.
+          # 4. Replace both trusted case patterns below with DRY_RUN_NEVER_MATCH
+          #    so the test does not depend on the tester's GitHub identity:
+          #    MEMBER|OWNER and admin|maintain|write|triage.
+          # 5. Commit these changes as a temporary dry-run test commit and revert
+          #    that commit before merge.
           DRY_RUN_REVIEW_LABEL_WRITES: false
 
           # API request context/auth

--- a/cuda_bindings/README.md
+++ b/cuda_bindings/README.md
@@ -1,5 +1,7 @@
 # `cuda.bindings`: Low-level CUDA interfaces
 
+<!-- TEMPORARY: restricted-paths-guard dry-run trigger -->
+
 `cuda.bindings` is a standard set of low-level interfaces, providing full coverage of and access to the CUDA host APIs from Python. Checkout the [Overview page](https://nvidia.github.io/cuda-python/cuda-bindings/latest/overview.html) for the workflow and performance results.
 
 ## Installing

--- a/cuda_bindings/README.md
+++ b/cuda_bindings/README.md
@@ -1,7 +1,5 @@
 # `cuda.bindings`: Low-level CUDA interfaces
 
-<!-- TEMPORARY: restricted-paths-guard dry-run trigger -->
-
 `cuda.bindings` is a standard set of low-level interfaces, providing full coverage of and access to the CUDA host APIs from Python. Checkout the [Overview page](https://nvidia.github.io/cuda-python/cuda-bindings/latest/overview.html) for the workflow and performance results.
 
 ## Installing


### PR DESCRIPTION
## Summary

This PR expands the `CI: Restricted Paths Guard` comment that is posted when `Needs-Restricted-Paths-Review` is newly assigned.

The generated comment now explains that:

- external contributors cannot modify files under `cuda_bindings/` because `cuda_bindings/` is distributed under the NVIDIA Software License
- PRs containing external `cuda_bindings/` contributions should be closed
- changes outside `cuda_bindings/` can be resubmitted in a separate PR for review under the applicable license
- NVIDIA employees who believe the label was applied in error do not need to act; a maintainer can review and remove the label

## Testing Support

This PR also adds a reusable dry-run mode for the restricted-paths guard write path.

`DRY_RUN_REVIEW_LABEL_WRITES` defaults to `false`, so production behavior is unchanged. When temporarily set to `true`, the workflow writes the would-be label action and generated comment body to the job summary instead of calling GitHub label/comment write APIs.

This makes it possible to test the review-label/comment path from a temporary `pull_request` workflow run without hitting the expected write-permission failures that occur outside `pull_request_target`.

The workflow now includes an agent-facing temporary testing recipe describing how to:

- switch `pull_request_target` to `pull_request`
- enable dry-run mode
- add a dummy `cuda_bindings/README.md` change to trigger restricted-path detection
- replace trusted case patterns with `DRY_RUN_NEVER_MATCH` so the test does not depend on the tester's GitHub identity
- revert the temporary test commit before merge