### PR TITLE
[no-ci] Register `pytest.mark` authorship markers, add matching AGENTS.md instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,9 +117,10 @@ repos/{owner}/{repo}/milestones --jq '.[].title'`, and pick the best match.
 
 Use pytest markers to make the provenance of newly added unit tests explicit.
 Keep this provenance system minimal: choose from only these three markers.
-Place the marker immediately above the test function or test class. Use
-module-level `pytestmark` only when the whole test file has the same
-provenance.
+Place the marker immediately above each test function. A class-level marker is
+acceptable only when every test method in the class has the same provenance.
+Do not use module-level `pytestmark` for authorship provenance; it is too easy
+to miss in large files and makes later per-test provenance changes ambiguous.
 
 - `@pytest.mark.agent_authored(model="<model>")`: the test was authored by an
   agent and has not yet been materially reviewed or rewritten by a human.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,43 @@ repos/{owner}/{repo}/milestones --jq '.[].title'`, and pick the best match.
   end on clarifications unless truly blocked. Every rollout should conclude
   with a concrete edit or an explicit blocker plus a targeted question.
 
+## Test authorship markers
+
+Use pytest markers to make the provenance of newly added unit tests explicit.
+Keep this provenance system minimal: choose from only these three markers.
+Place the marker immediately above the test function or test class. Use
+module-level `pytestmark` only when the whole test file has the same
+provenance.
+
+- `@pytest.mark.agent_authored(model="<model>")`: the test was authored by an
+  agent and has not yet been materially reviewed or rewritten by a human.
+  Agents must add this marker when generating new unit tests, for example:
+
+  ```python
+  import pytest
+
+  @pytest.mark.agent_authored(model="gpt-5.5")
+  def test_something():
+      ...
+  ```
+
+- `@pytest.mark.human_reviewed`: a human has materially reviewed or rewritten
+  an agent-authored test. Prefer replacing
+  `@pytest.mark.agent_authored(model="<model>")` with this marker instead of
+  keeping both.
+- `@pytest.mark.human_authored`: the test was authored by a human, or
+  rewritten enough that the authorship is primarily human.
+
+Use at most one authorship marker per test. Treat missing markers as legacy or
+unknown provenance, not as implicit `@pytest.mark.human_authored`. Because
+these are pytest markers, tests can be selected with `pytest -m`, for example
+`pytest -m agent_authored`.
+
+When an agent notices a human adding a new test or materially modifying an
+existing test, suggest adding `@pytest.mark.human_authored` or replacing
+`@pytest.mark.agent_authored(model="<model>")` with
+`@pytest.mark.human_reviewed` as appropriate.
+
 
 # Editing constraints
 

--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -92,6 +92,8 @@ required_plugins = "pytest-benchmark"
 addopts = "--benchmark-disable --showlocals"
 norecursedirs = ["tests/cython", "examples"]
 xfail_strict = true
