### PR TITLE
cuda.core: reject negative IPC allocation fds under -O (Glasswing V3.2)

### DIFF
--- a/cuda_core/cuda/core/_memory/_ipc.pyx
+++ b/cuda_core/cuda/core/_memory/_ipc.pyx
@@ -111,7 +111,8 @@ cdef class IPCAllocationHandle:
     @classmethod
     def _init(cls, handle: int, uuid: uuid.UUID | None) -> IPCAllocationHandle:  # no-cython-lint
         cdef IPCAllocationHandle self = IPCAllocationHandle.__new__(cls)
-        assert handle >= 0
+        if handle < 0:
+            raise ValueError(f"Invalid allocation handle (fd) {handle}: must be non-negative")
         self._h_fd = create_fd_handle(handle)
         self._uuid = uuid
         return self

--- a/cuda_core/tests/memory_ipc/test_errors.py
+++ b/cuda_core/tests/memory_ipc/test_errors.py
@@ -31,6 +31,14 @@ def test_outer_timeout_marker_is_applied(request):
     assert marker.args == (expected,), f"unexpected timeout value: {marker.args!r}"
 
 
+def test_ipc_allocation_handle_rejects_negative_fd():
+    """Negative fds are rejected even when CPython runs with -O (Glasswing V3.2)."""
+    from cuda.core._memory._ipc import IPCAllocationHandle
+
+    with pytest.raises(ValueError, match=r"Invalid allocation handle \(fd\) -1: must be non-negative"):
+        IPCAllocationHandle._init(-1, None)
+
+
 class ChildErrorHarness:
     """Test harness for checking errors in child processes. Subclasses override
     PARENT_ACTION, CHILD_ACTION, and ASSERT (see below for examples)."""


### PR DESCRIPTION
## Summary

Addresses Glasswing security finding V3.2 (NVBUG 6268893): `IPCAllocationHandle._init` used `assert handle >= 0`, which CPython strips under `-O`. Replace with an explicit `ValueError` so negative allocation handles (fds) are always rejected.

## Changes

- `cuda_core/cuda/core/_memory/_ipc.pyx`: raise `ValueError` when `handle < 0` instead of asserting
- `cuda_core/tests/memory_ipc/test_errors.py`: add `test_ipc_allocation_handle_rejects_negative_fd`

## Test Coverage

- `test_ipc_allocation_handle_rejects_negative_fd` — verifies `IPCAllocationHandle._init(-1, None)` raises `ValueError` with the expected message (behavior preserved under `-O`)

## Related Work

- NVIDIA/cuda-python-private#382 (Glasswing V3.2, NVBugs 6268893)
- Part of Glasswing audit umbrella NVIDIA/cuda-python-private#358