### PR TITLE
cuda.core: validate IPC buffer import size against mapped extent (Glasswing V2.2)

### DIFF
--- a/cuda_core/cuda/core/_memory/_ipc.pyx
+++ b/cuda_core/cuda/core/_memory/_ipc.pyx
@@ -179,7 +179,20 @@ cdef Buffer Buffer_from_ipc_descriptor(
     )
     if not h_ptr:
         HANDLE_RETURN(get_last_error())
-    return Buffer_from_deviceptr_handle(h_ptr, ipc_descriptor.size, mr, ipc_descriptor)
+    cdef size_t mapped_size = 0
+    cdef size_t claimed_size = ipc_descriptor.size
+    with nogil:
+        HANDLE_RETURN(cydriver.cuPointerGetAttribute(
+            &mapped_size,
+            cydriver.CU_POINTER_ATTRIBUTE_RANGE_SIZE,
+            as_cu(h_ptr)))
+    if claimed_size > mapped_size:
+        h_ptr.reset()
+        raise ValueError(
+            f"IPC buffer descriptor size ({claimed_size}) exceeds "
+            f"mapped allocation extent ({mapped_size} bytes)"
+        )
+    return Buffer_from_deviceptr_handle(h_ptr, claimed_size, mr, ipc_descriptor)
 
 
 # _MemPool IPC Implementation

--- a/cuda_core/tests/memory_ipc/test_errors.py
+++ b/cuda_core/tests/memory_ipc/test_errors.py
@@ -9,6 +9,7 @@ import pytest
 from helpers.child_processes import child_timeout_sec, kill_subprocesses
 
 from cuda.core import Buffer, Device, DeviceMemoryResource, DeviceMemoryResourceOptions
+from cuda.core._memory import IPCBufferDescriptor
 from cuda.core._utils.cuda_utils import CUDAError
 
 CHILD_TIMEOUT_SEC = child_timeout_sec()
@@ -86,6 +87,25 @@ class ChildErrorHarness:
         else:
             exc_info = None, None
         pipe[1].put(exc_info)
+
+
+class TestImportOversizedBufferDescriptorSize(ChildErrorHarness):
+    """Reject peer-supplied sizes larger than the mapped allocation extent."""
+
+    def PARENT_ACTION(self, queue):
+        self.buffer = self.mr.allocate(NBYTES, stream=self.device.default_stream)
+        payload, _ = self.buffer.ipc_descriptor.__reduce__()[1]
+        oversized = IPCBufferDescriptor._init(payload, NBYTES * 100)
+        queue.put(oversized)
+
+    def CHILD_ACTION(self, queue):
+        oversized = queue.get(timeout=CHILD_TIMEOUT_SEC)
+        Buffer.from_ipc_descriptor(self.mr, oversized, stream=self.device.default_stream)
+
+    def ASSERT(self, exc_type, exc_msg):
+        assert exc_type is ValueError
+        assert "exceeds" in exc_msg
+        assert "mapped allocation extent" in exc_msg
 
 
 class TestAllocFromImportedMr(ChildErrorHarness):


### PR DESCRIPTION
## Summary

Addresses Glasswing finding V2.2 (NVBUG 6268889): a peer-supplied `IPCBufferDescriptor.size` was trusted as `buf._size` and used as the `cuMemcpyAsync` length without checking against the actual mapped allocation extent, enabling an oversized device copy when the receiver imported and copied a forged descriptor.

## Changes

- `cuda_core/cuda/core/_memory/_ipc.pyx`: after `deviceptr_import_ipc`, query `CU_POINTER_ATTRIBUTE_RANGE_SIZE` on the imported pointer and reject descriptors whose advertised size exceeds the mapped extent before calling `Buffer_from_deviceptr_handle`
- `cuda_core/tests/memory_ipc/test_errors.py`: `TestImportOversizedBufferDescriptorSize` — cross-process harness that forges an oversized size on a valid export payload and asserts import raises `ValueError`

## Test Coverage

- `TestImportOversizedBufferDescriptorSize` — peer forges oversized `size` on a valid 64-byte export blob; child import raises `ValueError` (DeviceMR and PinnedMR parametrizations)

## Related Work

- NVIDIA/cuda-python-private#361 (Glasswing V2.2, NVBugs [6268889](https://nvbugspro.nvidia.com/bug/6268889))
- Part of Glasswing audit umbrella NVIDIA/cuda-python-private#358
- Complements #2223 (descriptor payload length validation, V2.1/V7.1)