+# Keep this authorship marker registry in sync across all pytest config roots.
+# Search for "agent_authored(model)" before editing.
 markers = [
     "agent_authored(model): agent-authored test not yet materially human-reviewed",
     "human_reviewed: agent-authored test materially reviewed or rewritten by a human",

--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -92,6 +92,11 @@ required_plugins = "pytest-benchmark"
 addopts = "--benchmark-disable --showlocals"
 norecursedirs = ["tests/cython", "examples"]
 xfail_strict = true
+markers = [
+    "agent_authored(model): agent-authored test not yet materially human-reviewed",
+    "human_reviewed: agent-authored test materially reviewed or rewritten by a human",
+    "human_authored: test authored primarily by a human",
+]
 
 [tool.setuptools_scm]
 root = ".."

--- a/cuda_core/pytest.ini
+++ b/cuda_core/pytest.ini
@@ -5,3 +5,7 @@
 [pytest]
 addopts = --showlocals
 norecursedirs = cython
+markers =
+    agent_authored(model): agent-authored test not yet materially human-reviewed
+    human_reviewed: agent-authored test materially reviewed or rewritten by a human
+    human_authored: test authored primarily by a human

--- a/cuda_core/pytest.ini
+++ b/cuda_core/pytest.ini
@@ -6,6 +6,8 @@
 addopts = --showlocals
 norecursedirs = cython
 markers =
+    # Keep this authorship marker registry in sync across all pytest config roots.
+    # Search for "agent_authored(model)" before editing.
     agent_authored(model): agent-authored test not yet materially human-reviewed
     human_reviewed: agent-authored test materially reviewed or rewritten by a human
     human_authored: test authored primarily by a human

--- a/cuda_pathfinder/pyproject.toml
+++ b/cuda_pathfinder/pyproject.toml
@@ -104,6 +104,11 @@ git_describe_command = [ "git", "describe", "--dirty", "--tags", "--long", "--ma
 [tool.pytest.ini_options]
 addopts = "--showlocals"
 thread_unsafe_fixtures = ['mocker']
+markers = [
+    "agent_authored(model): agent-authored test not yet materially human-reviewed",
+    "human_reviewed: agent-authored test materially reviewed or rewritten by a human",
+    "human_authored: test authored primarily by a human",
+]
 
 [tool.mypy]
 # Try to keep the mypy configuration similar between the subprojects

--- a/cuda_pathfinder/pyproject.toml
+++ b/cuda_pathfinder/pyproject.toml
@@ -104,6 +104,8 @@ git_describe_command = [ "git", "describe", "--dirty", "--tags", "--long", "--ma
 [tool.pytest.ini_options]
 addopts = "--showlocals"
 thread_unsafe_fixtures = ['mocker']
+# Keep this authorship marker registry in sync across all pytest config roots.
+# Search for "agent_authored(model)" before editing.
 markers = [
     "agent_authored(model): agent-authored test not yet materially human-reviewed",
     "human_reviewed: agent-authored test materially reviewed or rewritten by a human",

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,6 +20,8 @@ markers =
     core: tests for cuda_core
     cython: cython tests
     smoke: meta-level smoke tests
+    # Keep this authorship marker registry in sync across all pytest config roots.
+    # Search for "agent_authored(model)" before editing.
     agent_authored(model): agent-authored test not yet materially human-reviewed
     human_reviewed: agent-authored test materially reviewed or rewritten by a human
     human_authored: test authored primarily by a human

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,6 +20,9 @@ markers =
     core: tests for cuda_core
     cython: cython tests
     smoke: meta-level smoke tests
+    agent_authored(model): agent-authored test not yet materially human-reviewed
+    human_reviewed: agent-authored test materially reviewed or rewritten by a human
+    human_authored: test authored primarily by a human
     flaky: mark test as flaky (provided by pytest-rerunfailures)
     # pytest-run-parallel related markers
     thread_unsafe: mark test as thread unsafe (provided by pytest-run-parallel)


### PR DESCRIPTION
## Summary

This adds repository-wide `AGENTS.md` guidance for marking the provenance of newly added unit tests using pytest markers, and registers those markers in the pytest config roots.

The marker system is intentionally minimal. The design goal is to keep agents and humans choosing from no more than three clear states:

- `@pytest.mark.agent_authored(model="<model>")` for tests authored by an agent and not yet materially reviewed or rewritten by a human.
- `@pytest.mark.human_reviewed` for agent-authored tests that a human has materially reviewed or rewritten.
- `@pytest.mark.human_authored` for tests authored by a human, or rewritten enough that the authorship is primarily human.

The guidance keeps markers local to the tests they describe: markers should be placed immediately above each test function, with class-level markers only when every test method in the class has the same provenance. It also says not to use module-level `pytestmark` for authorship provenance, because that is easy to miss in large files and makes later per-test provenance changes ambiguous.

The pytest marker registrations include sync comments so future edits keep the copies aligned across pytest config roots.

## Relationship to #2232

This is an alternative to #2232. PR #2232 uses lightweight comment tags; this version uses formal pytest markers so tests can be selected by provenance with `pytest -m`, for example `pytest -m agent_authored`.

## Purpose

The purpose of these markers is to preserve ground-truth test provenance at the moment when it is easiest and most reliable to capture.

Provenance can be useful when interpreting a test. If a test was carefully authored or materially reviewed by a human, we may reasonably give it more evidentiary weight when investigating ambiguous behavior, evaluating an API change, or deciding whether an assertion reflects deliberate intent. This is not a guarantee that the test is correct, nor does an agent-authored marker imply that a test is inferior; it is additional context that would otherwise be lost.

Recording the generating model also makes the annotations actionable over time. As newer models become available, we could run automated passes over tests written by older models to review assumptions, strengthen assertions, identify missing cases, or remove low-value duplication. The provenance markers provide a practical way to select those cohorts and record when meaningful human review has occurred.

The accumulated metadata may also support useful empirical analysis. In the future, we could examine whether test provenance correlates with factors such as defect frequency, regressions detected, coverage, flakiness, or maintenance cost. We do not yet know which correlations will prove meaningful, but such analysis will only be practical if we capture the ground truth while it is readily available. Reconstructing provenance later from commit history or pull-request discussion would be incomplete and unreliable.

For now, the markers are informational. They do not automatically change CI behavior or assign a quality score. Their purpose is to preserve lightweight, machine-readable evidence that future reviewers, tools, and studies can use.
