### PR TITLE
Move release CI tools tests to nightly

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Nightly CI pipeline that tests optional dependencies (PyTorch, numba-cuda)
-# against the latest cuda-python wheels built on main, and runs the standard
-# test suite on runners reserved for nightly-only use (e.g. arm64 l4×2).
+# against the latest cuda-python wheels built on main, runs the standard
+# test suite on runners reserved for nightly-only use (e.g. arm64 l4×2), and
+# exercises release-time CI helper scripts so they do not silently rot between releases.
 #
 # This workflow does NOT build wheels — it downloads them from the latest
 # successful CI run on main and runs integration/standard tests.
@@ -31,6 +32,21 @@ on:
         default: ''
 
 jobs:
+  test-ci-tools-for-release:
+    name: "Nightly: CI tools for release"
+    if: ${{ github.repository_owner == 'nvidia' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          fetch-depth: 1
+
+      - name: Run CI tools unit tests
+        run: |
+          python -m pip install pytest
+          python -m pytest -v ci/tools/tests
+
   find-wheels:
     runs-on: ubuntu-latest
     outputs:
@@ -219,6 +235,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     needs:
+      - test-ci-tools-for-release
       - find-wheels
       - test-pytorch-linux
       - test-pytorch-linux-aarch64
@@ -235,7 +252,9 @@ jobs:
           # See ci.yml for the full rationale on why we must use always()
           # and explicitly check each result rather than relying on the
           # default behaviour.
-          if ${{ needs.find-wheels.result != 'success' }}; then
+          if ${{ needs.test-ci-tools-for-release.result == 'cancelled' ||
+                 needs.test-ci-tools-for-release.result == 'failure' ||
+                 needs.find-wheels.result != 'success' }}; then
             exit 1
           fi
           if ${{ needs.test-pytorch-linux.result == 'cancelled' ||

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -45,7 +45,8 @@ jobs:
       - name: Run CI tools unit tests
         run: |
           python -m pip install pytest
-          python -m pytest -v ci/tools/tests
+          # Standalone CI tool tests; skip repo-root conftest.py (imports cuda.pathfinder).
+          python -m pytest -v --noconftest ci/tools/tests
 
   find-wheels:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,11 +164,6 @@ jobs:
         with:
           python-version: "3.12"
 
-      # - name: Self-test release-notes checker
-      #   run: |
-      #     pip install pytest
-      #     pytest ci/tools/tests
-
       - name: Check versioned release notes exist
         run: |
           python ci/tools/check_release_notes.py \

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,7 +12,6 @@ testpaths =
     cuda_bindings/tests
     cuda_core/tests
     tests/integration
-    ci/tools/tests
 
 markers =
     pathfinder: tests for cuda_pathfinder


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #2174 

Move `ci/tools/tests/` out of the pre-merge test path and into nightly CI so release-time helpers (notably `check_release_notes.py`, used by `release.yml`) are exercised regularly without adding meta-tests to every PR.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
