### PR TITLE
tests: fix duplicate parametrization rejected by pytest 9.1.0 (#2212 backport)

### DIFF
--- a/cuda_bindings/tests/test_nvfatbin.py
+++ b/cuda_bindings/tests/test_nvfatbin.py
@@ -122,8 +122,7 @@ def nvcc_smoke(tmpdir) -> str:
     return nvcc
 
 
-@pytest.fixture
-def CUBIN(arch):
+def _build_cubin(arch):
     def CHECK_NVRTC(err):
         if err != nvrtc.nvrtcResult.NVRTC_SUCCESS:
             raise RuntimeError(repr(err))
@@ -140,6 +139,11 @@ def CUBIN(arch):
     (err,) = nvrtc.nvrtcDestroyProgram(program_handle)
     CHECK_NVRTC(err)
     return cubin
+
+
+@pytest.fixture
+def CUBIN(arch):
+    return _build_cubin(arch)
 
 
 # create a valid LTOIR input for testing
@@ -261,11 +265,11 @@ def test_nvfatbin_add_ptx(PTX, arch):
     nvfatbin.destroy(handle)
 
 
-@pytest.mark.parametrize("arch", ["sm_80"], indirect=True)
-def test_nvfatbin_add_cubin_ELF_SIZE_MISMATCH(CUBIN, arch):
+def test_nvfatbin_add_cubin_ELF_SIZE_MISMATCH():
+    cubin = _build_cubin("sm_80")
     handle = nvfatbin.create([], 0)
     with pytest.raises(nvfatbin.nvFatbinError, match="ERROR_ELF_ARCH_MISMATCH"):
-        nvfatbin.add_cubin(handle, CUBIN, len(CUBIN), "75", "inc")
+        nvfatbin.add_cubin(handle, cubin, len(cubin), "75", "inc")
 
     nvfatbin.destroy(handle)
 
@@ -282,11 +286,11 @@ def test_nvfatbin_add_cubin(CUBIN, arch):
     nvfatbin.destroy(handle)
 
 
-@pytest.mark.parametrize("arch", ["sm_80"], indirect=True)
-def test_nvfatbin_add_cubin_ELF_ARCH_MISMATCH(CUBIN, arch):
+def test_nvfatbin_add_cubin_ELF_ARCH_MISMATCH():
+    cubin = _build_cubin("sm_80")
     handle = nvfatbin.create([], 0)
     with pytest.raises(nvfatbin.nvFatbinError, match="ERROR_ELF_ARCH_MISMATCH"):
-        nvfatbin.add_cubin(handle, CUBIN, len(CUBIN), "75", "inc")
+        nvfatbin.add_cubin(handle, cubin, len(cubin), "75", "inc")
 
     nvfatbin.destroy(handle)
 


### PR DESCRIPTION
## Summary

Backport of #2212, scoped down to the `cuda_bindings/tests/test_nvfatbin.py` portion that applies to 12.9.x.

The `cuda_core/tests/test_utils.py` portion of #2212 (the trailing-comma-in-parametrize-name fix) does not apply here — the 12.9.x version of that file uses `@pytest.mark.parametrize("in_arr,use_stream", (*gpu_array_samples(),))` (two names matching tuple values), no stray comma.

Hunk body verified identical to the corresponding hunk in #2212 (commit a9156b6207).

Closes #2226.