### PR TITLE
tests: fix parametrize patterns rejected by pytest 9.1.0

### DIFF
--- a/cuda_bindings/tests/test_nvfatbin.py
+++ b/cuda_bindings/tests/test_nvfatbin.py
@@ -121,8 +121,7 @@ def nvcc_smoke(tmpdir) -> str:
     return nvcc
 
 
-@pytest.fixture
-def CUBIN(arch):
+def _build_cubin(arch):
     def CHECK_NVRTC(err):
         if err != nvrtc.nvrtcResult.NVRTC_SUCCESS:
             raise RuntimeError(repr(err))
@@ -139,6 +138,11 @@ def CUBIN(arch):
     (err,) = nvrtc.nvrtcDestroyProgram(program_handle)
     CHECK_NVRTC(err)
     return cubin
+
+
+@pytest.fixture
+def CUBIN(arch):
+    return _build_cubin(arch)
 
 
 # create a valid LTOIR input for testing
@@ -259,11 +263,11 @@ def test_nvfatbin_add_ptx(PTX, arch):
     nvfatbin.destroy(handle)
 
 
-@pytest.mark.parametrize("arch", ["sm_80"], indirect=True)
-def test_nvfatbin_add_cubin_ELF_SIZE_MISMATCH(CUBIN, arch):
+def test_nvfatbin_add_cubin_ELF_SIZE_MISMATCH():
+    cubin = _build_cubin("sm_80")
     handle = nvfatbin.create([], 0)
     with pytest.raises(nvfatbin.nvFatbinError, match="ERROR_ELF_ARCH_MISMATCH"):
-        nvfatbin.add_cubin(handle, CUBIN, len(CUBIN), "75", "inc")
+        nvfatbin.add_cubin(handle, cubin, len(cubin), "75", "inc")
 
     nvfatbin.destroy(handle)
 
@@ -280,11 +284,11 @@ def test_nvfatbin_add_cubin(CUBIN, arch):
     nvfatbin.destroy(handle)
 
 
-@pytest.mark.parametrize("arch", ["sm_80"], indirect=True)
-def test_nvfatbin_add_cubin_ELF_ARCH_MISMATCH(CUBIN, arch):
+def test_nvfatbin_add_cubin_ELF_ARCH_MISMATCH():
+    cubin = _build_cubin("sm_80")
     handle = nvfatbin.create([], 0)
     with pytest.raises(nvfatbin.nvFatbinError, match="ERROR_ELF_ARCH_MISMATCH"):
-        nvfatbin.add_cubin(handle, CUBIN, len(CUBIN), "75", "inc")
+        nvfatbin.add_cubin(handle, cubin, len(cubin), "75", "inc")
 
     nvfatbin.destroy(handle)
 

--- a/cuda_core/tests/test_utils.py
+++ b/cuda_core/tests/test_utils.py
@@ -148,7 +148,7 @@ def _cpu_array_samples():
     return samples
 
 
-@pytest.mark.parametrize("in_arr,", _cpu_array_samples())
+@pytest.mark.parametrize("in_arr", _cpu_array_samples())
 class TestViewCPU:
     def test_args_viewable_as_strided_memory_cpu(self, in_arr):
         @args_viewable_as_strided_memory((0,))


### PR DESCRIPTION
## Summary

main has been red since pytest 9.1.0 landed on PyPI — every `Test linux-*` / `Test win-*` matrix entry fails at *pytest collection time*, before any actual test runs. Two unrelated latent bugs in our test code, both tolerated by older pytest but rejected by pytest 9.1.0's stricter `parametrize` validation:

### Bug 1: trailing comma in `parametrize` name (cuda_core)

`cuda_core/tests/test_utils.py:151` had:
```python
@pytest.mark.parametrize("in_arr,", _cpu_array_samples())
```
The `,` inside the string was a stray. pytest 9 splits names on comma, ends up with one name but 3-tuple values, and fails collection with:
```
in "parametrize" the number of names (1):
  ['in_arr']
must be equal to the number of values (3):
  (665115599, 23133, 0)
```
*Fix*: drop the trailing comma.

### Bug 2: `indirect=True` override of a fixture-level parametrize (cuda_bindings)

`cuda_bindings/tests/test_nvfatbin.py` has an `arch` fixture parametrized with `params=ARCHITECTURES`. Two tests overrode it via `@pytest.mark.parametrize("arch", ["sm_80"], indirect=True)`. pytest 9 now rejects this as:
```
duplicate parametrization of 'arch'
```
*Fix*: extract the CUBIN-building logic from the `CUBIN` fixture into a `_build_cubin(arch)` helper, drop the `indirect` override on the two affected tests, and call the helper directly with `"sm_80"` (preserving the original intent — those tests *intentionally* used only sm_80, since target arch `"75"` must not match the CUBIN's arch).

## Backwards compatibility

Both fixes are pytest-version-agnostic — pip pin (`pytest>=6.2.4`) doesn't need to change. Verified by collecting against three pytest versions (minimal repros, included below for reproducibility):

| pytest | broken pattern 1 | fixed 1 | broken pattern 2 | fixed 2 |
|--------|------------------|---------|------------------|---------|
| 9.1.0  | collection error | clean   | collection error | clean   |
| 9.0.2  | clean (tolerant) | clean   | clean (tolerant) | clean   |
| 8.4.2  | clean (tolerant) | clean   | clean (tolerant) | clean   |

## Reference

Affected CI runs on main:
- 8ba39e85: https://github.com/NVIDIA/cuda-python/actions/runs/27475559263
- 8ba39e85 (re-run): https://github.com/NVIDIA/cuda-python/actions/runs/27483372849
- ae1617dd: https://github.com/NVIDIA/cuda-python/actions/runs/27487967018

Same pattern on my open #2210: https://github.com/NVIDIA/cuda-python/actions/runs/27489049015 — 38 `Run cuda.core tests` failures + 23 `Run cuda.bindings tests` failures all stem from these two collection errors.