### PR TITLE
cuda.core: make managed-prefetch test page-size aware

### DIFF
--- a/cuda_core/tests/memory/test_managed_ops.py
+++ b/cuda_core/tests/memory/test_managed_ops.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import mmap
+
 import pytest
 from helpers.buffers import DummyDeviceMemoryResource, DummyUnifiedMemoryResource
 
@@ -9,7 +11,14 @@ from cuda.bindings import driver
 from cuda.core import Device, Host, ManagedBuffer
 from cuda.core._memory._managed_buffer import _get_int_attr
 
-_MANAGED_TEST_ALLOCATION_SIZE = 4096
+# Managed-memory prefetch and CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION
+# operate at physical-page granularity. Test buffers must each occupy a full
+# page; otherwise the pool packs sub-page allocations into one page and
+# per-buffer prefetch locations become indistinguishable. ``mmap.PAGESIZE``
+# tracks the OS page size (4 KiB on most x86, 64 KiB on nvidia-64k aarch64
+# kernels), so allocations stay one-page-per-buffer on every platform.
+_PAGE_SIZE = mmap.PAGESIZE
+_MANAGED_TEST_ALLOCATION_SIZE = _PAGE_SIZE
 _READ_MOSTLY_ENABLED = 1
 _HOST_LOCATION_ID = -1
 _INVALID_HOST_DEVICE_ORDINAL = 0
@@ -19,6 +28,12 @@ _INVALID_HOST_DEVICE_ORDINAL = 0
 # ``ManagedBuffer`` exposes mem-range attributes directly.
 def _last_prefetch_location(buf):
     return _get_int_attr(buf, driver.CUmem_range_attribute.CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION)
+
+
+def _page_base(buf):
+    # Page-aligned base of the buffer's start address; two buffers sharing a
+    # page cannot be prefetched to different locations independently.
+    return int(buf.handle) & ~(_PAGE_SIZE - 1)
 
 
 def _skip_if_raw_managed_alloc_unsupported(device):
@@ -216,6 +231,10 @@ class TestPrefetchBatch:
 
         device = location_ops_device
         bufs = [location_ops_mr.allocate(_MANAGED_TEST_ALLOCATION_SIZE, stream=device.default_stream) for _ in range(2)]
+        # Per-buffer prefetch locations are only observable when the buffers sit
+        # on distinct physical pages; assert that here so a pool-packing change
+        # fails loudly instead of silently migrating one shared page.
+        assert _page_base(bufs[0]) != _page_base(bufs[1])
         stream = device.create_stream()
 
         prefetch_batch(stream, bufs, [Host(), device])


### PR DESCRIPTION
## Summary

`TestPrefetchBatch.test_per_buffer_location` started failing on the CTK 13.x linux-aarch64 CI configs after the runners moved to the `nvidia-64k` (64 KB page-size) kernel:

```
>       assert last0 == _HOST_LOCATION_ID
E       assert 0 == -1
```

### Root cause

The test hardcoded a 4096-byte allocation and assumed two pooled buffers landed on **separate physical pages**. Managed-memory prefetch and `CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION` operate at **page granularity**, and `ManagedMemoryResource` is a pool, so the two `allocate(4096)` calls are packed adjacently (pointers 4 KB apart).

- **4 KB pages:** each 4 KB buffer is its own page → per-buffer prefetch is independent → passes.
- **64 KB pages:** both buffers share one 64 KB page → prefetching `bufs[1]` to the device migrates the whole shared page → querying `bufs[0]` reports device 0 instead of host (-1) → `assert 0 == -1`.

The prefetch itself worked correctly; the test's premise (sub-page allocations are independently prefetchable) only holds when buffer size ≥ page size. The failure is latent on any genuine 64 KB-page platform (Grace / Grace-Blackwell), so reverting the runner kernel only masks it.

### Fix

- Derive `_MANAGED_TEST_ALLOCATION_SIZE` from `mmap.PAGESIZE` so each buffer occupies a full page on every platform (no hardcoded page size).
- Add a precondition asserting the two buffers sit on distinct physical pages, so a future pool-packing change fails loudly instead of silently migrating a shared page.

### Verification

`pytest tests/memory/test_managed_ops.py` → `34 passed, 1 skipped` on an x86 (4 KB page) RTX 5880 Ada box, including the guarded `test_per_buffer_location`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)