### PR TITLE
Catch up with recent cybind changes

### DIFF
--- a/cuda_bindings/cuda/bindings/_internal/nvjitlink.pxd
+++ b/cuda_bindings/cuda/bindings/_internal/nvjitlink.pxd
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.0.1 to 13.2.0, generator version 0.3.1.dev1422+gf4812259e.d20260318. Do not modify it directly.
+# This code was automatically generated across versions from 12.0.1 to 13.3.0, generator version 0.3.1.dev1752+g89e531539. Do not modify it directly.
 
 from ..cynvjitlink cimport *
 
@@ -25,3 +25,5 @@ cdef nvJitLinkResult _nvJitLinkGetErrorLog(nvJitLinkHandle handle, char* log) ex
 cdef nvJitLinkResult _nvJitLinkGetInfoLogSize(nvJitLinkHandle handle, size_t* size) except?_NVJITLINKRESULT_INTERNAL_LOADING_ERROR nogil
 cdef nvJitLinkResult _nvJitLinkGetInfoLog(nvJitLinkHandle handle, char* log) except?_NVJITLINKRESULT_INTERNAL_LOADING_ERROR nogil
 cdef nvJitLinkResult _nvJitLinkVersion(unsigned int* major, unsigned int* minor) except?_NVJITLINKRESULT_INTERNAL_LOADING_ERROR nogil
+cdef nvJitLinkResult _nvJitLinkGetLinkedLTOIRSize(nvJitLinkHandle handle, size_t* size) except?_NVJITLINKRESULT_INTERNAL_LOADING_ERROR nogil
+cdef nvJitLinkResult _nvJitLinkGetLinkedLTOIR(nvJitLinkHandle handle, void* ltoir) except?_NVJITLINKRESULT_INTERNAL_LOADING_ERROR nogil

--- a/cuda_bindings/cuda/bindings/cudla.pyx
+++ b/cuda_bindings/cuda/bindings/cudla.pyx
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated across versions from 1.5.0 to 13.3.0, generator version 0.3.1.dev1719+g565f73f4e. Do not modify it directly.
+# This code was automatically generated across versions from 1.5.0 to 13.3.0, generator version 0.3.1.dev1752+g89e531539. Do not modify it directly.
 
 cimport cython  # NOQA
 from libc.stdint cimport intptr_t, uintptr_t
