### PR TITLE
CI: shrink checkouts via shallow / treeless partial clones

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout ${{ github.event.repository.name }}
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ inputs.git-tag }}
 
       - name: Read build CTK version

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -42,7 +42,10 @@ jobs:
       - name: Checkout ${{ github.event.repository.name }}
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          # Treeless clone: setuptools-scm needs the commit graph (`git describe`)
+          # but not historical blobs.
           fetch-depth: 0
+          filter: blob:none
 
       - name: Install latest rapidsai/sccache
         if: ${{ startsWith(inputs.host-platform, 'linux') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Get CUDA build versions
         id: get-vars
         run: |
@@ -106,7 +106,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          # Treeless clone: commit graph is needed for `git merge-base` and
+          # `git diff --name-only` below, but historical blobs aren't.
           fetch-depth: 0
+          filter: blob:none
 
       # copy-pr-bot pushes every PR (whether it targets main or a backport
       # branch such as 12.9.x) to pull-request/<N>, so the base branch

--- a/.github/workflows/cleanup-pr-previews.yml
+++ b/.github/workflows/cleanup-pr-previews.yml
@@ -30,8 +30,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6.0.3
         with:
-          # Fetch all history and branches for worktree operations
+          # Treeless clone: `git worktree add gh-pages` needs the commit graph,
+          # but historical blobs aren't required.
           fetch-depth: 0
+          filter: blob:none
 
       - name: Configure git identity
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -66,7 +66,10 @@ jobs:
       - name: Checkout ${{ github.event.repository.name }}
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          # Treeless clone: setuptools-scm needs the commit graph (`git describe`)
+          # but not historical blobs.
           fetch-depth: 0
+          filter: blob:none
 
       - name: Fix workspace ownership
         run: |
@@ -198,7 +201,10 @@ jobs:
       - name: Checkout ${{ github.event.repository.name }}
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          # Treeless clone: setuptools-scm needs the commit graph (`git describe`)
+          # but not historical blobs.
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
@@ -269,7 +275,7 @@ jobs:
       - name: Checkout ${{ github.event.repository.name }}
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main

--- a/.github/workflows/release-cuda-pathfinder.yml
+++ b/.github/workflows/release-cuda-pathfinder.yml
@@ -61,7 +61,9 @@ jobs:
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
-          fetch-depth: 0
+          # lookup-run-id resolves the git tag to a SHA; we need tags but not history.
+          fetch-depth: 1
+          fetch-tags: true
           # Resolve only the exact tag ref; checkout fails if the tag does not exist.
           ref: refs/tags/${{ steps.vars.outputs.tag }}
 
@@ -161,7 +163,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ needs.prepare.outputs.tag }}
 
       - name: Create source archive

--- a/.github/workflows/release-upload.yml
+++ b/.github/workflows/release-upload.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ inputs.git-tag }}
 
       - name: Create Release Directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,9 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
-          # fetch-depth: 0 is required so the lookup-run-id script can access all git tags
-          fetch-depth: 0
+          # lookup-run-id resolves the git tag to a SHA; we need tags but not history.
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Determine Run ID
         id: lookup-run-id
@@ -62,7 +63,7 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Check or create draft release for the tag
         env:

--- a/.github/workflows/test-sdist-linux.yml
+++ b/.github/workflows/test-sdist-linux.yml
@@ -28,7 +28,10 @@ jobs:
       - name: Checkout ${{ github.event.repository.name }}
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          # Treeless clone: setuptools-scm (invoked via `python -m build`) needs
+          # the commit graph (`git describe`) but not historical blobs.
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0

--- a/.github/workflows/test-sdist-windows.yml
+++ b/.github/workflows/test-sdist-windows.yml
@@ -34,7 +34,10 @@ jobs:
       - name: Checkout ${{ github.event.repository.name }}
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          # Treeless clone: setuptools-scm (invoked via `python -m build`) needs
+          # the commit graph (`git describe`) but not historical blobs.
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0


### PR DESCRIPTION
## Summary

Closes #2091.

15 workflow checkouts used `fetch-depth: 0` (full clone with every blob in history). The audit in #2091 showed only 7 actually need the commit graph (setuptools-scm, `git merge-base`, `git worktree`), and none need historical blobs. The remaining 8 either do no local git operations or only need tag resolution. This PR applies the three patterns from that audit.

### Patterns applied

- **Plain shallow clone** — `fetch-depth: 1` (6 sites, no local git ops)
  - `ci.yml` ci-vars
  - `build-docs.yml`
  - `release-upload.yml`
  - `release.yml` check-tag
  - `release-cuda-pathfinder.yml` upload-assets
  - `coverage.yml` coverage-windows

- **Shallow + tags** — `fetch-depth: 1` + `fetch-tags: true` (2 sites, `lookup-run-id` does `git rev-parse <tag>`)
  - `release.yml` determine-run-id
  - `release-cuda-pathfinder.yml` prepare

- **Treeless** — `fetch-depth: 0` + `filter: blob:none` (7 sites, commit graph needed but not historical blobs)
  - `build-wheel.yml` (setuptools-scm)
  - `ci.yml` detect-changes (`git merge-base` + `git diff --name-only`)
  - `cleanup-pr-previews.yml` (`git worktree add gh-pages`)
  - `coverage.yml` coverage-linux (setuptools-scm)
  - `coverage.yml` build-wheel-windows (setuptools-scm)
  - `test-sdist-linux.yml` (`python -m build` → setuptools-scm)
  - `test-sdist-windows.yml` (same)

Should noticeably reduce checkout time, especially on Windows where git operations are slower.

## Test plan

- [ ] CI passes on this PR (exercises all three patterns: detect-changes, build-wheel, coverage, test-sdist)
- [ ] release dry-run / next release exercises `release.yml` and `release-cuda-pathfinder.yml` paths (these aren't triggered by PR CI)

-- Leo's bot