### PR TITLE
cuda.core: validate IPC descriptor lengths before import (Glasswing V2.1/V7.1)

### DIFF
--- a/cuda_core/cuda/core/_event.pyx
+++ b/cuda_core/cuda/core/_event.pyx
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 cimport cpython
+from libc.stddef cimport size_t
 from libc.string cimport memcpy
 from cuda.bindings cimport cydriver
 from cuda.core._context cimport Context
@@ -232,6 +233,13 @@ cdef class Event:
             A new event backed by the imported IPC handle.
 
         """
+        cdef size_t reserved_size = len(ipc_descriptor._reserved)
+        cdef size_t expected_size = sizeof(cydriver.CUipcEventHandle)
+        if reserved_size < expected_size:
+            raise ValueError(
+                f"IPC event descriptor reserved field is {reserved_size} bytes; "
+                f"expected at least {expected_size}"
+            )
         cdef cydriver.CUipcEventHandle data
         memcpy(data.reserved, <const void*><const char*>(ipc_descriptor._reserved), sizeof(data.reserved))
         cdef Event self = Event.__new__(cls)

--- a/cuda_core/cuda/core/_memory/_ipc.pyx
+++ b/cuda_core/cuda/core/_memory/_ipc.pyx
@@ -4,6 +4,7 @@
 
 cimport cpython
 
+from libc.stddef cimport size_t
 from cuda.bindings cimport cydriver
 from cuda.core._memory._buffer cimport Buffer, Buffer_from_deviceptr_handle
 from cuda.core._memory._memory_pool cimport _MemPool
@@ -170,6 +171,13 @@ cdef Buffer Buffer_from_ipc_descriptor(
     """Import a buffer that was exported from another process."""
     if not mr.is_ipc_enabled:
         raise RuntimeError("Memory resource is not IPC-enabled")
+    cdef size_t payload_size = len(ipc_descriptor._payload)
+    cdef size_t expected_size = sizeof(cydriver.CUmemPoolPtrExportData)
+    if payload_size < expected_size:
+        raise ValueError(
+            f"IPC buffer descriptor payload is {payload_size} bytes; "
+            f"expected at least {expected_size}"
+        )
     cdef Stream s = Stream_accept(stream)
     cdef DevicePtrHandle h_ptr = deviceptr_import_ipc(
         mr._h_pool,

--- a/cuda_core/tests/memory_ipc/test_errors.py
+++ b/cuda_core/tests/memory_ipc/test_errors.py
@@ -9,6 +9,7 @@ import pytest
 from helpers.child_processes import child_timeout_sec, kill_subprocesses
 
 from cuda.core import Buffer, Device, DeviceMemoryResource, DeviceMemoryResourceOptions
+from cuda.core._memory import IPCBufferDescriptor
 from cuda.core._utils.cuda_utils import CUDAError
 
 CHILD_TIMEOUT_SEC = child_timeout_sec()
@@ -29,6 +30,13 @@ def test_outer_timeout_marker_is_applied(request):
     marker = request.node.get_closest_marker("timeout")
     assert marker is not None, "memory_ipc/conftest.py did not apply a timeout marker"
     assert marker.args == (expected,), f"unexpected timeout value: {marker.args!r}"
+
+
+def test_import_truncated_buffer_descriptor(ipc_device, ipc_memory_resource):
+    """Truncated IPC buffer descriptor payload is rejected before driver import."""
+    desc = IPCBufferDescriptor._init(b"\x00" * 8, NBYTES)
+    with pytest.raises(ValueError, match=r"payload is 8 bytes; expected at least 64"):
+        Buffer.from_ipc_descriptor(ipc_memory_resource, desc, stream=ipc_device.default_stream)
 
 
 class ChildErrorHarness:

--- a/cuda_core/tests/test_event.py
+++ b/cuda_core/tests/test_event.py
@@ -235,6 +235,15 @@ def test_event_is_done_false(init_cuda):
     event.sync()
 
 
+def test_import_truncated_event_descriptor():
+    """Truncated IPC event descriptor reserved field is rejected before memcpy."""
+    import cuda.core._event as _event_module
+
+    desc = _event_module.IPCEventDescriptor._init(b"\x00" * 8, True)
+    with pytest.raises(ValueError, match=r"reserved field is 8 bytes; expected at least 64"):
+        Event.from_ipc_descriptor(desc)
+
+
 def test_ipc_event_descriptor_direct_init():
     """IPCEventDescriptor cannot be instantiated directly."""
     import cuda.core._event as _event_module


### PR DESCRIPTION
## Summary

Addresses two related Glasswing IPC import findings: peer-supplied descriptor payloads shorter than the driver struct size could be read past bounds during buffer pointer import or event-handle memcpy.

## Changes

- `cuda_core/cuda/core/_memory/_ipc.pyx`: reject `IPCBufferDescriptor` payloads smaller than `sizeof(CUmemPoolPtrExportData)` before `deviceptr_import_ipc` (V2.1)
- `cuda_core/cuda/core/_event.pyx`: reject `IPCEventDescriptor` reserved fields smaller than `sizeof(CUipcEventHandle)` before `memcpy` (V7.1)
- `cuda_core/tests/memory_ipc/test_errors.py`: `test_import_truncated_buffer_descriptor`
- `cuda_core/tests/test_event.py`: `test_import_truncated_event_descriptor`

## Test Coverage

- Truncated buffer descriptor raises `ValueError` before driver import (IPC fixture)
- Truncated event descriptor raises `ValueError` before memcpy (no GPU required)

## Related Work

- NVIDIA/cuda-python-private#360 (Glasswing V2.1, NVBugs [6268888](https://nvbugspro.nvidia.com/bug/6268888))
- NVIDIA/cuda-python-private#364 (Glasswing V7.1, NVBugs [6268898](https://nvbugspro.nvidia.com/bug/6268898))
- Part of Glasswing audit umbrella NVIDIA/cuda-python-private#358
- Related: #373 (pickle → IPC) defers hard length validation to V2.1