### PR TITLE
Restart sccache to avoid timeouts

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -456,6 +456,17 @@ jobs:
           path: ${{ env.CUDA_CORE_CYTHON_TESTS_DIR }}/test_*${{ env.PY_EXT_SUFFIX }}
           if-no-files-found: error
 
+      # Restart sccache before the second cuda.core build. For py3.15t, the
+      # preceding numpy-from-source build can take 10+ minutes during which
+      # the sccache daemon may become unhealthy (crashed or lost its GHA
+      # cache connection). A clean restart avoids the "Timed out waiting for
+      # server startup" failure in the second cibuildwheel run.
+      - name: Restart sccache server
+        if: ${{ startsWith(inputs.host-platform, 'linux') }}
+        run: |
+          ${{ env.SCCACHE_PATH }} --stop-server || true
+          ${{ env.SCCACHE_PATH }} --start-server
+
       # Note: This overwrites CUDA_PATH etc
       - name: Set up mini CTK
         uses: ./.github/actions/fetch_ctk


### PR DESCRIPTION
I have been see a number of sccache timeout failures with out 3.15 builds.  What makes them special is they have to build numpy from source.  This is my agent's suggestion to help with that -- I have no idea why it would fail and why this would help, but thought I would at least run the experiment.