### PR TITLE
[DO-NOT-MERGE] Demonstrate CI gating-check bug: build fail -> Check job status green

### DIFF
--- a/ci/tools/env-vars
+++ b/ci/tools/env-vars
@@ -15,6 +15,14 @@ if [[ ${#} -ne 1 ]]; then
   exit 1
 fi
 
+# [demo] Intentional failure to reproduce gating-check bug.
+# See https://github.com/NVIDIA/cuda-python/issues/2208
+# DO NOT MERGE. This block must be removed before merge.
+if [[ "${1}" == "build" ]]; then
+  echo "::error::INTENTIONAL FAILURE for CI gating-check bug demo. See https://github.com/NVIDIA/cuda-python/issues/2208" >&2
+  exit 7
+fi
+
 PYTHON_VERSION_FORMATTED=$(echo "${PY_VER}" | tr -d '.')
 
 if [[ "${HOST_PLATFORM}" == linux* ]]; then


### PR DESCRIPTION
**Do not merge.** This is a demonstration of the bug described in #2208.

Injects `exit 7` early in `ci/tools/env-vars` so every `Build *` matrix entry fails at the env-vars step (before cibuildwheel runs). Tests downstream will be `skipped` due to needs-failure propagation.

Expected outcome:
- `Build linux-64`, `Build linux-aarch64`, `Build win-64` → failure
- `Test linux-64`, `Test linux-aarch64`, `Test win-64`, `Test sdist *` → skipped
- **`Check job status` → success** ← the bug being demonstrated

This PR will be closed once CI confirms the reproduction.

Refs #2208