### PR TITLE
ci: fix Check job status to detect skipped results (fixes #2208)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,52 +432,42 @@ jobs:
     steps:
       - name: Exit
         run: |
-          # if any dependencies were cancelled or failed, that's a failure
-          #
-          # see https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#always
-          # and https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
-          # for why this cannot be encoded in the job-level `if:` field
-          #
-          # TL; DR: `$REASONS`
-          #
-          # The intersection of skipped-as-success and required status checks
-          # creates a scenario where if you DON'T `always()` run this job, the
-          # status check UI will block merging and if you DO `always()` run and
-          # a dependency is _cancelled_ (due to a critical failure, which is
-          # somehow not considered a failure ¯\_(ツ)_/¯) then the critically
-          # failing job(s) will timeout causing a cancellation here and the
-          # build to succeed which we don't want (originally this was just
-          # 'exit 0')
-          #
-          # Note: When [doc-only] is in PR title, test jobs are intentionally
-          # skipped and should not cause failure.
-          #
-          # detect-changes gates whether heavy test matrices run at all; if it
-          # does not succeed, downstream test jobs are skipped rather than
-          # failed, which would otherwise go unnoticed here. Require its
-          # success explicitly so a broken gating step cannot masquerade as a
-          # green CI run.
-          doc_only=${{ needs.should-skip.outputs.doc-only }}
-          if ${{ needs.detect-changes.result != 'success' }}; then
-            exit 1
+          # GitHub treats `result == 'skipped'` as success for required
+          # status checks (see CCCL gate comment + cccl#605). The previous
+          # `cancelled || failure` predicate let upstream build failures
+          # propagate as `skipped` on downstream test jobs and silently
+          # pass this aggregator. Adopt CCCL's `check_result` pattern:
+          # require an explicit `expected` status per dependency, where
+          # anything else (including `skipped` from a failed upstream)
+          # fails the gate. `if: always()` on the job still ensures this
+          # step runs even when needs are skipped.
+          if [[ "${{ needs.should-skip.outputs.skip }}" == "true" ]]; then
+            echo "[no-ci] - skipping aggregator checks"
+            exit 0
           fi
-          if ${{ needs.doc.result == 'cancelled' || needs.doc.result == 'failure' }}; then
-            exit 1
-          fi
-          if ${{ needs.test-sdist-linux.result == 'cancelled' ||
-                 needs.test-sdist-linux.result == 'failure' ||
-                 needs.test-sdist-windows.result == 'cancelled' ||
-                 needs.test-sdist-windows.result == 'failure' }}; then
-            exit 1
-          fi
-          if [[ "${doc_only}" != "true" ]]; then
-            if ${{ needs.test-linux-64.result == 'cancelled' ||
-                   needs.test-linux-64.result == 'failure' ||
-                   needs.test-linux-aarch64.result == 'cancelled' ||
-                   needs.test-linux-aarch64.result == 'failure' ||
-                   needs.test-windows.result == 'cancelled' ||
-                   needs.test-windows.result == 'failure' }}; then
-              exit 1
+
+          doc_only="${{ needs.should-skip.outputs.doc-only }}"
+          status="success"
+          check_result() {
+            name=$1; expected=$2; result=$3
+            echo "Checking $name: result='$result' (expected '$expected')"
+            if [[ "$result" != "$expected" ]]; then
+              echo "::error::$name did not match expected result"
+              status="failed"
             fi
-          fi
-          exit 0
+          }
+
+          # always expected to succeed (even in [doc-only] mode)
+          check_result "should-skip"    "success" "${{ needs.should-skip.result }}"
+          check_result "detect-changes" "success" "${{ needs.detect-changes.result }}"
+          check_result "doc"            "success" "${{ needs.doc.result }}"
+
+          # [doc-only] flips these from 'success' to 'skipped'
+          if [[ "$doc_only" == "true" ]]; then expected="skipped"; else expected="success"; fi
+          check_result "test-sdist-linux"   "$expected" "${{ needs.test-sdist-linux.result }}"
+          check_result "test-sdist-windows" "$expected" "${{ needs.test-sdist-windows.result }}"
+          check_result "test-linux-64"      "$expected" "${{ needs.test-linux-64.result }}"
+          check_result "test-linux-aarch64" "$expected" "${{ needs.test-linux-aarch64.result }}"
+          check_result "test-windows"       "$expected" "${{ needs.test-windows.result }}"
+
+          [[ "$status" == "success" ]]

--- a/ci/tools/env-vars
+++ b/ci/tools/env-vars
@@ -15,16 +15,6 @@ if [[ ${#} -ne 1 ]]; then
   exit 1
 fi
 
-# [demo] Intentional failure to validate the gating-check fix in this PR.
-# Mirrors the #2209 reproducer: every Build matrix entry should fail here,
-# downstream Test jobs should be skipped, and -- with the new aggregator --
-# Check job status should now report failure (whereas it reported success
-# in #2209 before the fix). REMOVE THIS BLOCK before merging.
-if [[ "${1}" == "build" ]]; then
-  echo "::error::INTENTIONAL FAILURE validating gating-check fix on PR #2210. See https://github.com/NVIDIA/cuda-python/issues/2208" >&2
-  exit 7
-fi
-
 PYTHON_VERSION_FORMATTED=$(echo "${PY_VER}" | tr -d '.')
 
 if [[ "${HOST_PLATFORM}" == linux* ]]; then

--- a/ci/tools/env-vars
+++ b/ci/tools/env-vars
@@ -15,6 +15,16 @@ if [[ ${#} -ne 1 ]]; then
   exit 1
 fi
 
+# [demo] Intentional failure to validate the gating-check fix in this PR.
+# Mirrors the #2209 reproducer: every Build matrix entry should fail here,
+# downstream Test jobs should be skipped, and -- with the new aggregator --
+# Check job status should now report failure (whereas it reported success
+# in #2209 before the fix). REMOVE THIS BLOCK before merging.
+if [[ "${1}" == "build" ]]; then
+  echo "::error::INTENTIONAL FAILURE validating gating-check fix on PR #2210. See https://github.com/NVIDIA/cuda-python/issues/2208" >&2
+  exit 7
+fi
+
 PYTHON_VERSION_FORMATTED=$(echo "${PY_VER}" | tr -d '.')
 
 if [[ "${HOST_PLATFORM}" == linux* ]]; then


### PR DESCRIPTION
Fixes #2208.

Replaces the `cancelled || failure` predicate in `.github/workflows/ci.yml`'s `checks:` job with CCCL's `check_result` pattern: per-dep `expected="success"`, with `expected="skipped"` for legitimate `[doc-only]` skips, and an early short-circuit for `[no-ci]`.

Reference: https://github.com/NVIDIA/cccl/blob/8c0e6cb1b6412d7bd0070f9ac3f55fa80231961a/.github/workflows/ci-workflow-pull-request.yml#L463-L526

End-to-end validation (pre-fix vs post-fix reproducer): https://github.com/NVIDIA/cuda-python/pull/2210#issuecomment-4714140531