### PR TITLE
Stop skip-masking missing CUDA checkpoint bindings

### DIFF
--- a/cuda_core/tests/test_checkpoint.py
+++ b/cuda_core/tests/test_checkpoint.py
@@ -33,8 +33,26 @@ def _checkpoint_available():
     try:
         checkpoint._get_driver()
         return True
-    except RuntimeError:
-        return False
+    except RuntimeError as exc:
+        if _checkpoint_unavailable_can_skip(str(exc)):
+            return False
+        raise
+
+
+def _checkpoint_unavailable_can_skip(message):
+    if message.startswith(
+        (
+            "CUDA checkpointing is not supported by the installed NVIDIA driver.",
+            "CUDA checkpointing requires cuda.bindings with CUDA checkpoint API support. Found cuda.bindings ",
+        )
+    ):
+        return True
+
+    return (
+        checkpoint._binding_version()[0] == 12
+        and message
+        == "CUDA checkpointing requires cuda.bindings with CUDA checkpoint API support. Missing: CUcheckpointGpuPair"
+    )
 
 
 needs_checkpoint = pytest.mark.skipif(


### PR DESCRIPTION
## What This Change Does

This PR changes only the `cuda_core` checkpoint test availability guard in `cuda_core/tests/test_checkpoint.py`.

Before this change, `_checkpoint_available()` caught every `RuntimeError` raised by `cuda.core.checkpoint._get_driver()` and returned `False`. Because `_checkpoint_available()` is used by the checkpoint test skip marker, that meant all `RuntimeError`s from `_get_driver()` were treated as unsupported-environment skips.

That was too broad. `_get_driver()` uses `RuntimeError` for two different categories:

- expected unsupported environments, such as an installed NVIDIA driver without checkpoint API support
- real binding-surface problems, such as a supported `cuda.bindings` version missing a required checkpoint symbol

The `CUcheckpointRestoreArgs` issue exposed the problem. PR #2144 fixed the generated binding itself, but before that fix the missing `CUcheckpointRestoreArgs` symbol was already detected by `cuda.core.checkpoint._get_driver()`. The checkpoint tests still skipped because their availability guard swallowed the `RuntimeError` and classified it as unsupported environment.

This PR narrows the guard so it still skips only the known unsupported cases:

- driver does not support CUDA checkpointing
- installed `cuda.bindings` is older than the checkpoint API support boundary
- CUDA 12.x reports missing `CUcheckpointGpuPair`, which is an older checkpoint API shape rather than the CUDA 13.x `CUcheckpointRestoreArgs` regression

For other `RuntimeError`s, including missing required symbols such as `CUcheckpointRestoreArgs`, `_checkpoint_available()` now re-raises. That turns the previous skip-masked failure into a real test failure.

## Scope

This is intentionally minimal:

- no new `cuda_bindings` coverage
- no new `cuda_core` tests
- no production changes in `cuda_core/cuda/core/checkpoint.py`
- no GPU-remapping availability split

The only behavior change is that the checkpoint test skip guard no longer treats every `_get_driver()` `RuntimeError` as a reason to skip.

## Connection To PR #2150

PR #2150 was the broader version of this fix. It added direct `cuda_bindings` coverage for the checkpoint symbols used by `cuda.core`, added focused policy coverage in `cuda_core`, and split baseline checkpoint support from CUDA 13.x GPU-remapping support.

This PR extracts only the pure test escape fix from PR #2150. It keeps the core correction from that PR: missing required checkpoint bindings should fail tests instead of being reported as unsupported-environment skips. Everything else from PR #2150 is deliberately left out so the review can focus on the smallest possible change that closes the escape.