### PR TITLE
Remove upper limit on setuptools-scm

### DIFF
--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -3,8 +3,7 @@
 [build-system]
 requires = [
     "setuptools>=80.0.0",
-    "setuptools_scm[simple]>=8,<10.1",
-    "vcs-versioning<2.0",
+    "setuptools_scm[simple]>=8,!=10.1.1",
     "cython>=3.2,<3.3",
     "pyclibrary>=0.1.7",
     "cuda-pathfinder>=1.5",

--- a/cuda_core/pyproject.toml
+++ b/cuda_core/pyproject.toml
@@ -5,8 +5,7 @@
 [build-system]
 requires = [
     "setuptools>=80",
-    "setuptools-scm[simple]>=8,<10.1",
-    "vcs-versioning<2.0",
+    "setuptools-scm[simple]>=8,!=10.1.1",
     "Cython>=3.2,<3.3",
     "cuda-pathfinder>=1.5"
 ]

--- a/cuda_pathfinder/pyproject.toml
+++ b/cuda_pathfinder/pyproject.toml
@@ -88,8 +88,7 @@ readme = { file = ["DESCRIPTION.rst"], content-type = "text/x-rst" }
 [build-system]
 requires = [
     "setuptools>=80.0.0",
-    "setuptools_scm[simple]>=8,<10.1",
-    "vcs-versioning<2.0",
+    "setuptools_scm[simple]>=8,!=10.1.1",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"

--- a/cuda_python/pyproject.toml
+++ b/cuda_python/pyproject.toml
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 
 [build-system]
-requires = ["setuptools>=80.0.0", "setuptools-scm[simple]>=8"]
+requires = ["setuptools>=80.0.0", "setuptools-scm[simple]>=8,!=10.1.1"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Yesterday, in #2241, an upper limit on the version of setuptools-scm was added to avoid the broken 10.1.1 version.  Since then, 10.1.2 was released which reportedly fixes the bug.  This makes our workaround more specific.