### PR TITLE
Fix sdist tests in CI

### DIFF
--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -4,6 +4,7 @@
 requires = [
     "setuptools>=80.0.0",
     "setuptools_scm[simple]>=8,<10.1",
+    "vcs-versioning<2.0",
     "cython>=3.2,<3.3",
     "pyclibrary>=0.1.7",
     "cuda-pathfinder>=1.5",

--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -3,7 +3,7 @@
 [build-system]
 requires = [
     "setuptools>=80.0.0",
-    "setuptools_scm[simple]>=8",
+    "setuptools_scm[simple]>=8,<10.1",
     "cython>=3.2,<3.3",
     "pyclibrary>=0.1.7",
     "cuda-pathfinder>=1.5",

--- a/cuda_core/pyproject.toml
+++ b/cuda_core/pyproject.toml
@@ -5,7 +5,7 @@
 [build-system]
 requires = [
     "setuptools>=80",
-    "setuptools-scm[simple]>=8",
+    "setuptools-scm[simple]>=8,<10.1",
     "Cython>=3.2,<3.3",
     "cuda-pathfinder>=1.5"
 ]

--- a/cuda_core/pyproject.toml
+++ b/cuda_core/pyproject.toml
@@ -6,6 +6,7 @@
 requires = [
     "setuptools>=80",
     "setuptools-scm[simple]>=8,<10.1",
+    "vcs-versioning<2.0",
     "Cython>=3.2,<3.3",
     "cuda-pathfinder>=1.5"
 ]

--- a/cuda_pathfinder/pyproject.toml
+++ b/cuda_pathfinder/pyproject.toml
@@ -89,6 +89,7 @@ readme = { file = ["DESCRIPTION.rst"], content-type = "text/x-rst" }
 requires = [
     "setuptools>=80.0.0",
     "setuptools_scm[simple]>=8,<10.1",
+    "vcs-versioning<2.0",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"

--- a/cuda_pathfinder/pyproject.toml
+++ b/cuda_pathfinder/pyproject.toml
@@ -88,7 +88,7 @@ readme = { file = ["DESCRIPTION.rst"], content-type = "text/x-rst" }
 [build-system]
 requires = [
     "setuptools>=80.0.0",
-    "setuptools_scm[simple]>=8",
+    "setuptools_scm[simple]>=8,<10.1",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
setuptools-scm 10.1.1 broke our sdist builds.

This appears to be a known issue that at least xarray is also running into: https://github.com/pypa/setuptools-scm/issues/1423

This places an upper bound on `setuptools-scm` and also (necessarily) one of its dependencies to get our CI working again.  We can remove these upper bounds when the bug is fixed upstream.
