### PR TITLE
Add pathfinder support for `cupti64_2026.2.1.dll` (released with CTK 13.3.1)

### DIFF
--- a/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/descriptor_catalog.py
+++ b/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/descriptor_catalog.py
@@ -272,6 +272,7 @@ DESCRIPTOR_CATALOG: tuple[DescriptorSpec, ...] = (
         linux_sonames=("libcupti.so.12", "libcupti.so.13"),
         windows_dlls=(
             "cupti64_2026.3.0.dll",
+            "cupti64_2026.2.1.dll",
             "cupti64_2026.2.0.dll",
             "cupti64_2026.1.1.dll",
             "cupti64_2026.1.0.dll",

--- a/cuda_pathfinder/docs/nv-versions.json
+++ b/cuda_pathfinder/docs/nv-versions.json
@@ -4,6 +4,10 @@
         "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/latest/"
     },
     {
+        "version": "1.5.6",
+        "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/1.5.6/"
+    },
+    {
         "version": "1.5.5",
         "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/1.5.5/"
     },

--- a/cuda_pathfinder/docs/source/release/1.5.6-notes.rst
+++ b/cuda_pathfinder/docs/source/release/1.5.6-notes.rst
@@ -12,4 +12,4 @@ Highlights
 * Add support for the Windows CTK 13.3.1 CUPTI DLL name
   ``cupti64_2026.2.1.dll`` so ``load_nvidia_dynamic_lib("cupti")`` can
   recognize the installed library on CTK 13.3.1 systems.
-  (`PR #9999 <https://github.com/NVIDIA/cuda-python/pull/9999>`_)
+  (`PR #2276 <https://github.com/NVIDIA/cuda-python/pull/2276>`_)

--- a/cuda_pathfinder/docs/source/release/1.5.6-notes.rst
+++ b/cuda_pathfinder/docs/source/release/1.5.6-notes.rst
@@ -12,3 +12,4 @@ Highlights
 * Add support for the Windows CTK 13.3.1 CUPTI DLL name
   ``cupti64_2026.2.1.dll`` so ``load_nvidia_dynamic_lib("cupti")`` can
   recognize the installed library on CTK 13.3.1 systems.
+  (`PR #9999 <https://github.com/NVIDIA/cuda-python/pull/9999>`_)

--- a/cuda_pathfinder/docs/source/release/1.5.6-notes.rst
+++ b/cuda_pathfinder/docs/source/release/1.5.6-notes.rst
@@ -1,0 +1,14 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+.. py:currentmodule:: cuda.pathfinder
+
+``cuda-pathfinder`` 1.5.6 Release notes
+=======================================
+
+Highlights
+----------
+
+* Add support for the Windows CTK 13.3.1 CUPTI DLL name
+  ``cupti64_2026.2.1.dll`` so ``load_nvidia_dynamic_lib("cupti")`` can
+  recognize the installed library on CTK 13.3.1 systems.


### PR DESCRIPTION
- Add `cupti64_2026.2.1.dll` to the pathfinder descriptor catalog so `load_nvidia_dynamic_lib("cupti")` recognizes the DLL shipped with Windows CTK 13.3.1.
- Add the `cuda-pathfinder` `1.5.6` release notes and version-switcher entry.

___

Minor note: this PR is very similar to PR #1906.