### PR TITLE
[no-ci] docs: instruct agents to use personal fork, not upstream, for PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ guide for package-specific conventions and workflows.
 
 # Pull requests
 
-**Never push branches or commits to the upstream fork (github.com/NVIDIA/cuda-python).
+**Never push branches or commits to the upstream repo (github.com/NVIDIA/cuda-python).
 Treat it as read-only.** All branch creation and pushes must go to the contributor's
 personal fork. Before pushing, confirm which remote points to the contributor's
 personal fork (not `upstream`) by running `git remote -v`, then push there

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,14 @@ guide for package-specific conventions and workflows.
 
 # Pull requests
 
+**Never push branches or commits to the upstream fork (github.com/NVIDIA/cuda-python).
+Treat it as read-only.** All branch creation and pushes must go to the contributor's
+personal fork. Before pushing, confirm which remote points to the contributor's
+personal fork (not `upstream`) by running `git remote -v`, then push there
+(`git push <personal-fork-remote> <branch>`). Open the PR from that fork with
+`gh pr create`. Do not use `git push upstream` or any command that writes to
+the `upstream` remote.
+
 When creating pull requests with `gh pr create`, always assign at least one
 label and a milestone. CI enforces this via the `pr-metadata-check` workflow
 and will block PRs that are missing labels or a milestone. Use `--label` and


### PR DESCRIPTION
## Summary

- Adds a bolded warning at the top of the `# Pull requests` section in `AGENTS.md` instructing coding agents never to push to `github.com/NVIDIA/cuda-python`
- Directs agents to discover the correct personal-fork remote via `git remote -v` before pushing, making the instruction generic for any contributor
- Reinforces that `upstream` is read-only

## Test plan

- [x] Verify the instruction appears correctly in `AGENTS.md`
- [ ] Confirm agents in future sessions respect the fork policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)