### PR TITLE
cuda.core: validate accessed_by kinds before cuMemAdvise (Glasswing V19.1)

### DIFF
--- a/cuda_core/cuda/core/_memory/_managed_buffer.py
+++ b/cuda_core/cuda/core/_memory/_managed_buffer.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from cuda.core._device import Device
 from cuda.core._host import Host
 from cuda.core._memory._buffer import Buffer
+from cuda.core._memory._managed_location import _coerce_location
 from cuda.core._memory._managed_memory_ops import (
     _advise_one,
     _do_single_discard_prefetch_py,
@@ -227,6 +228,11 @@ class ManagedBuffer(Buffer):
             if not isinstance(loc, (Device, Host)):
                 raise TypeError(f"accessed_by entries must be Device or Host, got {type(loc).__name__}")
             target.add(loc)
+        for loc in target:
+            spec = _coerce_location(loc)
+            assert spec is not None
+            if spec.kind not in ("device", "host"):
+                raise ValueError(f"advise {_SET_ACCESSED_BY.name} does not support location_type='{spec.kind}'")
         current = set(_query_accessed_by(self))
         for loc in current - target:
             _advise_one(self, _UNSET_ACCESSED_BY, loc)

--- a/cuda_core/tests/memory/test_managed_ops.py
+++ b/cuda_core/tests/memory/test_managed_ops.py
@@ -426,6 +426,25 @@ class TestManagedBuffer:
         buf.accessed_by = set()
         assert device not in buf.accessed_by
 
+    def test_accessed_by_set_assignment_validates_kind_before_mutation(
+        self, location_ops_device, external_managed_buffer
+    ):
+        """Invalid kinds in bulk assignment must not partially mutate driver state."""
+        device = location_ops_device
+        buf = external_managed_buffer
+        buf.accessed_by = {device, Host()}
+        assert device in buf.accessed_by
+        assert Host() in buf.accessed_by
+
+        with pytest.raises(
+            (ValueError, TypeError),
+            match=r"does not support location_type='host_numa'|cuda-bindings 13\.0\+",
+        ):
+            buf.accessed_by = {device, Host(numa_id=0)}
+
+        assert device in buf.accessed_by
+        assert Host() in buf.accessed_by
+
     def test_instance_prefetch(self, location_ops_device, managed_buffer):
         device = location_ops_device
         buf = managed_buffer


### PR DESCRIPTION
## Summary

Addresses Glasswing finding V19.1 (NVBUG 6268913): the `ManagedBuffer.accessed_by` setter validated element types up front but deferred location-kind checks to `_advise_one` inside the update loop. A bulk assignment containing an invalid kind (e.g. `Host(numa_id=...)`, which maps to `host_numa`) could unset valid entries before raising, leaving torn driver state.

## Changes

- `cuda_core/cuda/core/_memory/_managed_buffer.py`: dry-run `_coerce_location` and reject unsupported kinds for `CU_MEM_ADVISE_SET_ACCESSED_BY` before any `cuMemAdvise` calls
- `cuda_core/tests/memory/test_managed_ops.py`: add `test_accessed_by_set_assignment_validates_kind_before_mutation`

## Test Coverage

- `test_accessed_by_set_assignment_validates_kind_before_mutation` — invalid bulk assignment raises without removing previously applied `accessed_by` entries

## Related Work

- NVIDIA/cuda-python-private#380 (Glasswing V19.1, NVBugs [6268913](https://nvbugspro.nvidia.com/bug/6268913))
- Part of Glasswing audit umbrella NVIDIA/cuda-python-private#358