### PR TITLE
[doc-only] cuda.{core,bindings,pathfinder}: nightly install docs and unify "Development environment" structure

### DIFF
--- a/cuda_bindings/docs/source/install.rst
+++ b/cuda_bindings/docs/source/install.rst
@@ -113,10 +113,10 @@ major version is built on ``main``; wheels for the prior CUDA major are
 published from the corresponding backport branch.
 
 Installing from Source
-----------------------
+~~~~~~~~~~~~~~~~~~~~~~
 
 Requirements
-~~~~~~~~~~~~
+^^^^^^^^^^^^
 
 * CUDA Toolkit headers[^1]
 * CUDA Runtime static library[^2]
@@ -138,7 +138,7 @@ See :doc:`Environment Variables <environment_variables>` for a description of ot
    Only ``cydriver``, ``cyruntime`` and ``cynvrtc`` are impacted by the header requirement.
 
 Editable Install
-~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^
 
 You can use:
 

--- a/cuda_bindings/docs/source/install.rst
+++ b/cuda_bindings/docs/source/install.rst
@@ -80,6 +80,38 @@ For example:
 
    Tegra users can install the cuDLA conda package from conda-forge through ``conda install -c conda-forge libcudla cuda-version=13``, if it does not already exist on the system.
 
+Development environment
+-----------------------
+
+The sections above cover end-user installation. The section below focuses on
+a repeatable *development* workflow (editable installs and running tests).
+
+Installing the latest nightly (top-of-tree builds)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These are useful for users looking to test new features or bug fixes prior to
+their inclusion in a release.
+
+CI publishes wheels as GitHub Actions artifacts on every push to ``main``. To
+obtain the most recent build, use the following commands:
+
+.. code-block:: console
+
+   $ # Find the latest successful CI run on main:
+   $ RUN_ID=$(gh run list -R NVIDIA/cuda-python -w ci.yml -b main -s success -L1 --json databaseId -q '.[0].databaseId')
+
+   $ # Download the wheel (pick your Python version and platform):
+   $ gh run download "$RUN_ID" -R NVIDIA/cuda-python -p "cuda-bindings-python312-cuda13*-linux-64-*"
+
+   $ # Install the downloaded wheel:
+   $ pip install cuda-bindings-python312-cuda13*-linux-64-*/cuda_bindings*.whl[all]
+
+Replace ``python312`` with your Python version (e.g. ``python310``, ``python311``,
+``python313``, ``python314``, ``python314t``). For aarch64, replace ``linux-64``
+with ``linux-aarch64``; for Windows, use ``win-64``. Only the current CUDA
+major version is built on ``main``; wheels for the prior CUDA major are
+published from the corresponding backport branch.
+
 Installing from Source
 ----------------------
 

--- a/cuda_core/docs/source/install.rst
+++ b/cuda_core/docs/source/install.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
 Installation
@@ -147,7 +147,7 @@ Use ``-e cu12`` to test against CUDA 12 instead.
 .. _pixi: https://pixi.sh/
 
 Installing from Source
-----------------------
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: console
 

--- a/cuda_pathfinder/docs/source/index.rst
+++ b/cuda_pathfinder/docs/source/index.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
 ``cuda.pathfinder``: Utilities for locating CUDA components

--- a/cuda_pathfinder/docs/source/index.rst
+++ b/cuda_pathfinder/docs/source/index.rst
@@ -8,6 +8,7 @@
    :maxdepth: 2
    :caption: Contents:
 
+   install
    api
    contribute
    license

