### PR TITLE
TST: Pin test dependencies to exact versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,51 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 
 version: 2
 updates:
+  # Python test-dependency updates for cuda_bindings
+  - package-ecosystem: pip
+    directory: /cuda_bindings
+    schedule:
+      interval: "monthly"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 5
+    groups:
+      test-deps:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
+
+  # Python test-dependency updates for cuda_core
+  - package-ecosystem: pip
+    directory: /cuda_core
+    schedule:
+      interval: "monthly"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 5
+    groups:
+      test-deps:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
+
+  # Python test-dependency updates for cuda_pathfinder
+  - package-ecosystem: pip
+    directory: /cuda_pathfinder
+    schedule:
+      interval: "monthly"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 5
+    groups:
+      test-deps:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
+
   # GitHub Actions updates targeting the default branch (main)
   - package-ecosystem: github-actions
     directory: /

--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -48,7 +48,7 @@ test = [
     "setuptools>=80.0.0",
     # TODO: remove the Python 3.15 guard once 3.15 is officially supported
     "matplotlib==3.10.9; python_version < '3.15'",
-    "numpy==2.4.6",
+    "numpy==2.2.6",
     "pytest==9.1.0",
     "pytest-benchmark==5.2.3",
     "pytest-repeat==0.9.4",

--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -48,7 +48,7 @@ test = [
     "setuptools>=80.0.0",
     # TODO: remove the Python 3.15 guard once 3.15 is officially supported
     "matplotlib>=3.5.0,<=3.10.9; python_version < '3.15'",
-    "numpy>=1.21.1,<=2.2.6",
+    "numpy>=1.21.1,<=2.5.0",
     "pytest==9.1.0",
     "pytest-benchmark==5.2.3",
     "pytest-repeat==0.9.4",

--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -47,8 +47,8 @@ test = [
     "cython>=3.2,<3.3",
     "setuptools>=80.0.0",
     # TODO: remove the Python 3.15 guard once 3.15 is officially supported
-    "matplotlib==3.10.9; python_version < '3.15'",
-    "numpy==2.2.6",
+    "matplotlib; python_version < '3.15'",
+    "numpy",
     "pytest==9.1.0",
     "pytest-benchmark==5.2.3",
     "pytest-repeat==0.9.4",

--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -47,7 +47,7 @@ test = [
     "cython>=3.2,<3.3",
     "setuptools>=80.0.0",
     # TODO: remove the Python 3.15 guard once 3.15 is officially supported
-    "matplotlib==3.11.0; python_version < '3.15'",
+    "matplotlib==3.10.9; python_version < '3.15'",
     "numpy==2.4.6",
     "pytest==9.1.0",
     "pytest-benchmark==5.2.3",

--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -47,8 +47,8 @@ test = [
     "cython>=3.2,<3.3",
     "setuptools>=80.0.0",
     # TODO: remove the Python 3.15 guard once 3.15 is officially supported
-    "matplotlib; python_version < '3.15'",
-    "numpy",
+    "matplotlib>=3.5.0,<=3.10.9; python_version < '3.15'",
+    "numpy>=1.21.1,<=2.2.6",
     "pytest==9.1.0",
     "pytest-benchmark==5.2.3",
     "pytest-repeat==0.9.4",

--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -45,15 +45,15 @@ all = [
 [dependency-groups]
 test = [
     "cython>=3.2,<3.3",
-    "setuptools>=77.0.0",
+    "setuptools>=80.0.0",
     # TODO: remove the Python 3.15 guard once 3.15 is officially supported
-    "matplotlib>=3.5.0; python_version < '3.15'",
-    "numpy>=1.21.1",
-    "pytest>=6.2.4",
-    "pytest-benchmark>=3.4.1",
-    "pytest-repeat",
-    "pytest-randomly",
-    "pyglet>=2.1.9",
+    "matplotlib==3.11.0; python_version < '3.15'",
+    "numpy==2.4.6",
+    "pytest==9.1.0",
+    "pytest-benchmark==5.2.3",
+    "pytest-repeat==0.9.4",
+    "pytest-randomly==4.1.0",
+    "pyglet==2.1.14",
 ]
 
 [project.urls]

--- a/cuda_core/pyproject.toml
+++ b/cuda_core/pyproject.toml
@@ -59,11 +59,18 @@ cu13 = ["cuda-bindings[all]==13.*", "cuda-toolkit==13.*"]
 
 [dependency-groups]
 test = [
-    "cython>=3.2,<3.3", "setuptools", "pytest>=6.2.4", "pytest-benchmark",
-    "pytest-randomly", "pytest-repeat", "pytest-rerunfailures", "pytest-timeout",
-    "cloudpickle", "psutil",
+    "cython>=3.2,<3.3",
+    "setuptools>=80",
+    "pytest==9.1.0",
+    "pytest-benchmark==5.2.3",
+    "pytest-randomly==4.1.0",
+    "pytest-repeat==0.9.4",
+    "pytest-rerunfailures==16.3",
+    "pytest-timeout==2.4.0",
+    "cloudpickle==3.1.2",
+    "psutil==7.2.2",
     # TODO: remove the Python 3.15 guard once 3.15 is officially supported
-    "cffi; python_version < '3.15'",
+    "cffi==2.0.0; python_version < '3.15'",
 ]
 ml-dtypes = ["ml-dtypes>=0.5.4,<0.6.0"]
 test-cu12 = [ {include-group = "ml-dtypes" }, {include-group = "test" }, "cupy-cuda12x; python_version < '3.14'", "cuda-toolkit[cudart]==12.*"]  # runtime headers needed by CuPy

--- a/cuda_pathfinder/pyproject.toml
+++ b/cuda_pathfinder/pyproject.toml
@@ -12,10 +12,10 @@ dependencies = []
 
 [dependency-groups]
 test = [
-    "pytest>=6.2.4",
-    "pytest-mock",
-    "pytest-repeat",
-    "pytest-randomly",
+    "pytest==9.1.0",
+    "pytest-mock==3.15.1",
+    "pytest-repeat==0.9.4",
+    "pytest-randomly==4.1.0",
 ]
 # Internal organization of test dependencies.
 cu12 = [


### PR DESCRIPTION
This is in response to #2227 causing an unwelcome surprise when pytest was updated.  It was fine at the time, but this kind of thing gets really annoying during release time.

There is no reason not to pin our test dependencies, and let dependabot handle updating them so we can deal with any breakages when we want to, not to urgently unblock CI.

## Summary

- Pin all test `[dependency-groups]` specifiers to exact `==` versions in `cuda_bindings`, `cuda_core`, and `cuda_pathfinder` so CI runs against a known-good set of packages
- Add three `pip` ecosystem entries to `.github/dependabot.yml` (one per subproject) so Dependabot opens PRs when newer PyPI versions are available

## Notes

- `cython` and `setuptools` are intentionally left as range specifiers (`>=3.2,<3.3` and `>=80`) since they are build-time dependencies with looser compatibility constraints
- `ml-dtypes` in `cuda_core` is left as `>=0.5.4,<0.6.0` for the same reason

## Test plan

- [ ] Verify CI passes with pinned versions
- [ ] Confirm dependabot config parses cleanly (check Actions tab after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)