### PR TITLE
Revert new dependabot config from #2230

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,48 +4,6 @@
 
 version: 2
 updates:
-  # Python test-dependency updates for cuda_bindings
-  - package-ecosystem: pip
-    directory: /cuda_bindings
-    schedule:
-      interval: "monthly"
-      time: "09:00"
-      timezone: "America/Los_Angeles"
-    open-pull-requests-limit: 5
-    groups:
-      test-deps:
-        applies-to: version-updates
-        patterns: ["*"]
-        update-types: ["major", "minor", "patch"]
-
-  # Python test-dependency updates for cuda_core
-  - package-ecosystem: pip
-    directory: /cuda_core
-    schedule:
-      interval: "monthly"
-      time: "09:00"
-      timezone: "America/Los_Angeles"
-    open-pull-requests-limit: 5
-    groups:
-      test-deps:
-        applies-to: version-updates
-        patterns: ["*"]
-        update-types: ["major", "minor", "patch"]
-
-  # Python test-dependency updates for cuda_pathfinder
-  - package-ecosystem: pip
-    directory: /cuda_pathfinder
-    schedule:
-      interval: "monthly"
-      time: "09:00"
-      timezone: "America/Los_Angeles"
-    open-pull-requests-limit: 5
-    groups:
-      test-deps:
-        applies-to: version-updates
-        patterns: ["*"]
-        update-types: ["major", "minor", "patch"]
-
   # GitHub Actions updates targeting the default branch (main)
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
The dependabot config in #2230 was intended to only suggest updates to the test group.  Instead, it suggests updates to the entire pyproject.toml file, and we have some pretty careful design requirements there, so it mostly gets it wrong.  I think it best to just revert this for now (so it doesn't flood our inbox) and explore how to get dependabot to do the right thing at our leisure, if we feel it's worth it.