--- a/cuda_pathfinder/docs/source/install.rst
+++ b/cuda_pathfinder/docs/source/install.rst
@@ -1,0 +1,70 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+Installation
+============
+
+Runtime Requirements
+--------------------
+
+``cuda.pathfinder`` is a pure-Python package with no runtime dependencies:
+
+* Linux (x86-64, arm64) and Windows (x86-64)
+* Python 3.10 - 3.14
+
+Installing from PyPI
+--------------------
+
+.. code-block:: console
+
+   $ pip install -U cuda-pathfinder
+
+Installing from Conda (conda-forge)
+-----------------------------------
+
+.. code-block:: console
+
+   $ conda install -c conda-forge cuda-pathfinder
+
+Development environment
+-----------------------
+
+The sections above cover end-user installation. The section below focuses on
+a repeatable *development* workflow (editable installs and running tests).
+
+Installing the latest nightly (top-of-tree builds)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These are useful for users looking to test new features or bug fixes prior to
+their inclusion in a release.
+
+CI publishes the wheel as a GitHub Actions artifact on every push to ``main``.
+Because ``cuda.pathfinder`` is pure Python, a single wheel covers every
+supported Python version and platform. To obtain the most recent build, use
+the following commands:
+
+.. code-block:: console
+
+   $ # Find the latest successful CI run on main:
+   $ RUN_ID=$(gh run list -R NVIDIA/cuda-python -w ci.yml -b main -s success -L1 --json databaseId -q '.[0].databaseId')
+
+   $ # Download the wheel:
+   $ gh run download "$RUN_ID" -R NVIDIA/cuda-python -p "cuda-pathfinder-wheel"
+
+   $ # Install the downloaded wheel:
+   $ pip install cuda-pathfinder-wheel/*.whl
+
+Installing from Source
+----------------------
+
+.. code-block:: console
+
+   $ git clone https://github.com/NVIDIA/cuda-python
+   $ cd cuda-python/cuda_pathfinder
+   $ pip install .
+
+For an editable install (e.g. when developing ``cuda.pathfinder`` itself):
+
+.. code-block:: console
+
+   $ pip install -v -e .

--- a/cuda_pathfinder/docs/source/install.rst
+++ b/cuda_pathfinder/docs/source/install.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
 Installation
@@ -55,7 +55,7 @@ the following commands:
    $ pip install cuda-pathfinder-wheel/*.whl
 
 Installing from Source
-----------------------
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: console
 


### PR DESCRIPTION
## What

Extends #2175 to the remaining components named in #2166 (which covers all three of cuda.pathfinder, cuda.bindings, and cuda.core — the original PR only added the nightly recipe for cuda.core), and unifies the install-doc structure across all three components.

**Commit 1 — nightly recipes for the other two components**
- `cuda_bindings/docs/source/install.rst`: add a new **Development environment** section with an **Installing the latest nightly (top-of-tree builds)** subsection, between *Installing from Conda* and *Installing from Source*. Mirrors the cuda.core layout. The artifact pattern includes the CUDA major (`cuda13*`) because cuda-bindings wheels are CUDA-versioned.
- `cuda_pathfinder/docs/source/install.rst` (NEW): cuda.pathfinder previously had no install page. Adds a minimal install.rst (PyPI / Conda / Development environment → nightly / Source). Nightly uses the single pure-Python `cuda-pathfinder-wheel` artifact — no python/platform/CUDA selection needed.
- `cuda_pathfinder/docs/source/index.rst`: wire `install` into the toctree.

**Commit 2 — consistent nesting of "Installing from Source"**
- Across all three components, drop *Installing from Source* from `---` to `~~~` so it lives under *Development environment* as a sibling of the nightly / uv / pixi subsections (instead of as a top-level sibling of *Development environment*).
- For cuda.bindings, also drop its *Requirements* and *Editable Install* subsections from `~~~` to `^^^` so the depth still works.
- Bump SPDX copyright on the three touched existing files to `2025-2026`; the new cuda_pathfinder `install.rst` carries `2026`.

## Why

#2166 asks for the top-of-tree install recipe to be documented in the developer guide for all components. #2175 only covered cuda.core; this PR closes the gap for the other two and additionally unifies the section nesting so the developer-workflow group reads consistently across all three install pages.

## Tested

- `gh run list -R NVIDIA/cuda-python -w ci.yml -b main -s success -L1` resolves cleanly against the live repo.
- Local `sphinx-build` of all three docs sets (`cuda_core/docs`, `cuda_bindings/docs`, `cuda_pathfinder/docs`) succeeds with no new warnings on the changed/added install.rst files. Pre-existing autosummary warnings in cuda_pathfinder (the package isn't installed in the build env) are unchanged.
- Verified the cuda.bindings artifact name pattern against `ci/tools/env-vars` (`cuda-bindings-python{PY}-cuda{CUDA_VER}-{PLATFORM}-{SHA}`) and the cuda.pathfinder upload step (`cuda-pathfinder-wheel`, single artifact per run).

## Notes

- Content is intentionally additive in commit 1; commit 2 only changes underline characters and copyright years.
- Not auto-closing #2166 since you already closed it on #2175; happy to reopen-and-close on merge if you prefer.