### PR TITLE
ci: remove release-time self-test of release-notes checker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,11 +164,6 @@ jobs:
         with:
           python-version: "3.12"
 
-      # - name: Self-test release-notes checker
-      #   run: |
-      #     pip install pytest
-      #     pytest ci/tools/tests
-
       - name: Check versioned release notes exist
         run: |
           python ci/tools/check_release_notes.py \


### PR DESCRIPTION
## Description

Fixes #2062.

The `check-release-notes` job in `release.yml` ran `pytest ci/tools/tests` from the repo root. Pytest then discovers the root `conftest.py`, which imports `cuda.pathfinder`. The job installs only `pytest` (not the project packages), so collection aborted with exit code 4 before any test ran, and the job never reached the actual `Check versioned release notes exist` step.

As noted in the issue, running infra/tooling tests during a release is the wrong place for them. The step was already disabled (commented out) and carried to `main` via #2073. This removes the dead block so the release workflow only validates that the versioned release notes exist.

## Change

- Remove the commented-out `Self-test release-notes checker` step from the `check-release-notes` job in `.github/workflows/release.yml`.

The `Set up Python` step is retained because `Check versioned release notes exist` still runs `python ci/tools/check_release_notes.py`.

## Follow-up (out of scope)

The tooling tests under `ci/tools/tests` can be exercised in a PR-triggered CI workflow so they stay covered without the release-time package-import problem. Happy to do that as a separate PR if maintainers want it; running them cleanly needs to avoid loading the root `conftest.py` (e.g. `--confcutdir`), so it is kept separate from this minimal fix.