### PR TITLE
Fix small bug in nvml.unit_get_devices()

### DIFF
--- a/cuda_bindings/cuda/bindings/nvml.pyx
+++ b/cuda_bindings/cuda/bindings/nvml.pyx
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
 #
-# This code was automatically generated across versions from 12.9.1 to 13.3.0, generator version 0.3.1.dev1602+g3c8d84404. Do not modify it directly.
+# This code was automatically generated across versions from 12.9.1 to 13.3.0, generator version 0.3.1.dev1779+ga8cc71818.d20260626. Do not modify it directly.
 
 cimport cython  # NOQA
 
@@ -26815,13 +26815,13 @@ cpdef object unit_get_devices(intptr_t unit):
     """
     cdef unsigned int[1] deviceCount = [0]
     with nogil:
-        __status__ = nvmlUnitGetDevices(<nvmlUnit_t *>unit, <unsigned int*>deviceCount, NULL)
+        __status__ = nvmlUnitGetDevices(<nvmlUnit_t>unit, <unsigned int*>deviceCount, NULL)
     check_status_size(__status__)
     if deviceCount[0] == 0:
         return view.array(shape=(1,), itemsize=sizeof(intptr_t), format="P", mode="c")[:0]
     cdef view.array deviceArray = view.array(shape=(deviceCount[0],), itemsize=sizeof(intptr_t), format="P", mode="c")
     with nogil:
-        __status__ = nvmlUnitGetDevices(<nvmlUnit_t *>unit, <unsigned int*>deviceCount, <nvmlDevice_t *>deviceArray.data)
+        __status__ = nvmlUnitGetDevices(<nvmlUnit_t>unit, <unsigned int*>deviceCount, <nvmlDevice_t *>deviceArray.data)
     check_status(__status__)
     return deviceArray
 

--- a/cuda_bindings/tests/nvml/test_unit.py
+++ b/cuda_bindings/tests/nvml/test_unit.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
+
+import pytest
+
+from cuda.bindings import nvml
+
+
+@pytest.fixture
+def unit_handles(nvml_init):
+    """Yield all unit handles, or skip if no units are present."""
+    count = nvml.unit_get_count()
+    if count == 0:
+        pytest.skip("No NVML units present on this system")
+    return [nvml.unit_get_handle_by_index(i) for i in range(count)]
+
+
+@pytest.mark.agent_authored(model="claude-sonnet-4-6")
+def test_unit_get_devices_returns_array(unit_handles):
+    """Regression test: unit_get_devices must not crash due to double-pointer cast.
+
+    Previously nvmlUnitGetDevices was called with <nvmlUnit_t *>unit instead of
+    <nvmlUnit_t>unit, causing undefined behaviour because nvmlUnit_t is itself an
+    opaque pointer handle.
+    """
+    for unit in unit_handles:
+        devices = nvml.unit_get_devices(unit)
+        # Result is a memoryview / cython array of intptr_t device handles.
+        assert hasattr(devices, "__len__")
+        # Each element must be a non-zero pointer (valid device handle).
+        for dev in devices:
+            assert dev != 0


### PR DESCRIPTION
This fixes a small bug in the hand-written wrappers for NVML, that was discovered while rebuilding `cuda.bindings.nvml` by including the upstream header while investigating #1663.  (A nice side-effect of that is that it finds real bugs!).

Unfortunately, I don't know if this test can/will run on any of our hardware.
