### PR TITLE
[no-ci] Add test authorship tags to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,9 +116,11 @@ repos/{owner}/{repo}/milestones --jq '.[].title'`, and pick the best match.
 ## Test authorship tags
 
 Use these tags to make the provenance of newly added unit tests explicit. Use
-the host language's comment syntax, and place the tag immediately above the
-test function, test class, or at the top of a new test file when the whole file
-has the same provenance.
+the host language's comment syntax, and place the tag immediately above each
+test function. A class-level tag is acceptable only when every test method in
+the class has the same provenance. Do not use file-level tags for authorship
+provenance; they are too easy to miss in large files and make later per-test
+provenance changes unclear.
 
 - `AGENT-AUTHORED <model>`: the test was authored by an agent and has not yet
   been materially reviewed or rewritten by a human. Agents must add this tag

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,33 @@ repos/{owner}/{repo}/milestones --jq '.[].title'`, and pick the best match.
   end on clarifications unless truly blocked. Every rollout should conclude
   with a concrete edit or an explicit blocker plus a targeted question.
 
+## Test authorship tags
+
+Use these tags to make the provenance of newly added unit tests explicit. Use
+the host language's comment syntax, and place the tag immediately above the
+test function, test class, or at the top of a new test file when the whole file
+has the same provenance.
+
+- `AGENT-AUTHORED <model>`: the test was authored by an agent and has not yet
+  been materially reviewed or rewritten by a human. Agents must add this tag
+  when generating new unit tests, for example:
+
+  ```python
+  # AGENT-AUTHORED gpt-5.5
+  ```
+
+- `HUMAN-REVIEWED`: a human has materially reviewed or rewritten an
+  agent-authored test. Prefer replacing `AGENT-AUTHORED <model>` with this tag
+  instead of keeping both.
+- `HUMAN-AUTHORED`: the test was authored by a human, or rewritten enough that
+  the authorship is primarily human.
+
+Use at most one authorship tag per test. Treat missing tags as legacy or
+unknown provenance, not as implicit `HUMAN-AUTHORED`. When an agent notices a
+human adding a new test or materially modifying an existing test, suggest
+adding `HUMAN-AUTHORED` or replacing `AGENT-AUTHORED <model>` with
+`HUMAN-REVIEWED` as appropriate.
+
 
 # Editing constraints
 


### PR DESCRIPTION
## Summary

This adds repository-wide `AGENTS.md` guidance for marking the provenance of newly added unit tests with lightweight comment tags.

The tag system is intentionally minimal. The design goal is to keep agents and humans choosing from no more than three clear states:

- `AGENT-AUTHORED <model>` for tests authored by an agent and not yet materially reviewed or rewritten by a human.
- `HUMAN-REVIEWED` for agent-authored tests that a human has materially reviewed or rewritten.
- `HUMAN-AUTHORED` for tests authored by a human, or rewritten enough that the authorship is primarily human.

The guidance keeps tags local to the tests they describe: tags should be placed immediately above each test function, with class-level tags only when every test method in the class has the same provenance. It also says to use at most one authorship tag per test and to treat missing tags as legacy or unknown provenance rather than implicit human authorship.

## Relationship to #2245

An alternative pytest marker-based version is available in #2245. That version uses formal `pytest.mark` markers and registers them in the pytest config roots so tests can be selected by provenance. This PR keeps the simpler comment-tag approach for direct comparison.