### PR TITLE
[doc-only] cuda.bindings: clarify getLocalRuntimeVersion docstring

### DIFF
--- a/cuda_bindings/cuda/bindings/runtime.pyx.in
+++ b/cuda_bindings/cuda/bindings/runtime.pyx.in
@@ -42117,15 +42117,18 @@ def cudaGraphicsVDPAURegisterOutputSurface(vdpSurface, unsigned int flags):
 
 @cython.embedsignature(True)
 def getLocalRuntimeVersion():
-    """ Returns the CUDA Runtime version of local shared library.
+    """ Returns the CUDA Runtime version of the locally installed shared library.
 
-    Returns in `*runtimeVersion` the version number of the current CUDA
-    Runtime instance. The version is returned as (1000 * major + 10 *
-    minor). For example, CUDA 9.2 would be represented by 9020.
+    Locates the CUDA Runtime (``cudart``) shared library on the host using
+    :py:obj:`cuda.pathfinder.load_nvidia_dynamic_lib`, then calls
+    ``cudaRuntimeGetVersion`` from that dynamically loaded library. The
+    returned value reflects the CUDA Toolkit version of the locally
+    discovered ``cudart``, which may differ from the version that
+    :py:obj:`cuda.bindings` was built against (as reported by
+    :py:obj:`~.cudaRuntimeGetVersion`).
 
-    As of CUDA 12.0, this function no longer initializes CUDA. The purpose
-    of this API is solely to return a compile-time constant stating the
-    CUDA Toolkit version in the above format.
+    The version is returned as (1000 * major + 10 * minor). For example,
+    CUDA 9.2 would be represented by 9020.
 
     This function automatically returns :py:obj:`~.cudaErrorInvalidValue`
     if the `runtimeVersion` argument is NULL.
@@ -42139,7 +42142,7 @@ def getLocalRuntimeVersion():
 
     See Also
     --------
-    :py:obj:`~.cudaDriverGetVersion`, :py:obj:`~.cuDriverGetVersion`
+    :py:obj:`~.cudaRuntimeGetVersion`, :py:obj:`~.cudaDriverGetVersion`, :py:obj:`~.cuDriverGetVersion`
     """
     cdef int runtimeVersion = 0
     err = cyruntime.getLocalRuntimeVersion(&runtimeVersion)


### PR DESCRIPTION
Closes #1062

## What
Rewrites the docstring for `getLocalRuntimeVersion()` in `cuda_bindings/cuda/bindings/runtime.pyx.in` to clearly differentiate it from `cudaRuntimeGetVersion()`:

- **`getLocalRuntimeVersion()`** locates the CUDA Runtime shared library on the host via `cuda.pathfinder.load_nvidia_dynamic_lib` and calls `cudaRuntimeGetVersion` from that dynamically loaded library. The result reflects the **locally discovered** `cudart` version.
- **`cudaRuntimeGetVersion()`** returns the version `cuda.bindings` was **built against** — a compile-time constant.

Also drops a stray "compile-time constant" sentence from the `getLocalRuntimeVersion` docstring that actually describes `cudaRuntimeGetVersion` (originally copy-pasted between the two), and adds `cudaRuntimeGetVersion` to the **See Also** section so readers can compare directly.

## Why
Per #1062, the two functions' docstrings were nearly identical and didn't explain the distinction, leaving users without a way to choose between them.

## Tested
- Read both functions' implementations in the source to derive the actual semantic difference (`getLocalRuntimeVersion` calls into pathfinder; `cudaRuntimeGetVersion` reflects the build-time constant).
- No code path changed — only the docstring on the public `getLocalRuntimeVersion` shim.
- Sphinx markup (`:py:obj:`) preserved; section structure (Returns / Notes / See Also) unchanged.

## Verification
```
branch: hunter/issue-1062
files-changed: 1
commit: e3ebf05
```