### PR TITLE
CI: require N consecutive nvidia-smi successes after Windows device cycle

### DIFF
--- a/ci/tools/configure_driver_mode.ps1
+++ b/ci/tools/configure_driver_mode.ps1
@@ -31,7 +31,6 @@ function Set-DriverMode {
     }
 
     # Only restart NVIDIA display adapters, not other display devices (e.g. QEMU VGA).
-    # @(...) forces an array even when there's a single device, so .Count works.
     $nvidia_devices = @(Get-PnpDevice -Class Display -FriendlyName "NVIDIA*")
     $gpu_count = $nvidia_devices.Count
     foreach ($device in $nvidia_devices) {

--- a/ci/tools/configure_driver_mode.ps1
+++ b/ci/tools/configure_driver_mode.ps1
@@ -40,20 +40,11 @@ function Set-DriverMode {
         pnputil /enable-device "$($device.InstanceId)"
     }
 
-    # Restore the unconditional 5-sec settle that the pre-#2176
-    # install_gpu_driver.ps1 had after the cycle. With #2176, on
-    # DRIVER=latest rows we no longer run an install (which previously
-    # acted as additional warm-up), so the floor had effectively
-    # dropped to whatever the poll's first iteration was.
+    # Initial settle after the device cycle.
     Start-Sleep -Seconds 5
 
-    # Then poll nvidia-smi until NVML can initialize, or give up after
-    # ~60s. Require N consecutive successes where N == number of GPUs
-    # we just cycled: on multi-GPU rows (observed on 2x H100 MCDM)
-    # NVML briefly reports "ok" mid-init then flaps back to "Not
-    # Found", so a single success isn't enough. Scaling the
-    # consecutive-success requirement to the device count gives the
-    # settle window room to grow with the hardware.
+    # Poll nvidia-smi for N consecutive successes (N == cycled GPUs)
+    # so a mid-init "ok" flap doesn't fool the loop; bail after ~60s.
     Write-Output "Waiting for nvidia-smi/NVML to come back up after device cycle..."
     $deadline = (Get-Date).AddSeconds(60)
     $consecutive_ok = 0

--- a/ci/tools/configure_driver_mode.ps1
+++ b/ci/tools/configure_driver_mode.ps1
@@ -40,13 +40,20 @@ function Set-DriverMode {
         pnputil /enable-device "$($device.InstanceId)"
     }
 
-    # Poll nvidia-smi until NVML can initialize, or give up after ~60s.
-    # Require N consecutive successes where N == number of GPUs we just
-    # cycled: on multi-GPU rows (observed on 2x H100 MCDM), NVML briefly
-    # reports "ok" mid-init then flaps back to "Not Found", so a single
-    # success isn't enough. Scaling the consecutive-success requirement
-    # to the device count gives the settle window room to grow with the
-    # hardware.
+    # Restore the unconditional 5-sec settle that the pre-#2176
+    # install_gpu_driver.ps1 had after the cycle. With #2176, on
+    # DRIVER=latest rows we no longer run an install (which previously
+    # acted as additional warm-up), so the floor had effectively
+    # dropped to whatever the poll's first iteration was.
+    Start-Sleep -Seconds 5
+
+    # Then poll nvidia-smi until NVML can initialize, or give up after
+    # ~60s. Require N consecutive successes where N == number of GPUs
+    # we just cycled: on multi-GPU rows (observed on 2x H100 MCDM)
+    # NVML briefly reports "ok" mid-init then flaps back to "Not
+    # Found", so a single success isn't enough. Scaling the
+    # consecutive-success requirement to the device count gives the
+    # settle window room to grow with the hardware.
     Write-Output "Waiting for nvidia-smi/NVML to come back up after device cycle..."
     $deadline = (Get-Date).AddSeconds(60)
     $consecutive_ok = 0

--- a/ci/tools/configure_driver_mode.ps1
+++ b/ci/tools/configure_driver_mode.ps1
@@ -30,8 +30,10 @@ function Set-DriverMode {
         exit 1
     }
 
-    # Only restart NVIDIA display adapters, not other display devices (e.g. QEMU VGA)
-    $nvidia_devices = Get-PnpDevice -Class Display -FriendlyName "NVIDIA*"
+    # Only restart NVIDIA display adapters, not other display devices (e.g. QEMU VGA).
+    # @(...) forces an array even when there's a single device, so .Count works.
+    $nvidia_devices = @(Get-PnpDevice -Class Display -FriendlyName "NVIDIA*")
+    $gpu_count = $nvidia_devices.Count
     foreach ($device in $nvidia_devices) {
         Write-Output "Restarting device: $($device.FriendlyName) ($($device.InstanceId))"
         pnputil /disable-device "$($device.InstanceId)"
@@ -39,17 +41,22 @@ function Set-DriverMode {
     }
 
     # Poll nvidia-smi until NVML can initialize, or give up after ~60s.
-    # A fixed sleep is not enough on slower-coming-back-up multi-GPU rows
-    # (e.g. 2x H100 MCDM) where pnputil enable returns before NVML is
-    # ready. Pattern borrowed from the runner-team `nvgha-driver.ps1`.
+    # Require N consecutive successes where N == number of GPUs we just
+    # cycled: on multi-GPU rows (observed on 2x H100 MCDM), NVML briefly
+    # reports "ok" mid-init then flaps back to "Not Found", so a single
+    # success isn't enough. Scaling the consecutive-success requirement
+    # to the device count gives the settle window room to grow with the
+    # hardware.
     Write-Output "Waiting for nvidia-smi/NVML to come back up after device cycle..."
     $deadline = (Get-Date).AddSeconds(60)
+    $consecutive_ok = 0
     do {
-        Start-Sleep -Seconds 2
+        Start-Sleep -Seconds 3
         & nvidia-smi.exe 2>&1 | Out-Null
-    } while ($LASTEXITCODE -ne 0 -and (Get-Date) -lt $deadline)
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "nvidia-smi did not return cleanly within 60s of the device cycle"
+        if ($LASTEXITCODE -eq 0) { $consecutive_ok++ } else { $consecutive_ok = 0 }
+    } while ($consecutive_ok -lt $gpu_count -and (Get-Date) -lt $deadline)
+    if ($consecutive_ok -lt $gpu_count) {
+        Write-Error "nvidia-smi did not return cleanly $gpu_count times in a row within 60s of the device cycle"
         exit 1
     }
 }


