### PR TITLE
CI: Bump to ubuntu 24.04 for CI runs and re-activate 3.15t testing

### DIFF
--- a/.github/workflows/ci-pixi-source-test.yml
+++ b/.github/workflows/ci-pixi-source-test.yml
@@ -112,7 +112,7 @@ jobs:
     timeout-minutes: 90
     container:
       options: -u root --security-opt seccomp=unconfined --shm-size 16g
-      image: ubuntu:22.04
+      image: ubuntu:24.04
     steps:
       - name: Ensure GPU is working
         run: nvidia-smi

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,7 +47,7 @@ jobs:
     # TODO: use a different (nvidia?) container
     container:
       options: -u root --security-opt seccomp=unconfined --shm-size 16g
-      image: ubuntu:22.04
+      image: ubuntu:24.04
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
         PIP_CACHE_DIR: "/tmp/pip-cache"

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -118,7 +118,7 @@ jobs:
       # can nsenter to the host for the install + refresh the toolkit bind mounts
       # back inside the container. Stock options for latest/earliest rows.
       options: ${{ ((matrix.DRIVER == 'latest' || matrix.DRIVER == 'earliest') && '-u root --security-opt seccomp=unconfined --shm-size 16g') || '-u root --security-opt seccomp=unconfined --shm-size 16g --privileged --pid=host' }}
-      image: ubuntu:22.04
+      image: ubuntu:24.04
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
         PIP_CACHE_DIR: "/tmp/pip-cache"

--- a/ci/test-matrix.yml
+++ b/ci/test-matrix.yml
@@ -52,8 +52,7 @@ linux:
     - { ARCH: 'amd64', PY_VER: '3.14t', CUDA_VER: '13.0.2', LOCAL_CTK: '1', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest' }
     - { ARCH: 'amd64', PY_VER: '3.14t', CUDA_VER: '13.3.0', LOCAL_CTK: '1', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest' }
     - { ARCH: 'amd64', PY_VER: '3.15',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest' }
-    # Blocked by NVIDIA/cuda-python#2171
-    # - { ARCH: 'amd64', PY_VER: '3.15t', CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest' }
+    - { ARCH: 'amd64', PY_VER: '3.15t', CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest' }
     # linux-aarch64
     - { ARCH: 'arm64', PY_VER: '3.10',  CUDA_VER: '12.9.1', LOCAL_CTK: '1', GPU: 'a100',       GPU_COUNT: '1', DRIVER: 'latest' }
     - { ARCH: 'arm64', PY_VER: '3.10',  CUDA_VER: '13.0.2', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest' }


### PR DESCRIPTION
It seemed that setup-python 22.04 free-threaded 3.15.0b1 is broken in weird ways (``PyObject_Realloc(0, 128)`` segfaults).

But the 24.04 build is fine, since there is probable no real reason to use 22.04 specifically, simply bump to 24.04.

(If there is a reason to stick with 22.04, we should just close this.)

Closes gh-2171

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