@@ -67,7 +67,7 @@ cdef __getbuffer(object self, cpython.Py_buffer *buffer, void *ptr, int size, bi
 ###############################################################################
 
 cdef _get_external_memory_handle_desc_dtype_offsets():
-    cdef cudlaExternalMemoryHandleDesc_t pod = cudlaExternalMemoryHandleDesc_t()
+    cdef cudlaExternalMemoryHandleDesc_t pod
     return _numpy.dtype({
         'names': ['ext_buf_object', 'size_'],
         'formats': [_numpy.intp, _numpy.uint64],
@@ -210,7 +210,7 @@ cdef class ExternalMemoryHandleDesc:
 
 
 cdef _get_external_semaphore_handle_desc_dtype_offsets():
-    cdef cudlaExternalSemaphoreHandleDesc_t pod = cudlaExternalSemaphoreHandleDesc_t()
+    cdef cudlaExternalSemaphoreHandleDesc_t pod
     return _numpy.dtype({
         'names': ['ext_sync_object'],
         'formats': [_numpy.intp],
@@ -341,7 +341,7 @@ cdef class ExternalSemaphoreHandleDesc:
 
 
 cdef _get_module_tensor_descriptor_dtype_offsets():
-    cdef cudlaModuleTensorDescriptor pod = cudlaModuleTensorDescriptor()
+    cdef cudlaModuleTensorDescriptor pod
     return _numpy.dtype({
         'names': ['name', 'size_', 'n', 'c', 'h', 'w', 'data_format', 'data_type', 'data_category', 'pixel_format', 'pixel_mapping', 'stride'],
         'formats': [(_numpy.int8, 81), _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint8, _numpy.uint8, _numpy.uint8, _numpy.uint8, _numpy.uint8, (_numpy.uint32, 8)],
@@ -614,7 +614,7 @@ cdef class ModuleTensorDescriptor:
 
 
 cdef _get_fence_dtype_offsets():
-    cdef CudlaFence pod = CudlaFence()
+    cdef CudlaFence pod
     return _numpy.dtype({
         'names': ['fence', 'type'],
         'formats': [_numpy.intp, _numpy.int32],
@@ -1055,7 +1055,7 @@ cdef class ModuleAttribute:
 
 
 cdef _get_wait_events_dtype_offsets():
-    cdef cudlaWaitEvents pod = cudlaWaitEvents()
+    cdef cudlaWaitEvents pod
     return _numpy.dtype({
         'names': ['pre_fences', 'num_events'],
         'formats': [_numpy.intp, _numpy.uint32],
@@ -1195,7 +1195,7 @@ cdef class WaitEvents:
 
 
 cdef _get_signal_events_dtype_offsets():
-    cdef cudlaSignalEvents pod = cudlaSignalEvents()
+    cdef cudlaSignalEvents pod
     return _numpy.dtype({
         'names': ['dev_ptrs', 'eof_fences', 'num_events'],
         'formats': [_numpy.intp, _numpy.intp, _numpy.uint32],
@@ -1361,7 +1361,7 @@ cdef class SignalEvents:
 
 
 cdef _get_task_dtype_offsets():
-    cdef cudlaTask pod = cudlaTask()
+    cdef cudlaTask pod
     return _numpy.dtype({
         'names': ['module_handle', 'output_tensor', 'num_output_tensors', 'num_input_tensors', 'input_tensor', 'wait_events', 'signal_events'],
         'formats': [_numpy.intp, _numpy.intp, _numpy.uint32, _numpy.uint32, _numpy.intp, _numpy.intp, _numpy.intp],

--- a/cuda_bindings/cuda/bindings/cufile.pyx
+++ b/cuda_bindings/cuda/bindings/cufile.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.9.1 to 13.2.0, generator version 0.3.1.dev1568+g289771de9.d20260413. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.1 to 13.3.0, generator version 0.3.1.dev1752+g89e531539. Do not modify it directly.
 
 cimport cython  # NOQA
 from libc cimport errno
@@ -205,7 +205,7 @@ cdef class _py_anon_pod1:
 
 
 cdef _get__py_anon_pod3_dtype_offsets():
-    cdef cuda_bindings_cufile__anon_pod3 pod = cuda_bindings_cufile__anon_pod3()
+    cdef cuda_bindings_cufile__anon_pod3 pod
     return _numpy.dtype({
         'names': ['dev_ptr_base', 'file_offset', 'dev_ptr_offset', 'size_'],
         'formats': [_numpy.intp, _numpy.int64, _numpy.int64, _numpy.uint64],
@@ -372,7 +372,7 @@ cdef class _py_anon_pod3:
 
 
 cdef _get_io_events_dtype_offsets():
-    cdef CUfileIOEvents_t pod = CUfileIOEvents_t()
+    cdef CUfileIOEvents_t pod
     return _numpy.dtype({
         'names': ['cookie', 'status', 'ret'],
         'formats': [_numpy.intp, _numpy.int32, _numpy.uint64],
@@ -537,7 +537,7 @@ cdef class IOEvents:
 
 
 cdef _get_op_counter_dtype_offsets():
-    cdef CUfileOpCounter_t pod = CUfileOpCounter_t()
+    cdef CUfileOpCounter_t pod
     return _numpy.dtype({
         'names': ['ok', 'err'],
         'formats': [_numpy.uint64, _numpy.uint64],
@@ -680,7 +680,7 @@ cdef class OpCounter:
 
 
 cdef _get_per_gpu_stats_dtype_offsets():
-    cdef CUfilePerGpuStats_t pod = CUfilePerGpuStats_t()
+    cdef CUfilePerGpuStats_t pod
     return _numpy.dtype({
         'names': ['uuid', 'read_bytes', 'read_bw_bytes_per_sec', 'read_utilization', 'read_duration_us', 'n_total_reads', 'n_p2p_reads', 'n_nvfs_reads', 'n_posix_reads', 'n_unaligned_reads', 'n_dr_reads', 'n_sparse_regions', 'n_inline_regions', 'n_reads_err', 'writes_bytes', 'write_bw_bytes_per_sec', 'write_utilization', 'write_duration_us', 'n_total_writes', 'n_p2p_writes', 'n_nvfs_writes', 'n_posix_writes', 'n_unaligned_writes', 'n_dr_writes', 'n_writes_err', 'n_mmap', 'n_mmap_ok', 'n_mmap_err', 'n_mmap_free', 'reg_bytes'],
         'formats': [(_numpy.int8, 16), _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64],
@@ -1167,7 +1167,7 @@ cdef class PerGpuStats:
 
 
 cdef _get_descr_dtype_offsets():
-    cdef CUfileDescr_t pod = CUfileDescr_t()
+    cdef CUfileDescr_t pod
     return _numpy.dtype({
         'names': ['type', 'handle', 'fs_ops'],
         'formats': [_numpy.int32, _py_anon_pod1_dtype, _numpy.intp],
@@ -1456,7 +1456,7 @@ cdef class _py_anon_pod2:
 
 
 cdef _get_stats_level1_dtype_offsets():
-    cdef CUfileStatsLevel1_t pod = CUfileStatsLevel1_t()
+    cdef CUfileStatsLevel1_t pod
     return _numpy.dtype({
         'names': ['read_ops', 'write_ops', 'hdl_register_ops', 'hdl_deregister_ops', 'buf_register_ops', 'buf_deregister_ops', 'read_bytes', 'write_bytes', 'read_bw_bytes_per_sec', 'write_bw_bytes_per_sec', 'read_lat_avg_us', 'write_lat_avg_us', 'read_ops_per_sec', 'write_ops_per_sec', 'read_lat_sum_us', 'write_lat_sum_us', 'batch_submit_ops', 'batch_complete_ops', 'batch_setup_ops', 'batch_cancel_ops', 'batch_destroy_ops', 'batch_enqueued_ops', 'batch_posix_enqueued_ops', 'batch_processed_ops', 'batch_posix_processed_ops', 'batch_nvfs_submit_ops', 'batch_p2p_submit_ops', 'batch_aio_submit_ops', 'batch_iouring_submit_ops', 'batch_mixed_io_submit_ops', 'batch_total_submit_ops', 'batch_read_bytes', 'batch_write_bytes', 'batch_read_bw_bytes', 'batch_write_bw_bytes', 'batch_submit_lat_avg_us', 'batch_completion_lat_avg_us', 'batch_submit_ops_per_sec', 'batch_complete_ops_per_sec', 'batch_submit_lat_sum_us', 'batch_completion_lat_sum_us', 'last_batch_read_bytes', 'last_batch_write_bytes'],
         'formats': [op_counter_dtype, op_counter_dtype, op_counter_dtype, op_counter_dtype, op_counter_dtype, op_counter_dtype, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, op_counter_dtype, op_counter_dtype, op_counter_dtype, op_counter_dtype, op_counter_dtype, op_counter_dtype, op_counter_dtype, op_counter_dtype, op_counter_dtype, op_counter_dtype, op_counter_dtype, op_counter_dtype, op_counter_dtype, op_counter_dtype, op_counter_dtype, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64],
@@ -2112,7 +2112,7 @@ cdef class StatsLevel1:
 
 
 cdef _get_io_params_dtype_offsets():
-    cdef CUfileIOParams_t pod = CUfileIOParams_t()
+    cdef CUfileIOParams_t pod
     return _numpy.dtype({
         'names': ['mode', 'u', 'fh', 'opcode', 'cookie'],
         'formats': [_numpy.int32, _py_anon_pod2_dtype, _numpy.intp, _numpy.int32, _numpy.intp],
@@ -2299,7 +2299,7 @@ cdef class IOParams:
 
 
 cdef _get_stats_level2_dtype_offsets():
-    cdef CUfileStatsLevel2_t pod = CUfileStatsLevel2_t()
+    cdef CUfileStatsLevel2_t pod
     return _numpy.dtype({
         'names': ['basic', 'read_size_kb_hist', 'write_size_kb_hist'],
         'formats': [stats_level1_dtype, (_numpy.uint64, 32), (_numpy.uint64, 32)],
@@ -2467,7 +2467,7 @@ cdef class StatsLevel2:
 
 
 cdef _get_stats_level3_dtype_offsets():
-    cdef CUfileStatsLevel3_t pod = CUfileStatsLevel3_t()
+    cdef CUfileStatsLevel3_t pod
     return _numpy.dtype({
         'names': ['detailed', 'num_gpus', 'per_gpu_stats'],
         'formats': [stats_level2_dtype, _numpy.uint32, (per_gpu_stats_dtype, 16)],
@@ -3198,7 +3198,7 @@ cpdef get_stats_l1(intptr_t stats):
     """Get Level 1 cuFile statistics.
 
     Args:
-        stats (intptr_t): Pointer to CUfileStatsLevel1_t structure to be filled.
+        stats (intptr_t): Pointer to ``CUfileStatsLevel1_t`` structure to be filled.
 
     .. seealso:: `cuFileGetStatsL1`
     """
@@ -3211,7 +3211,7 @@ cpdef get_stats_l2(intptr_t stats):
     """Get Level 2 cuFile statistics.
 
     Args:
-        stats (intptr_t): Pointer to CUfileStatsLevel2_t structure to be filled.
+        stats (intptr_t): Pointer to ``CUfileStatsLevel2_t`` structure to be filled.
 
     .. seealso:: `cuFileGetStatsL2`
     """
@@ -3224,7 +3224,7 @@ cpdef get_stats_l3(intptr_t stats):
     """Get Level 3 cuFile statistics.
 
     Args:
-        stats (intptr_t): Pointer to CUfileStatsLevel3_t structure to be filled.
+        stats (intptr_t): Pointer to ``CUfileStatsLevel3_t`` structure to be filled.
 
     .. seealso:: `cuFileGetStatsL3`
     """

--- a/cuda_bindings/cuda/bindings/cycufile.pxd
+++ b/cuda_bindings/cuda/bindings/cycufile.pxd
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.9.1 to 13.2.0, generator version 0.3.1.dev1422+gf4812259e.d20260318. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.1 to 13.3.0, generator version 0.3.1.dev1752+g89e531539. Do not modify it directly.
 
 from libc.stdint cimport uint32_t, uint64_t
 from libc.time cimport time_t
@@ -33,7 +33,7 @@ cdef extern from "<sys/socket.h>":
 
 
     # enums
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef enum CUfileOpError:
         CU_FILE_SUCCESS
         CU_FILE_DRIVER_NOT_INITIALIZED
@@ -85,7 +85,7 @@ cdef extern from '<cufile.h>':
         CU_FILE_BATCH_NOCOMPAT_ERROR
         CU_FILE_IO_MAX_ERROR
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef enum CUfileDriverStatusFlags_t:
         CU_FILE_LUSTRE_SUPPORTED
         CU_FILE_WEKAFS_SUPPORTED
@@ -102,14 +102,14 @@ cdef extern from '<cufile.h>':
         CU_FILE_VIRTIOFS_SUPPORTED
         CU_FILE_MAX_TARGET_TYPES
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef enum CUfileDriverControlFlags_t:
         CU_FILE_USE_POLL_MODE
         CU_FILE_ALLOW_COMPAT_MODE
         CU_FILE_POSIX_IO_MODE
         CU_FILE_FALLBACK_IO_MODE
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef enum CUfileFeatureFlags_t:
         CU_FILE_DYN_ROUTING_SUPPORTED
         CU_FILE_BATCH_IO_SUPPORTED
@@ -117,18 +117,18 @@ cdef extern from '<cufile.h>':
         CU_FILE_PARALLEL_IO_SUPPORTED
         CU_FILE_P2P_SUPPORTED
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef enum CUfileFileHandleType:
         CU_FILE_HANDLE_TYPE_OPAQUE_FD
         CU_FILE_HANDLE_TYPE_OPAQUE_WIN32
         CU_FILE_HANDLE_TYPE_USERSPACE_FS
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef enum CUfileOpcode_t:
         CUFILE_READ
         CUFILE_WRITE
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef enum CUfileStatus_t:
         CUFILE_WAITING
         CUFILE_PENDING
@@ -138,11 +138,11 @@ cdef extern from '<cufile.h>':
         CUFILE_TIMEOUT
         CUFILE_FAILED
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef enum CUfileBatchMode_t:
         CUFILE_BATCH
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef enum CUFileSizeTConfigParameter_t:
         CUFILE_PARAM_PROFILE_STATS
         CUFILE_PARAM_EXECUTION_MAX_IO_QUEUE_DEPTH
@@ -157,7 +157,7 @@ cdef extern from '<cufile.h>':
         CUFILE_PARAM_POLLTHRESHOLD_SIZE_KB
         CUFILE_PARAM_PROPERTIES_BATCH_IO_TIMEOUT_MS
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef enum CUFileBoolConfigParameter_t:
         CUFILE_PARAM_PROPERTIES_USE_POLL_MODE
         CUFILE_PARAM_PROPERTIES_ALLOW_COMPAT_MODE
@@ -172,37 +172,38 @@ cdef extern from '<cufile.h>':
         CUFILE_PARAM_SKIP_TOPOLOGY_DETECTION
         CUFILE_PARAM_STREAM_MEMOPS_BYPASS
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef enum CUFileStringConfigParameter_t:
         CUFILE_PARAM_LOGGING_LEVEL
         CUFILE_PARAM_ENV_LOGFILE_PATH
         CUFILE_PARAM_LOG_DIR
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef enum CUFileArrayConfigParameter_t:
         CUFILE_PARAM_POSIX_POOL_SLAB_SIZE_KB
         CUFILE_PARAM_POSIX_POOL_SLAB_COUNT
         CUFILE_PARAM_GPU_BOUNCE_BUFFER_SLAB_SIZE_KB
         CUFILE_PARAM_GPU_BOUNCE_BUFFER_SLAB_COUNT
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef enum CUfileP2PFlags_t:
         CUFILE_P2PDMA
         CUFILE_NVFS
         CUFILE_DMABUF
         CUFILE_C2C
         CUFILE_NVIDIA_PEERMEM
+cdef enum: _CUFILEERROR_T_INTERNAL_LOADING_ERROR = -42
 
     # types
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef void* CUfileHandle_t 'CUfileHandle_t'
 
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef void* CUfileBatchHandle_t 'CUfileBatchHandle_t'
 
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef struct CUfileError_t 'CUfileError_t':
         CUfileOpError err
         CUresult cu_err
@@ -215,13 +216,13 @@ cdef struct cuda_bindings_cufile__anon_pod0:
     unsigned int dstatusflags
     unsigned int dcontrolflags
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef struct cufileRDMAInfo_t 'cufileRDMAInfo_t':
         int version
         int desc_len
         char* desc_str
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef struct CUfileFSOps_t 'CUfileFSOps_t':
         char* (*fs_type)(const void*)
         int (*getRDMADeviceList)(const void*, sockaddr_t**)
@@ -239,18 +240,18 @@ cdef struct cuda_bindings_cufile__anon_pod3:
     off_t devPtr_offset
     size_t size
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef struct CUfileIOEvents_t 'CUfileIOEvents_t':
         void* cookie
         CUfileStatus_t status
         size_t ret
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef struct CUfileOpCounter_t 'CUfileOpCounter_t':
         uint64_t ok
         uint64_t err
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef struct CUfilePerGpuStats_t 'CUfilePerGpuStats_t':
         char uuid[16]
         uint64_t read_bytes
@@ -283,7 +284,7 @@ cdef extern from '<cufile.h>':
         uint64_t n_mmap_free
         uint64_t reg_bytes
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef struct CUfileDrvProps_t 'CUfileDrvProps_t':
         cuda_bindings_cufile__anon_pod0 nvfs
         unsigned int fflags
@@ -293,7 +294,7 @@ cdef extern from '<cufile.h>':
         unsigned int max_batch_io_size
         unsigned int max_batch_io_timeout_msecs
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef struct CUfileDescr_t 'CUfileDescr_t':
         CUfileFileHandleType type
         cuda_bindings_cufile__anon_pod1 handle
@@ -302,7 +303,7 @@ cdef extern from '<cufile.h>':
 cdef union cuda_bindings_cufile__anon_pod2:
     cuda_bindings_cufile__anon_pod3 batch
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef struct CUfileStatsLevel1_t 'CUfileStatsLevel1_t':
         CUfileOpCounter_t read_ops
         CUfileOpCounter_t write_ops
@@ -348,7 +349,7 @@ cdef extern from '<cufile.h>':
         uint64_t last_batch_read_bytes
         uint64_t last_batch_write_bytes
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef struct CUfileIOParams_t 'CUfileIOParams_t':
         CUfileBatchMode_t mode
         cuda_bindings_cufile__anon_pod2 u
@@ -356,13 +357,13 @@ cdef extern from '<cufile.h>':
         CUfileOpcode_t opcode
         void* cookie
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef struct CUfileStatsLevel2_t 'CUfileStatsLevel2_t':
         CUfileStatsLevel1_t basic
         uint64_t read_size_kb_hist[32]
         uint64_t write_size_kb_hist[32]
 
-cdef extern from '<cufile.h>':
+cdef extern from 'cufile.h':
     ctypedef struct CUfileStatsLevel3_t 'CUfileStatsLevel3_t':
         CUfileStatsLevel2_t detailed
         uint32_t num_gpus

--- a/cuda_bindings/cuda/bindings/cynvjitlink.pxd
+++ b/cuda_bindings/cuda/bindings/cynvjitlink.pxd
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.0.1 to 13.2.0, generator version 0.3.1.dev1422+gf4812259e.d20260318. Do not modify it directly.
+# This code was automatically generated across versions from 12.0.1 to 13.3.0, generator version 0.3.1.dev1752+g89e531539. Do not modify it directly.
 
 from libc.stdint cimport intptr_t, uint32_t
 
@@ -68,3 +68,5 @@ cdef nvJitLinkResult nvJitLinkGetErrorLog(nvJitLinkHandle handle, char* log) exc
 cdef nvJitLinkResult nvJitLinkGetInfoLogSize(nvJitLinkHandle handle, size_t* size) except?_NVJITLINKRESULT_INTERNAL_LOADING_ERROR nogil
 cdef nvJitLinkResult nvJitLinkGetInfoLog(nvJitLinkHandle handle, char* log) except?_NVJITLINKRESULT_INTERNAL_LOADING_ERROR nogil
 cdef nvJitLinkResult nvJitLinkVersion(unsigned int* major, unsigned int* minor) except?_NVJITLINKRESULT_INTERNAL_LOADING_ERROR nogil
+cdef nvJitLinkResult nvJitLinkGetLinkedLTOIRSize(nvJitLinkHandle handle, size_t* size) except?_NVJITLINKRESULT_INTERNAL_LOADING_ERROR nogil
+cdef nvJitLinkResult nvJitLinkGetLinkedLTOIR(nvJitLinkHandle handle, void* ltoir) except?_NVJITLINKRESULT_INTERNAL_LOADING_ERROR nogil

--- a/cuda_bindings/cuda/bindings/cynvjitlink.pyx
+++ b/cuda_bindings/cuda/bindings/cynvjitlink.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.0.1 to 13.2.0, generator version 0.3.1.dev1422+gf4812259e.d20260318. Do not modify it directly.
+# This code was automatically generated across versions from 12.0.1 to 13.3.0, generator version 0.3.1.dev1752+g89e531539. Do not modify it directly.
 
 from ._internal cimport nvjitlink as _nvjitlink
 
@@ -65,3 +65,11 @@ cdef nvJitLinkResult nvJitLinkGetInfoLog(nvJitLinkHandle handle, char* log) exce
 
 cdef nvJitLinkResult nvJitLinkVersion(unsigned int* major, unsigned int* minor) except?_NVJITLINKRESULT_INTERNAL_LOADING_ERROR nogil:
     return _nvjitlink._nvJitLinkVersion(major, minor)
+
+
+cdef nvJitLinkResult nvJitLinkGetLinkedLTOIRSize(nvJitLinkHandle handle, size_t* size) except?_NVJITLINKRESULT_INTERNAL_LOADING_ERROR nogil:
+    return _nvjitlink._nvJitLinkGetLinkedLTOIRSize(handle, size)
+
+
+cdef nvJitLinkResult nvJitLinkGetLinkedLTOIR(nvJitLinkHandle handle, void* ltoir) except?_NVJITLINKRESULT_INTERNAL_LOADING_ERROR nogil:
+    return _nvjitlink._nvJitLinkGetLinkedLTOIR(handle, ltoir)

--- a/cuda_bindings/cuda/bindings/driver.pyx
+++ b/cuda_bindings/cuda/bindings/driver.pyx
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.3.0, generator version 0.3.1.dev1622+g48467ab08.d20260421. Do not modify it directly.
+# This code was automatically generated with version 13.3.0, generator version 0.3.1.dev1752+g89e531539. Do not modify it directly.
 from typing import Any, Optional
 import cython
 import ctypes
@@ -52,16 +52,16 @@ CU_IPC_HANDLE_SIZE = cydriver.CU_IPC_HANDLE_SIZE
 
 #: Legacy stream handle
 #:
-#: Stream handle that can be passed as a CUstream to use an implicit stream
-#: with legacy synchronization behavior.
+#: Stream handle that can be passed as a :py:obj:`~.CUstream` to use an
+#: implicit stream with legacy synchronization behavior.
 #:
 #: See details of the \link_sync_behavior
 CU_STREAM_LEGACY = cydriver.CU_STREAM_LEGACY
 
 #: Per-thread stream handle
 #:
-#: Stream handle that can be passed as a CUstream to use an implicit stream
-#: with per-thread synchronization behavior.
+#: Stream handle that can be passed as a :py:obj:`~.CUstream` to use an
+#: implicit stream with per-thread synchronization behavior.
 #:
 #: See details of the \link_sync_behavior
 CU_STREAM_PER_THREAD = cydriver.CU_STREAM_PER_THREAD
@@ -229,8 +229,8 @@ CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_POST_LAUNCH_SYNC = cydriver.CUDA_COOPERA
 
 #: If set, the CUDA array is a collection of layers, where each layer is
 #: either a 1D or a 2D array and the Depth member of
-#: CUDA_ARRAY3D_DESCRIPTOR specifies the number of layers, not the depth of
-#: a 3D array.
+#: :py:obj:`~.CUDA_ARRAY3D_DESCRIPTOR` specifies the number of layers, not
+#: the depth of a 3D array.
 CUDA_ARRAY3D_LAYERED = cydriver.CUDA_ARRAY3D_LAYERED
 
 #: Deprecated, use CUDA_ARRAY3D_LAYERED
@@ -413,7 +413,8 @@ class CUctx_flags(_FastEnum):
 
     CU_CTX_BLOCKING_SYNC = (
         cydriver.CUctx_flags_enum.CU_CTX_BLOCKING_SYNC,
-        'Set blocking synchronization as default scheduling [Deprecated]\n'
+        'Set blocking synchronization as default scheduling\n'
+        '[Deprecated]\n'
     )
 
     CU_CTX_SCHED_MASK = cydriver.CUctx_flags_enum.CU_CTX_SCHED_MASK
@@ -2663,7 +2664,7 @@ class CUfunction_attribute(_FastEnum):
     CU_FUNC_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE = (
         cydriver.CUfunction_attribute_enum.CU_FUNC_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE,
         'The block scheduling policy of a function. The value type is\n'
-        'CUclusterSchedulingPolicy / cudaClusterSchedulingPolicy. See\n'
+        ':py:obj:`~.CUclusterSchedulingPolicy` / cudaClusterSchedulingPolicy. See\n'
         ':py:obj:`~.cuFuncSetAttribute`, :py:obj:`~.cuKernelSetAttribute`\n'
     )
 
@@ -4599,7 +4600,8 @@ class CUresult(_FastEnum):
     CUDA_ERROR_CONTEXT_ALREADY_CURRENT = (
         cydriver.cudaError_enum.CUDA_ERROR_CONTEXT_ALREADY_CURRENT,
         'This indicated that the context being supplied as a parameter to the API\n'
-        'call was already the active context. [Deprecated]\n'
+        'call was already the active context.\n'
+        '[Deprecated]\n'
     )
 
 
@@ -5798,7 +5800,8 @@ class CUmemAllocationHandleType(_FastEnum):
 
     CU_MEM_HANDLE_TYPE_FABRIC = (
         cydriver.CUmemAllocationHandleType_enum.CU_MEM_HANDLE_TYPE_FABRIC,
-        'Allows a fabric handle to be used for exporting. (CUmemFabricHandle)\n'
+        'Allows a fabric handle to be used for exporting.\n'
+        '(:py:obj:`~.CUmemFabricHandle`)\n'
     )
 
     CU_MEM_HANDLE_TYPE_MAX = cydriver.CUmemAllocationHandleType_enum.CU_MEM_HANDLE_TYPE_MAX
@@ -6091,54 +6094,55 @@ class CUmemPool_attribute(_FastEnum):
 
     CU_MEMPOOL_ATTR_RELEASE_THRESHOLD = (
         cydriver.CUmemPool_attribute_enum.CU_MEMPOOL_ATTR_RELEASE_THRESHOLD,
-        '(value type = cuuint64_t) Amount of reserved memory in bytes to hold onto\n'
-        'before trying to release memory back to the OS. When more than the release\n'
-        'threshold bytes of memory are held by the memory pool, the allocator will\n'
-        'try to release memory back to the OS on the next call to stream, event or\n'
-        'context synchronize. (default 0)\n'
+        '(value type = :py:obj:`~.cuuint64_t`) Amount of reserved memory in bytes to\n'
+        'hold onto before trying to release memory back to the OS. When more than\n'
+        'the release threshold bytes of memory are held by the memory pool, the\n'
+        'allocator will try to release memory back to the OS on the next call to\n'
+        'stream, event or context synchronize. (default 0)\n'
     )
 
 
     CU_MEMPOOL_ATTR_RESERVED_MEM_CURRENT = (
         cydriver.CUmemPool_attribute_enum.CU_MEMPOOL_ATTR_RESERVED_MEM_CURRENT,
-        '(value type = cuuint64_t) Amount of backing memory currently allocated for\n'
-        'the mempool.\n'
+        '(value type = :py:obj:`~.cuuint64_t`) Amount of backing memory currently\n'
+        'allocated for the mempool.\n'
     )
 
 
     CU_MEMPOOL_ATTR_RESERVED_MEM_HIGH = (
         cydriver.CUmemPool_attribute_enum.CU_MEMPOOL_ATTR_RESERVED_MEM_HIGH,
-        '(value type = cuuint64_t) High watermark of backing memory allocated for\n'
-        'the mempool since the last time it was reset. High watermark can only be\n'
-        'reset to zero.\n'
+        '(value type = :py:obj:`~.cuuint64_t`) High watermark of backing memory\n'
+        'allocated for the mempool since the last time it was reset. High watermark\n'
+        'can only be reset to zero.\n'
     )
 
 
     CU_MEMPOOL_ATTR_USED_MEM_CURRENT = (
         cydriver.CUmemPool_attribute_enum.CU_MEMPOOL_ATTR_USED_MEM_CURRENT,
-        '(value type = cuuint64_t) Amount of memory from the pool that is currently\n'
-        'in use by the application.\n'
+        '(value type = :py:obj:`~.cuuint64_t`) Amount of memory from the pool that\n'
+        'is currently in use by the application.\n'
     )
 
 
     CU_MEMPOOL_ATTR_USED_MEM_HIGH = (
         cydriver.CUmemPool_attribute_enum.CU_MEMPOOL_ATTR_USED_MEM_HIGH,
-        '(value type = cuuint64_t) High watermark of the amount of memory from the\n'
-        'pool that was in use by the application since the last time it was reset.\n'
-        'High watermark can only be reset to zero.\n'
+        '(value type = :py:obj:`~.cuuint64_t`) High watermark of the amount of\n'
+        'memory from the pool that was in use by the application since the last time\n'
+        'it was reset. High watermark can only be reset to zero.\n'
     )
 
 
     CU_MEMPOOL_ATTR_ALLOCATION_TYPE = (
         cydriver.CUmemPool_attribute_enum.CU_MEMPOOL_ATTR_ALLOCATION_TYPE,
-        '(value type = CUmemAllocationType) The allocation type of the mempool\n'
+        '(value type = :py:obj:`~.CUmemAllocationType`) The allocation type of the\n'
+        'mempool\n'
     )
 
 
     CU_MEMPOOL_ATTR_EXPORT_HANDLE_TYPES = (
         cydriver.CUmemPool_attribute_enum.CU_MEMPOOL_ATTR_EXPORT_HANDLE_TYPES,
-        '(value type = CUmemAllocationHandleType) Available export handle types for\n'
-        'the mempool. For imported pools this value is always\n'
+        '(value type = :py:obj:`~.CUmemAllocationHandleType`) Available export\n'
+        'handle types for the mempool. For imported pools this value is always\n'
         'CU_MEM_HANDLE_TYPE_NONE as an imported pool cannot be re-exported\n'
     )
 
@@ -6153,18 +6157,18 @@ class CUmemPool_attribute(_FastEnum):
 
     CU_MEMPOOL_ATTR_LOCATION_TYPE = (
         cydriver.CUmemPool_attribute_enum.CU_MEMPOOL_ATTR_LOCATION_TYPE,
-        '(value type = CUmemLocationType) The location type for the mempool. For\n'
-        'imported memory pools where the device is not directly visible to the\n'
-        'importing process or pools imported via fabric handles across nodes this\n'
-        'will be CU_MEM_LOCATION_TYPE_INVISIBLE.\n'
+        '(value type = :py:obj:`~.CUmemLocationType`) The location type for the\n'
+        'mempool. For imported memory pools where the device is not directly visible\n'
+        'to the importing process or pools imported via fabric handles across nodes\n'
+        'this will be CU_MEM_LOCATION_TYPE_INVISIBLE.\n'
     )
 
 
     CU_MEMPOOL_ATTR_MAX_POOL_SIZE = (
         cydriver.CUmemPool_attribute_enum.CU_MEMPOOL_ATTR_MAX_POOL_SIZE,
-        '(value type = cuuint64_t) Maximum size of the pool in bytes, this value may\n'
-        'be higher than what was initially passed to cuMemPoolCreate due to\n'
-        'alignment requirements. A value of 0 indicates no maximum size. For\n'
+        '(value type = :py:obj:`~.cuuint64_t`) Maximum size of the pool in bytes,\n'
+        'this value may be higher than what was initially passed to cuMemPoolCreate\n'
+        'due to alignment requirements. A value of 0 indicates no maximum size. For\n'
         'CU_MEM_ALLOCATION_TYPE_MANAGED and IPC imported pools this value will be\n'
         'system dependent.\n'
     )
@@ -6251,7 +6255,7 @@ class CUmemcpy3DOperandType(_FastEnum):
 
     CU_MEMCPY_OPERAND_TYPE_ARRAY = (
         cydriver.CUmemcpy3DOperandType_enum.CU_MEMCPY_OPERAND_TYPE_ARRAY,
-        'Memcpy operand is a CUarray.\n'
+        'Memcpy operand is a :py:obj:`~.CUarray`.\n'
     )
 
     CU_MEMCPY_OPERAND_TYPE_MAX = cydriver.CUmemcpy3DOperandType_enum.CU_MEMCPY_OPERAND_TYPE_MAX
@@ -6264,30 +6268,30 @@ class CUgraphMem_attribute(_FastEnum):
 
     CU_GRAPH_MEM_ATTR_USED_MEM_CURRENT = (
         cydriver.CUgraphMem_attribute_enum.CU_GRAPH_MEM_ATTR_USED_MEM_CURRENT,
-        '(value type = cuuint64_t) Amount of memory, in bytes, currently associated\n'
-        'with graphs\n'
+        '(value type = :py:obj:`~.cuuint64_t`) Amount of memory, in bytes, currently\n'
+        'associated with graphs\n'
     )
 
 
     CU_GRAPH_MEM_ATTR_USED_MEM_HIGH = (
         cydriver.CUgraphMem_attribute_enum.CU_GRAPH_MEM_ATTR_USED_MEM_HIGH,
-        '(value type = cuuint64_t) High watermark of memory, in bytes, associated\n'
-        'with graphs since the last time it was reset. High watermark can only be\n'
-        'reset to zero.\n'
+        '(value type = :py:obj:`~.cuuint64_t`) High watermark of memory, in bytes,\n'
+        'associated with graphs since the last time it was reset. High watermark can\n'
+        'only be reset to zero.\n'
     )
 
 
     CU_GRAPH_MEM_ATTR_RESERVED_MEM_CURRENT = (
         cydriver.CUgraphMem_attribute_enum.CU_GRAPH_MEM_ATTR_RESERVED_MEM_CURRENT,
-        '(value type = cuuint64_t) Amount of memory, in bytes, currently allocated\n'
-        'for use by the CUDA graphs asynchronous allocator.\n'
+        '(value type = :py:obj:`~.cuuint64_t`) Amount of memory, in bytes, currently\n'
+        'allocated for use by the CUDA graphs asynchronous allocator.\n'
     )
 
 
     CU_GRAPH_MEM_ATTR_RESERVED_MEM_HIGH = (
         cydriver.CUgraphMem_attribute_enum.CU_GRAPH_MEM_ATTR_RESERVED_MEM_HIGH,
-        '(value type = cuuint64_t) High watermark of memory, in bytes, currently\n'
-        'allocated for use by the CUDA graphs asynchronous allocator.\n'
+        '(value type = :py:obj:`~.cuuint64_t`) High watermark of memory, in bytes,\n'
+        'currently allocated for use by the CUDA graphs asynchronous allocator.\n'
     )
 
 class CUgraphChildGraphNodeOwnership(_FastEnum):
@@ -6419,49 +6423,49 @@ class CUgraphDebugDot_flags(_FastEnum):
 
     CU_GRAPH_DEBUG_DOT_FLAGS_KERNEL_NODE_PARAMS = (
         cydriver.CUgraphDebugDot_flags_enum.CU_GRAPH_DEBUG_DOT_FLAGS_KERNEL_NODE_PARAMS,
-        'Adds CUDA_KERNEL_NODE_PARAMS values to output\n'
+        'Adds :py:obj:`~.CUDA_KERNEL_NODE_PARAMS` values to output\n'
     )
 
 
     CU_GRAPH_DEBUG_DOT_FLAGS_MEMCPY_NODE_PARAMS = (
         cydriver.CUgraphDebugDot_flags_enum.CU_GRAPH_DEBUG_DOT_FLAGS_MEMCPY_NODE_PARAMS,
-        'Adds CUDA_MEMCPY3D values to output\n'
+        'Adds :py:obj:`~.CUDA_MEMCPY3D` values to output\n'
     )
 
 
     CU_GRAPH_DEBUG_DOT_FLAGS_MEMSET_NODE_PARAMS = (
         cydriver.CUgraphDebugDot_flags_enum.CU_GRAPH_DEBUG_DOT_FLAGS_MEMSET_NODE_PARAMS,
-        'Adds CUDA_MEMSET_NODE_PARAMS values to output\n'
+        'Adds :py:obj:`~.CUDA_MEMSET_NODE_PARAMS` values to output\n'
     )
 
 
     CU_GRAPH_DEBUG_DOT_FLAGS_HOST_NODE_PARAMS = (
         cydriver.CUgraphDebugDot_flags_enum.CU_GRAPH_DEBUG_DOT_FLAGS_HOST_NODE_PARAMS,
-        'Adds CUDA_HOST_NODE_PARAMS values to output\n'
+        'Adds :py:obj:`~.CUDA_HOST_NODE_PARAMS` values to output\n'
     )
 
 
     CU_GRAPH_DEBUG_DOT_FLAGS_EVENT_NODE_PARAMS = (
         cydriver.CUgraphDebugDot_flags_enum.CU_GRAPH_DEBUG_DOT_FLAGS_EVENT_NODE_PARAMS,
-        'Adds CUevent handle from record and wait nodes to output\n'
+        'Adds :py:obj:`~.CUevent` handle from record and wait nodes to output\n'
     )
 
 
     CU_GRAPH_DEBUG_DOT_FLAGS_EXT_SEMAS_SIGNAL_NODE_PARAMS = (
         cydriver.CUgraphDebugDot_flags_enum.CU_GRAPH_DEBUG_DOT_FLAGS_EXT_SEMAS_SIGNAL_NODE_PARAMS,
-        'Adds CUDA_EXT_SEM_SIGNAL_NODE_PARAMS values to output\n'
+        'Adds :py:obj:`~.CUDA_EXT_SEM_SIGNAL_NODE_PARAMS` values to output\n'
     )
 
 
     CU_GRAPH_DEBUG_DOT_FLAGS_EXT_SEMAS_WAIT_NODE_PARAMS = (
         cydriver.CUgraphDebugDot_flags_enum.CU_GRAPH_DEBUG_DOT_FLAGS_EXT_SEMAS_WAIT_NODE_PARAMS,
-        'Adds CUDA_EXT_SEM_WAIT_NODE_PARAMS values to output\n'
+        'Adds :py:obj:`~.CUDA_EXT_SEM_WAIT_NODE_PARAMS` values to output\n'
     )
 
 
     CU_GRAPH_DEBUG_DOT_FLAGS_KERNEL_NODE_ATTRIBUTES = (
         cydriver.CUgraphDebugDot_flags_enum.CU_GRAPH_DEBUG_DOT_FLAGS_KERNEL_NODE_ATTRIBUTES,
-        'Adds CUkernelNodeAttrValue values to output\n'
+        'Adds :py:obj:`~.CUkernelNodeAttrValue` values to output\n'
     )
 
 
@@ -28711,17 +28715,17 @@ def cuModuleGetGlobal(hmod, char* name):
 def cuLinkCreate(unsigned int numOptions, options : Optional[tuple[CUjit_option] | list[CUjit_option]], optionValues : Optional[tuple[Any] | list[Any]]):
     """ Creates a pending JIT linker invocation.
 
-    If the call is successful, the caller owns the returned CUlinkState,
-    which should eventually be destroyed with :py:obj:`~.cuLinkDestroy`.
-    The device code machine size (32 or 64 bit) will match the calling
-    application.
+    If the call is successful, the caller owns the returned
+    :py:obj:`~.CUlinkState`, which should eventually be destroyed with
+    :py:obj:`~.cuLinkDestroy`. The device code machine size (32 or 64 bit)
+    will match the calling application.
 
     Both linker and compiler options may be specified. Compiler options
     will be applied to inputs to this linker action which must be compiled
     from PTX. The options :py:obj:`~.CU_JIT_WALL_TIME`,
     :py:obj:`~.CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES`, and
     :py:obj:`~.CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES` will accumulate data
-    until the CUlinkState is destroyed.
+    until the :py:obj:`~.CUlinkState` is destroyed.
 
     The data passed in via :py:obj:`~.cuLinkAddData` and
     :py:obj:`~.cuLinkAddFile` will be treated as relocatable (-rdc=true to
@@ -28729,9 +28733,9 @@ def cuLinkCreate(unsigned int numOptions, options : Optional[tuple[CUjit_option]
     and will have similar consequences as offline relocatable device code
     linking.
 
-    `optionValues` must remain valid for the life of the CUlinkState if
-    output options are used. No other references to inputs are maintained
-    after this call returns.
+    `optionValues` must remain valid for the life of the
+    :py:obj:`~.CUlinkState` if output options are used. No other references
+    to inputs are maintained after this call returns.
 
     Parameters
     ----------
@@ -28747,8 +28751,8 @@ def cuLinkCreate(unsigned int numOptions, options : Optional[tuple[CUjit_option]
     CUresult
         :py:obj:`~.CUDA_SUCCESS`, :py:obj:`~.CUDA_ERROR_DEINITIALIZED`, :py:obj:`~.CUDA_ERROR_NOT_INITIALIZED`, :py:obj:`~.CUDA_ERROR_INVALID_CONTEXT`, :py:obj:`~.CUDA_ERROR_INVALID_VALUE`, :py:obj:`~.CUDA_ERROR_OUT_OF_MEMORY`, :py:obj:`~.CUDA_ERROR_JIT_COMPILER_NOT_FOUND`
     stateOut : :py:obj:`~.CUlinkState`
-        On success, this will contain a CUlinkState to specify and complete
-        this action
+        On success, this will contain a :py:obj:`~.CUlinkState` to specify
+        and complete this action
 
     See Also
     --------
@@ -29764,7 +29768,7 @@ def cuKernelGetAttribute(attrib not None : CUfunction_attribute, kernel, dev):
 
     - :py:obj:`~.CU_FUNC_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE`:
       The block scheduling policy of a function. The value type is
-      CUclusterSchedulingPolicy.
+      :py:obj:`~.CUclusterSchedulingPolicy`.
 
     Parameters
     ----------
@@ -29879,7 +29883,7 @@ def cuKernelSetAttribute(attrib not None : CUfunction_attribute, int val, kernel
 
     - :py:obj:`~.CU_FUNC_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE`:
       The block scheduling policy of a function. The value type is
-      CUclusterSchedulingPolicy.
+      :py:obj:`~.CUclusterSchedulingPolicy`.
 
     Parameters
     ----------
@@ -31023,8 +31027,8 @@ def cuIpcGetEventHandle(event):
     CUresult
         :py:obj:`~.CUDA_SUCCESS`, :py:obj:`~.CUDA_ERROR_INVALID_HANDLE`, :py:obj:`~.CUDA_ERROR_OUT_OF_MEMORY`, :py:obj:`~.CUDA_ERROR_MAP_FAILED`, :py:obj:`~.CUDA_ERROR_INVALID_VALUE`
     pHandle : :py:obj:`~.CUipcEventHandle`
-        Pointer to a user allocated CUipcEventHandle in which to return the
-        opaque event handle
+        Pointer to a user allocated :py:obj:`~.CUipcEventHandle` in which
+        to return the opaque event handle
 
     See Also
     --------
@@ -35891,11 +35895,11 @@ def cuMemPoolSetAttribute(pool, attr not None : CUmemPool_attribute, value):
     Supported attributes are:
 
     - :py:obj:`~.CU_MEMPOOL_ATTR_RELEASE_THRESHOLD`: (value type =
-      cuuint64_t) Amount of reserved memory in bytes to hold onto before
-      trying to release memory back to the OS. When more than the release
-      threshold bytes of memory are held by the memory pool, the allocator
-      will try to release memory back to the OS on the next call to stream,
-      event or context synchronize. (default 0)
+      :py:obj:`~.cuuint64_t`) Amount of reserved memory in bytes to hold
+      onto before trying to release memory back to the OS. When more than
+      the release threshold bytes of memory are held by the memory pool,
+      the allocator will try to release memory back to the OS on the next
+      call to stream, event or context synchronize. (default 0)
 
     - :py:obj:`~.CU_MEMPOOL_ATTR_REUSE_FOLLOW_EVENT_DEPENDENCIES`: (value
       type = int) Allow :py:obj:`~.cuMemAllocAsync` to use memory
@@ -35915,13 +35919,13 @@ def cuMemPoolSetAttribute(pool, attr not None : CUmemPool_attribute, value):
       (default enabled).
 
     - :py:obj:`~.CU_MEMPOOL_ATTR_RESERVED_MEM_HIGH`: (value type =
-      cuuint64_t) Reset the high watermark that tracks the amount of
-      backing memory that was allocated for the memory pool. It is illegal
-      to set this attribute to a non-zero value.
+      :py:obj:`~.cuuint64_t`) Reset the high watermark that tracks the
+      amount of backing memory that was allocated for the memory pool. It
+      is illegal to set this attribute to a non-zero value.
 
-    - :py:obj:`~.CU_MEMPOOL_ATTR_USED_MEM_HIGH`: (value type = cuuint64_t)
-      Reset the high watermark that tracks the amount of used memory that
-      was allocated for the memory pool.
+    - :py:obj:`~.CU_MEMPOOL_ATTR_USED_MEM_HIGH`: (value type =
+      :py:obj:`~.cuuint64_t`) Reset the high watermark that tracks the
+      amount of used memory that was allocated for the memory pool.
 
     Parameters
     ----------
@@ -35963,11 +35967,11 @@ def cuMemPoolGetAttribute(pool, attr not None : CUmemPool_attribute):
     Supported attributes are:
 
     - :py:obj:`~.CU_MEMPOOL_ATTR_RELEASE_THRESHOLD`: (value type =
-      cuuint64_t) Amount of reserved memory in bytes to hold onto before
-      trying to release memory back to the OS. When more than the release
-      threshold bytes of memory are held by the memory pool, the allocator
-      will try to release memory back to the OS on the next call to stream,
-      event or context synchronize. (default 0)
+      :py:obj:`~.cuuint64_t`) Amount of reserved memory in bytes to hold
+      onto before trying to release memory back to the OS. When more than
+      the release threshold bytes of memory are held by the memory pool,
+      the allocator will try to release memory back to the OS on the next
+      call to stream, event or context synchronize. (default 0)
 
     - :py:obj:`~.CU_MEMPOOL_ATTR_REUSE_FOLLOW_EVENT_DEPENDENCIES`: (value
       type = int) Allow :py:obj:`~.cuMemAllocAsync` to use memory
@@ -35987,30 +35991,30 @@ def cuMemPoolGetAttribute(pool, attr not None : CUmemPool_attribute):
       (default enabled).
 
     - :py:obj:`~.CU_MEMPOOL_ATTR_RESERVED_MEM_CURRENT`: (value type =
-      cuuint64_t) Amount of backing memory currently allocated for the
-      mempool
+      :py:obj:`~.cuuint64_t`) Amount of backing memory currently allocated
+      for the mempool
 
     - :py:obj:`~.CU_MEMPOOL_ATTR_RESERVED_MEM_HIGH`: (value type =
-      cuuint64_t) High watermark of backing memory allocated for the
-      mempool since the last time it was reset.
+      :py:obj:`~.cuuint64_t`) High watermark of backing memory allocated
+      for the mempool since the last time it was reset.
 
     - :py:obj:`~.CU_MEMPOOL_ATTR_USED_MEM_CURRENT`: (value type =
-      cuuint64_t) Amount of memory from the pool that is currently in use
-      by the application.
+      :py:obj:`~.cuuint64_t`) Amount of memory from the pool that is
+      currently in use by the application.
 
-    - :py:obj:`~.CU_MEMPOOL_ATTR_USED_MEM_HIGH`: (value type = cuuint64_t)
-      High watermark of the amount of memory from the pool that was in use
-      by the application.
+    - :py:obj:`~.CU_MEMPOOL_ATTR_USED_MEM_HIGH`: (value type =
+      :py:obj:`~.cuuint64_t`) High watermark of the amount of memory from
+      the pool that was in use by the application.
 
     The following properties can be also be queried on imported and default
     pools:
 
     - :py:obj:`~.CU_MEMPOOL_ATTR_ALLOCATION_TYPE`: (value type =
-      CUmemAllocationType) The allocation type of the mempool
+      :py:obj:`~.CUmemAllocationType`) The allocation type of the mempool
 
     - :py:obj:`~.CU_MEMPOOL_ATTR_EXPORT_HANDLE_TYPES`: (value type =
-      CUmemAllocationHandleType) Available export handle types for the
-      mempool. For imported pools this value is always
+      :py:obj:`~.CUmemAllocationHandleType`) Available export handle types
+      for the mempool. For imported pools this value is always
       CU_MEM_HANDLE_TYPE_NONE as an imported pool cannot be re-exported
 
     - :py:obj:`~.CU_MEMPOOL_ATTR_LOCATION_ID`: (value type = int) The
@@ -36018,16 +36022,16 @@ def cuMemPoolGetAttribute(pool, attr not None : CUmemPool_attribute):
       CU_MEM_LOCATION_TYPE_INVISIBLE then ID will be CU_DEVICE_INVALID.
 
     - :py:obj:`~.CU_MEMPOOL_ATTR_LOCATION_TYPE`: (value type =
-      CUmemLocationType) The location type for the mempool. For imported
-      memory pools where the device is not directly visible to the
+      :py:obj:`~.CUmemLocationType`) The location type for the mempool. For
+      imported memory pools where the device is not directly visible to the
       importing process or pools imported via fabric handles across nodes
       this will be CU_MEM_LOCATION_TYPE_INVISIBLE.
 
-    - :py:obj:`~.CU_MEMPOOL_ATTR_MAX_POOL_SIZE`: (value type = cuuint64_t)
-      Maximum size of the pool in bytes, this value may be higher than what
-      was initially passed to cuMemPoolCreate due to alignment
-      requirements. A value of 0 indicates no maximum size. For
-      CU__MEM_ALLOCATION_TYPE_MANAGED and IPC imported pools this value
+    - :py:obj:`~.CU_MEMPOOL_ATTR_MAX_POOL_SIZE`: (value type =
+      :py:obj:`~.cuuint64_t`) Maximum size of the pool in bytes, this value
+      may be higher than what was initially passed to cuMemPoolCreate due
+      to alignment requirements. A value of 0 indicates no maximum size.
+      For CU__MEM_ALLOCATION_TYPE_MANAGED and IPC imported pools this value
       will be system dependent.
 
     - :py:obj:`~.CU_MEMPOOL_ATTR_HW_DECOMPRESS_ENABLED`: (value type = int)
@@ -36543,7 +36547,7 @@ def cuMemPoolExportToShareableHandle(pool, handleType not None : CUmemAllocation
 
     Notes
     -----
-    : To create an IPC capable mempool, create a mempool with a CUmemAllocationHandleType other than CU_MEM_HANDLE_TYPE_NONE.
+    : To create an IPC capable mempool, create a mempool with a :py:obj:`~.CUmemAllocationHandleType` other than CU_MEM_HANDLE_TYPE_NONE.
     """
     cdef cydriver.CUmemoryPool cypool
     if pool is None:
@@ -38046,7 +38050,7 @@ def cuPointerGetAttribute(attribute not None : CUpointer_attribute, ptr):
 
     - Returns in `*data` the device pointer value through which `ptr` may
       be accessed by kernels running in the current :py:obj:`~.CUcontext`.
-      The type of `data` must be CUdeviceptr *.
+      The type of `data` must be :py:obj:`~.CUdeviceptr` *.
 
     - If there exists no device pointer value through which kernels running
       in the current :py:obj:`~.CUcontext` may access `ptr` then
@@ -38073,7 +38077,7 @@ def cuPointerGetAttribute(attribute not None : CUpointer_attribute, ptr):
 
     - Returns in `*data` two tokens for use with the nv-p2p.h Linux kernel
       interface. `data` must be a struct of type
-      CUDA_POINTER_ATTRIBUTE_P2P_TOKENS.
+      :py:obj:`~.CUDA_POINTER_ATTRIBUTE_P2P_TOKENS`.
 
     - `ptr` must be a pointer to memory obtained from
       :py:obj:`~.py`:obj:`~.cuMemAlloc()`. Note that p2pToken and
@@ -42461,7 +42465,7 @@ def cuFuncGetAttribute(attrib not None : CUfunction_attribute, hfunc):
 
     - :py:obj:`~.CU_FUNC_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE`:
       The block scheduling policy of a function. The value type is
-      CUclusterSchedulingPolicy.
+      :py:obj:`~.CUclusterSchedulingPolicy`.
 
     With a few execeptions, function attributes may also be queried on
     unloaded function handles returned from
@@ -42571,7 +42575,7 @@ def cuFuncSetAttribute(hfunc, attrib not None : CUfunction_attribute, int value)
 
     - :py:obj:`~.CU_FUNC_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE`:
       The block scheduling policy of a function. The value type is
-      CUclusterSchedulingPolicy.
+      :py:obj:`~.CUclusterSchedulingPolicy`.
 
     Parameters
     ----------
@@ -44314,7 +44318,7 @@ def cuGraphAddKernelNode(hGraph, dependencies : Optional[tuple[CUgraphNode] | li
     root of the graph. `dependencies` may not have any duplicate entries. A
     handle to the new node will be returned in `phGraphNode`.
 
-    The CUDA_KERNEL_NODE_PARAMS structure is defined as:
+    The :py:obj:`~.CUDA_KERNEL_NODE_PARAMS` structure is defined as:
 
     **View CUDA Toolkit Documentation for a C++ code example**
 
@@ -48765,8 +48769,8 @@ def cuGraphDebugDotPrint(hGraph, char* path, unsigned int flags):
     path : bytes
         The path to write the DOT file to
     flags : unsigned int
-        Flags from CUgraphDebugDot_flags for specifying which additional
-        node information to write
+        Flags from :py:obj:`~.CUgraphDebugDot_flags` for specifying which
+        additional node information to write
 
     Returns
     -------
@@ -51170,8 +51174,8 @@ def cuTexObjectCreate(pResDesc : Optional[CUDA_RESOURCE_DESC], pTexDesc : Option
       supported address mode is :py:obj:`~.CU_TR_ADDRESS_MODE_CLAMP`.
 
     - :py:obj:`~.CUDA_TEXTURE_DESC.filterMode` specifies the filtering mode
-      to be used when fetching from the texture. CUfilter_mode is defined
-      as:
+      to be used when fetching from the texture. :py:obj:`~.CUfilter_mode`
+      is defined as:
 
     - **View CUDA Toolkit Documentation for a C++ code example**
 
@@ -54132,12 +54136,12 @@ def cuGreenCtxCreate(desc, dev, unsigned int flags):
 
     The API does not set the green context current. In order to set it
     current, you need to explicitly set it current by first converting the
-    green context to a CUcontext using :py:obj:`~.cuCtxFromGreenCtx` and
-    subsequently calling :py:obj:`~.cuCtxSetCurrent` /
-    :py:obj:`~.cuCtxPushCurrent`. It should be noted that a green context
-    can be current to only one thread at a time. There is no internal
-    synchronization to make API calls accessing the same green context from
-    multiple threads work.
+    green context to a :py:obj:`~.CUcontext` using
+    :py:obj:`~.cuCtxFromGreenCtx` and subsequently calling
+    :py:obj:`~.cuCtxSetCurrent` / :py:obj:`~.cuCtxPushCurrent`. It should
+    be noted that a green context can be current to only one thread at a
+    time. There is no internal synchronization to make API calls accessing
+    the same green context from multiple threads work.
 
     Note: The API is not supported on 32-bit platforms.
 
@@ -55543,11 +55547,11 @@ def cuProfilerStop():
 def cuGraphicsEGLRegisterImage(image, unsigned int flags):
     """ Registers an EGL image.
 
-    Registers the EGLImageKHR specified by `image` for access by CUDA. A
-    handle to the registered object is returned as `pCudaResource`.
-    Additional Mapping/Unmapping is not required for the registered
-    resource and :py:obj:`~.cuGraphicsResourceGetMappedEglFrame` can be
-    directly called on the `pCudaResource`.
+    Registers the :py:obj:`~.EGLImageKHR` specified by `image` for access
+    by CUDA. A handle to the registered object is returned as
+    `pCudaResource`. Additional Mapping/Unmapping is not required for the
+    registered resource and :py:obj:`~.cuGraphicsResourceGetMappedEglFrame`
+    can be directly called on the `pCudaResource`.
 
     The application will be responsible for synchronizing access to shared
     objects. The application must ensure that any pending operation which
@@ -55575,14 +55579,15 @@ def cuGraphicsEGLRegisterImage(image, unsigned int flags):
       entire contents of the resource, so none of the data previously
       stored in the resource will be preserved.
 
-    The EGLImageKHR is an object which can be used to create EGLImage
-    target resource. It is defined as a void pointer. typedef void*
-    EGLImageKHR
+    The :py:obj:`~.EGLImageKHR` is an object which can be used to create
+    EGLImage target resource. It is defined as a void pointer. typedef
+    void* :py:obj:`~.EGLImageKHR`
 
     Parameters
     ----------
     image : :py:obj:`~.EGLImageKHR`
-        An EGLImageKHR image which can be used to create target resource.
+        An :py:obj:`~.EGLImageKHR` image which can be used to create target
+        resource.
     flags : unsigned int
         Map flags
 
@@ -55616,15 +55621,16 @@ def cuGraphicsEGLRegisterImage(image, unsigned int flags):
 def cuEGLStreamConsumerConnect(stream):
     """ Connect CUDA to EGLStream as a consumer.
 
-    Connect CUDA as a consumer to EGLStreamKHR specified by `stream`.
+    Connect CUDA as a consumer to :py:obj:`~.EGLStreamKHR` specified by
+    `stream`.
 
-    The EGLStreamKHR is an EGL object that transfers a sequence of image
-    frames from one API to another.
+    The :py:obj:`~.EGLStreamKHR` is an EGL object that transfers a sequence
+    of image frames from one API to another.
 
     Parameters
     ----------
     stream : :py:obj:`~.EGLStreamKHR`
-        EGLStreamKHR handle
+        :py:obj:`~.EGLStreamKHR` handle
 
     Returns
     -------
@@ -55656,8 +55662,9 @@ def cuEGLStreamConsumerConnect(stream):
 def cuEGLStreamConsumerConnectWithFlags(stream, unsigned int flags):
     """ Connect CUDA to EGLStream as a consumer with given flags.
 
-    Connect CUDA as a consumer to EGLStreamKHR specified by `stream` with
-    specified `flags` defined by CUeglResourceLocationFlags.
+    Connect CUDA as a consumer to :py:obj:`~.EGLStreamKHR` specified by
+    `stream` with specified `flags` defined by
+    :py:obj:`~.CUeglResourceLocationFlags`.
 
     The flags specify whether the consumer wants to access frames from
     system memory or video memory. Default is
@@ -55666,7 +55673,7 @@ def cuEGLStreamConsumerConnectWithFlags(stream, unsigned int flags):
     Parameters
     ----------
     stream : :py:obj:`~.EGLStreamKHR`
-        EGLStreamKHR handle
+        :py:obj:`~.EGLStreamKHR` handle
     flags : unsigned int
         Flags denote intended location - system or video.
 
@@ -55700,7 +55707,7 @@ def cuEGLStreamConsumerConnectWithFlags(stream, unsigned int flags):
 def cuEGLStreamConsumerDisconnect(conn):
     """ Disconnect CUDA as a consumer to EGLStream .
 
-    Disconnect CUDA as a consumer to EGLStreamKHR.
+    Disconnect CUDA as a consumer to :py:obj:`~.EGLStreamKHR`.
 
     Parameters
     ----------
@@ -55734,12 +55741,12 @@ def cuEGLStreamConsumerDisconnect(conn):
 def cuEGLStreamConsumerAcquireFrame(conn, pCudaResource, pStream, unsigned int timeout):
     """ Acquire an image frame from the EGLStream with CUDA as a consumer.
 
-    Acquire an image frame from EGLStreamKHR. This API can also acquire an
-    old frame presented by the producer unless explicitly disabled by
-    setting EGL_SUPPORT_REUSE_NV flag to EGL_FALSE during stream
-    initialization. By default, EGLStream is created with this flag set to
-    EGL_TRUE. :py:obj:`~.cuGraphicsResourceGetMappedEglFrame` can be called
-    on `pCudaResource` to get :py:obj:`~.CUeglFrame`.
+    Acquire an image frame from :py:obj:`~.EGLStreamKHR`. This API can also
+    acquire an old frame presented by the producer unless explicitly
+    disabled by setting EGL_SUPPORT_REUSE_NV flag to EGL_FALSE during
+    stream initialization. By default, EGLStream is created with this flag
+    set to EGL_TRUE. :py:obj:`~.cuGraphicsResourceGetMappedEglFrame` can be
+    called on `pCudaResource` to get :py:obj:`~.CUeglFrame`.
 
     Parameters
     ----------
@@ -55804,10 +55811,10 @@ def cuEGLStreamConsumerReleaseFrame(conn, pCudaResource, pStream):
     """ Releases the last frame acquired from the EGLStream.
 
     Release the acquired image frame specified by `pCudaResource` to
-    EGLStreamKHR. If EGL_SUPPORT_REUSE_NV flag is set to EGL_TRUE, at the
-    time of EGL creation this API doesn't release the last frame acquired
-    on the EGLStream. By default, EGLStream is created with this flag set
-    to EGL_TRUE.
+    :py:obj:`~.EGLStreamKHR`. If EGL_SUPPORT_REUSE_NV flag is set to
+    EGL_TRUE, at the time of EGL creation this API doesn't release the last
+    frame acquired on the EGLStream. By default, EGLStream is created with
+    this flag set to EGL_TRUE.
 
     Parameters
     ----------
@@ -55863,15 +55870,16 @@ def cuEGLStreamConsumerReleaseFrame(conn, pCudaResource, pStream):
 def cuEGLStreamProducerConnect(stream, width, height):
     """ Connect CUDA to EGLStream as a producer.
 
-    Connect CUDA as a producer to EGLStreamKHR specified by `stream`.
+    Connect CUDA as a producer to :py:obj:`~.EGLStreamKHR` specified by
+    `stream`.
 
-    The EGLStreamKHR is an EGL object that transfers a sequence of image
-    frames from one API to another.
+    The :py:obj:`~.EGLStreamKHR` is an EGL object that transfers a sequence
+    of image frames from one API to another.
 
     Parameters
     ----------
     stream : :py:obj:`~.EGLStreamKHR`
-        EGLStreamKHR handle
+        :py:obj:`~.EGLStreamKHR` handle
     width : :py:obj:`~.EGLint`
         width of the image to be submitted to the stream
     height : :py:obj:`~.EGLint`
@@ -55923,7 +55931,7 @@ def cuEGLStreamProducerConnect(stream, width, height):
 def cuEGLStreamProducerDisconnect(conn):
     """ Disconnect CUDA as a producer to EGLStream .
 
-    Disconnect CUDA as a producer to EGLStreamKHR.
+    Disconnect CUDA as a producer to :py:obj:`~.EGLStreamKHR`.
 
     Parameters
     ----------
@@ -56122,8 +56130,8 @@ def cuGraphicsResourceGetMappedEglFrame(resource, unsigned int index, unsigned i
 def cuEventCreateFromEGLSync(eglSync, unsigned int flags):
     """ Creates an event from EGLSync object.
 
-    Creates an event *phEvent from an EGLSyncKHR eglSync with the flags
-    specified via `flags`. Valid flags include:
+    Creates an event *phEvent from an :py:obj:`~.EGLSyncKHR` eglSync with
+    the flags specified via `flags`. Valid flags include:
 
     - :py:obj:`~.CU_EVENT_DEFAULT`: Default event creation flag.
 
@@ -56138,8 +56146,8 @@ def cuEventCreateFromEGLSync(eglSync, unsigned int flags):
     :py:obj:`~.cuEventRecord` and TimingData are not supported for events
     created from EGLSync.
 
-    The EGLSyncKHR is an opaque handle to an EGL sync object. typedef void*
-    EGLSyncKHR
+    The :py:obj:`~.EGLSyncKHR` is an opaque handle to an EGL sync object.
+    typedef void* :py:obj:`~.EGLSyncKHR`
 
     Parameters
     ----------
@@ -56401,9 +56409,9 @@ def cuVDPAUGetDevice(vdpDevice, vdpGetProcAddress):
     Parameters
     ----------
     vdpDevice : :py:obj:`~.VdpDevice`
-        A VdpDevice handle
+        A :py:obj:`~.VdpDevice` handle
     vdpGetProcAddress : :py:obj:`~.VdpGetProcAddress`
-        VDPAU's VdpGetProcAddress function pointer
+        VDPAU's :py:obj:`~.VdpGetProcAddress` function pointer
 
     Returns
     -------
@@ -56458,9 +56466,9 @@ def cuVDPAUCtxCreate(unsigned int flags, device, vdpDevice, vdpGetProcAddress):
     device : :py:obj:`~.CUdevice`
         Device on which to create the context
     vdpDevice : :py:obj:`~.VdpDevice`
-        The VdpDevice to interop with
+        The :py:obj:`~.VdpDevice` to interop with
     vdpGetProcAddress : :py:obj:`~.VdpGetProcAddress`
-        VDPAU's VdpGetProcAddress function pointer
+        VDPAU's :py:obj:`~.VdpGetProcAddress` function pointer
 
     Returns
     -------
@@ -56508,11 +56516,12 @@ def cuVDPAUCtxCreate(unsigned int flags, device, vdpDevice, vdpGetProcAddress):
 
 @cython.embedsignature(True)
 def cuGraphicsVDPAURegisterVideoSurface(vdpSurface, unsigned int flags):
-    """ Registers a VDPAU VdpVideoSurface object.
+    """ Registers a VDPAU :py:obj:`~.VdpVideoSurface` object.
 
-    Registers the VdpVideoSurface specified by `vdpSurface` for access by
-    CUDA. A handle to the registered object is returned as `pCudaResource`.
-    The surface's intended usage is specified using `flags`, as follows:
+    Registers the :py:obj:`~.VdpVideoSurface` specified by `vdpSurface` for
+    access by CUDA. A handle to the registered object is returned as
+    `pCudaResource`. The surface's intended usage is specified using
+    `flags`, as follows:
 
     - :py:obj:`~.CU_GRAPHICS_MAP_RESOURCE_FLAGS_NONE`: Specifies no hints
       about how this resource will be used. It is therefore assumed that
@@ -56527,8 +56536,8 @@ def cuGraphicsVDPAURegisterVideoSurface(vdpSurface, unsigned int flags):
       entire contents of the resource, so none of the data previously
       stored in the resource will be preserved.
 
-    The VdpVideoSurface is presented as an array of subresources that may
-    be accessed using pointers returned by
+    The :py:obj:`~.VdpVideoSurface` is presented as an array of
+    subresources that may be accessed using pointers returned by
     :py:obj:`~.cuGraphicsSubResourceGetMappedArray`. The exact number of
     valid `arrayIndex` values depends on the VDPAU surface format. The
     mapping is shown in the table below. `mipLevel` must be 0.
@@ -56536,7 +56545,7 @@ def cuGraphicsVDPAURegisterVideoSurface(vdpSurface, unsigned int flags):
     Parameters
     ----------
     vdpSurface : :py:obj:`~.VdpVideoSurface`
-        The VdpVideoSurface to be registered
+        The :py:obj:`~.VdpVideoSurface` to be registered
     flags : unsigned int
         Map flags
 
@@ -56568,11 +56577,12 @@ def cuGraphicsVDPAURegisterVideoSurface(vdpSurface, unsigned int flags):
 
 @cython.embedsignature(True)
 def cuGraphicsVDPAURegisterOutputSurface(vdpSurface, unsigned int flags):
-    """ Registers a VDPAU VdpOutputSurface object.
+    """ Registers a VDPAU :py:obj:`~.VdpOutputSurface` object.
 
-    Registers the VdpOutputSurface specified by `vdpSurface` for access by
-    CUDA. A handle to the registered object is returned as `pCudaResource`.
-    The surface's intended usage is specified using `flags`, as follows:
+    Registers the :py:obj:`~.VdpOutputSurface` specified by `vdpSurface`
+    for access by CUDA. A handle to the registered object is returned as
+    `pCudaResource`. The surface's intended usage is specified using
+    `flags`, as follows:
 
     - :py:obj:`~.CU_GRAPHICS_MAP_RESOURCE_FLAGS_NONE`: Specifies no hints
       about how this resource will be used. It is therefore assumed that
@@ -56587,8 +56597,8 @@ def cuGraphicsVDPAURegisterOutputSurface(vdpSurface, unsigned int flags):
       entire contents of the resource, so none of the data previously
       stored in the resource will be preserved.
 
-    The VdpOutputSurface is presented as an array of subresources that may
-    be accessed using pointers returned by
+    The :py:obj:`~.VdpOutputSurface` is presented as an array of
+    subresources that may be accessed using pointers returned by
     :py:obj:`~.cuGraphicsSubResourceGetMappedArray`. The exact number of
     valid `arrayIndex` values depends on the VDPAU surface format. The
     mapping is shown in the table below. `mipLevel` must be 0.
@@ -56596,7 +56606,7 @@ def cuGraphicsVDPAURegisterOutputSurface(vdpSurface, unsigned int flags):
     Parameters
     ----------
     vdpSurface : :py:obj:`~.VdpOutputSurface`
-        The VdpOutputSurface to be registered
+        The :py:obj:`~.VdpOutputSurface` to be registered
     flags : unsigned int
         Map flags
 

--- a/cuda_bindings/cuda/bindings/nvfatbin.pyx
+++ b/cuda_bindings/cuda/bindings/nvfatbin.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.4.1 to 13.3.0, generator version 0.3.1.dev1719+g565f73f4e. Do not modify it directly.
+# This code was automatically generated across versions from 12.4.1 to 13.3.0, generator version 0.3.1.dev1752+g89e531539. Do not modify it directly.
 
 cimport cython  # NOQA
 
@@ -19,8 +19,8 @@ from libcpp.vector cimport vector
 
 class Result(_IntEnum):
     """
-    The enumerated type nvFatbinResult defines API call result codes.
-    nvFatbin APIs return nvFatbinResult codes to indicate the result.
+    The enumerated type `nvFatbinResult` defines API call result codes.
+    nvFatbin APIs return `nvFatbinResult` codes to indicate the result.
 
     See `nvFatbinResult`.
     """

--- a/cuda_bindings/cuda/bindings/nvjitlink.pxd
+++ b/cuda_bindings/cuda/bindings/nvjitlink.pxd
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.0.1 to 13.2.0, generator version 0.3.1.dev1422+gf4812259e.d20260318. Do not modify it directly.
+# This code was automatically generated across versions from 12.0.1 to 13.3.0, generator version 0.3.1.dev1752+g89e531539. Do not modify it directly.
 
 from libc.stdint cimport intptr_t, uint32_t
 
@@ -41,3 +41,5 @@ cpdef get_error_log(intptr_t handle, log)
 cpdef size_t get_info_log_size(intptr_t handle) except? 0
 cpdef get_info_log(intptr_t handle, log)
 cpdef tuple version()
+cpdef size_t get_linked_ltoir_size(intptr_t handle) except? 0
+cpdef get_linked_ltoir(intptr_t handle, ltoir)

--- a/cuda_bindings/cuda/bindings/nvjitlink.pyx
+++ b/cuda_bindings/cuda/bindings/nvjitlink.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.0.1 to 13.2.0, generator version 0.3.1.dev1422+gf4812259e.d20260318. Do not modify it directly.
+# This code was automatically generated across versions from 12.0.1 to 13.3.0, generator version 0.3.1.dev1752+g89e531539. Do not modify it directly.
 
 cimport cython  # NOQA
 
@@ -19,8 +19,8 @@ from libcpp.vector cimport vector
 
 class Result(_FastEnum):
     """
-    The enumerated type nvJitLinkResult defines API call result codes.
-    nvJitLink APIs return nvJitLinkResult codes to indicate the result.
+    The enumerated type `nvJitLinkResult` defines API call result codes.
+    nvJitLink APIs return `nvJitLinkResult` codes to indicate the result.
 
     See `nvJitLinkResult`.
     """
@@ -46,8 +46,8 @@ class Result(_FastEnum):
 
 class InputType(_FastEnum):
     """
-    The enumerated type nvJitLinkInputType defines the kind of inputs that
-    can be passed to nvJitLinkAdd* APIs.
+    The enumerated type `nvJitLinkInputType` defines the kind of inputs
+    that can be passed to nvJitLinkAdd* APIs.
 
     See `nvJitLinkInputType`.
     """
@@ -105,7 +105,7 @@ cpdef destroy(intptr_t handle):
 
 
 cpdef intptr_t create(uint32_t num_options, options) except -1:
-    """nvJitLinkCreate creates an instance of nvJitLinkHandle with the given input options, and sets the output parameter ``handle``.
+    """nvJitLinkCreate creates an instance of ``nvJitLinkHandle`` with the given input options, and sets the output parameter ``handle``.
 
     Args:
         num_options (uint32_t): Number of options passed.
@@ -334,3 +334,36 @@ cpdef tuple version():
         __status__ = nvJitLinkVersion(&major, &minor)
     check_status(__status__)
     return (major, minor)
+
+
+cpdef size_t get_linked_ltoir_size(intptr_t handle) except? 0:
+    """nvJitLinkGetLinkedLTOIRSize gets the size of the linked LTOIR.
+
+    Args:
+        handle (intptr_t): nvJitLink handle.
+
+    Returns:
+        size_t: Size of the linked LTOIR.
+
+    .. seealso:: `nvJitLinkGetLinkedLTOIRSize`
+    """
+    cdef size_t size
+    with nogil:
+        __status__ = nvJitLinkGetLinkedLTOIRSize(<Handle>handle, &size)
+    check_status(__status__)
+    return size
+
+
+cpdef get_linked_ltoir(intptr_t handle, ltoir):
+    """nvJitLinkGetLinkedLTOIR gets the linked LTOIR.
+
+    Args:
+        handle (intptr_t): nvJitLink handle.
+        ltoir (bytes): The linked LTOIR in Container format.
+
+    .. seealso:: `nvJitLinkGetLinkedLTOIR`
+    """
+    cdef void* _ltoir_ = get_buffer_pointer(ltoir, -1, readonly=False)
+    with nogil:
+        __status__ = nvJitLinkGetLinkedLTOIR(<Handle>handle, <void*>_ltoir_)
+    check_status(__status__)

--- a/cuda_bindings/cuda/bindings/nvml.pyx
+++ b/cuda_bindings/cuda/bindings/nvml.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.9.1 to 13.3.0, generator version 0.3.1.dev1719+g565f73f4e. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.1 to 13.3.0, generator version 0.3.1.dev1602+g3c8d84404. Do not modify it directly.
 
 cimport cython  # NOQA
 
@@ -97,7 +97,7 @@ class NvLinkUtilizationCountPktTypes(_FastEnum):
     """
     Enum to represent the NvLink utilization counter packet types to count
     ** this is ONLY applicable with the units as packets or bytes ** as
-    specified in `nvmlNvLinkUtilizationCountUnits_t` ** all packet filter
+    specified in ``nvmlNvLinkUtilizationCountUnits_t`` ** all packet filter
     descriptions are target GPU centric ** these can be "OR'd" together
 
     See `nvmlNvLinkUtilizationCountPktTypes_t`.
@@ -244,7 +244,7 @@ class PerfPolicyType(_FastEnum):
     PERF_POLICY_BOARD_LIMIT = (NVML_PERF_POLICY_BOARD_LIMIT, 'How long did the board limit cause the GPU to be below application clocks.')
     PERF_POLICY_LOW_UTILIZATION = (NVML_PERF_POLICY_LOW_UTILIZATION, 'How long did low utilization cause the GPU to be below application clocks.')
     PERF_POLICY_RELIABILITY = (NVML_PERF_POLICY_RELIABILITY, 'How long did the board reliability limit cause the GPU to be below application clocks.')
-    PERF_POLICY_TOTAL_APP_CLOCKS = (NVML_PERF_POLICY_TOTAL_APP_CLOCKS, 'Total time the GPU was held below application clocks by any limiter (0 - 5 above)')
+    PERF_POLICY_TOTAL_APP_CLOCKS = (NVML_PERF_POLICY_TOTAL_APP_CLOCKS, 'Total time the GPU was held below application clocks by any limiter (0 - 5 above).')
     PERF_POLICY_TOTAL_BASE_CLOCKS = (NVML_PERF_POLICY_TOTAL_BASE_CLOCKS, 'Total time the GPU was held below base clocks.')
     PERF_POLICY_COUNT = NVML_PERF_POLICY_COUNT
 
@@ -436,7 +436,7 @@ class EccCounterType(_FastEnum):
     See `nvmlEccCounterType_t`.
     """
     VOLATILE_ECC = (NVML_VOLATILE_ECC, 'Volatile counts are reset each time the driver loads.')
-    AGGREGATE_ECC = (NVML_AGGREGATE_ECC, 'Aggregate counts persist across reboots (i.e. for the lifetime of the device)')
+    AGGREGATE_ECC = (NVML_AGGREGATE_ECC, 'Aggregate counts persist across reboots (i.e. for the lifetime of the device).')
     COUNT = (NVML_ECC_COUNTER_TYPE_COUNT, 'Count of memory counter types.')
 
 class ClockType(_FastEnum):
@@ -453,7 +453,7 @@ class ClockType(_FastEnum):
 
 class ClockId(_FastEnum):
     """
-    Clock Ids. These are used in combination with nvmlClockType_t to
+    Clock Ids. These are used in combination with `nvmlClockType_t` to
     specify a single clock value.
 
     See `nvmlClockId_t`.
@@ -529,7 +529,7 @@ class Return(_FastEnum):
     See `nvmlReturn_t`.
     """
     SUCCESS = (NVML_SUCCESS, 'The operation was successful.')
-    ERROR_UNINITIALIZED = (NVML_ERROR_UNINITIALIZED, 'NVML was not first initialized with `nvmlInit()`')
+    ERROR_UNINITIALIZED = (NVML_ERROR_UNINITIALIZED, 'NVML was not first initialized with `nvmlInit()`.')
     ERROR_INVALID_ARGUMENT = (NVML_ERROR_INVALID_ARGUMENT, 'A supplied argument is invalid.')
     ERROR_NOT_SUPPORTED = (NVML_ERROR_NOT_SUPPORTED, 'The requested operation is not available on target device.')
     ERROR_NO_PERMISSION = (NVML_ERROR_NO_PERMISSION, 'The current user does not have permission for operation.')
@@ -1192,7 +1192,7 @@ class ProcessMode(_FastEnum):
     COMPUTE = (NVML_PROCESS_MODE_COMPUTE, 'Processes with a compute context.')
     GRAPHICS = (NVML_PROCESS_MODE_GRAPHICS, 'Processes with a graphics context.')
     MPS = (NVML_PROCESS_MODE_MPS, 'Processes with a MPS (Multi-Process Service) compute context.')
-    ALL = (NVML_PROCESS_MODE_ALL, 'All processes running on the GPU (compute, graphics, MPS, and other types)')
+    ALL = (NVML_PROCESS_MODE_ALL, 'All processes running on the GPU (compute, graphics, MPS, and other types).')
     MAX = (NVML_PROCESS_MODE_MAX, 'Maximum value for bounds checking.')
 
 class CPERType(_FastEnum):
@@ -2146,7 +2146,7 @@ cpdef int check_status_size(int status) except 1 nogil:
 
 
 cdef _get_pci_info_ext_v1_dtype_offsets():
-    cdef nvmlPciInfoExt_v1_t pod = nvmlPciInfoExt_v1_t()
+    cdef nvmlPciInfoExt_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'domain', 'bus', 'device_', 'pci_device_id', 'pci_sub_system_id', 'base_class', 'sub_class', 'bus_id'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, (_numpy.int8, 32)],
@@ -2322,7 +2322,7 @@ cdef class PciInfoExt_v1:
 
     @property
     def bus_id(self):
-        """~_numpy.int8: (array of length 32).The tuple domain:bus:device.function PCI identifier (& NULL terminator)"""
+        """~_numpy.int8: (array of length 32).The tuple domain:bus:device.function PCI identifier (& NULL terminator)."""
         return cpython.PyUnicode_FromString(self._ptr[0].busId)
 
     @bus_id.setter
@@ -2377,7 +2377,7 @@ cdef class PciInfoExt_v1:
 
 
 cdef _get_pci_info_dtype_offsets():
-    cdef nvmlPciInfo_t pod = nvmlPciInfo_t()
+    cdef nvmlPciInfo_t pod
     return _numpy.dtype({
         'names': ['bus_id_legacy', 'domain', 'bus', 'device_', 'pci_device_id', 'pci_sub_system_id', 'bus_id'],
         'formats': [(_numpy.int8, 16), _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, (_numpy.int8, 32)],
@@ -2588,7 +2588,7 @@ cdef class PciInfo:
 
 
 cdef _get_utilization_dtype_offsets():
-    cdef nvmlUtilization_t pod = nvmlUtilization_t()
+    cdef nvmlUtilization_t pod
     return _numpy.dtype({
         'names': ['gpu', 'memory'],
         'formats': [_numpy.uint32, _numpy.uint32],
@@ -2731,7 +2731,7 @@ cdef class Utilization:
 
 
 cdef _get_memory_dtype_offsets():
-    cdef nvmlMemory_t pod = nvmlMemory_t()
+    cdef nvmlMemory_t pod
     return _numpy.dtype({
         'names': ['total', 'free', 'used'],
         'formats': [_numpy.uint64, _numpy.uint64, _numpy.uint64],
@@ -2886,7 +2886,7 @@ cdef class Memory:
 
 
 cdef _get_memory_v2_dtype_offsets():
-    cdef nvmlMemory_v2_t pod = nvmlMemory_v2_t()
+    cdef nvmlMemory_v2_t pod
     return _numpy.dtype({
         'names': ['version', 'total', 'reserved', 'free', 'used'],
         'formats': [_numpy.uint32, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64],
@@ -3065,7 +3065,7 @@ cdef class Memory_v2:
 
 
 cdef _get_ba_r1memory_dtype_offsets():
-    cdef nvmlBAR1Memory_t pod = nvmlBAR1Memory_t()
+    cdef nvmlBAR1Memory_t pod
     return _numpy.dtype({
         'names': ['bar1_total', 'bar1_free', 'bar1_used'],
         'formats': [_numpy.uint64, _numpy.uint64, _numpy.uint64],
@@ -3220,7 +3220,7 @@ cdef class BAR1Memory:
 
 
 cdef _get_process_info_dtype_offsets():
-    cdef nvmlProcessInfo_t pod = nvmlProcessInfo_t()
+    cdef nvmlProcessInfo_t pod
     return _numpy.dtype({
         'names': ['pid', 'used_gpu_memory', 'gpu_instance_id', 'compute_instance_id'],
         'formats': [_numpy.uint32, _numpy.uint64, _numpy.uint32, _numpy.uint32],
@@ -3397,7 +3397,7 @@ cdef class ProcessInfo:
 
 
 cdef _get_process_detail_v1_dtype_offsets():
-    cdef nvmlProcessDetail_v1_t pod = nvmlProcessDetail_v1_t()
+    cdef nvmlProcessDetail_v1_t pod
     return _numpy.dtype({
         'names': ['pid', 'used_gpu_memory', 'gpu_instance_id', 'compute_instance_id', 'used_gpu_cc_protected_memory'],
         'formats': [_numpy.uint32, _numpy.uint64, _numpy.uint32, _numpy.uint32, _numpy.uint64],
@@ -3586,7 +3586,7 @@ cdef class ProcessDetail_v1:
 
 
 cdef _get_device_attributes_dtype_offsets():
-    cdef nvmlDeviceAttributes_t pod = nvmlDeviceAttributes_t()
+    cdef nvmlDeviceAttributes_t pod
     return _numpy.dtype({
         'names': ['multiprocessor_count', 'shared_copy_engine_count', 'shared_decoder_count', 'shared_encoder_count', 'shared_jpeg_count', 'shared_ofa_count', 'gpu_instance_slice_count', 'compute_instance_slice_count', 'memory_size_mb'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint64],
@@ -3813,7 +3813,7 @@ cdef class DeviceAttributes:
 
 
 cdef _get_c2c_mode_info_v1_dtype_offsets():
-    cdef nvmlC2cModeInfo_v1_t pod = nvmlC2cModeInfo_v1_t()
+    cdef nvmlC2cModeInfo_v1_t pod
     return _numpy.dtype({
         'names': ['is_c2c_enabled'],
         'formats': [_numpy.uint32],
@@ -3944,7 +3944,7 @@ cdef class C2cModeInfo_v1:
 
 
 cdef _get_row_remapper_histogram_values_dtype_offsets():
-    cdef nvmlRowRemapperHistogramValues_t pod = nvmlRowRemapperHistogramValues_t()
+    cdef nvmlRowRemapperHistogramValues_t pod
     return _numpy.dtype({
         'names': ['max_', 'high', 'partial', 'low', 'none'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32],
@@ -4123,7 +4123,7 @@ cdef class RowRemapperHistogramValues:
 
 
 cdef _get_bridge_chip_info_dtype_offsets():
-    cdef nvmlBridgeChipInfo_t pod = nvmlBridgeChipInfo_t()
+    cdef nvmlBridgeChipInfo_t pod
     return _numpy.dtype({
         'names': ['type', 'fw_version'],
         'formats': [_numpy.int32, _numpy.uint32],
@@ -4473,7 +4473,7 @@ cdef class Value:
 
 
 cdef _get__py_anon_pod0_dtype_offsets():
-    cdef cuda_bindings_nvml__anon_pod0 pod = cuda_bindings_nvml__anon_pod0()
+    cdef cuda_bindings_nvml__anon_pod0 pod
     return _numpy.dtype({
         'names': ['controller', 'default_min_temp', 'default_max_temp', 'current_temp', 'target'],
         'formats': [_numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32],
@@ -4652,7 +4652,7 @@ cdef class _py_anon_pod0:
 
 
 cdef _get_cooler_info_v1_dtype_offsets():
-    cdef nvmlCoolerInfo_v1_t pod = nvmlCoolerInfo_v1_t()
+    cdef nvmlCoolerInfo_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'index', 'signal_type', 'target'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.int32, _numpy.int32],
@@ -4819,7 +4819,7 @@ cdef class CoolerInfo_v1:
 
 
 cdef _get_clk_mon_fault_info_dtype_offsets():
-    cdef nvmlClkMonFaultInfo_t pod = nvmlClkMonFaultInfo_t()
+    cdef nvmlClkMonFaultInfo_t pod
     return _numpy.dtype({
         'names': ['clk_api_domain', 'clk_domain_fault_mask'],
         'formats': [_numpy.uint32, _numpy.uint32],
@@ -4972,7 +4972,7 @@ cdef class ClkMonFaultInfo:
 
 
 cdef _get_clock_offset_v1_dtype_offsets():
-    cdef nvmlClockOffset_v1_t pod = nvmlClockOffset_v1_t()
+    cdef nvmlClockOffset_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'type', 'pstate', 'clock_offset_m_hz', 'min_clock_offset_m_hz', 'max_clock_offset_m_hz'],
         'formats': [_numpy.uint32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32],
@@ -5163,7 +5163,7 @@ cdef class ClockOffset_v1:
 
 
 cdef _get_process_utilization_sample_dtype_offsets():
-    cdef nvmlProcessUtilizationSample_t pod = nvmlProcessUtilizationSample_t()
+    cdef nvmlProcessUtilizationSample_t pod
     return _numpy.dtype({
         'names': ['pid', 'time_stamp', 'sm_util', 'mem_util', 'enc_util', 'dec_util'],
         'formats': [_numpy.uint32, _numpy.uint64, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32],
@@ -5364,7 +5364,7 @@ cdef class ProcessUtilizationSample:
 
 
 cdef _get_process_utilization_info_v1_dtype_offsets():
-    cdef nvmlProcessUtilizationInfo_v1_t pod = nvmlProcessUtilizationInfo_v1_t()
+    cdef nvmlProcessUtilizationInfo_v1_t pod
     return _numpy.dtype({
         'names': ['time_stamp', 'pid', 'sm_util', 'mem_util', 'enc_util', 'dec_util', 'jpg_util', 'ofa_util'],
         'formats': [_numpy.uint64, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32],
@@ -5589,7 +5589,7 @@ cdef class ProcessUtilizationInfo_v1:
 
 
 cdef _get_ecc_sram_error_status_v1_dtype_offsets():
-    cdef nvmlEccSramErrorStatus_v1_t pod = nvmlEccSramErrorStatus_v1_t()
+    cdef nvmlEccSramErrorStatus_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'aggregate_unc_parity', 'aggregate_unc_sec_ded', 'aggregate_cor', 'volatile_unc_parity', 'volatile_unc_sec_ded', 'volatile_cor', 'aggregate_unc_bucket_l2', 'aggregate_unc_bucket_sm', 'aggregate_unc_bucket_pcie', 'aggregate_unc_bucket_mcu', 'aggregate_unc_bucket_other', 'b_threshold_exceeded'],
         'formats': [_numpy.uint32, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint32],
@@ -5864,7 +5864,7 @@ cdef class EccSramErrorStatus_v1:
 
 
 cdef _get_platform_info_v1_dtype_offsets():
-    cdef nvmlPlatformInfo_v1_t pod = nvmlPlatformInfo_v1_t()
+    cdef nvmlPlatformInfo_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'ib_guid', 'rack_guid', 'chassis_physical_slot_number', 'compute_slot_index', 'node_index', 'peer_type', 'module_id'],
         'formats': [_numpy.uint32, (_numpy.uint8, 16), (_numpy.uint8, 16), _numpy.uint8, _numpy.uint8, _numpy.uint8, _numpy.uint8, _numpy.uint8],
@@ -5962,7 +5962,7 @@ cdef class PlatformInfo_v1:
 
     @property
     def ib_guid(self):
-        """~_numpy.uint8: (array of length 16).Infiniband GUID reported by platform (for Blackwell, ibGuid is 8 bytes so indices 8-15 are zero)"""
+        """~_numpy.uint8: (array of length 16).Infiniband GUID reported by platform (for Blackwell, ibGuid is 8 bytes so indices 8-15 are zero)."""
         cdef view.array arr = view.array(shape=(16,), itemsize=sizeof(unsigned char), format="B", mode="c", allocate_buffer=False)
         arr.data = <char *>(&(self._ptr[0].ibGuid))
         return _numpy.asarray(arr)
@@ -5979,7 +5979,7 @@ cdef class PlatformInfo_v1:
 
     @property
     def rack_guid(self):
-        """~_numpy.uint8: (array of length 16).GUID of the rack containing this GPU (for Blackwell rackGuid is 13 bytes so indices 13-15 are zero)"""
+        """~_numpy.uint8: (array of length 16).GUID of the rack containing this GPU (for Blackwell rackGuid is 13 bytes so indices 13-15 are zero)."""
         cdef view.array arr = view.array(shape=(16,), itemsize=sizeof(unsigned char), format="B", mode="c", allocate_buffer=False)
         arr.data = <char *>(&(self._ptr[0].rackGuid))
         return _numpy.asarray(arr)
@@ -5996,7 +5996,7 @@ cdef class PlatformInfo_v1:
 
     @property
     def chassis_physical_slot_number(self):
-        """int: The slot number in the rack containing this GPU (includes switches)"""
+        """int: The slot number in the rack containing this GPU (includes switches)."""
         return self._ptr[0].chassisPhysicalSlotNumber
 
     @chassis_physical_slot_number.setter
@@ -6007,7 +6007,7 @@ cdef class PlatformInfo_v1:
 
     @property
     def compute_slot_index(self):
-        """int: The index within the compute slots in the rack containing this GPU (does not include switches)"""
+        """int: The index within the compute slots in the rack containing this GPU (does not include switches)."""
         return self._ptr[0].computeSlotIndex
 
     @compute_slot_index.setter
@@ -6029,7 +6029,7 @@ cdef class PlatformInfo_v1:
 
     @property
     def peer_type(self):
-        """int: Platform indicated NVLink-peer type (e.g. switch present or not)"""
+        """int: Platform indicated NVLink-peer type (e.g. switch present or not)."""
         return self._ptr[0].peerType
 
     @peer_type.setter
@@ -6091,7 +6091,7 @@ cdef class PlatformInfo_v1:
 
 
 cdef _get_platform_info_v2_dtype_offsets():
-    cdef nvmlPlatformInfo_v2_t pod = nvmlPlatformInfo_v2_t()
+    cdef nvmlPlatformInfo_v2_t pod
     return _numpy.dtype({
         'names': ['version', 'ib_guid', 'chassis_serial_number', 'slot_number', 'tray_index', 'host_id', 'peer_type', 'module_id'],
         'formats': [_numpy.uint32, (_numpy.uint8, 16), (_numpy.uint8, 16), _numpy.uint8, _numpy.uint8, _numpy.uint8, _numpy.uint8, _numpy.uint8],
@@ -6189,7 +6189,7 @@ cdef class PlatformInfo_v2:
 
     @property
     def ib_guid(self):
-        """~_numpy.uint8: (array of length 16).Infiniband GUID reported by platform (for Blackwell, ibGuid is 8 bytes so indices 8-15 are zero)"""
+        """~_numpy.uint8: (array of length 16).Infiniband GUID reported by platform (for Blackwell, ibGuid is 8 bytes so indices 8-15 are zero)."""
         cdef view.array arr = view.array(shape=(16,), itemsize=sizeof(unsigned char), format="B", mode="c", allocate_buffer=False)
         arr.data = <char *>(&(self._ptr[0].ibGuid))
         return _numpy.asarray(arr)
@@ -6206,7 +6206,7 @@ cdef class PlatformInfo_v2:
 
     @property
     def chassis_serial_number(self):
-        """~_numpy.uint8: (array of length 16).Serial number of the chassis containing this GPU (for Blackwell it is 13 bytes so indices 13-15 are zero)"""
+        """~_numpy.uint8: (array of length 16).Serial number of the chassis containing this GPU (for Blackwell it is 13 bytes so indices 13-15 are zero)."""
         cdef view.array arr = view.array(shape=(16,), itemsize=sizeof(unsigned char), format="B", mode="c", allocate_buffer=False)
         arr.data = <char *>(&(self._ptr[0].chassisSerialNumber))
         return _numpy.asarray(arr)
@@ -6223,7 +6223,7 @@ cdef class PlatformInfo_v2:
 
     @property
     def slot_number(self):
-        """int: The slot number in the chassis containing this GPU (includes switches)"""
+        """int: The slot number in the chassis containing this GPU (includes switches)."""
         return self._ptr[0].slotNumber
 
     @slot_number.setter
@@ -6234,7 +6234,7 @@ cdef class PlatformInfo_v2:
 
     @property
     def tray_index(self):
-        """int: The tray index within the compute slots in the chassis containing this GPU (does not include switches)"""
+        """int: The tray index within the compute slots in the chassis containing this GPU (does not include switches)."""
         return self._ptr[0].trayIndex
 
     @tray_index.setter
@@ -6256,7 +6256,7 @@ cdef class PlatformInfo_v2:
 
     @property
     def peer_type(self):
-        """int: Platform indicated NVLink-peer type (e.g. switch present or not)"""
+        """int: Platform indicated NVLink-peer type (e.g. switch present or not)."""
         return self._ptr[0].peerType
 
     @peer_type.setter
@@ -6318,7 +6318,7 @@ cdef class PlatformInfo_v2:
 
 
 cdef _get__py_anon_pod1_dtype_offsets():
-    cdef cuda_bindings_nvml__anon_pod1 pod = cuda_bindings_nvml__anon_pod1()
+    cdef cuda_bindings_nvml__anon_pod1 pod
     return _numpy.dtype({
         'names': ['b_is_present', 'percentage', 'inc_threshold', 'dec_threshold'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32],
@@ -6485,7 +6485,7 @@ cdef class _py_anon_pod1:
 
 
 cdef _get_vgpu_placement_list_v2_dtype_offsets():
-    cdef nvmlVgpuPlacementList_v2_t pod = nvmlVgpuPlacementList_v2_t()
+    cdef nvmlVgpuPlacementList_v2_t pod
     return _numpy.dtype({
         'names': ['version', 'placement_size', 'count', 'placement_ids', 'mode'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.intp, _numpy.uint32],
@@ -6664,7 +6664,7 @@ cdef class VgpuPlacementList_v2:
 
 
 cdef _get_vgpu_type_bar1info_v1_dtype_offsets():
-    cdef nvmlVgpuTypeBar1Info_v1_t pod = nvmlVgpuTypeBar1Info_v1_t()
+    cdef nvmlVgpuTypeBar1Info_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'bar1size'],
         'formats': [_numpy.uint32, _numpy.uint64],
@@ -6807,7 +6807,7 @@ cdef class VgpuTypeBar1Info_v1:
 
 
 cdef _get_vgpu_process_utilization_info_v1_dtype_offsets():
-    cdef nvmlVgpuProcessUtilizationInfo_v1_t pod = nvmlVgpuProcessUtilizationInfo_v1_t()
+    cdef nvmlVgpuProcessUtilizationInfo_v1_t pod
     return _numpy.dtype({
         'names': ['process_name', 'time_stamp', 'vgpu_instance', 'pid', 'sm_util', 'mem_util', 'enc_util', 'dec_util', 'jpg_util', 'ofa_util'],
         'formats': [(_numpy.int8, 64), _numpy.uint64, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32],
@@ -7054,7 +7054,7 @@ cdef class VgpuProcessUtilizationInfo_v1:
 
 
 cdef _get__py_anon_pod2_dtype_offsets():
-    cdef cuda_bindings_nvml__anon_pod2 pod = cuda_bindings_nvml__anon_pod2()
+    cdef cuda_bindings_nvml__anon_pod2 pod
     return _numpy.dtype({
         'names': ['avg_factor', 'timeslice'],
         'formats': [_numpy.uint32, _numpy.uint32],
@@ -7197,7 +7197,7 @@ cdef class _py_anon_pod2:
 
 
 cdef _get__py_anon_pod3_dtype_offsets():
-    cdef cuda_bindings_nvml__anon_pod3 pod = cuda_bindings_nvml__anon_pod3()
+    cdef cuda_bindings_nvml__anon_pod3 pod
     return _numpy.dtype({
         'names': ['timeslice'],
         'formats': [_numpy.uint32],
@@ -7328,7 +7328,7 @@ cdef class _py_anon_pod3:
 
 
 cdef _get_vgpu_scheduler_log_entry_dtype_offsets():
-    cdef nvmlVgpuSchedulerLogEntry_t pod = nvmlVgpuSchedulerLogEntry_t()
+    cdef nvmlVgpuSchedulerLogEntry_t pod
     return _numpy.dtype({
         'names': ['timestamp', 'time_run_total', 'time_run', 'sw_runlist_id', 'target_time_slice', 'cumulative_preemption_time'],
         'formats': [_numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint32, _numpy.uint64, _numpy.uint64],
@@ -7529,7 +7529,7 @@ cdef class VgpuSchedulerLogEntry:
 
 
 cdef _get__py_anon_pod4_dtype_offsets():
-    cdef cuda_bindings_nvml__anon_pod4 pod = cuda_bindings_nvml__anon_pod4()
+    cdef cuda_bindings_nvml__anon_pod4 pod
     return _numpy.dtype({
         'names': ['avg_factor', 'frequency'],
         'formats': [_numpy.uint32, _numpy.uint32],
@@ -7672,7 +7672,7 @@ cdef class _py_anon_pod4:
 
 
 cdef _get__py_anon_pod5_dtype_offsets():
-    cdef cuda_bindings_nvml__anon_pod5 pod = cuda_bindings_nvml__anon_pod5()
+    cdef cuda_bindings_nvml__anon_pod5 pod
     return _numpy.dtype({
         'names': ['timeslice'],
         'formats': [_numpy.uint32],
@@ -7803,7 +7803,7 @@ cdef class _py_anon_pod5:
 
 
 cdef _get_vgpu_scheduler_capabilities_dtype_offsets():
-    cdef nvmlVgpuSchedulerCapabilities_t pod = nvmlVgpuSchedulerCapabilities_t()
+    cdef nvmlVgpuSchedulerCapabilities_t pod
     return _numpy.dtype({
         'names': ['supported_schedulers', 'max_timeslice', 'min_timeslice', 'is_arr_mode_supported', 'max_frequency_for_arr', 'min_frequency_for_arr', 'max_avg_factor_for_arr', 'min_avg_factor_for_arr'],
         'formats': [(_numpy.uint32, 3), _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32],
@@ -8024,7 +8024,7 @@ cdef class VgpuSchedulerCapabilities:
 
 
 cdef _get_vgpu_license_expiry_dtype_offsets():
-    cdef nvmlVgpuLicenseExpiry_t pod = nvmlVgpuLicenseExpiry_t()
+    cdef nvmlVgpuLicenseExpiry_t pod
     return _numpy.dtype({
         'names': ['year', 'month', 'day', 'hour', 'min_', 'sec', 'status'],
         'formats': [_numpy.uint32, _numpy.uint16, _numpy.uint16, _numpy.uint16, _numpy.uint16, _numpy.uint16, _numpy.uint8],
@@ -8227,7 +8227,7 @@ cdef class VgpuLicenseExpiry:
 
 
 cdef _get_grid_license_expiry_dtype_offsets():
-    cdef nvmlGridLicenseExpiry_t pod = nvmlGridLicenseExpiry_t()
+    cdef nvmlGridLicenseExpiry_t pod
     return _numpy.dtype({
         'names': ['year', 'month', 'day', 'hour', 'min_', 'sec', 'status'],
         'formats': [_numpy.uint32, _numpy.uint16, _numpy.uint16, _numpy.uint16, _numpy.uint16, _numpy.uint16, _numpy.uint8],
@@ -8430,7 +8430,7 @@ cdef class GridLicenseExpiry:
 
 
 cdef _get_vgpu_type_id_info_v1_dtype_offsets():
-    cdef nvmlVgpuTypeIdInfo_v1_t pod = nvmlVgpuTypeIdInfo_v1_t()
+    cdef nvmlVgpuTypeIdInfo_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'vgpu_count', 'vgpu_type_ids'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.intp],
@@ -8585,7 +8585,7 @@ cdef class VgpuTypeIdInfo_v1:
 
 
 cdef _get_active_vgpu_instance_info_v1_dtype_offsets():
-    cdef nvmlActiveVgpuInstanceInfo_v1_t pod = nvmlActiveVgpuInstanceInfo_v1_t()
+    cdef nvmlActiveVgpuInstanceInfo_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'vgpu_count', 'vgpu_instances'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.intp],
@@ -8740,7 +8740,7 @@ cdef class ActiveVgpuInstanceInfo_v1:
 
 
 cdef _get_vgpu_creatable_placement_info_v1_dtype_offsets():
-    cdef nvmlVgpuCreatablePlacementInfo_v1_t pod = nvmlVgpuCreatablePlacementInfo_v1_t()
+    cdef nvmlVgpuCreatablePlacementInfo_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'vgpu_type_id', 'count', 'placement_ids', 'placement_size'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.intp, _numpy.uint32],
@@ -8919,7 +8919,7 @@ cdef class VgpuCreatablePlacementInfo_v1:
 
 
 cdef _get_hwbc_entry_dtype_offsets():
-    cdef nvmlHwbcEntry_t pod = nvmlHwbcEntry_t()
+    cdef nvmlHwbcEntry_t pod
     return _numpy.dtype({
         'names': ['hwbc_id', 'firmware_version'],
         'formats': [_numpy.uint32, (_numpy.int8, 32)],
@@ -9070,7 +9070,7 @@ cdef class HwbcEntry:
 
 
 cdef _get_led_state_dtype_offsets():
-    cdef nvmlLedState_t pod = nvmlLedState_t()
+    cdef nvmlLedState_t pod
     return _numpy.dtype({
         'names': ['cause', 'color'],
         'formats': [(_numpy.int8, 256), _numpy.int32],
@@ -9217,7 +9217,7 @@ cdef class LedState:
 
 
 cdef _get_unit_info_dtype_offsets():
-    cdef nvmlUnitInfo_t pod = nvmlUnitInfo_t()
+    cdef nvmlUnitInfo_t pod
     return _numpy.dtype({
         'names': ['name', 'id', 'serial', 'firmware_version'],
         'formats': [(_numpy.int8, 96), (_numpy.int8, 96), (_numpy.int8, 96), (_numpy.int8, 96)],
@@ -9400,7 +9400,7 @@ cdef class UnitInfo:
 
 
 cdef _get_psu_info_dtype_offsets():
-    cdef nvmlPSUInfo_t pod = nvmlPSUInfo_t()
+    cdef nvmlPSUInfo_t pod
     return _numpy.dtype({
         'names': ['state', 'current', 'voltage', 'power'],
         'formats': [(_numpy.int8, 256), _numpy.uint32, _numpy.uint32, _numpy.uint32],
@@ -9571,7 +9571,7 @@ cdef class PSUInfo:
 
 
 cdef _get_unit_fan_info_dtype_offsets():
-    cdef nvmlUnitFanInfo_t pod = nvmlUnitFanInfo_t()
+    cdef nvmlUnitFanInfo_t pod
     return _numpy.dtype({
         'names': ['speed', 'state'],
         'formats': [_numpy.uint32, _numpy.int32],
@@ -9724,7 +9724,7 @@ cdef class UnitFanInfo:
 
 
 cdef _get_event_data_dtype_offsets():
-    cdef nvmlEventData_t pod = nvmlEventData_t()
+    cdef nvmlEventData_t pod
     return _numpy.dtype({
         'names': ['device_', 'event_type', 'event_data', 'gpu_instance_id', 'compute_instance_id'],
         'formats': [_numpy.intp, _numpy.uint64, _numpy.uint64, _numpy.uint32, _numpy.uint32],
@@ -9903,7 +9903,7 @@ cdef class EventData:
 
 
 cdef _get_system_event_data_v1_dtype_offsets():
-    cdef nvmlSystemEventData_v1_t pod = nvmlSystemEventData_v1_t()
+    cdef nvmlSystemEventData_v1_t pod
     return _numpy.dtype({
         'names': ['event_type', 'gpu_id'],
         'formats': [_numpy.uint64, _numpy.uint32],
@@ -10056,7 +10056,7 @@ cdef class SystemEventData_v1:
 
 
 cdef _get_accounting_stats_dtype_offsets():
-    cdef nvmlAccountingStats_t pod = nvmlAccountingStats_t()
+    cdef nvmlAccountingStats_t pod
     return _numpy.dtype({
         'names': ['gpu_utilization', 'memory_utilization', 'max_memory_usage', 'time', 'start_time', 'is_running', 'reserved'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint32, (_numpy.uint32, 5)],
@@ -10248,7 +10248,7 @@ cdef class AccountingStats:
 
 
 cdef _get_encoder_session_info_dtype_offsets():
-    cdef nvmlEncoderSessionInfo_t pod = nvmlEncoderSessionInfo_t()
+    cdef nvmlEncoderSessionInfo_t pod
     return _numpy.dtype({
         'names': ['session_id', 'pid', 'vgpu_instance', 'codec_type', 'h_resolution', 'v_resolution', 'average_fps', 'average_latency'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.int32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32],
@@ -10473,7 +10473,7 @@ cdef class EncoderSessionInfo:
 
 
 cdef _get_fbc_stats_dtype_offsets():
-    cdef nvmlFBCStats_t pod = nvmlFBCStats_t()
+    cdef nvmlFBCStats_t pod
     return _numpy.dtype({
         'names': ['sessions_count', 'average_fps', 'average_latency'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32],
@@ -10628,7 +10628,7 @@ cdef class FBCStats:
 
 
 cdef _get_fbc_session_info_dtype_offsets():
-    cdef nvmlFBCSessionInfo_t pod = nvmlFBCSessionInfo_t()
+    cdef nvmlFBCSessionInfo_t pod
     return _numpy.dtype({
         'names': ['session_id', 'pid', 'vgpu_instance', 'display_ordinal', 'session_type', 'session_flags', 'h_max_resolution', 'v_max_resolution', 'h_resolution', 'v_resolution', 'average_fps', 'average_latency'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.int32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32],
@@ -10901,7 +10901,7 @@ cdef class FBCSessionInfo:
 
 
 cdef _get_conf_compute_system_caps_dtype_offsets():
-    cdef nvmlConfComputeSystemCaps_t pod = nvmlConfComputeSystemCaps_t()
+    cdef nvmlConfComputeSystemCaps_t pod
     return _numpy.dtype({
         'names': ['cpu_caps', 'gpus_caps'],
         'formats': [_numpy.uint32, _numpy.uint32],
@@ -11044,7 +11044,7 @@ cdef class ConfComputeSystemCaps:
 
 
 cdef _get_conf_compute_system_state_dtype_offsets():
-    cdef nvmlConfComputeSystemState_t pod = nvmlConfComputeSystemState_t()
+    cdef nvmlConfComputeSystemState_t pod
     return _numpy.dtype({
         'names': ['environment', 'cc_feature', 'dev_tools_mode'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32],
@@ -11199,7 +11199,7 @@ cdef class ConfComputeSystemState:
 
 
 cdef _get_system_conf_compute_settings_v1_dtype_offsets():
-    cdef nvmlSystemConfComputeSettings_v1_t pod = nvmlSystemConfComputeSettings_v1_t()
+    cdef nvmlSystemConfComputeSettings_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'environment', 'cc_feature', 'dev_tools_mode', 'multi_gpu_mode'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32],
@@ -11378,7 +11378,7 @@ cdef class SystemConfComputeSettings_v1:
 
 
 cdef _get_conf_compute_mem_size_info_dtype_offsets():
-    cdef nvmlConfComputeMemSizeInfo_t pod = nvmlConfComputeMemSizeInfo_t()
+    cdef nvmlConfComputeMemSizeInfo_t pod
     return _numpy.dtype({
         'names': ['protected_mem_size_kib', 'unprotected_mem_size_kib'],
         'formats': [_numpy.uint64, _numpy.uint64],
@@ -11521,7 +11521,7 @@ cdef class ConfComputeMemSizeInfo:
 
 
 cdef _get_conf_compute_gpu_certificate_dtype_offsets():
-    cdef nvmlConfComputeGpuCertificate_t pod = nvmlConfComputeGpuCertificate_t()
+    cdef nvmlConfComputeGpuCertificate_t pod
     return _numpy.dtype({
         'names': ['cert_chain_size', 'attestation_cert_chain_size', 'cert_chain', 'attestation_cert_chain'],
         'formats': [_numpy.uint32, _numpy.uint32, (_numpy.uint8, 4096), (_numpy.uint8, 5120)],
@@ -11688,7 +11688,7 @@ cdef class ConfComputeGpuCertificate:
 
 
 cdef _get_conf_compute_gpu_attestation_report_dtype_offsets():
-    cdef nvmlConfComputeGpuAttestationReport_t pod = nvmlConfComputeGpuAttestationReport_t()
+    cdef nvmlConfComputeGpuAttestationReport_t pod
     return _numpy.dtype({
         'names': ['is_cec_attestation_report_present', 'attestation_report_size', 'cec_attestation_report_size', 'nonce', 'attestation_report', 'cec_attestation_report'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, (_numpy.uint8, 32), (_numpy.uint8, 8192), (_numpy.uint8, 4096)],
@@ -11885,7 +11885,7 @@ cdef class ConfComputeGpuAttestationReport:
 
 
 cdef _get_gpu_fabric_info_v2_dtype_offsets():
-    cdef nvmlGpuFabricInfo_v2_t pod = nvmlGpuFabricInfo_v2_t()
+    cdef nvmlGpuFabricInfo_v2_t pod
     return _numpy.dtype({
         'names': ['version', 'cluster_uuid', 'status', 'clique_id', 'state', 'health_mask'],
         'formats': [_numpy.uint32, (_numpy.uint8, 16), _numpy.int32, _numpy.uint32, _numpy.uint8, _numpy.uint32],
@@ -11970,7 +11970,7 @@ cdef class GpuFabricInfo_v2:
 
     @property
     def version(self):
-        """int: Structure version identifier (set to nvmlGpuFabricInfo_v2)"""
+        """int: Structure version identifier (set to nvmlGpuFabricInfo_v2)."""
         return self._ptr[0].version
 
     @version.setter
@@ -12082,7 +12082,7 @@ cdef class GpuFabricInfo_v2:
 
 
 cdef _get_nvlink_supported_bw_modes_v1_dtype_offsets():
-    cdef nvmlNvlinkSupportedBwModes_v1_t pod = nvmlNvlinkSupportedBwModes_v1_t()
+    cdef nvmlNvlinkSupportedBwModes_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'bw_modes', 'total_bw_modes'],
         'formats': [_numpy.uint32, (_numpy.uint8, 23), _numpy.uint8],
@@ -12237,7 +12237,7 @@ cdef class NvlinkSupportedBwModes_v1:
 
 
 cdef _get_nvlink_get_bw_mode_v1_dtype_offsets():
-    cdef nvmlNvlinkGetBwMode_v1_t pod = nvmlNvlinkGetBwMode_v1_t()
+    cdef nvmlNvlinkGetBwMode_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'b_is_best', 'bw_mode'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint8],
@@ -12392,7 +12392,7 @@ cdef class NvlinkGetBwMode_v1:
 
 
 cdef _get_nvlink_set_bw_mode_v1_dtype_offsets():
-    cdef nvmlNvlinkSetBwMode_v1_t pod = nvmlNvlinkSetBwMode_v1_t()
+    cdef nvmlNvlinkSetBwMode_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'b_set_best', 'bw_mode'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint8],
@@ -12547,7 +12547,7 @@ cdef class NvlinkSetBwMode_v1:
 
 
 cdef _get_vgpu_version_dtype_offsets():
-    cdef nvmlVgpuVersion_t pod = nvmlVgpuVersion_t()
+    cdef nvmlVgpuVersion_t pod
     return _numpy.dtype({
         'names': ['min_version', 'max_version'],
         'formats': [_numpy.uint32, _numpy.uint32],
@@ -12690,7 +12690,7 @@ cdef class VgpuVersion:
 
 
 cdef _get_vgpu_metadata_dtype_offsets():
-    cdef nvmlVgpuMetadata_t pod = nvmlVgpuMetadata_t()
+    cdef nvmlVgpuMetadata_t pod
     return _numpy.dtype({
         'names': ['version', 'revision', 'guest_info_state', 'guest_driver_version', 'host_driver_version', 'reserved', 'vgpu_virtualization_caps', 'guest_vgpu_version', 'opaque_data_size', 'opaque_data'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.int32, (_numpy.int8, 80), (_numpy.int8, 80), (_numpy.uint32, 6), _numpy.uint32, _numpy.uint32, _numpy.uint32, (_numpy.int8, 4)],
@@ -12930,7 +12930,7 @@ cdef class VgpuMetadata:
 
 
 cdef _get_vgpu_pgpu_compatibility_dtype_offsets():
-    cdef nvmlVgpuPgpuCompatibility_t pod = nvmlVgpuPgpuCompatibility_t()
+    cdef nvmlVgpuPgpuCompatibility_t pod
     return _numpy.dtype({
         'names': ['vgpu_vm_compatibility', 'compatibility_limit_code'],
         'formats': [_numpy.int32, _numpy.int32],
@@ -13073,7 +13073,7 @@ cdef class VgpuPgpuCompatibility:
 
 
 cdef _get_gpu_instance_placement_dtype_offsets():
-    cdef nvmlGpuInstancePlacement_t pod = nvmlGpuInstancePlacement_t()
+    cdef nvmlGpuInstancePlacement_t pod
     return _numpy.dtype({
         'names': ['start', 'size_'],
         'formats': [_numpy.uint32, _numpy.uint32],
@@ -13226,7 +13226,7 @@ cdef class GpuInstancePlacement:
 
 
 cdef _get_gpu_instance_profile_info_v3_dtype_offsets():
-    cdef nvmlGpuInstanceProfileInfo_v3_t pod = nvmlGpuInstanceProfileInfo_v3_t()
+    cdef nvmlGpuInstanceProfileInfo_v3_t pod
     return _numpy.dtype({
         'names': ['version', 'id', 'slice_count', 'instance_count', 'multiprocessor_count', 'copy_engine_count', 'decoder_count', 'encoder_count', 'jpeg_count', 'ofa_count', 'memory_size_mb', 'name', 'capabilities'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint64, (_numpy.int8, 96), _numpy.uint32],
@@ -13505,7 +13505,7 @@ cdef class GpuInstanceProfileInfo_v3:
 
 
 cdef _get_compute_instance_placement_dtype_offsets():
-    cdef nvmlComputeInstancePlacement_t pod = nvmlComputeInstancePlacement_t()
+    cdef nvmlComputeInstancePlacement_t pod
     return _numpy.dtype({
         'names': ['start', 'size_'],
         'formats': [_numpy.uint32, _numpy.uint32],
@@ -13658,7 +13658,7 @@ cdef class ComputeInstancePlacement:
 
 
 cdef _get_compute_instance_profile_info_v2_dtype_offsets():
-    cdef nvmlComputeInstanceProfileInfo_v2_t pod = nvmlComputeInstanceProfileInfo_v2_t()
+    cdef nvmlComputeInstanceProfileInfo_v2_t pod
     return _numpy.dtype({
         'names': ['version', 'id', 'slice_count', 'instance_count', 'multiprocessor_count', 'shared_copy_engine_count', 'shared_decoder_count', 'shared_encoder_count', 'shared_jpeg_count', 'shared_ofa_count', 'name'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, (_numpy.int8, 96)],
@@ -13913,7 +13913,7 @@ cdef class ComputeInstanceProfileInfo_v2:
 
 
 cdef _get_compute_instance_profile_info_v3_dtype_offsets():
-    cdef nvmlComputeInstanceProfileInfo_v3_t pod = nvmlComputeInstanceProfileInfo_v3_t()
+    cdef nvmlComputeInstanceProfileInfo_v3_t pod
     return _numpy.dtype({
         'names': ['version', 'id', 'slice_count', 'instance_count', 'multiprocessor_count', 'shared_copy_engine_count', 'shared_decoder_count', 'shared_encoder_count', 'shared_jpeg_count', 'shared_ofa_count', 'name', 'capabilities'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, (_numpy.int8, 96), _numpy.uint32],
@@ -14180,7 +14180,7 @@ cdef class ComputeInstanceProfileInfo_v3:
 
 
 cdef _get_device_addressing_mode_v1_dtype_offsets():
-    cdef nvmlDeviceAddressingMode_v1_t pod = nvmlDeviceAddressingMode_v1_t()
+    cdef nvmlDeviceAddressingMode_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'value'],
         'formats': [_numpy.uint32, _numpy.uint32],
@@ -14323,7 +14323,7 @@ cdef class DeviceAddressingMode_v1:
 
 
 cdef _get_repair_status_v1_dtype_offsets():
-    cdef nvmlRepairStatus_v1_t pod = nvmlRepairStatus_v1_t()
+    cdef nvmlRepairStatus_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'b_channel_repair_pending', 'b_tpc_repair_pending'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32],
@@ -14478,7 +14478,7 @@ cdef class RepairStatus_v1:
 
 
 cdef _get_device_power_mizer_modes_v1_dtype_offsets():
-    cdef nvmlDevicePowerMizerModes_v1_t pod = nvmlDevicePowerMizerModes_v1_t()
+    cdef nvmlDevicePowerMizerModes_v1_t pod
     return _numpy.dtype({
         'names': ['current_mode', 'mode', 'supported_power_mizer_modes'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32],
@@ -14633,7 +14633,7 @@ cdef class DevicePowerMizerModes_v1:
 
 
 cdef _get_ecc_sram_unique_uncorrected_error_entry_v1_dtype_offsets():
-    cdef nvmlEccSramUniqueUncorrectedErrorEntry_v1_t pod = nvmlEccSramUniqueUncorrectedErrorEntry_v1_t()
+    cdef nvmlEccSramUniqueUncorrectedErrorEntry_v1_t pod
     return _numpy.dtype({
         'names': ['unit', 'location', 'sublocation', 'extlocation', 'address', 'is_parity', 'count'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32],
@@ -14846,7 +14846,7 @@ cdef class EccSramUniqueUncorrectedErrorEntry_v1:
 
 
 cdef _get_gpu_fabric_info_v3_dtype_offsets():
-    cdef nvmlGpuFabricInfo_v3_t pod = nvmlGpuFabricInfo_v3_t()
+    cdef nvmlGpuFabricInfo_v3_t pod
     return _numpy.dtype({
         'names': ['version', 'cluster_uuid', 'status', 'clique_id', 'state', 'health_mask', 'health_summary'],
         'formats': [_numpy.uint32, (_numpy.uint8, 16), _numpy.int32, _numpy.uint32, _numpy.uint8, _numpy.uint32, _numpy.uint8],
@@ -14932,7 +14932,7 @@ cdef class GpuFabricInfo_v3:
 
     @property
     def version(self):
-        """int: Structure version identifier (set to nvmlGpuFabricInfo_v2)"""
+        """int: Structure version identifier (set to nvmlGpuFabricInfo_v2)."""
         return self._ptr[0].version
 
     @version.setter
@@ -15055,7 +15055,7 @@ cdef class GpuFabricInfo_v3:
 
 
 cdef _get_nv_link_info_v1_dtype_offsets():
-    cdef nvmlNvLinkInfo_v1_t pod = nvmlNvLinkInfo_v1_t()
+    cdef nvmlNvLinkInfo_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'is_nvle_enabled'],
         'formats': [_numpy.uint32, _numpy.uint32],
@@ -15198,7 +15198,7 @@ cdef class NvLinkInfo_v1:
 
 
 cdef _get_nvlink_firmware_version_dtype_offsets():
-    cdef nvmlNvlinkFirmwareVersion_t pod = nvmlNvlinkFirmwareVersion_t()
+    cdef nvmlNvlinkFirmwareVersion_t pod
     return _numpy.dtype({
         'names': ['ucode_type', 'major', 'minor', 'sub_minor'],
         'formats': [_numpy.uint8, _numpy.uint32, _numpy.uint32, _numpy.uint32],
@@ -15365,7 +15365,7 @@ cdef class NvlinkFirmwareVersion:
 
 
 cdef _get_prm_counter_input_v1_dtype_offsets():
-    cdef nvmlPRMCounterInput_v1_t pod = nvmlPRMCounterInput_v1_t()
+    cdef nvmlPRMCounterInput_v1_t pod
     return _numpy.dtype({
         'names': ['local_port'],
         'formats': [_numpy.uint32],
@@ -15496,7 +15496,7 @@ cdef class PRMCounterInput_v1:
 
 
 cdef _get_vgpu_scheduler_state_info_v2_dtype_offsets():
-    cdef nvmlVgpuSchedulerStateInfo_v2_t pod = nvmlVgpuSchedulerStateInfo_v2_t()
+    cdef nvmlVgpuSchedulerStateInfo_v2_t pod
     return _numpy.dtype({
         'names': ['engine_id', 'scheduler_policy', 'avg_factor', 'timeslice'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32],
@@ -15663,7 +15663,7 @@ cdef class VgpuSchedulerStateInfo_v2:
 
 
 cdef _get_vgpu_scheduler_log_entry_v2_dtype_offsets():
-    cdef nvmlVgpuSchedulerLogEntry_v2_t pod = nvmlVgpuSchedulerLogEntry_v2_t()
+    cdef nvmlVgpuSchedulerLogEntry_v2_t pod
     return _numpy.dtype({
         'names': ['timestamp', 'time_run_total', 'time_run', 'sw_runlist_id', 'target_time_slice', 'cumulative_preemption_time', 'weight'],
         'formats': [_numpy.uint64, _numpy.uint64, _numpy.uint64, _numpy.uint32, _numpy.uint64, _numpy.uint64, _numpy.uint32],
@@ -15876,7 +15876,7 @@ cdef class VgpuSchedulerLogEntry_v2:
 
 
 cdef _get_vgpu_scheduler_state_v2_dtype_offsets():
-    cdef nvmlVgpuSchedulerState_v2_t pod = nvmlVgpuSchedulerState_v2_t()
+    cdef nvmlVgpuSchedulerState_v2_t pod
     return _numpy.dtype({
         'names': ['engine_id', 'scheduler_policy', 'avg_factor', 'frequency'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32],
@@ -16043,7 +16043,7 @@ cdef class VgpuSchedulerState_v2:
 
 
 cdef _get_excluded_device_info_dtype_offsets():
-    cdef nvmlExcludedDeviceInfo_t pod = nvmlExcludedDeviceInfo_t()
+    cdef nvmlExcludedDeviceInfo_t pod
     return _numpy.dtype({
         'names': ['pci_info', 'uuid'],
         'formats': [pci_info_dtype, (_numpy.int8, 80)],
@@ -16191,7 +16191,7 @@ cdef class ExcludedDeviceInfo:
 
 
 cdef _get_process_detail_list_v1_dtype_offsets():
-    cdef nvmlProcessDetailList_v1_t pod = nvmlProcessDetailList_v1_t()
+    cdef nvmlProcessDetailList_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'mode', 'num_proc_array_entries', 'proc_array'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.intp],
@@ -16355,7 +16355,7 @@ cdef class ProcessDetailList_v1:
 
 
 cdef _get_bridge_chip_hierarchy_dtype_offsets():
-    cdef nvmlBridgeChipHierarchy_t pod = nvmlBridgeChipHierarchy_t()
+    cdef nvmlBridgeChipHierarchy_t pod
     return _numpy.dtype({
         'names': ['bridge_count', 'bridge_chip_info'],
         'formats': [_numpy.uint8, (bridge_chip_info_dtype, 128)],
@@ -16493,7 +16493,7 @@ cdef class BridgeChipHierarchy:
 
 
 cdef _get_sample_dtype_offsets():
-    cdef nvmlSample_t pod = nvmlSample_t()
+    cdef nvmlSample_t pod
     return _numpy.dtype({
         'names': ['time_stamp', 'sample_value'],
         'formats': [_numpy.uint64, value_dtype],
@@ -16644,7 +16644,7 @@ cdef class Sample:
 
 
 cdef _get_vgpu_instance_utilization_sample_dtype_offsets():
-    cdef nvmlVgpuInstanceUtilizationSample_t pod = nvmlVgpuInstanceUtilizationSample_t()
+    cdef nvmlVgpuInstanceUtilizationSample_t pod
     return _numpy.dtype({
         'names': ['vgpu_instance', 'time_stamp', 'sm_util', 'mem_util', 'enc_util', 'dec_util'],
         'formats': [_numpy.uint32, _numpy.uint64, value_dtype, value_dtype, value_dtype, value_dtype],
@@ -16837,7 +16837,7 @@ cdef class VgpuInstanceUtilizationSample:
 
 
 cdef _get_vgpu_instance_utilization_info_v1_dtype_offsets():
-    cdef nvmlVgpuInstanceUtilizationInfo_v1_t pod = nvmlVgpuInstanceUtilizationInfo_v1_t()
+    cdef nvmlVgpuInstanceUtilizationInfo_v1_t pod
     return _numpy.dtype({
         'names': ['time_stamp', 'vgpu_instance', 'sm_util', 'mem_util', 'enc_util', 'dec_util', 'jpg_util', 'ofa_util'],
         'formats': [_numpy.uint64, _numpy.uint32, value_dtype, value_dtype, value_dtype, value_dtype, value_dtype, value_dtype],
@@ -17050,7 +17050,7 @@ cdef class VgpuInstanceUtilizationInfo_v1:
 
 
 cdef _get_field_value_dtype_offsets():
-    cdef nvmlFieldValue_t pod = nvmlFieldValue_t()
+    cdef nvmlFieldValue_t pod
     return _numpy.dtype({
         'names': ['field_id', 'scope_id', 'timestamp', 'latency_usec', 'value_type', 'nvml_return', 'value'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.int64, _numpy.int64, _numpy.int32, _numpy.int32, value_dtype],
@@ -17261,7 +17261,7 @@ cdef class FieldValue:
 
 
 cdef _get_prm_counter_value_v1_dtype_offsets():
-    cdef nvmlPRMCounterValue_v1_t pod = nvmlPRMCounterValue_v1_t()
+    cdef nvmlPRMCounterValue_v1_t pod
     return _numpy.dtype({
         'names': ['status', 'output_type', 'output_value'],
         'formats': [_numpy.int32, _numpy.int32, value_dtype],
@@ -17417,7 +17417,7 @@ cdef class PRMCounterValue_v1:
 
 
 cdef _get_gpu_thermal_settings_dtype_offsets():
-    cdef nvmlGpuThermalSettings_t pod = nvmlGpuThermalSettings_t()
+    cdef nvmlGpuThermalSettings_t pod
     return _numpy.dtype({
         'names': ['count', 'sensor'],
         'formats': [_numpy.uint32, (_py_anon_pod0_dtype, 3)],
@@ -17563,7 +17563,7 @@ cdef class GpuThermalSettings:
 
 
 cdef _get_clk_mon_status_dtype_offsets():
-    cdef nvmlClkMonStatus_t pod = nvmlClkMonStatus_t()
+    cdef nvmlClkMonStatus_t pod
     return _numpy.dtype({
         'names': ['b_global_status', 'clk_mon_list_size', 'clk_mon_list'],
         'formats': [_numpy.uint32, _numpy.uint32, (clk_mon_fault_info_dtype, 32)],
@@ -17713,7 +17713,7 @@ cdef class ClkMonStatus:
 
 
 cdef _get_processes_utilization_info_v1_dtype_offsets():
-    cdef nvmlProcessesUtilizationInfo_v1_t pod = nvmlProcessesUtilizationInfo_v1_t()
+    cdef nvmlProcessesUtilizationInfo_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'process_samples_count', 'last_seen_time_stamp', 'proc_util_array'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint64, _numpy.intp],
@@ -17877,7 +17877,7 @@ cdef class ProcessesUtilizationInfo_v1:
 
 
 cdef _get_gpu_dynamic_pstates_info_dtype_offsets():
-    cdef nvmlGpuDynamicPstatesInfo_t pod = nvmlGpuDynamicPstatesInfo_t()
+    cdef nvmlGpuDynamicPstatesInfo_t pod
     return _numpy.dtype({
         'names': ['flags_', 'utilization'],
         'formats': [_numpy.uint32, (_py_anon_pod1_dtype, 8)],
@@ -18023,7 +18023,7 @@ cdef class GpuDynamicPstatesInfo:
 
 
 cdef _get_vgpu_processes_utilization_info_v1_dtype_offsets():
-    cdef nvmlVgpuProcessesUtilizationInfo_v1_t pod = nvmlVgpuProcessesUtilizationInfo_v1_t()
+    cdef nvmlVgpuProcessesUtilizationInfo_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'vgpu_process_count', 'last_seen_time_stamp', 'vgpu_proc_util_array'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint64, _numpy.intp],
@@ -18465,7 +18465,7 @@ cdef class VgpuSchedulerSetParams:
 
 
 cdef _get_vgpu_license_info_dtype_offsets():
-    cdef nvmlVgpuLicenseInfo_t pod = nvmlVgpuLicenseInfo_t()
+    cdef nvmlVgpuLicenseInfo_t pod
     return _numpy.dtype({
         'names': ['is_licensed', 'license_expiry', 'current_state'],
         'formats': [_numpy.uint8, vgpu_license_expiry_dtype, _numpy.uint32],
@@ -18621,7 +18621,7 @@ cdef class VgpuLicenseInfo:
 
 
 cdef _get_grid_licensable_feature_dtype_offsets():
-    cdef nvmlGridLicensableFeature_t pod = nvmlGridLicensableFeature_t()
+    cdef nvmlGridLicensableFeature_t pod
     return _numpy.dtype({
         'names': ['feature_code', 'feature_state', 'license_info', 'product_name', 'feature_enabled', 'license_expiry'],
         'formats': [_numpy.int32, _numpy.uint32, (_numpy.int8, 128), (_numpy.int8, 128), _numpy.uint32, grid_license_expiry_dtype],
@@ -18816,7 +18816,7 @@ cdef class GridLicensableFeature:
 
 
 cdef _get_unit_fan_speeds_dtype_offsets():
-    cdef nvmlUnitFanSpeeds_t pod = nvmlUnitFanSpeeds_t()
+    cdef nvmlUnitFanSpeeds_t pod
     return _numpy.dtype({
         'names': ['fans', 'count'],
         'formats': [(unit_fan_info_dtype, 24), _numpy.uint32],
@@ -18962,7 +18962,7 @@ cdef class UnitFanSpeeds:
 
 
 cdef _get_vgpu_pgpu_metadata_dtype_offsets():
-    cdef nvmlVgpuPgpuMetadata_t pod = nvmlVgpuPgpuMetadata_t()
+    cdef nvmlVgpuPgpuMetadata_t pod
     return _numpy.dtype({
         'names': ['version', 'revision', 'host_driver_version', 'pgpu_virtualization_caps', 'reserved', 'host_supported_vgpu_range', 'opaque_data_size', 'opaque_data'],
         'formats': [_numpy.uint32, _numpy.uint32, (_numpy.int8, 80), _numpy.uint32, (_numpy.uint32, 5), vgpu_version_dtype, _numpy.uint32, (_numpy.int8, 4)],
@@ -19175,7 +19175,7 @@ cdef class VgpuPgpuMetadata:
 
 
 cdef _get_gpu_instance_info_dtype_offsets():
-    cdef nvmlGpuInstanceInfo_t pod = nvmlGpuInstanceInfo_t()
+    cdef nvmlGpuInstanceInfo_t pod
     return _numpy.dtype({
         'names': ['device_', 'id', 'profile_id', 'placement'],
         'formats': [_numpy.intp, _numpy.uint32, _numpy.uint32, gpu_instance_placement_dtype],
@@ -19343,7 +19343,7 @@ cdef class GpuInstanceInfo:
 
 
 cdef _get_compute_instance_info_dtype_offsets():
-    cdef nvmlComputeInstanceInfo_t pod = nvmlComputeInstanceInfo_t()
+    cdef nvmlComputeInstanceInfo_t pod
     return _numpy.dtype({
         'names': ['device_', 'gpu_instance', 'id', 'profile_id', 'placement'],
         'formats': [_numpy.intp, _numpy.intp, _numpy.uint32, _numpy.uint32, compute_instance_placement_dtype],
@@ -19523,7 +19523,7 @@ cdef class ComputeInstanceInfo:
 
 
 cdef _get_ecc_sram_unique_uncorrected_error_counts_v1_dtype_offsets():
-    cdef nvmlEccSramUniqueUncorrectedErrorCounts_v1_t pod = nvmlEccSramUniqueUncorrectedErrorCounts_v1_t()
+    cdef nvmlEccSramUniqueUncorrectedErrorCounts_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'entry_count', 'entries'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.intp],
@@ -19675,7 +19675,7 @@ cdef class EccSramUniqueUncorrectedErrorCounts_v1:
 
 
 cdef _get_nvlink_firmware_info_dtype_offsets():
-    cdef nvmlNvlinkFirmwareInfo_t pod = nvmlNvlinkFirmwareInfo_t()
+    cdef nvmlNvlinkFirmwareInfo_t pod
     return _numpy.dtype({
         'names': ['firmware_version', 'num_valid_entries'],
         'formats': [(nvlink_firmware_version_dtype, 100), _numpy.uint32],
@@ -19821,7 +19821,7 @@ cdef class NvlinkFirmwareInfo:
 
 
 cdef _get_vgpu_scheduler_log_info_v2_dtype_offsets():
-    cdef nvmlVgpuSchedulerLogInfo_v2_t pod = nvmlVgpuSchedulerLogInfo_v2_t()
+    cdef nvmlVgpuSchedulerLogInfo_v2_t pod
     return _numpy.dtype({
         'names': ['engine_id', 'scheduler_policy', 'avg_factor', 'timeslice', 'entries_count', 'log_entries'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, (vgpu_scheduler_log_entry_v2_dtype, 200)],
@@ -20015,7 +20015,7 @@ cdef class VgpuSchedulerLogInfo_v2:
 
 
 cdef _get_vgpu_instances_utilization_info_v1_dtype_offsets():
-    cdef nvmlVgpuInstancesUtilizationInfo_v1_t pod = nvmlVgpuInstancesUtilizationInfo_v1_t()
+    cdef nvmlVgpuInstancesUtilizationInfo_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'sample_val_type', 'vgpu_instance_count', 'last_seen_time_stamp', 'vgpu_util_array'],
         'formats': [_numpy.uint32, _numpy.int32, _numpy.uint32, _numpy.uint64, _numpy.intp],
@@ -20191,7 +20191,7 @@ cdef class VgpuInstancesUtilizationInfo_v1:
 
 
 cdef _get_prm_counter_v1_dtype_offsets():
-    cdef nvmlPRMCounter_v1_t pod = nvmlPRMCounter_v1_t()
+    cdef nvmlPRMCounter_v1_t pod
     return _numpy.dtype({
         'names': ['counter_id', 'in_data', 'counter_value'],
         'formats': [_numpy.uint32, prm_counter_input_v1_dtype, prm_counter_value_v1_dtype],
@@ -20352,7 +20352,7 @@ cdef class PRMCounter_v1:
 
 
 cdef _get_vgpu_scheduler_log_dtype_offsets():
-    cdef nvmlVgpuSchedulerLog_t pod = nvmlVgpuSchedulerLog_t()
+    cdef nvmlVgpuSchedulerLog_t pod
     return _numpy.dtype({
         'names': ['engine_id', 'scheduler_policy', 'arr_mode', 'scheduler_params', 'entries_count', 'log_entries'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, vgpu_scheduler_params_dtype, _numpy.uint32, (vgpu_scheduler_log_entry_dtype, 200)],
@@ -20547,7 +20547,7 @@ cdef class VgpuSchedulerLog:
 
 
 cdef _get_vgpu_scheduler_get_state_dtype_offsets():
-    cdef nvmlVgpuSchedulerGetState_t pod = nvmlVgpuSchedulerGetState_t()
+    cdef nvmlVgpuSchedulerGetState_t pod
     return _numpy.dtype({
         'names': ['scheduler_policy', 'arr_mode', 'scheduler_params'],
         'formats': [_numpy.uint32, _numpy.uint32, vgpu_scheduler_params_dtype],
@@ -20703,7 +20703,7 @@ cdef class VgpuSchedulerGetState:
 
 
 cdef _get_vgpu_scheduler_state_info_v1_dtype_offsets():
-    cdef nvmlVgpuSchedulerStateInfo_v1_t pod = nvmlVgpuSchedulerStateInfo_v1_t()
+    cdef nvmlVgpuSchedulerStateInfo_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'engine_id', 'scheduler_policy', 'arr_mode', 'scheduler_params'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, vgpu_scheduler_params_dtype],
@@ -20883,7 +20883,7 @@ cdef class VgpuSchedulerStateInfo_v1:
 
 
 cdef _get_vgpu_scheduler_log_info_v1_dtype_offsets():
-    cdef nvmlVgpuSchedulerLogInfo_v1_t pod = nvmlVgpuSchedulerLogInfo_v1_t()
+    cdef nvmlVgpuSchedulerLogInfo_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'engine_id', 'scheduler_policy', 'arr_mode', 'scheduler_params', 'entries_count', 'log_entries'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, vgpu_scheduler_params_dtype, _numpy.uint32, (vgpu_scheduler_log_entry_dtype, 200)],
@@ -21090,7 +21090,7 @@ cdef class VgpuSchedulerLogInfo_v1:
 
 
 cdef _get_vgpu_scheduler_state_v1_dtype_offsets():
-    cdef nvmlVgpuSchedulerState_v1_t pod = nvmlVgpuSchedulerState_v1_t()
+    cdef nvmlVgpuSchedulerState_v1_t pod
     return _numpy.dtype({
         'names': ['version', 'engine_id', 'scheduler_policy', 'enable_arr_mode', 'scheduler_params'],
         'formats': [_numpy.uint32, _numpy.uint32, _numpy.uint32, _numpy.uint32, vgpu_scheduler_set_params_dtype],
@@ -21270,7 +21270,7 @@ cdef class VgpuSchedulerState_v1:
 
 
 cdef _get_grid_licensable_features_dtype_offsets():
-    cdef nvmlGridLicensableFeatures_t pod = nvmlGridLicensableFeatures_t()
+    cdef nvmlGridLicensableFeatures_t pod
     return _numpy.dtype({
         'names': ['is_grid_license_supported', 'licensable_features_count', 'grid_licensable_features'],
         'formats': [_numpy.int32, _numpy.uint32, (grid_licensable_feature_dtype, 3)],
@@ -21420,7 +21420,7 @@ cdef class GridLicensableFeatures:
 
 
 cdef _get_nv_link_info_v2_dtype_offsets():
-    cdef nvmlNvLinkInfo_v2_t pod = nvmlNvLinkInfo_v2_t()
+    cdef nvmlNvLinkInfo_v2_t pod
     return _numpy.dtype({
         'names': ['version', 'is_nvle_enabled', 'firmware_info'],
         'formats': [_numpy.uint32, _numpy.uint32, nvlink_firmware_info_dtype],
@@ -23626,7 +23626,7 @@ cpdef object device_get_fbc_stats(intptr_t device):
         device (intptr_t): The identifier of the target device.
 
     Returns:
-        nvmlFBCStats_t: Reference to nvmlFBCStats_t structure containing NvFBC stats.
+        nvmlFBCStats_t: Reference to ``nvmlFBCStats_t`` structure containing NvFBC stats.
 
     .. seealso:: `nvmlDeviceGetFBCStats`
     """
@@ -25656,7 +25656,7 @@ cpdef object vgpu_instance_get_fbc_stats(unsigned int vgpu_instance):
         vgpu_instance (unsigned int): Identifier of the target vGPU instance.
 
     Returns:
-        nvmlFBCStats_t: Reference to nvmlFBCStats_t structure containing NvFBC stats.
+        nvmlFBCStats_t: Reference to ``nvmlFBCStats_t`` structure containing NvFBC stats.
 
     .. seealso:: `nvmlVgpuInstanceGetFBCStats`
     """
@@ -25779,7 +25779,7 @@ cpdef gpu_instance_set_vgpu_scheduler_state(intptr_t gpu_instance, intptr_t p_sc
 
     Args:
         gpu_instance (intptr_t): The GPU instance handle.
-        p_scheduler (intptr_t): Pointer to the caller-provided structure of nvmlVgpuSchedulerState_t.
+        p_scheduler (intptr_t): Pointer to the caller-provided structure of ``nvmlVgpuSchedulerState_t``.
 
     .. seealso:: `nvmlGpuInstanceSetVgpuSchedulerState`
     """

--- a/cuda_bindings/cuda/bindings/nvrtc.pxd
+++ b/cuda_bindings/cuda/bindings/nvrtc.pxd
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.3.0, generator version 0.3.1.dev1738+g1060a290f. Do not modify it directly.
+# This code was automatically generated with version 13.3.0, generator version 0.3.1.dev1752+g89e531539. Do not modify it directly.
 cimport cuda.bindings.cynvrtc as cynvrtc
 
 include "_lib/utils.pxd"

--- a/cuda_bindings/cuda/bindings/nvrtc.pyx
+++ b/cuda_bindings/cuda/bindings/nvrtc.pyx
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.3.0, generator version 0.3.1.dev1738+g1060a290f. Do not modify it directly.
+# This code was automatically generated with version 13.3.0, generator version 0.3.1.dev1752+g89e531539. Do not modify it directly.
 from typing import Any, Optional
 import cython
 import ctypes
@@ -58,8 +58,9 @@ NVRTC_INSTALL_HEADERS_NO_WAIT = cynvrtc.NVRTC_INSTALL_HEADERS_NO_WAIT
 
 class nvrtcResult(_FastEnum):
     """
-    The enumerated type nvrtcResult defines API call result codes.
-    NVRTC API functions return nvrtcResult to indicate the call result.
+    The enumerated type :py:obj:`~.nvrtcResult` defines API call result
+    codes. NVRTC API functions return :py:obj:`~.nvrtcResult` to
+    indicate the call result.
     """
 
     NVRTC_SUCCESS = cynvrtc.nvrtcResult.NVRTC_SUCCESS
@@ -316,7 +317,7 @@ cdef class nvrtcBundledHeadersInfo(anon_struct0):
 
 @cython.embedsignature(True)
 def nvrtcGetErrorString(result not None : nvrtcResult):
-    """ nvrtcGetErrorString is a helper function that returns a string describing the given nvrtcResult code, e.g., NVRTC_SUCCESS to `"NVRTC_SUCCESS"`. For unrecognized enumeration values, it returns `"NVRTC_ERROR unknown"`.
+    """ nvrtcGetErrorString is a helper function that returns a string describing the given :py:obj:`~.nvrtcResult` code, e.g., NVRTC_SUCCESS to `"NVRTC_SUCCESS"`. For unrecognized enumeration values, it returns `"NVRTC_ERROR unknown"`.
 
     Parameters
     ----------
@@ -404,7 +405,7 @@ def nvrtcGetSupportedArchs():
 
 @cython.embedsignature(True)
 def nvrtcCreateProgram(char* src, char* name, int numHeaders, headers : Optional[tuple[bytes] | list[bytes]], includeNames : Optional[tuple[bytes] | list[bytes]]):
-    """ nvrtcCreateProgram creates an instance of nvrtcProgram with the given input parameters, and sets the output parameter `prog` with it.
+    """ nvrtcCreateProgram creates an instance of :py:obj:`~.nvrtcProgram` with the given input parameters, and sets the output parameter `prog` with it.
 
     Parameters
     ----------

--- a/cuda_bindings/cuda/bindings/runtime.pyx.in
+++ b/cuda_bindings/cuda/bindings/runtime.pyx.in
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
-# This code was automatically generated with version 13.3.0, generator version 0.3.1.dev1630+gadce055ea.d20260422. Do not modify it directly.
+# This code was automatically generated with version 13.3.0, generator version 0.3.1.dev1752+g89e531539. Do not modify it directly.
 from typing import Any, Optional
 import cython
 import ctypes
@@ -83,16 +83,16 @@ cudaStreamNonBlocking = cyruntime.cudaStreamNonBlocking
 
 #: Legacy stream handle
 #:
-#: Stream handle that can be passed as a cudaStream_t to use an implicit
-#: stream with legacy synchronization behavior.
+#: Stream handle that can be passed as a :py:obj:`~.cudaStream_t` to use an
+#: implicit stream with legacy synchronization behavior.
 #:
 #: See details of the \link_sync_behavior
 cudaStreamLegacy = cyruntime.cudaStreamLegacy
 
 #: Per-thread stream handle
 #:
-#: Stream handle that can be passed as a cudaStream_t to use an implicit
-#: stream with per-thread synchronization behavior.
+#: Stream handle that can be passed as a :py:obj:`~.cudaStream_t` to use an
+#: implicit stream with per-thread synchronization behavior.
 #:
 #: See details of the \link_sync_behavior
 cudaStreamPerThread = cyruntime.cudaStreamPerThread
@@ -136,7 +136,9 @@ cudaDeviceScheduleYield = cyruntime.cudaDeviceScheduleYield
 #: Device flag - Use blocking synchronization
 cudaDeviceScheduleBlockingSync = cyruntime.cudaDeviceScheduleBlockingSync
 
-#: Device flag - Use blocking synchronization [Deprecated]
+#: Device flag - Use blocking synchronization
+#:
+#: [Deprecated]
 cudaDeviceBlockingSync = cyruntime.cudaDeviceBlockingSync
 
 #: Device schedule flags mask
@@ -443,14 +445,16 @@ class cudaError_t(_FastEnum):
     cudaErrorInvalidHostPointer = (
         cyruntime.cudaError.cudaErrorInvalidHostPointer,
         'This indicates that at least one host pointer passed to the API call is not\n'
-        'a valid host pointer. [Deprecated]\n'
+        'a valid host pointer.\n'
+        '[Deprecated]\n'
     ){{endif}}
     {{if 'cudaErrorInvalidDevicePointer' in found_values}}
 
     cudaErrorInvalidDevicePointer = (
         cyruntime.cudaError.cudaErrorInvalidDevicePointer,
         'This indicates that at least one device pointer passed to the API call is\n'
-        'not a valid device pointer. [Deprecated]\n'
+        'not a valid device pointer.\n'
+        '[Deprecated]\n'
     ){{endif}}
     {{if 'cudaErrorInvalidTexture' in found_values}}
 
@@ -486,28 +490,32 @@ class cudaError_t(_FastEnum):
     cudaErrorAddressOfConstant = (
         cyruntime.cudaError.cudaErrorAddressOfConstant,
         'This indicated that the user has taken the address of a constant variable,\n'
-        'which was forbidden up until the CUDA 3.1 release. [Deprecated]\n'
+        'which was forbidden up until the CUDA 3.1 release.\n'
+        '[Deprecated]\n'
     ){{endif}}
     {{if 'cudaErrorTextureFetchFailed' in found_values}}
 
     cudaErrorTextureFetchFailed = (
         cyruntime.cudaError.cudaErrorTextureFetchFailed,
         'This indicated that a texture fetch was not able to be performed. This was\n'
-        'previously used for device emulation of texture operations. [Deprecated]\n'
+        'previously used for device emulation of texture operations.\n'
+        '[Deprecated]\n'
     ){{endif}}
     {{if 'cudaErrorTextureNotBound' in found_values}}
 
     cudaErrorTextureNotBound = (
         cyruntime.cudaError.cudaErrorTextureNotBound,
         'This indicated that a texture was not bound for access. This was previously\n'
-        'used for device emulation of texture operations. [Deprecated]\n'
+        'used for device emulation of texture operations.\n'
+        '[Deprecated]\n'
     ){{endif}}
     {{if 'cudaErrorSynchronizationError' in found_values}}
 
     cudaErrorSynchronizationError = (
         cyruntime.cudaError.cudaErrorSynchronizationError,
         'This indicated that a synchronization operation had failed. This was\n'
-        'previously used for some device emulation functions. [Deprecated]\n'
+        'previously used for some device emulation functions.\n'
+        '[Deprecated]\n'
     ){{endif}}
     {{if 'cudaErrorInvalidFilterSetting' in found_values}}
 
@@ -527,21 +535,24 @@ class cudaError_t(_FastEnum):
 
     cudaErrorMixedDeviceExecution = (
         cyruntime.cudaError.cudaErrorMixedDeviceExecution,
-        'Mixing of device and device emulation code was not allowed. [Deprecated]\n'
+        'Mixing of device and device emulation code was not allowed.\n'
+        '[Deprecated]\n'
     ){{endif}}
     {{if 'cudaErrorNotYetImplemented' in found_values}}
 
     cudaErrorNotYetImplemented = (
         cyruntime.cudaError.cudaErrorNotYetImplemented,
         'This indicates that the API call is not yet implemented. Production\n'
-        'releases of CUDA will never return this error. [Deprecated]\n'
+        'releases of CUDA will never return this error.\n'
+        '[Deprecated]\n'
     ){{endif}}
     {{if 'cudaErrorMemoryValueTooLarge' in found_values}}
 
     cudaErrorMemoryValueTooLarge = (
         cyruntime.cudaError.cudaErrorMemoryValueTooLarge,
         'This indicated that an emulated device pointer exceeded the 32-bit address\n'
-        'range. [Deprecated]\n'
+        'range.\n'
+        '[Deprecated]\n'
     ){{endif}}
     {{if 'cudaErrorStubLibrary' in found_values}}
 
@@ -618,7 +629,7 @@ class cudaError_t(_FastEnum):
         'Driver context was created using an older version of the API, because the\n'
         'Runtime API call expects a primary driver context and the Driver context is\n'
         'not primary, or because the Driver context has been destroyed. Please see\n'
-        ':py:obj:`~.Interactions`with the CUDA Driver API" for more information.\n'
+        ':py:obj:`~.Interactions with the CUDA Driver API` for more information.\n'
     ){{endif}}
     {{if 'cudaErrorMissingConfiguration' in found_values}}
 
@@ -633,7 +644,8 @@ class cudaError_t(_FastEnum):
     cudaErrorPriorLaunchFailure = (
         cyruntime.cudaError.cudaErrorPriorLaunchFailure,
         'This indicated that a previous kernel launch failed. This was previously\n'
-        'used for device emulation of kernel launches. [Deprecated]\n'
+        'used for device emulation of kernel launches.\n'
+        '[Deprecated]\n'
     ){{endif}}
     {{if 'cudaErrorLaunchMaxDepthExceeded' in found_values}}
 
@@ -3871,7 +3883,7 @@ class cudaFuncCache(_FastEnum):
 
 class cudaSharedMemConfig(_FastEnum):
     """
-    CUDA shared memory configuration [Deprecated]
+    CUDA shared memory configuration  [Deprecated]
     """
     {{if 'cudaSharedMemBankSizeDefault' in found_values}}
     cudaSharedMemBankSizeDefault = cyruntime.cudaSharedMemConfig.cudaSharedMemBankSizeDefault{{endif}}
@@ -5074,14 +5086,15 @@ class cudaMemPoolAttr(_FastEnum):
 
     cudaMemPoolAttrAllocationType = (
         cyruntime.cudaMemPoolAttr.cudaMemPoolAttrAllocationType,
-        '(value type = cudaMemAllocationType) The allocation type of the mempool\n'
+        '(value type = :py:obj:`~.cudaMemAllocationType`) The allocation type of the\n'
+        'mempool\n'
     ){{endif}}
     {{if 'cudaMemPoolAttrExportHandleTypes' in found_values}}
 
     cudaMemPoolAttrExportHandleTypes = (
         cyruntime.cudaMemPoolAttr.cudaMemPoolAttrExportHandleTypes,
-        '(value type = cudaMemAllocationHandleType) Available export handle types\n'
-        'for the mempool. For imported pools this value is always\n'
+        '(value type = :py:obj:`~.cudaMemAllocationHandleType`) Available export\n'
+        'handle types for the mempool. For imported pools this value is always\n'
         'cudaMemHandleTypeNone as an imported pool cannot be re-exported\n'
     ){{endif}}
     {{if 'cudaMemPoolAttrLocationId' in found_values}}
@@ -5096,10 +5109,10 @@ class cudaMemPoolAttr(_FastEnum):
 
     cudaMemPoolAttrLocationType = (
         cyruntime.cudaMemPoolAttr.cudaMemPoolAttrLocationType,
-        '(value type = cudaMemLocationType) The location type for the mempool. For\n'
-        'imported memory pools where the device is not directly visible to the\n'
-        'importing process or pools imported via fabric handles across nodes this\n'
-        'will be cudaMemLocationTypeInvisible\n'
+        '(value type = :py:obj:`~.cudaMemLocationType`) The location type for the\n'
+        'mempool. For imported memory pools where the device is not directly visible\n'
+        'to the importing process or pools imported via fabric handles across nodes\n'
+        'this will be cudaMemLocationTypeInvisible\n'
     ){{endif}}
     {{if 'cudaMemPoolAttrMaxPoolSize' in found_values}}
 
@@ -5255,7 +5268,8 @@ class cudaMemAllocationHandleType(_FastEnum):
 
     cudaMemHandleTypeFabric = (
         cyruntime.cudaMemAllocationHandleType.cudaMemHandleTypeFabric,
-        'Allows a fabric handle to be used for exporting. (cudaMemFabricHandle_t)\n'
+        'Allows a fabric handle to be used for exporting.\n'
+        '(:py:obj:`~.cudaMemFabricHandle_t`)\n'
     ){{endif}}
 
 {{endif}}
@@ -5976,13 +5990,13 @@ class cudaKernelFunctionType(_FastEnum):
 
     cudaKernelFunctionTypeKernel = (
         cyruntime.cudaKernelFunctionType.cudaKernelFunctionTypeKernel,
-        'Function handle is a cudaKernel_t\n'
+        'Function handle is a :py:obj:`~.cudaKernel_t`\n'
     ){{endif}}
     {{if 'cudaKernelFunctionTypeFunction' in found_values}}
 
     cudaKernelFunctionTypeFunction = (
         cyruntime.cudaKernelFunctionType.cudaKernelFunctionTypeFunction,
-        'Function handle is a cudaFunction_t\n'
+        'Function handle is a :py:obj:`~.cudaFunction_t`\n'
     ){{endif}}
 
 {{endif}}
@@ -6376,7 +6390,7 @@ class cudaGraphDebugDotFlags(_FastEnum):
 
     cudaGraphDebugDotFlagsEventNodeParams = (
         cyruntime.cudaGraphDebugDotFlags.cudaGraphDebugDotFlagsEventNodeParams,
-        'Adds cudaEvent_t handle from record and wait nodes to output\n'
+        'Adds :py:obj:`~.cudaEvent_t` handle from record and wait nodes to output\n'
     ){{endif}}
     {{if 'cudaGraphDebugDotFlagsExtSemasSignalNodeParams' in found_values}}
 
@@ -22131,9 +22145,11 @@ def cudaDeviceFlushGPUDirectRDMAWrites(target not None : cudaFlushGPUDirectRDMAW
     Parameters
     ----------
     target : :py:obj:`~.cudaFlushGPUDirectRDMAWritesTarget`
-        The target of the operation, see cudaFlushGPUDirectRDMAWritesTarget
+        The target of the operation, see
+        :py:obj:`~.cudaFlushGPUDirectRDMAWritesTarget`
     scope : :py:obj:`~.cudaFlushGPUDirectRDMAWritesScope`
-        The scope of the operation, see cudaFlushGPUDirectRDMAWritesScope
+        The scope of the operation, see
+        :py:obj:`~.cudaFlushGPUDirectRDMAWritesScope`
 
     Returns
     -------
@@ -26167,7 +26183,7 @@ def cudaFuncSetAttribute(func, attr not None : cudaFuncAttribute, int value):
 
     - :py:obj:`~.cudaFuncAttributeClusterSchedulingPolicyPreference`: The
       block scheduling policy of a function. The value type is
-      cudaClusterSchedulingPolicy.
+      :py:obj:`~.cudaClusterSchedulingPolicy`.
 
     cudaLaunchKernel (C++ API), cudaFuncSetCacheConfig (C++ API),
     :py:obj:`~.cudaFuncGetAttributes (C API)`,
@@ -27521,7 +27537,7 @@ def cudaMalloc3D(extent not None : cudaExtent):
 
     See Also
     --------
-    :py:obj:`~.cudaMallocPitch`, :py:obj:`~.cudaFree`, :py:obj:`~.cudaMemcpy3D`, :py:obj:`~.cudaMemset3D`, :py:obj:`~.cudaMalloc3DArray`, :py:obj:`~.cudaMallocArray`, :py:obj:`~.cudaFreeArray`, :py:obj:`~.cudaMallocHost (C API)`, :py:obj:`~.cudaFreeHost`, :py:obj:`~.cudaHostAlloc`, make_cudaPitchedPtr, make_cudaExtent, :py:obj:`~.cuMemAllocPitch`
+    :py:obj:`~.cudaMallocPitch`, :py:obj:`~.cudaFree`, :py:obj:`~.cudaMemcpy3D`, :py:obj:`~.cudaMemset3D`, :py:obj:`~.cudaMalloc3DArray`, :py:obj:`~.cudaMallocArray`, :py:obj:`~.cudaFreeArray`, :py:obj:`~.cudaMallocHost (C API)`, :py:obj:`~.cudaFreeHost`, :py:obj:`~.cudaHostAlloc`, :py:obj:`~.make_cudaPitchedPtr`, :py:obj:`~.make_cudaExtent`, :py:obj:`~.cuMemAllocPitch`
     """
     cdef cudaPitchedPtr pitchedDevPtr = cudaPitchedPtr()
     with nogil:
@@ -27643,7 +27659,7 @@ def cudaMalloc3DArray(desc : Optional[cudaChannelFormatDesc], extent not None : 
 
     See Also
     --------
-    :py:obj:`~.cudaMalloc3D`, :py:obj:`~.cudaMalloc`, :py:obj:`~.cudaMallocPitch`, :py:obj:`~.cudaFree`, :py:obj:`~.cudaFreeArray`, :py:obj:`~.cudaMallocHost (C API)`, :py:obj:`~.cudaFreeHost`, :py:obj:`~.cudaHostAlloc`, make_cudaExtent, :py:obj:`~.cuArray3DCreate`
+    :py:obj:`~.cudaMalloc3D`, :py:obj:`~.cudaMalloc`, :py:obj:`~.cudaMallocPitch`, :py:obj:`~.cudaFree`, :py:obj:`~.cudaFreeArray`, :py:obj:`~.cudaMallocHost (C API)`, :py:obj:`~.cudaFreeHost`, :py:obj:`~.cudaHostAlloc`, :py:obj:`~.make_cudaExtent`, :py:obj:`~.cuArray3DCreate`
     """
     cdef cudaArray_t array = cudaArray_t()
     cdef cyruntime.cudaChannelFormatDesc* cydesc_ptr = <cyruntime.cudaChannelFormatDesc*>desc._pvt_ptr if desc is not None else NULL
@@ -27769,7 +27785,7 @@ def cudaMallocMipmappedArray(desc : Optional[cudaChannelFormatDesc], extent not 
 
     See Also
     --------
-    :py:obj:`~.cudaMalloc3D`, :py:obj:`~.cudaMalloc`, :py:obj:`~.cudaMallocPitch`, :py:obj:`~.cudaFree`, :py:obj:`~.cudaFreeArray`, :py:obj:`~.cudaMallocHost (C API)`, :py:obj:`~.cudaFreeHost`, :py:obj:`~.cudaHostAlloc`, make_cudaExtent, :py:obj:`~.cuMipmappedArrayCreate`
+    :py:obj:`~.cudaMalloc3D`, :py:obj:`~.cudaMalloc`, :py:obj:`~.cudaMallocPitch`, :py:obj:`~.cudaFree`, :py:obj:`~.cudaFreeArray`, :py:obj:`~.cudaMallocHost (C API)`, :py:obj:`~.cudaFreeHost`, :py:obj:`~.cudaHostAlloc`, :py:obj:`~.make_cudaExtent`, :py:obj:`~.cuMipmappedArrayCreate`
     """
     cdef cudaMipmappedArray_t mipmappedArray = cudaMipmappedArray_t()
     cdef cyruntime.cudaChannelFormatDesc* cydesc_ptr = <cyruntime.cudaChannelFormatDesc*>desc._pvt_ptr if desc is not None else NULL
@@ -27811,7 +27827,7 @@ def cudaGetMipmappedArrayLevel(mipmappedArray, unsigned int level):
 
     See Also
     --------
-    :py:obj:`~.cudaMalloc3D`, :py:obj:`~.cudaMalloc`, :py:obj:`~.cudaMallocPitch`, :py:obj:`~.cudaFree`, :py:obj:`~.cudaFreeArray`, :py:obj:`~.cudaMallocHost (C API)`, :py:obj:`~.cudaFreeHost`, :py:obj:`~.cudaHostAlloc`, make_cudaExtent, :py:obj:`~.cuMipmappedArrayGetLevel`
+    :py:obj:`~.cudaMalloc3D`, :py:obj:`~.cudaMalloc`, :py:obj:`~.cudaMallocPitch`, :py:obj:`~.cudaFree`, :py:obj:`~.cudaFreeArray`, :py:obj:`~.cudaMallocHost (C API)`, :py:obj:`~.cudaFreeHost`, :py:obj:`~.cudaHostAlloc`, :py:obj:`~.make_cudaExtent`, :py:obj:`~.cuMipmappedArrayGetLevel`
     """
     cdef cyruntime.cudaMipmappedArray_const_t cymipmappedArray
     if mipmappedArray is None:
@@ -27905,7 +27921,7 @@ def cudaMemcpy3D(p : Optional[cudaMemcpy3DParms]):
 
     See Also
     --------
-    :py:obj:`~.cudaMalloc3D`, :py:obj:`~.cudaMalloc3DArray`, :py:obj:`~.cudaMemset3D`, :py:obj:`~.cudaMemcpy3DAsync`, :py:obj:`~.cudaMemcpy`, :py:obj:`~.cudaMemcpy2D`, :py:obj:`~.cudaMemcpy2DToArray`, :py:obj:`~.cudaMemcpy2DFromArray`, :py:obj:`~.cudaMemcpy2DArrayToArray`, :py:obj:`~.cudaMemcpyToSymbol`, :py:obj:`~.cudaMemcpyFromSymbol`, :py:obj:`~.cudaMemcpyAsync`, :py:obj:`~.cudaMemcpy2DAsync`, :py:obj:`~.cudaMemcpy2DToArrayAsync`, :py:obj:`~.cudaMemcpy2DFromArrayAsync`, :py:obj:`~.cudaMemcpyToSymbolAsync`, :py:obj:`~.cudaMemcpyFromSymbolAsync`, make_cudaExtent, make_cudaPos, :py:obj:`~.cuMemcpy3D`
+    :py:obj:`~.cudaMalloc3D`, :py:obj:`~.cudaMalloc3DArray`, :py:obj:`~.cudaMemset3D`, :py:obj:`~.cudaMemcpy3DAsync`, :py:obj:`~.cudaMemcpy`, :py:obj:`~.cudaMemcpy2D`, :py:obj:`~.cudaMemcpy2DToArray`, :py:obj:`~.cudaMemcpy2DFromArray`, :py:obj:`~.cudaMemcpy2DArrayToArray`, :py:obj:`~.cudaMemcpyToSymbol`, :py:obj:`~.cudaMemcpyFromSymbol`, :py:obj:`~.cudaMemcpyAsync`, :py:obj:`~.cudaMemcpy2DAsync`, :py:obj:`~.cudaMemcpy2DToArrayAsync`, :py:obj:`~.cudaMemcpy2DFromArrayAsync`, :py:obj:`~.cudaMemcpyToSymbolAsync`, :py:obj:`~.cudaMemcpyFromSymbolAsync`, :py:obj:`~.make_cudaExtent`, :py:obj:`~.make_cudaPos`, :py:obj:`~.cuMemcpy3D`
     """
     cdef cyruntime.cudaMemcpy3DParms* cyp_ptr = <cyruntime.cudaMemcpy3DParms*>p._pvt_ptr if p is not None else NULL
     with nogil:
@@ -28039,7 +28055,7 @@ def cudaMemcpy3DAsync(p : Optional[cudaMemcpy3DParms], stream):
 
     See Also
     --------
-    :py:obj:`~.cudaMalloc3D`, :py:obj:`~.cudaMalloc3DArray`, :py:obj:`~.cudaMemset3D`, :py:obj:`~.cudaMemcpy3D`, :py:obj:`~.cudaMemcpy`, :py:obj:`~.cudaMemcpy2D`, :py:obj:`~.cudaMemcpy2DToArray`, ::::py:obj:`~.cudaMemcpy2DFromArray`, :py:obj:`~.cudaMemcpy2DArrayToArray`, :py:obj:`~.cudaMemcpyToSymbol`, :py:obj:`~.cudaMemcpyFromSymbol`, :py:obj:`~.cudaMemcpyAsync`, :py:obj:`~.cudaMemcpy2DAsync`, :py:obj:`~.cudaMemcpy2DToArrayAsync`, :py:obj:`~.cudaMemcpy2DFromArrayAsync`, :py:obj:`~.cudaMemcpyToSymbolAsync`, :py:obj:`~.cudaMemcpyFromSymbolAsync`, make_cudaExtent, make_cudaPos, :py:obj:`~.cuMemcpy3DAsync`
+    :py:obj:`~.cudaMalloc3D`, :py:obj:`~.cudaMalloc3DArray`, :py:obj:`~.cudaMemset3D`, :py:obj:`~.cudaMemcpy3D`, :py:obj:`~.cudaMemcpy`, :py:obj:`~.cudaMemcpy2D`, :py:obj:`~.cudaMemcpy2DToArray`, ::::py:obj:`~.cudaMemcpy2DFromArray`, :py:obj:`~.cudaMemcpy2DArrayToArray`, :py:obj:`~.cudaMemcpyToSymbol`, :py:obj:`~.cudaMemcpyFromSymbol`, :py:obj:`~.cudaMemcpyAsync`, :py:obj:`~.cudaMemcpy2DAsync`, :py:obj:`~.cudaMemcpy2DToArrayAsync`, :py:obj:`~.cudaMemcpy2DFromArrayAsync`, :py:obj:`~.cudaMemcpyToSymbolAsync`, :py:obj:`~.cudaMemcpyFromSymbolAsync`, :py:obj:`~.make_cudaExtent`, :py:obj:`~.make_cudaPos`, :py:obj:`~.cuMemcpy3DAsync`
     """
     cdef cyruntime.cudaStream_t cystream
     if stream is None:
@@ -29738,7 +29754,7 @@ def cudaMemset3D(pitchedDevPtr not None : cudaPitchedPtr, int value, extent not 
 
     See Also
     --------
-    :py:obj:`~.cudaMemset`, :py:obj:`~.cudaMemset2D`, :py:obj:`~.cudaMemsetAsync`, :py:obj:`~.cudaMemset2DAsync`, :py:obj:`~.cudaMemset3DAsync`, :py:obj:`~.cudaMalloc3D`, make_cudaPitchedPtr, make_cudaExtent
+    :py:obj:`~.cudaMemset`, :py:obj:`~.cudaMemset2D`, :py:obj:`~.cudaMemsetAsync`, :py:obj:`~.cudaMemset2DAsync`, :py:obj:`~.cudaMemset3DAsync`, :py:obj:`~.cudaMalloc3D`, :py:obj:`~.make_cudaPitchedPtr`, :py:obj:`~.make_cudaExtent`
     """
     with nogil:
         err = cyruntime.cudaMemset3D(pitchedDevPtr._pvt_ptr[0], value, extent._pvt_ptr[0])
@@ -29915,7 +29931,7 @@ def cudaMemset3DAsync(pitchedDevPtr not None : cudaPitchedPtr, int value, extent
 
     See Also
     --------
-    :py:obj:`~.cudaMemset`, :py:obj:`~.cudaMemset2D`, :py:obj:`~.cudaMemset3D`, :py:obj:`~.cudaMemsetAsync`, :py:obj:`~.cudaMemset2DAsync`, :py:obj:`~.cudaMalloc3D`, make_cudaPitchedPtr, make_cudaExtent
+    :py:obj:`~.cudaMemset`, :py:obj:`~.cudaMemset2D`, :py:obj:`~.cudaMemset3D`, :py:obj:`~.cudaMemsetAsync`, :py:obj:`~.cudaMemset2DAsync`, :py:obj:`~.cudaMalloc3D`, :py:obj:`~.make_cudaPitchedPtr`, :py:obj:`~.make_cudaExtent`
     """
     cdef cyruntime.cudaStream_t cystream
     if stream is None:
@@ -31404,11 +31420,11 @@ def cudaMemPoolGetAttribute(memPool, attr not None : cudaMemPoolAttr):
     pools:
 
     - :py:obj:`~.cudaMemPoolAttrAllocationType`: (value type =
-      cudaMemAllocationType) The allocation type of the mempool
+      :py:obj:`~.cudaMemAllocationType`) The allocation type of the mempool
 
     - :py:obj:`~.cudaMemPoolAttrExportHandleTypes`: (value type =
-      cudaMemAllocationHandleType) Available export handle types for the
-      mempool. For imported pools this value is always
+      :py:obj:`~.cudaMemAllocationHandleType`) Available export handle
+      types for the mempool. For imported pools this value is always
       cudaMemHandleTypeNone as an imported pool cannot be re-exported
 
     - :py:obj:`~.cudaMemPoolAttrLocationId`: (value type = int) The
@@ -31416,10 +31432,10 @@ def cudaMemPoolGetAttribute(memPool, attr not None : cudaMemPoolAttr):
       cudaMemLocationTypeInvisible then ID will be cudaInvalidDeviceId.
 
     - :py:obj:`~.cudaMemPoolAttrLocationType`: (value type =
-      cudaMemLocationType) The location type for the mempool. For imported
-      memory pools where the device is not directly visible to the
-      importing process or pools imported via fabric handles across nodes
-      this will be cudaMemlocataionTypeInvisible.
+      :py:obj:`~.cudaMemLocationType`) The location type for the mempool.
+      For imported memory pools where the device is not directly visible to
+      the importing process or pools imported via fabric handles across
+      nodes this will be cudaMemlocataionTypeInvisible.
 
     - :py:obj:`~.cudaMemPoolAttrMaxPoolSize`: (value type = cuuint64_t)
       Maximum size of the pool in bytes, this value may be higher than what
@@ -31620,7 +31636,7 @@ def cudaMemPoolCreate(poolProps : Optional[cudaMemPoolProps]):
     /dev/nvidia-caps-imex-channels/channel0 c <major number> 0`
 
     To create a managed memory pool, applications must set
-    :py:obj:`~.cudaMemPoolProps`:cudaMemAllocationType to
+    :py:obj:`~.cudaMemPoolProps.py`:obj:`~.cudaMemAllocationType` to
     :py:obj:`~.cudaMemAllocationTypeManaged`.
     :py:obj:`~.cudaMemPoolProps.cudaMemAllocationHandleType` must also be
     set to :py:obj:`~.cudaMemHandleTypeNone` since IPC is not supported.
@@ -38312,8 +38328,8 @@ def cudaGraphDebugDotPrint(graph, char* path, unsigned int flags):
     path : bytes
         The path to write the DOT file to
     flags : unsigned int
-        Flags from cudaGraphDebugDotFlags for specifying which additional
-        node information to write
+        Flags from :py:obj:`~.cudaGraphDebugDotFlags` for specifying which
+        additional node information to write
 
     Returns
     -------
@@ -39758,7 +39774,7 @@ def cudaKernelSetAttributeForDevice(kernel, attr not None : cudaFuncAttribute, i
 
     - :py:obj:`~.cudaFuncAttributeClusterSchedulingPolicyPreference`: The
       block scheduling policy of a function. The value type is
-      cudaClusterSchedulingPolicy.
+      :py:obj:`~.cudaClusterSchedulingPolicy`.
 
     Parameters
     ----------
@@ -39822,7 +39838,7 @@ def cudaDeviceGetDevResource(int device, typename not None : cudaDevResourceType
     cudaError_t
         :py:obj:`~.cudaSuccess`, :py:obj:`~.cudaErrorInvalidValue`, :py:obj:`~.cudaErrorNotPermitted`, :py:obj:`~.cudaErrorInvalidDevice`, :py:obj:`~.cudaErrorInvalidResourceType`, :py:obj:`~.cudaErrorNotSupported`, :py:obj:`~.cudaErrorCudartUnloading`, :py:obj:`~.cudaErrorInitializationError`
     resource : :py:obj:`~.cudaDevResource`
-        Output pointer to a cudaDevResource structure
+        Output pointer to a :py:obj:`~.cudaDevResource` structure
 
     See Also
     --------
@@ -40343,7 +40359,7 @@ def cudaExecutionCtxGetDevResource(ctx, typename not None : cudaDevResourceType)
     cudaError_t
         :py:obj:`~.cudaSuccess`, :py:obj:`~.cudaErrorInvalidValue`, :py:obj:`~.cudaErrorNotSupported`, :py:obj:`~.cudaErrorNotPermitted`, :py:obj:`~.cudaErrorCudartUnloading`, :py:obj:`~.cudaErrorInitializationError`
     resource : :py:obj:`~.cudaDevResource`
-        Output pointer to a cudaDevResource structure
+        Output pointer to a :py:obj:`~.cudaDevResource` structure
 
     See Also
     --------
@@ -40593,7 +40609,7 @@ def cudaStreamGetDevResource(hStream, typename not None : cudaDevResourceType):
     cudaError_t
         :py:obj:`~.cudaSuccess`, :py:obj:`~.cudaErrorCudartUnloading`, :py:obj:`~.cudaErrorInitializationError`, :py:obj:`~.cudaErrorDeviceUninitialized`, :py:obj:`~.cudaErrorInvalidResourceType`, :py:obj:`~.cudaErrorInvalidValue`, :py:obj:`~.cudaErrorInvalidHandle`, :py:obj:`~.cudaErrorNotPermitted`, :py:obj:`~.cudaErrorCallRequiresNewerDriver`,
     resource : :py:obj:`~.cudaDevResource`
-        Output pointer to a cudaDevResource structure
+        Output pointer to a :py:obj:`~.cudaDevResource` structure
 
     See Also
     --------
@@ -40741,8 +40757,9 @@ def cudaDeviceGetExecutionCtx(int device):
 
     Returns in `ctx` the execution context for the specified device. This
     is the device's primary context. The returned context can then be
-    passed to APIs that take in a cudaExecutionContext_t enabling explicit
-    context-based programming without relying on thread-local state.
+    passed to APIs that take in a :py:obj:`~.cudaExecutionContext_t`
+    enabling explicit context-based programming without relying on thread-
+    local state.
 
     Passing the returned execution context to
     :py:obj:`~.cudaExecutionCtxDestroy()` is not allowed and will result in

--- a/cuda_bindings/docs/source/module/nvrtc.rst
+++ b/cuda_bindings/docs/source/module/nvrtc.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 .. SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 -----
@@ -139,7 +139,7 @@ NVRTC defines the following types and functions for bundled headers installation
 Supported Compile Options
 -------------------------
 
-NVRTC supports the compile options below. Option names with two preceding dashs (``--``\ ) are long option names and option names with one preceding dash (``-``\ ) are short option names. Short option names can be used instead of long option names. When a compile option takes an argument, an assignment operator (``=``\ ) is used to separate the compile option argument from the compile option name, e.g., ``"--gpu-architecture=compute_100"``\ . Alternatively, the compile option name and the argument can be specified in separate strings without an assignment operator, .e.g, ``"--gpu-architecture"``\  ``"compute_100"``\ . Single-character short option names, such as ``-D``\ , ``-U``\ , and ``-I``\ , do not require an assignment operator, and the compile option name and the argument can be present in the same string with or without spaces between them. For instance, ``"-D=<def>"``\ , ``"-D<def>"``\ , and ``"-D <def>"``\  are all supported.
+NVRTC supports the compile options below. Option names with two preceding dashs (``--``) are long option names and option names with one preceding dash (``-``) are short option names. Short option names can be used instead of long option names. When a compile option takes an argument, an assignment operator (``=``) is used to separate the compile option argument from the compile option name, e.g., ``"--gpu-architecture=compute_100"``. Alternatively, the compile option name and the argument can be specified in separate strings without an assignment operator, .e.g, ``"--gpu-architecture"`` ``"compute_100"``. Single-character short option names, such as ``-D``, ``-U``, and ``-I``, do not require an assignment operator, and the compile option name and the argument can be present in the same string with or without spaces between them. For instance, ``"-D=<def>"``, ``"-D<def>"``, and ``"-D <def>"`` are all supported.
 
 
 
@@ -155,7 +155,7 @@ The valid compiler options are:
 
 
 
-  - ``--gpu-architecture=<arch>``\  (``-arch``\ )
+  - ``--gpu-architecture=<arch>`` (``-arch``)
 
 Specify the name of the class of GPU architectures for which the input must be compiled.
 
@@ -175,19 +175,9 @@ Specify the name of the class of GPU architectures for which the input must be c
 
 
 
-  - ``--device-c``\  (``-dc``\ )
+  - ``--device-c`` (``-dc``)
 
-Generate relocatable code that can be linked with other relocatable device code. It is equivalent to ``--relocatable-device-code=true``\ .
-
-
-
-
-
-
-
-  - ``--device-w``\  (``-dw``\ )
-
-Generate non-relocatable code. It is equivalent to ``--relocatable-device-code=false``\ .
+Generate relocatable code that can be linked with other relocatable device code. It is equivalent to ``--relocatable-device-code=true``.
 
 
 
@@ -195,7 +185,17 @@ Generate non-relocatable code. It is equivalent to ``--relocatable-device-code=f
 
 
 
-  - ``--relocatable-device-code={true|false}``\  (``-rdc``\ )
+  - ``--device-w`` (``-dw``)
+
+Generate non-relocatable code. It is equivalent to ``--relocatable-device-code=false``.
+
+
+
+
+
+
+
+  - ``--relocatable-device-code={true|false}`` (``-rdc``)
 
 Enable (disable) the generation of relocatable device code.
 
@@ -205,7 +205,7 @@ Enable (disable) the generation of relocatable device code.
 
 
 
-  - ``--extensible-whole-program``\  (``-ewp``\ )
+  - ``--extensible-whole-program`` (``-ewp``)
 
 Do extensible whole program compilation of device code.
 
@@ -223,19 +223,9 @@ Do extensible whole program compilation of device code.
 
 
 
-  - ``--enable-tile``\  (``-enable-tile``\ )
+  - ``--enable-tile`` (``-enable-tile``)
 
-Enable support for Tile constructs (e.g. ``__tile__``\  ) and define the macro ``__CUDACC_TILE__``\  .
-
-
-
-
-
-
-
-  - ``--tile-only``\  (``-tile-only``\ )
-
-Enable support for parsing Tile constructs and define the macro ``__CUDACC_TILE__``\ , but omit code generation for non-Tile code (e.g. ``__global__``\  function).
+Enable support for Tile constructs (e.g. ``__tile__`` ) and define the macro ``__CUDACC_TILE__`` .
 
 
 
@@ -243,21 +233,9 @@ Enable support for parsing Tile constructs and define the macro ``__CUDACC_TILE_
 
 
 
-  - ``--simt-only``\  (``-simt-only``\ )
+  - ``--tile-only`` (``-tile-only``)
 
-Enable support for parsing Tile constructs and define the macro ``__CUDACC_TILE__``\ , but omit code generation for Tile code (e.g. ``__tile_global__``\  function).
-
-
-
-
-
-
-
-  - ``--default-tile``\  (``--default-tile``\ )
-
-Consider an unannotated function or static storage duration variable as having an implicit ``__tile__``\  annotation. If the static storage duration variable violates Tile restrictions (e.g. cannot be of pointer type), then the implicit annotation is silently omitted by default; use ``-diagnose-implicit-tile-var``\  to enable compiler diagnostics for such cases.
-
-``-default-tile``\  can be used in conjunction with ``-default-device``\ . If both flags are specified, the unannotated function and/or static storage duration variable will be considered to have both ``__tile__``\  and ``__device__``\  implict annotations. There will be a separate copy of the function/variable in the generated SIMT and cuda_tile programs, at present.
+Enable support for parsing Tile constructs and define the macro ``__CUDACC_TILE__``, but omit code generation for non-Tile code (e.g. ``__global__`` function).
 
 
 
@@ -265,9 +243,31 @@ Consider an unannotated function or static storage duration variable as having a
 
 
 
-  - ``--diagnose-implicit-tile-var``\  (``-diagnose-implicit-tile-var``\ )
+  - ``--simt-only`` (``-simt-only``)
 
-When combined with ``-default-tile``\ , diagnose static storage duration variables that could not be implicitly annotated with the ``__tile__``\  memory space specifier (e.g., due to pointer type restrictions).
+Enable support for parsing Tile constructs and define the macro ``__CUDACC_TILE__``, but omit code generation for Tile code (e.g. ``__tile_global__`` function).
+
+
+
+
+
+
+
+  - ``--default-tile`` (``--default-tile``)
+
+Consider an unannotated function or static storage duration variable as having an implicit ``__tile__`` annotation. If the static storage duration variable violates Tile restrictions (e.g. cannot be of pointer type), then the implicit annotation is silently omitted by default; use ``-diagnose-implicit-tile-var`` to enable compiler diagnostics for such cases.
+
+``-default-tile`` can be used in conjunction with ``-default-device``. If both flags are specified, the unannotated function and/or static storage duration variable will be considered to have both ``__tile__`` and ``__device__`` implict annotations. There will be a separate copy of the function/variable in the generated SIMT and cuda_tile programs, at present.
+
+
+
+
+
+
+
+  - ``--diagnose-implicit-tile-var`` (``-diagnose-implicit-tile-var``)
+
+When combined with ``-default-tile``, diagnose static storage duration variables that could not be implicitly annotated with the ``__tile__`` memory space specifier (e.g., due to pointer type restrictions).
 
 
 
@@ -283,17 +283,17 @@ When combined with ``-default-tile``\ , diagnose static storage duration variabl
 
 
 
-  - ``--device-debug``\  (``-G``\ )
+  - ``--device-debug`` (``-G``)
 
-Generate debug information. If ``--dopt``\  is not specified, then turns off all optimizations.
-
-
+Generate debug information. If ``--dopt`` is not specified, then turns off all optimizations.
 
 
 
 
 
-  - ``--generate-line-info``\  (``-lineinfo``\ )
+
+
+  - ``--generate-line-info`` (``-lineinfo``)
 
 Generate line-number information.
 
@@ -311,7 +311,7 @@ Generate line-number information.
 
 
 
-  - ``--dopt``\  ``on``\  (``-dopt``\ )
+  - ``--dopt`` ``on`` (``-dopt``)
 
 
 
@@ -319,17 +319,17 @@ Generate line-number information.
 
 
 
-  - ``--dopt=on``\  
+  - ``--dopt=on`` 
 
-Enable device code optimization. When specified along with ``-G``\ , enables limited debug information generation for optimized device code (currently, only line number information). When ``-G``\  is not specified, ``-dopt=on``\  is implicit.
-
-
+Enable device code optimization. When specified along with ``-G``, enables limited debug information generation for optimized device code (currently, only line number information). When ``-G`` is not specified, ``-dopt=on`` is implicit.
 
 
 
 
 
-  - ``--Ofast-compile={0|min|mid|max}``\  (``-Ofc``\ )
+
+
+  - ``--Ofast-compile={0|min|mid|max}`` (``-Ofc``)
 
 Specify the fast-compile level for device code, which controls the tradeoff between compilation speed and runtime performance by disabling certain optimizations at varying levels.
 
@@ -339,7 +339,7 @@ Specify the fast-compile level for device code, which controls the tradeoff betw
 
 
 
-  - ``--ptxas-options``\  <options> (``-Xptxas``\ )
+  - ``--ptxas-options`` <options> (``-Xptxas``)
 
 
 
@@ -347,7 +347,7 @@ Specify the fast-compile level for device code, which controls the tradeoff betw
 
 
 
-  - ``--ptxas-options=<options>``\  
+  - ``--ptxas-options=<options>`` 
 
 Specify options directly to ptxas, the PTX optimizing assembler.
 
@@ -357,7 +357,7 @@ Specify options directly to ptxas, the PTX optimizing assembler.
 
 
 
-  - ``--maxrregcount=<N>``\  (``-maxrregcount``\ )
+  - ``--maxrregcount=<N>`` (``-maxrregcount``)
 
 Specify the maximum amount of registers that GPU functions can use. Until a function-specific limit, a higher value will generally increase the performance of individual GPU threads that execute this function. However, because thread registers are allocated from a global register pool on each GPU, a higher value of this option will also reduce the maximum thread block size, thereby reducing the amount of thread parallelism. Hence, a good maxrregcount value is the result of a trade-off. If this option is not specified, then no maximum is assumed. Value less than the minimum registers required by ABI will be bumped up by the compiler to ABI minimum limit.
 
@@ -367,11 +367,11 @@ Specify the maximum amount of registers that GPU functions can use. Until a func
 
 
 
-  - ``--ftz={true|false}``\  (``-ftz``\ )
+  - ``--ftz={true|false}`` (``-ftz``)
 
 When performing single-precision floating-point operations, flush denormal values to zero or preserve denormal values.
 
-``--use_fast_math``\  implies ``--ftz=true``\ .
+``--use_fast_math`` implies ``--ftz=true``.
 
 
 
@@ -379,23 +379,9 @@ When performing single-precision floating-point operations, flush denormal value
 
 
 
-  - ``--prec-sqrt={true|false}``\  (``-prec-sqrt``\ )
+  - ``--prec-sqrt={true|false}`` (``-prec-sqrt``)
 
-For single-precision floating-point square root, use IEEE round-to-nearest mode or use a faster approximation. ``--use_fast_math``\  implies ``--prec-sqrt=false``\ .
-
-
-
-
-
-
-
-  - ``--prec-div={true|false}``\  (``-prec-div``\ ) For single-precision floating-point division and reciprocals, use IEEE round-to-nearest mode or use a faster approximation. ``--use_fast_math``\  implies ``--prec-div=false``\ .
-
-
-
-
-
-    - Default: ``true``\  
+For single-precision floating-point square root, use IEEE round-to-nearest mode or use a faster approximation. ``--use_fast_math`` implies ``--prec-sqrt=false``.
 
 
 
@@ -403,21 +389,13 @@ For single-precision floating-point square root, use IEEE round-to-nearest mode 
 
 
 
-
-
-  - ``--fmad={true|false}``\  (``-fmad``\ )
-
-Enables (disables) the contraction of floating-point multiplies and adds/subtracts into floating-point multiply-add operations (FMAD, FFMA, or DFMA). ``--use_fast_math``\  implies ``--fmad=true``\ .
+  - ``--prec-div={true|false}`` (``-prec-div``) For single-precision floating-point division and reciprocals, use IEEE round-to-nearest mode or use a faster approximation. ``--use_fast_math`` implies ``--prec-div=false``.
 
 
 
 
 
-
-
-  - ``--use_fast_math``\  (``-use_fast_math``\ )
-
-Make use of fast math operations. ``--use_fast_math``\  implies ``--ftz=true``\  ``--prec-div=false``\  ``--prec-sqrt=false``\  ``--fmad=true``\ .
+    - Default: ``true`` 
 
 
 
@@ -425,7 +403,29 @@ Make use of fast math operations. ``--use_fast_math``\  implies ``--ftz=true``\ 
 
 
 
-  - ``--extra-device-vectorization``\  (``-extra-device-vectorization``\ )
+
+
+  - ``--fmad={true|false}`` (``-fmad``)
+
+Enables (disables) the contraction of floating-point multiplies and adds/subtracts into floating-point multiply-add operations (FMAD, FFMA, or DFMA). ``--use_fast_math`` implies ``--fmad=true``.
+
+
+
+
+
+
+
+  - ``--use_fast_math`` (``-use_fast_math``)
+
+Make use of fast math operations. ``--use_fast_math`` implies ``--ftz=true`` ``--prec-div=false`` ``--prec-sqrt=false`` ``--fmad=true``.
+
+
+
+
+
+
+
+  - ``--extra-device-vectorization`` (``-extra-device-vectorization``)
 
 Enables more aggressive device code vectorization in the NVVM optimizer.
 
@@ -435,19 +435,9 @@ Enables more aggressive device code vectorization in the NVVM optimizer.
 
 
 
-  - ``--modify-stack-limit={true|false}``\  (``-modify-stack-limit``\ )
+  - ``--modify-stack-limit={true|false}`` (``-modify-stack-limit``)
 
-On Linux, during compilation, use ``setrlimit()``\  to increase stack size to maximum allowed. The limit is reset to the previous value at the end of compilation. Note: ``setrlimit()``\  changes the value for the entire process.
-
-
-
-
-
-
-
-  - ``--dlink-time-opt``\  (``-dlto``\ )
-
-Generate intermediate code for later link-time optimization. It implies ``-rdc=true``\ . Note: when this option is used the ``nvrtcGetLTOIR``\  API should be used, as PTX or Cubin will not be generated.
+On Linux, during compilation, use ``setrlimit()`` to increase stack size to maximum allowed. The limit is reset to the previous value at the end of compilation. Note: ``setrlimit()`` changes the value for the entire process.
 
 
 
@@ -455,7 +445,17 @@ Generate intermediate code for later link-time optimization. It implies ``-rdc=t
 
 
 
-  - ``--gen-opt-lto``\  (``-gen-opt-lto``\ )
+  - ``--dlink-time-opt`` (``-dlto``)
+
+Generate intermediate code for later link-time optimization. It implies ``-rdc=true``. Note: when this option is used the ``nvrtcGetLTOIR`` API should be used, as PTX or Cubin will not be generated.
+
+
+
+
+
+
+
+  - ``--gen-opt-lto`` (``-gen-opt-lto``)
 
 Run the optimizer passes before generating the LTO IR.
 
@@ -465,9 +465,9 @@ Run the optimizer passes before generating the LTO IR.
 
 
 
-  - ``--optix-ir``\  (``-optix-ir``\ )
+  - ``--optix-ir`` (``-optix-ir``)
 
-Generate OptiX IR. The Optix IR is only intended for consumption by OptiX through appropriate APIs. This feature is not supported with link-time-optimization (``-dlto``\ ).
+Generate OptiX IR. The Optix IR is only intended for consumption by OptiX through appropriate APIs. This feature is not supported with link-time-optimization (``-dlto``).
 
 Note: when this option is used the nvrtcGetOptiX API should be used, as PTX or Cubin will not be generated.
 
@@ -477,7 +477,7 @@ Note: when this option is used the nvrtcGetOptiX API should be used, as PTX or C
 
 
 
-  - ``--jump-table-density=``\ [0-101] (``-jtd``\ )
+  - ``--jump-table-density=``\[0-101] (``-jtd``)
 
 Specify the case density percentage in switch statements, and use it as a minimal threshold to determine whether jump table(brx.idx instruction) will be used to implement a switch statement. Default value is 101. The percentage ranges from 0 to 101 inclusively.
 
@@ -487,7 +487,7 @@ Specify the case density percentage in switch statements, and use it as a minima
 
 
 
-  - ``--device-stack-protector={true|false}``\  (``-device-stack-protector``\ )
+  - ``--device-stack-protector={true|false}`` (``-device-stack-protector``)
 
 Enable (disable) the generation of stack canaries in device code.
 
@@ -497,7 +497,7 @@ Enable (disable) the generation of stack canaries in device code.
 
 
 
-  - ``--no-cache``\  (``-no-cache``\ )
+  - ``--no-cache`` (``-no-cache``)
 
 Disable the use of cache for both ptx and cubin code generation.
 
@@ -507,7 +507,7 @@ Disable the use of cache for both ptx and cubin code generation.
 
 
 
-  - ``--frandom-seed``\  (``-frandom-seed``\ )
+  - ``--frandom-seed`` (``-frandom-seed``)
 
 The user specified random seed will be used to replace random numbers used in generating symbol names and variable names. The option can be used to generate deterministically identical ptx and object files. If the input value is a valid number (decimal, octal, or hex), it will be used directly as the random seed. Otherwise, the CRC value of the passed string will be used instead.
 
@@ -525,19 +525,9 @@ The user specified random seed will be used to replace random numbers used in ge
 
 
 
-  - ``--define-macro=<def>``\  (``-D``\ )
+  - ``--define-macro=<def>`` (``-D``)
 
-``<def>``\  can be either ``<name>``\  or ``<name=definitions>``\ .
-
-
-
-
-
-
-
-  - ``--undefine-macro=<def>``\  (``-U``\ )
-
-Cancel any previous definition of ``<def>``\ .
+``<def>`` can be either ``<name>`` or ``<name=definitions>``.
 
 
 
@@ -545,19 +535,9 @@ Cancel any previous definition of ``<def>``\ .
 
 
 
-  - ``--include-path=<dir>``\  (``-I``\ )
+  - ``--undefine-macro=<def>`` (``-U``)
 
-Add the directory ``<dir>``\  to the list of directories to be searched for headers. These paths are searched after the list of headers given to nvrtcCreateProgram.
-
-
-
-
-
-
-
-  - ``--use-bundled-headers=<dir>``\  
-
-Install bundled CUDA headers to ``<dir>``\  and add include paths. This is a convenience flag that combines calling nvrtcInstallBundledHeaders and adding ``-I<dir>``\  and ``-I<dir>/cccl``\  to the include search path. Headers are installed only if they don't already exist at the specified location.
+Cancel any previous definition of ``<def>``.
 
 
 
@@ -565,17 +545,37 @@ Install bundled CUDA headers to ``<dir>``\  and add include paths. This is a con
 
 
 
-  - ``--pre-include=<header>``\  (``-include``\ )
+  - ``--include-path=<dir>`` (``-I``)
 
-Preinclude ``<header>``\  during preprocessing.
-
-
+Add the directory ``<dir>`` to the list of directories to be searched for headers. These paths are searched after the list of headers given to nvrtcCreateProgram.
 
 
 
 
 
-  - ``--no-source-include``\  (``-no-source-include``\ )
+
+
+  - ``--use-bundled-headers=<dir>`` 
+
+Install bundled CUDA headers to ``<dir>`` and add include paths. This is a convenience flag that combines calling nvrtcInstallBundledHeaders and adding ``-I<dir>`` and ``-I<dir>/cccl`` to the include search path. Headers are installed only if they don't already exist at the specified location.
+
+
+
+
+
+
+
+  - ``--pre-include=<header>`` (``-include``)
+
+Preinclude ``<header>`` during preprocessing.
+
+
+
+
+
+
+
+  - ``--no-source-include`` (``-no-source-include``)
 
 The preprocessor by default adds the directory of each input sources to the include path. This option disables this feature and only considers the path specified explicitly.
 
@@ -593,7 +593,7 @@ The preprocessor by default adds the directory of each input sources to the incl
 
 
 
-  - ``--std={c++03|c++11|c++14|c++17|c++20}``\  (``-std``\ )
+  - ``--std={c++03|c++11|c++14|c++17|c++20}`` (``-std``)
 
 Set language dialect to C++03, C++11, C++14, C++17 or C++20
 
@@ -603,19 +603,19 @@ Set language dialect to C++03, C++11, C++14, C++17 or C++20
 
 
 
-  - ``--builtin-move-forward={true|false}``\  (``-builtin-move-forward``\ )
+  - ``--builtin-move-forward={true|false}`` (``-builtin-move-forward``)
 
-Provide builtin definitions of ``std::move``\  and ``std::forward``\ , when C++11 or later language dialect is selected.
-
-
+Provide builtin definitions of ``std::move`` and ``std::forward``, when C++11 or later language dialect is selected.
 
 
 
 
 
-  - ``--builtin-initializer-list={true|false}``\  (``-builtin-initializer-list``\ )
 
-Provide builtin definitions of ``std::initializer_list``\  class and member functions when C++11 or later language dialect is selected.
+
+  - ``--builtin-initializer-list={true|false}`` (``-builtin-initializer-list``)
+
+Provide builtin definitions of ``std::initializer_list`` class and member functions when C++11 or later language dialect is selected.
 
 
 
@@ -631,7 +631,7 @@ Provide builtin definitions of ``std::initializer_list``\  class and member func
 
 
 
-  - ``--pch``\  (``-pch``\ )
+  - ``--pch`` (``-pch``)
 
 Enable automatic PCH processing.
 
@@ -641,7 +641,7 @@ Enable automatic PCH processing.
 
 
 
-  - ``--create-pch=<file-name>``\  (``-create-pch``\ )
+  - ``--create-pch=<file-name>`` (``-create-pch``)
 
 Create a PCH file.
 
@@ -651,7 +651,7 @@ Create a PCH file.
 
 
 
-  - ``--use-pch=<file-name>``\  (``-use-pch``\ )
+  - ``--use-pch=<file-name>`` (``-use-pch``)
 
 Use the specified PCH file.
 
@@ -661,17 +661,17 @@ Use the specified PCH file.
 
 
 
-  - ``--pch-dir=<directory-name>``\  (``-pch-dir``\ )
+  - ``--pch-dir=<directory-name>`` (``-pch-dir``)
 
-When using automatic PCH (``-pch``\ ), look for and create PCH files in the specified directory. When using explicit PCH (``-create-pch``\  or ``-use-pch``\ ), the directory name is prefixed before the specified file name, unless the file name is an absolute path name.
-
-
+When using automatic PCH (``-pch``), look for and create PCH files in the specified directory. When using explicit PCH (``-create-pch`` or ``-use-pch``), the directory name is prefixed before the specified file name, unless the file name is an absolute path name.
 
 
 
 
 
-  - ``--pch-verbose={true|false}``\  (``-pch-verbose``\ )
+
+
+  - ``--pch-verbose={true|false}`` (``-pch-verbose``)
 
 In automatic PCH mode, for each PCH file that could not be used in current compilation, print the reason in the compilation log.
 
@@ -681,7 +681,7 @@ In automatic PCH mode, for each PCH file that could not be used in current compi
 
 
 
-  - ``--pch-messages={true|false}``\  (``-pch-messages``\ )
+  - ``--pch-messages={true|false}`` (``-pch-messages``)
 
 Print a message in the compilation log, if a PCH file was created or used in the current compilation.
 
@@ -691,7 +691,7 @@ Print a message in the compilation log, if a PCH file was created or used in the
 
 
 
-  - ``--instantiate-templates-in-pch={true|false}``\  (``-instantiate-templates-in-pch``\ )
+  - ``--instantiate-templates-in-pch={true|false}`` (``-instantiate-templates-in-pch``)
 
 Enable or disable instantiatiation of templates before PCH creation. Instantiating templates may increase the size of the PCH file, while reducing the compilation cost when using the PCH file (since some template instantiations can be skipped).
 
@@ -709,7 +709,7 @@ Enable or disable instantiatiation of templates before PCH creation. Instantiati
 
 
 
-  - ``--disable-warnings``\  (``-w``\ )
+  - ``--disable-warnings`` (``-w``)
 
 Inhibit all warning messages.
 
@@ -719,7 +719,7 @@ Inhibit all warning messages.
 
 
 
-  - ``--Wreorder``\  (``-Wreorder``\ )
+  - ``--Wreorder`` (``-Wreorder``)
 
 Generate warnings when member initializers are reordered.
 
@@ -729,7 +729,7 @@ Generate warnings when member initializers are reordered.
 
 
 
-  - ``--warning-as-error=``\  <kind>,... (``-Werror``\ )
+  - ``--warning-as-error=`` <kind>,... (``-Werror``)
 
 Make warnings of the specified kinds into errors. The following is the list of warning kinds accepted by this option:
 
@@ -739,7 +739,7 @@ Make warnings of the specified kinds into errors. The following is the list of w
 
 
 
-  - ``--restrict``\  (``-restrict``\ )
+  - ``--restrict`` (``-restrict``)
 
 Programmer assertion that all kernel pointer parameters are restrict pointers.
 
@@ -749,19 +749,9 @@ Programmer assertion that all kernel pointer parameters are restrict pointers.
 
 
 
-  - ``--device-as-default-execution-space``\  (``-default-device``\ )
+  - ``--device-as-default-execution-space`` (``-default-device``)
 
-Treat entities with no execution space annotation as ``__device__``\  entities.
-
-
-
-
-
-
-
-  - ``--device-int128``\  (``-device-int128``\ )
-
-Allow the ``__int128``\  type in device code. Also causes the macro ``__CUDACC_RTC_INT128__``\  to be defined.
+Treat entities with no execution space annotation as ``__device__`` entities.
 
 
 
@@ -769,17 +759,27 @@ Allow the ``__int128``\  type in device code. Also causes the macro ``__CUDACC_R
 
 
 
-  - ``--device-float128``\  (``-device-float128``\ )
+  - ``--device-int128`` (``-device-int128``)
 
-Allow the ``__float128``\  and ``_Float128``\  types in device code. Also causes the macro ``D__CUDACC_RTC_FLOAT128__``\  to be defined.
-
-
+Allow the ``__int128`` type in device code. Also causes the macro ``__CUDACC_RTC_INT128__`` to be defined.
 
 
 
 
 
-  - ``--optimization-info=<kind>``\  (``-opt-info``\ )
+
+
+  - ``--device-float128`` (``-device-float128``)
+
+Allow the ``__float128`` and ``_Float128`` types in device code. Also causes the macro ``D__CUDACC_RTC_FLOAT128__`` to be defined.
+
+
+
+
+
+
+
+  - ``--optimization-info=<kind>`` (``-opt-info``)
 
 Provide optimization reports for the specified kind of optimization. The following kind tags are supported:
 
@@ -789,7 +789,7 @@ Provide optimization reports for the specified kind of optimization. The followi
 
 
 
-  - ``--display-error-number``\  (``-err-no``\ )
+  - ``--display-error-number`` (``-err-no``)
 
 Display diagnostic number for warning messages. (Default)
 
@@ -799,7 +799,7 @@ Display diagnostic number for warning messages. (Default)
 
 
 
-  - ``--no-display-error-number``\  (``-no-err-no``\ )
+  - ``--no-display-error-number`` (``-no-err-no``)
 
 Disables the display of a diagnostic number for warning messages.
 
@@ -809,7 +809,7 @@ Disables the display of a diagnostic number for warning messages.
 
 
 
-  - ``--diag-error=<error-number>``\ ,... (``-diag-error``\ )
+  - ``--diag-error=<error-number>``,... (``-diag-error``)
 
 Emit error for specified diagnostic message number(s). Message numbers can be separated by comma.
 
@@ -819,7 +819,7 @@ Emit error for specified diagnostic message number(s). Message numbers can be se
 
 
 
-  - ``--diag-suppress=<error-number>``\ ,... (``-diag-suppress``\ )
+  - ``--diag-suppress=<error-number>``,... (``-diag-suppress``)
 
 Suppress specified diagnostic message number(s). Message numbers can be separated by comma.
 
@@ -829,7 +829,7 @@ Suppress specified diagnostic message number(s). Message numbers can be separate
 
 
 
-  - ``--diag-warn=<error-number>``\ ,... (``-diag-warn``\ )
+  - ``--diag-warn=<error-number>``,... (``-diag-warn``)
 
 Emit warning for specified diagnostic message number(s). Message numbers can be separated by comma.
 
@@ -839,17 +839,17 @@ Emit warning for specified diagnostic message number(s). Message numbers can be 
 
 
 
-  - ``--brief-diagnostics={true|false}``\  (``-brief-diag``\ )
+  - ``--brief-diagnostics={true|false}`` (``-brief-diag``)
 
-This option disables or enables showing source line and column info in a diagnostic. The ``--brief-diagnostics=true``\  will not show the source line and column info.
-
-
+This option disables or enables showing source line and column info in a diagnostic. The ``--brief-diagnostics=true`` will not show the source line and column info.
 
 
 
 
 
-  - ``--time=<file-name>``\  (``-time``\ )
+
+
+  - ``--time=<file-name>`` (``-time``)
 
 Generate a comma separated value table with the time taken by each compilation phase, and append it at the end of the file given as the option argument. If the file does not exist, the column headings are generated in the first row of the table. If the file name is '-', the timing data is written to the compilation log.
 
@@ -859,17 +859,17 @@ Generate a comma separated value table with the time taken by each compilation p
 
 
 
-  - ``--split-compile=<number-of-threads>``\  (``-split-compile=<number-of-threads>``\ )
+  - ``--split-compile=<number-of-threads>`` (``-split-compile=<number-of-threads>``)
 
-Perform compiler optimizations in parallel. Split compilation attempts to reduce compile time by enabling the compiler to run certain optimization passes concurrently. This option accepts a numerical value that specifies the maximum number of threads the compiler can use. One can also allow the compiler to use the maximum threads available on the system by setting ``--split-compile=0``\ . Setting ``--split-compile=1``\  will cause this option to be ignored.
-
-
+Perform compiler optimizations in parallel. Split compilation attempts to reduce compile time by enabling the compiler to run certain optimization passes concurrently. This option accepts a numerical value that specifies the maximum number of threads the compiler can use. One can also allow the compiler to use the maximum threads available on the system by setting ``--split-compile=0``. Setting ``--split-compile=1`` will cause this option to be ignored.
 
 
 
 
 
-  - ``--fdevice-syntax-only``\  (``-fdevice-syntax-only``\ )
+
+
+  - ``--fdevice-syntax-only`` (``-fdevice-syntax-only``)
 
 Ends device compilation after front-end syntax checking. This option does not generate valid device code.
 
@@ -879,7 +879,7 @@ Ends device compilation after front-end syntax checking. This option does not ge
 
 
 
-  - ``--minimal``\  (``-minimal``\ )
+  - ``--minimal`` (``-minimal``)
 
 Omit certain language features to reduce compile time for small programs. In particular, the following are omitted:
 
@@ -889,7 +889,7 @@ Omit certain language features to reduce compile time for small programs. In par
 
 
 
-  - ``--device-stack-protector``\  (``-device-stack-protector``\ )
+  - ``--device-stack-protector`` (``-device-stack-protector``)
 
 Enable stack canaries in device code. Stack canaries make it more difficult to exploit certain types of memory safety bugs involving stack-local variables. The compiler uses heuristics to assess the risk of such a bug in each function. Only those functions which are deemed high-risk make use of a stack canary.
 
@@ -899,5 +899,5 @@ Enable stack canaries in device code. Stack canaries make it more difficult to e
 
 
 
-  - ``--fdevice-time-trace=<file-name>``\  (``-fdevice-time-trace=<file-name>``\ ) Enables the time profiler, outputting a JSON file based on given <file-name>. Results can be analyzed on chrome://tracing for a flamegraph visualization.
+  - ``--fdevice-time-trace=<file-name>`` (``-fdevice-time-trace=<file-name>``) Enables the time profiler, outputting a JSON file based on given <file-name>. Results can be analyzed on chrome://tracing for a flamegraph visualization.
 

--- a/cuda_core/tests/test_enum_coverage.py
+++ b/cuda_core/tests/test_enum_coverage.py
@@ -314,11 +314,12 @@ def test_wrapper_covers_all_binding_members(binding, str_enum, mapping, binding_
         required_count = len(required)
         covered_str_enum = set(str_enum.__members__) - str_enum_unmapped
         covered_count = len(covered_str_enum)
-        if required_count != covered_count:
+        if required_count > covered_count:
             raise AssertionError(
-                f"{str_enum.__name__} has {covered_count} members, but expected {required_count} based on {binding.__name__} "
-                "after accounting for unmapped members. This may indicate that some members are missing from the wrapper, "
-                "or that some wrapper members do not correspond to actual binding members."
+                f"`{str_enum.__module__}.{str_enum.__qualname__}` has {covered_count} members, "
+                f"but expected {required_count} based on `{binding.__module__}.{binding.__qualname__}` "
+                "after accounting for unmapped members. This may indicate that some members are missing "
+                "from the wrapper, or that some wrapper members do not correspond to actual binding members."
             )
 
 


### PR DESCRIPTION
Now that #1972, there was a backlog of things merged into cybind that need to be brought over here.  This is mainly:

- Not instantiating the objects that are needed to determine offsets to convert to numpy dtypes.  This reduces unnecessary warnings from Cython and the C++ compiler.

- There were two new functions added to nvjitlink as part of the CTK 13.3 work.  I don't know why these were not merged here earlier, but they definitely should have been and are here now.

- Various docstring formatting improvements.

- Our new enum CI rightfully detected that values added to cuda.bindings were not added to cuda.core, so this updates cuda.core to include the new values.