### PR TITLE
cuda.core: raise BufferError instead of RuntimeError in check_has_dlpack

### DIFF
--- a/cuda_core/cuda/core/_memoryview.pyx
+++ b/cuda_core/cuda/core/_memoryview.pyx
@@ -996,7 +996,7 @@ cdef bint check_has_dlpack(obj) except*:
     elif hasattr(obj, "__cuda_array_interface__"):
         has_dlpack = False
     else:
-        raise RuntimeError(
+        raise BufferError(
             "the input object does not support any data exchange protocol")
     return has_dlpack
 

--- a/cuda_core/tests/test_utils.py
+++ b/cuda_core/tests/test_utils.py
@@ -1044,7 +1044,7 @@ def test_check_has_dlpack_plain_object_raises():
     class _NoProto:
         pass
 
-    with pytest.raises(RuntimeError, match="does not support any data exchange protocol"):
+    with pytest.raises(BufferError, match="does not support any data exchange protocol"):
         StridedMemoryView.from_any_interface(_NoProto(), stream_ptr=-1)
 
 


### PR DESCRIPTION
## Description

<!-- Provide a standalone description of changes in this PR. -->
`check_has_dlpack` raised `RuntimeError` when an object supports neither DLPack nor the CUDA Array Interface, but the `StridedMemoryView` docstring documents `BufferError`. This fix aligns the implementation with the docs to raise BufferError.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [√] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
