### PR TITLE
[doc-only] cuda.core: document how to install nightly (top-of-tree) builds

### DIFF
--- a/cuda_core/docs/source/install.rst
+++ b/cuda_core/docs/source/install.rst
@@ -71,8 +71,14 @@ and likewise use ``cuda-version=13`` for CUDA 13.
 Note that to use ``cuda.core`` with nvJitLink installed from conda-forge requires ``cuda.bindings`` 12.8.0+.
 
 
+Development environment
+-----------------------
+
+The sections above cover end-user installation. The section below focuses on
+a repeatable *development* workflow (editable installs and running tests).
+
 Installing the latest nightly (top-of-tree builds)
---------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 These are useful for users looking to test new features or bug fixes prior to
 their inclusion in a release.
@@ -95,13 +101,6 @@ Replace ``python312`` with your Python version (e.g. ``python310``, ``python311`
 ``python313``, ``python314``, ``python314t``). For aarch64, replace ``linux-64``
 with ``linux-aarch64``; for Windows, use ``win-64``. Replace ``cu13`` with
 ``cu12`` for CUDA 12.x environments.
-
-
-Development environment
------------------------
-
-The sections above cover end-user installation. The section below focuses on
-a repeatable *development* workflow (editable installs and running tests).
 
 Development with uv
 ~~~~~~~~~~~~~~~~~~~

--- a/cuda_core/docs/source/install.rst
+++ b/cuda_core/docs/source/install.rst
@@ -71,6 +71,32 @@ and likewise use ``cuda-version=13`` for CUDA 13.
 Note that to use ``cuda.core`` with nvJitLink installed from conda-forge requires ``cuda.bindings`` 12.8.0+.
 
 
+Installing the latest nightly (top-of-tree builds)
+--------------------------------------------------
+
+These are useful for users looking to test new features or bug fixes prior to
+their inclusion in a release.
+
+CI publishes wheels as GitHub Actions artifacts on every push to ``main``. To
+obtain the most recent build, use the following commands:
+
+.. code-block:: console
+
+   $ # Find the latest successful CI run on main:
+   $ RUN_ID=$(gh run list -R NVIDIA/cuda-python -w ci.yml -b main -s success -L1 --json databaseId -q '.[0].databaseId')
+
+   $ # Download the wheel (pick your Python version and platform):
+   $ gh run download "$RUN_ID" -R NVIDIA/cuda-python -p "cuda-core-python312-linux-64-*"
+
+   $ # Install the downloaded wheel:
+   $ pip install cuda-core-python312-linux-64-*/cuda_core*.whl[cu13]
+
+Replace ``python312`` with your Python version (e.g. ``python310``, ``python311``,
+``python313``, ``python314``, ``python314t``). For aarch64, replace ``linux-64``
+with ``linux-aarch64``; for Windows, use ``win-64``. Replace ``cu13`` with
+``cu12`` for CUDA 12.x environments.
+
+
 Development environment
 -----------------------
 


### PR DESCRIPTION
Closes #2166

## What
Adds an **Installing the latest nightly (top-of-tree builds)** section to `cuda_core/docs/source/install.rst`. The section explains how to use `gh run download` to grab the wheel artifact from the most recent successful CI run on `main`, with notes for picking your Python version, target platform, and CUDA major version.

## Why
Per the issue, the equivalent section already exists in [numba-cuda-mlir](https://github.com/NVIDIA/numba-cuda-mlir/blob/main/INSTALL.md#top-of-tree-builds). The two repos share CI infrastructure, so the recipe transfers directly — only repo name, workflow file (`ci.yml`), and artifact pattern names needed adapting.

## Tested
- Verified `gh run list -R NVIDIA/cuda-python -w ci.yml -b main -s success -L1` resolves cleanly against the live repo (returns the latest successful CI run).
- Pure additive change — no surrounding content modified. Indentation matches the surrounding RST blocks.

## Verification
```
branch: hunter/issue-2166
files-changed: 1
commit: 6479b7f
```