### PR TITLE
Relax len(board_part_number) > 0 assertion in test_get_inforom_version for boards reporting N/A

### DIFF
--- a/cuda_core/tests/system/test_system_device.py
+++ b/cuda_core/tests/system/test_system_device.py
@@ -547,7 +547,9 @@ def test_get_inforom_version():
         with unsupported_before(device, "HAS_INFOROM"):
             board_part_number = inforom.board_part_number
         assert isinstance(board_part_number, str)
-        assert len(board_part_number) > 0
+
+        # Some boards (e.g. NVIDIA T4G) do not program a board part number
+        assert board_part_number == "" or board_part_number.strip() == board_part_number
 
         inforom.validate()
 


### PR DESCRIPTION
## Description

closes #2169

`test_get_inforom_version` asserts `len(inforom.board_part_number) > 0`, which fails on boards that did not have a board part number programmed into the InfoROM (e.g. NVIDIA T4G, Driver 595.45.04, CUDA 13.2). The cuda-python binding faithfully forwards NVML's value, so the empty string is a legitimate result; the `"N/A"` shown from `nvidia-smi -q` is its own display string, not what NVML returns.

Verified directly against `libnvidia-ml.so` through C API `nvmlDeviceGetBoardPartNumber` in `nvml.h`. NVML returns `NVML_SUCCESS` and writes a single `\0`.

The fix relaxes the assertion to accept the empty string.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.