### PR DESCRIPTION
## Description

Fix flakiness on the 2× H100 MCDM Windows runner, observed since #2176 landed (e.g. <https://github.com/NVIDIA/cuda-python/actions/runs/27293276910/job/80661578895>).

*What broke*: pre-#2176, every Windows row ran `install_gpu_driver.ps1` unconditionally, and that script ended with a fixed `Start-Sleep -Seconds 5` after the `pnputil` cycle. #2176 replaced that fixed 5-sec settle with a poll-until-success loop in `configure_driver_mode.ps1` — and that loop exits on the *first* `nvidia-smi` exit-0, ~2 sec into the cycle. On the H100 pair, NVML briefly reports success mid-init and then flaps back to "Not Found" a few seconds later, so the workflow's next "Ensure GPU is working" step lands in the flap window:

```
Waiting for nvidia-smi/NVML to come back up after device cycle...
+ nvidia-smi                    # next workflow step, ~4 sec later
Failed to initialize NVML: Not Found
Write-Error: Switching to driver mode MCDM failed!
```

*Fix*: two layers.

1. *Restore the pre-#2176 5-sec floor* — unconditional `Start-Sleep -Seconds 5` *before* the poll. That's the known-good baseline that worked across all Windows rows for a long time.
2. *Then require N consecutive successes in the poll*, where `N == Get-PnpDevice -Class Display -FriendlyName "NVIDIA*"`. On single-GPU rows that's still effectively one short success after the 5-sec floor. On the H100 pair it's two consecutive 3-sec-apart successes, so a mid-flap "ok" can't fool the loop. The 60-sec deadline cap is unchanged.

Net effect:
- *Single-GPU rows*: 5 sec sleep + ~3 sec (1 success) = ~8 sec floor (pre-#2176 was 5 sec, plus the install overhead).
- *2× H100 MCDM*: 5 sec sleep + ~6 sec (2 successes) = ~11 sec floor (pre-#2176 was 5 sec).
- *Pathological case*: 60-sec deadline still caps total wait, with a loud failure message instead of a silent ride into the next step.

## Checklist

- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
