### PR TITLE
CI: nightly-cuda-core + nightly-numba-cuda-mlir + PTDS fix

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -192,6 +192,82 @@ jobs:
       test-mode: nightly-numba-cuda
       matrix_filter: 'map(select(.ENV.MODE == "nightly-numba-cuda"))'
 
+  # ── numba-cuda-mlir tests ──
+
+  test-numba-cuda-mlir-linux-64:
+    name: "Nightly numba-cuda-mlir (linux-64)"
+    if: ${{ github.repository_owner == 'nvidia' }}
+    needs: find-wheels
+    permissions:
+      contents: read
+      actions: read
+    secrets: inherit
+    uses: ./.github/workflows/test-wheel-linux.yml
+    with:
+      build-type: nightly
+      host-platform: linux-64
+      build-ctk-ver: ${{ needs.find-wheels.outputs.CUDA_BUILD_VER }}
+      run-id: ${{ needs.find-wheels.outputs.RUN_ID }}
+      sha: ${{ needs.find-wheels.outputs.HEAD_SHA }}
+      test-mode: nightly-numba-cuda-mlir
+      matrix_filter: 'map(select(.ENV.MODE == "nightly-numba-cuda-mlir"))'
+
+  test-numba-cuda-mlir-linux-aarch64:
+    name: "Nightly numba-cuda-mlir (linux-aarch64)"
+    if: ${{ github.repository_owner == 'nvidia' }}
+    needs: find-wheels
+    permissions:
+      contents: read
+      actions: read
+    secrets: inherit
+    uses: ./.github/workflows/test-wheel-linux.yml
+    with:
+      build-type: nightly
+      host-platform: linux-aarch64
+      build-ctk-ver: ${{ needs.find-wheels.outputs.CUDA_BUILD_VER }}
+      run-id: ${{ needs.find-wheels.outputs.RUN_ID }}
+      sha: ${{ needs.find-wheels.outputs.HEAD_SHA }}
+      test-mode: nightly-numba-cuda-mlir
+      matrix_filter: 'map(select(.ENV.MODE == "nightly-numba-cuda-mlir"))'
+
+  # ── Released cuda-core against main pathfinder/bindings ──
+
+  test-cuda-core-linux-64:
+    name: "Nightly cuda-core (linux-64)"
+    if: ${{ github.repository_owner == 'nvidia' }}
+    needs: find-wheels
+    permissions:
+      contents: read
+      actions: read
+    secrets: inherit
+    uses: ./.github/workflows/test-wheel-linux.yml
+    with:
+      build-type: nightly
+      host-platform: linux-64
+      build-ctk-ver: ${{ needs.find-wheels.outputs.CUDA_BUILD_VER }}
+      run-id: ${{ needs.find-wheels.outputs.RUN_ID }}
+      sha: ${{ needs.find-wheels.outputs.HEAD_SHA }}
+      test-mode: nightly-cuda-core
+      matrix_filter: 'map(select(.ENV.MODE == "nightly-cuda-core"))'
+
+  test-cuda-core-windows:
+    name: "Nightly cuda-core (win-64)"
+    if: ${{ github.repository_owner == 'nvidia' }}
+    needs: find-wheels
+    permissions:
+      contents: read
+      actions: read
+    secrets: inherit
+    uses: ./.github/workflows/test-wheel-windows.yml
+    with:
+      build-type: nightly
+      host-platform: win-64
+      build-ctk-ver: ${{ needs.find-wheels.outputs.CUDA_BUILD_VER }}
+      run-id: ${{ needs.find-wheels.outputs.RUN_ID }}
+      sha: ${{ needs.find-wheels.outputs.HEAD_SHA }}
+      test-mode: nightly-cuda-core
+      matrix_filter: 'map(select(.ENV.MODE == "nightly-cuda-core"))'
+
   # ── Standard tests on nightly-only runners ──
 
   test-standard-linux-aarch64:
@@ -226,6 +302,10 @@ jobs:
       - test-numba-cuda-linux-64
       - test-numba-cuda-linux-aarch64
       - test-numba-cuda-windows
+      - test-numba-cuda-mlir-linux-64
+      - test-numba-cuda-mlir-linux-aarch64
+      - test-cuda-core-linux-64
+      - test-cuda-core-windows
       - test-standard-linux-aarch64
     steps:
       - name: Exit
@@ -250,6 +330,14 @@ jobs:
                  needs.test-numba-cuda-linux-aarch64.result == 'failure' ||
                  needs.test-numba-cuda-windows.result == 'cancelled' ||
                  needs.test-numba-cuda-windows.result == 'failure' ||
+                 needs.test-numba-cuda-mlir-linux-64.result == 'cancelled' ||
+                 needs.test-numba-cuda-mlir-linux-64.result == 'failure' ||
+                 needs.test-numba-cuda-mlir-linux-aarch64.result == 'cancelled' ||
+                 needs.test-numba-cuda-mlir-linux-aarch64.result == 'failure' ||
+                 needs.test-cuda-core-linux-64.result == 'cancelled' ||
+                 needs.test-cuda-core-linux-64.result == 'failure' ||
+                 needs.test-cuda-core-windows.result == 'cancelled' ||
+                 needs.test-cuda-core-windows.result == 'failure' ||
                  needs.test-standard-linux-aarch64.result == 'cancelled' ||
                  needs.test-standard-linux-aarch64.result == 'failure' }}; then
             exit 1

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -16,6 +16,10 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  push:
+    branches:
+      - "main"
+      - "pull-request/[0-9]+"
   schedule:
     # 2:17 AM UTC daily, after the midnight main CI build finishes.
     # Avoid minute 0 because GitHub documents high scheduled-workflow load

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -16,10 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - "main"
-      - "pull-request/[0-9]+"
   schedule:
     # 2:17 AM UTC daily, after the midnight main CI build finishes.
     # Avoid minute 0 because GitHub documents high scheduled-workflow load

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -212,18 +212,18 @@ jobs:
       test-mode: nightly-numba-cuda-mlir
       matrix_filter: 'map(select(.ENV.MODE == "nightly-numba-cuda-mlir"))'
 
-  test-numba-cuda-mlir-linux-aarch64:
-    name: "Nightly numba-cuda-mlir (linux-aarch64)"
+  test-numba-cuda-mlir-windows:
+    name: "Nightly numba-cuda-mlir (win-64)"
     if: ${{ github.repository_owner == 'nvidia' }}
     needs: find-wheels
     permissions:
       contents: read
       actions: read
     secrets: inherit
-    uses: ./.github/workflows/test-wheel-linux.yml
+    uses: ./.github/workflows/test-wheel-windows.yml
     with:
       build-type: nightly
-      host-platform: linux-aarch64
+      host-platform: win-64
       build-ctk-ver: ${{ needs.find-wheels.outputs.CUDA_BUILD_VER }}
       run-id: ${{ needs.find-wheels.outputs.RUN_ID }}
       sha: ${{ needs.find-wheels.outputs.HEAD_SHA }}
@@ -303,7 +303,7 @@ jobs:
       - test-numba-cuda-linux-aarch64
       - test-numba-cuda-windows
       - test-numba-cuda-mlir-linux-64
-      - test-numba-cuda-mlir-linux-aarch64
+      - test-numba-cuda-mlir-windows
       - test-cuda-core-linux-64
       - test-cuda-core-windows
       - test-standard-linux-aarch64
@@ -332,8 +332,8 @@ jobs:
                  needs.test-numba-cuda-windows.result == 'failure' ||
                  needs.test-numba-cuda-mlir-linux-64.result == 'cancelled' ||
                  needs.test-numba-cuda-mlir-linux-64.result == 'failure' ||
-                 needs.test-numba-cuda-mlir-linux-aarch64.result == 'cancelled' ||
-                 needs.test-numba-cuda-mlir-linux-aarch64.result == 'failure' ||
+                 needs.test-numba-cuda-mlir-windows.result == 'cancelled' ||
+                 needs.test-numba-cuda-mlir-windows.result == 'failure' ||
                  needs.test-cuda-core-linux-64.result == 'cancelled' ||
                  needs.test-cuda-core-linux-64.result == 'failure' ||
                  needs.test-cuda-core-windows.result == 'cancelled' ||

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -37,8 +37,9 @@ on:
         default: ''
       test-mode:
         description: >
-          Test mode: 'standard' (default), 'nightly-pytorch', or
-          'nightly-numba-cuda'.
+          Test mode: 'standard' (default), 'nightly-pytorch',
+          'nightly-numba-cuda', 'nightly-numba-cuda-mlir', or
+          'nightly-cuda-core'.
         type: string
         default: 'standard'
       sha:
@@ -409,6 +410,20 @@ jobs:
           LOCAL_CTK: ${{ matrix.LOCAL_CTK }}
         run: run-tests nightly-numba-cuda
 
+      - name: Install cuda-python wheels + numba-cuda-mlir
+        if: ${{ inputs.test-mode == 'nightly-numba-cuda-mlir' }}
+        env:
+          CUDA_VER: ${{ matrix.CUDA_VER }}
+          LOCAL_CTK: ${{ matrix.LOCAL_CTK }}
+        run: run-tests nightly-numba-cuda-mlir
+
+      - name: Install main pathfinder/bindings + released cuda-core
+        if: ${{ inputs.test-mode == 'nightly-cuda-core' }}
+        env:
+          CUDA_VER: ${{ matrix.CUDA_VER }}
+          LOCAL_CTK: ${{ matrix.LOCAL_CTK }}
+        run: run-tests nightly-cuda-core
+
       # ── Nightly: run tests ──
       - name: Run PyTorch interop tests
         if: ${{ inputs.test-mode == 'nightly-pytorch' }}
@@ -420,3 +435,17 @@ jobs:
       - name: Run numba-cuda tests
         if: ${{ inputs.test-mode == 'nightly-numba-cuda' }}
         run: python -m numba.runtests numba.cuda.tests
+
+      - name: Run numba-cuda-mlir tests
+        if: ${{ inputs.test-mode == 'nightly-numba-cuda-mlir' && env.NUMBA_CUDA_MLIR_TESTS_DIR != '' }}
+        run: |
+          pushd "${NUMBA_CUDA_MLIR_TESTS_DIR}"
+          pytest -rxXs -v --durations=0 tests/
+          popd
+
+      - name: Run released cuda-core tests
+        if: ${{ inputs.test-mode == 'nightly-cuda-core' && env.CUDA_CORE_RELEASED_TESTS_DIR != '' }}
+        run: |
+          pushd "${CUDA_CORE_RELEASED_TESTS_DIR}/cuda_core"
+          pytest -rxXs -v --durations=0 --randomly-dont-reorganize tests/
+          popd

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -455,22 +455,18 @@ jobs:
           # numba package at collection time, which cuSIMT intentionally does
           # not depend on. See NVIDIA/numba-cuda-mlir#136.
           #
-          # Deselects:
-          # - CudaArraySetting + TestCudaArrayInterface + test_fortran_contiguous:
-          #     serial-pytest contamination of `numba_cuda_mlir.cuda.cudadrv`
-          #     from an xfailed test in test_nrt_comprehensive.py. Upstream CI
-          #     hides it by running with `-n auto --dist loadscope`. See
-          #     NVIDIA/numba-cuda-mlir#135.
+          # Deselects observed to fail on linux-64 only:
+          # - TestCudaArrayInterface::*: serial-pytest contamination of
+          #     numba_cuda_mlir.cuda.cudadrv from an xfailed test in
+          #     test_nrt_comprehensive.py. Upstream CI hides it via
+          #     `-n auto --dist loadscope`. See NVIDIA/numba-cuda-mlir#135.
           # - TestLinkerDumpAssembly::test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn:
-          #     invokes `cuobjdump` subprocess, which is not on PATH in the
-          #     base ubuntu:24.04 container. Will file an upstream skip-guard
-          #     issue.
+          #     subprocess-invokes `cuobjdump`, which is not on PATH in the
+          #     base ubuntu:24.04 container. Windows runners ship cuobjdump
+          #     with the local CTK, so this doesn't repro there.
           pytest -rxXs -v --durations=0 \
             --ignore=tests/benchmarks \
             --ignore=tests/doc_examples \
-            --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_default_stream' \
-            --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_supplied_stream' \
-            --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_sync' \
             --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_consume_no_sync' \
             --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_consume_sync' \
             --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_no_sync' \
@@ -500,22 +496,10 @@ jobs:
           # patterns that pytest 9.1 rejects; the main-side fix (#2212) has
           # not yet shipped in a cuda-core release.
           pip install "pytest<9.1"
-          # Deselects, all pre-existing in released cuda-core v1.0.1:
-          # - NvlinkVersion: expected drift; main's cuda-bindings adds
-          #   VERSION_6_0, which the v1.0.1 wrapper mapping predates. The
-          #   nightly-cuda-core mode intentionally exercises released-core
-          #   against main-bindings, so this test is permanently red here.
-          # - rlcompleter opt-out: the "should crash" expectation baked into
-          #   v1.0.1 doesn't hold on all runners; passes on Linux, flakes on
-          #   Windows MCDM. Environment-dependent, not a code signal.
-          # - test_non_managed_resources_report_not_managed[pinned]: same
-          #   underlying "Failed to allocate memory from pool" that v1.0.1
-          #   already xfails in sibling test_pinned_memory_resource_initialization
-          #   (TODO(#9999)). Main has since fixed this parametrization to
-          #   xfail on the pinned branch too.
+          # NvlinkVersion: expected drift on this mode. main cuda-bindings
+          # adds NvlinkVersion.VERSION_6_0 which v1.0.1's wrapper mapping
+          # predates. Fails on both platforms.
           pytest -rxXs -v --durations=0 --randomly-dont-reorganize \
             --deselect 'tests/test_enum_coverage.py::test_wrapper_covers_all_binding_members[NvlinkVersion]' \
-            --deselect 'tests/test_rlcompleter_patch.py::test_opt_out_env_var_disables_patch_even_when_interactive' \
-            --deselect 'tests/test_memory.py::test_non_managed_resources_report_not_managed[pinned]' \
             tests/
           popd

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -455,25 +455,35 @@ jobs:
           # numba package at collection time, which cuSIMT intentionally does
           # not depend on. See NVIDIA/numba-cuda-mlir#136.
           #
-          # Deselects observed to fail on linux-64 only:
-          # - TestCudaArrayInterface::*: serial-pytest contamination of
-          #     numba_cuda_mlir.cuda.cudadrv from an xfailed test in
-          #     test_nrt_comprehensive.py. Upstream CI hides it via
-          #     `-n auto --dist loadscope`. See NVIDIA/numba-cuda-mlir#135.
-          # - TestLinkerDumpAssembly::test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn:
-          #     subprocess-invokes `cuobjdump`, which is not on PATH in the
-          #     base ubuntu:24.04 container. Windows runners ship cuobjdump
-          #     with the local CTK, so this doesn't repro there.
+          # Version-gated deselects: when a newer numba-cuda-mlir release
+          # ships with the referenced fix, the guard evaluates false and the
+          # tests get run automatically. If they still fail on the newer
+          # version we hear about it loudly (rather than silently masking).
+          DESELECTS=()
+          if python -c "from packaging.version import Version; import sys; sys.exit(0 if Version('${NUMBA_CUDA_MLIR_VER}') <= Version('0.4.0') else 1)"; then
+            # NVIDIA/numba-cuda-mlir#135: serial-pytest contamination of
+            # numba_cuda_mlir.cuda.cudadrv from an xfailed test in
+            # test_nrt_comprehensive.py. Upstream CI hides it via
+            # `-n auto --dist loadscope`.
+            #
+            # test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn:
+            # subprocess-invokes `cuobjdump`, not on PATH in the base
+            # ubuntu:24.04 container. (No upstream fix yet — pending a
+            # skip-guard bug to be filed against NVIDIA/numba-cuda-mlir.)
+            DESELECTS+=(
+              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_consume_no_sync'
+              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_consume_sync'
+              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_no_sync'
+              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_sync'
+              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_sync_two_streams'
+              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_fortran_contiguous'
+              --deselect 'tests/numba_cuda_tests/cudadrv/test_nvjitlink.py::TestLinkerDumpAssembly::test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn'
+            )
+          fi
           pytest -rxXs -v --durations=0 \
             --ignore=tests/benchmarks \
             --ignore=tests/doc_examples \
-            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_consume_no_sync' \
-            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_consume_sync' \
-            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_no_sync' \
-            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_sync' \
-            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_sync_two_streams' \
-            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_fortran_contiguous' \
-            --deselect 'tests/numba_cuda_tests/cudadrv/test_nvjitlink.py::TestLinkerDumpAssembly::test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn' \
+            "${DESELECTS[@]}" \
             tests/
           popd
 
@@ -496,10 +506,18 @@ jobs:
           # patterns that pytest 9.1 rejects; the main-side fix (#2212) has
           # not yet shipped in a cuda-core release.
           pip install "pytest<9.1"
-          # NvlinkVersion: expected drift on this mode. main cuda-bindings
-          # adds NvlinkVersion.VERSION_6_0 which v1.0.1's wrapper mapping
-          # predates. Fails on both platforms.
+          # Version-gated deselect: drops automatically when a newer
+          # cuda-core release with the wrapper-mapping update ships.
+          DESELECTS=()
+          if python -c "from packaging.version import Version; import sys; sys.exit(0 if Version('${CUDA_CORE_RELEASED_VER}') <= Version('1.0.1') else 1)"; then
+            # NvlinkVersion: v1.0.1's wrapper mapping predates
+            # NvlinkVersion.VERSION_6_0 which main cuda-bindings adds.
+            # Expected drift on this mode until released cuda-core catches up.
+            DESELECTS+=(
+              --deselect 'tests/test_enum_coverage.py::test_wrapper_covers_all_binding_members[NvlinkVersion]'
+            )
+          fi
           pytest -rxXs -v --durations=0 --randomly-dont-reorganize \
-            --deselect 'tests/test_enum_coverage.py::test_wrapper_covers_all_binding_members[NvlinkVersion]' \
+            "${DESELECTS[@]}" \
             tests/
           popd

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -475,5 +475,9 @@ jobs:
           # that cuda-core version shipped with.
           pip install --upgrade "pip>=25.1"
           pip install --group "${CUDA_CORE_TEST_GROUP}"
+          # Cap pytest below 9.1: released cuda-core <=1.0.1 has parametrize
+          # patterns that pytest 9.1 rejects; the main-side fix (#2212) has
+          # not yet shipped in a cuda-core release.
+          pip install "pytest<9.1"
           pytest -rxXs -v --durations=0 --randomly-dont-reorganize tests/
           popd

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -454,9 +454,30 @@ jobs:
           # Skip tests/benchmarks/ and tests/doc_examples/ — they import the
           # numba package at collection time, which cuSIMT intentionally does
           # not depend on. See NVIDIA/numba-cuda-mlir#136.
+          #
+          # Deselects:
+          # - CudaArraySetting + TestCudaArrayInterface + test_fortran_contiguous:
+          #     serial-pytest contamination of `numba_cuda_mlir.cuda.cudadrv`
+          #     from an xfailed test in test_nrt_comprehensive.py. Upstream CI
+          #     hides it by running with `-n auto --dist loadscope`. See
+          #     NVIDIA/numba-cuda-mlir#135.
+          # - TestLinkerDumpAssembly::test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn:
+          #     invokes `cuobjdump` subprocess, which is not on PATH in the
+          #     base ubuntu:24.04 container. Will file an upstream skip-guard
+          #     issue.
           pytest -rxXs -v --durations=0 \
             --ignore=tests/benchmarks \
             --ignore=tests/doc_examples \
+            --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_default_stream' \
+            --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_supplied_stream' \
+            --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_sync' \
+            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_consume_no_sync' \
+            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_consume_sync' \
+            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_no_sync' \
+            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_sync' \
+            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_sync_two_streams' \
+            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_fortran_contiguous' \
+            --deselect 'tests/numba_cuda_tests/cudadrv/test_nvjitlink.py::TestLinkerDumpAssembly::test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn' \
             tests/
           popd
 
@@ -479,5 +500,22 @@ jobs:
           # patterns that pytest 9.1 rejects; the main-side fix (#2212) has
           # not yet shipped in a cuda-core release.
           pip install "pytest<9.1"
-          pytest -rxXs -v --durations=0 --randomly-dont-reorganize tests/
+          # Deselects, all pre-existing in released cuda-core v1.0.1:
+          # - NvlinkVersion: expected drift; main's cuda-bindings adds
+          #   VERSION_6_0, which the v1.0.1 wrapper mapping predates. The
+          #   nightly-cuda-core mode intentionally exercises released-core
+          #   against main-bindings, so this test is permanently red here.
+          # - rlcompleter opt-out: the "should crash" expectation baked into
+          #   v1.0.1 doesn't hold on all runners; passes on Linux, flakes on
+          #   Windows MCDM. Environment-dependent, not a code signal.
+          # - test_non_managed_resources_report_not_managed[pinned]: same
+          #   underlying "Failed to allocate memory from pool" that v1.0.1
+          #   already xfails in sibling test_pinned_memory_resource_initialization
+          #   (TODO(#9999)). Main has since fixed this parametrization to
+          #   xfail on the pinned branch too.
+          pytest -rxXs -v --durations=0 --randomly-dont-reorganize \
+            --deselect 'tests/test_enum_coverage.py::test_wrapper_covers_all_binding_members[NvlinkVersion]' \
+            --deselect 'tests/test_rlcompleter_patch.py::test_opt_out_env_var_disables_patch_even_when_interactive' \
+            --deselect 'tests/test_memory.py::test_non_managed_resources_report_not_managed[pinned]' \
+            tests/
           popd

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -463,14 +463,23 @@ jobs:
           if python -c "from packaging.version import Version; import sys; sys.exit(0 if Version('${NUMBA_CUDA_MLIR_VER}') <= Version('0.4.0') else 1)"; then
             # NVIDIA/numba-cuda-mlir#135: serial-pytest contamination of
             # numba_cuda_mlir.cuda.cudadrv from an xfailed test in
-            # test_nrt_comprehensive.py. Upstream CI hides it via
-            # `-n auto --dist loadscope`.
+            # test_nrt_comprehensive.py contaminates any later test that
+            # touches cuda.cudadrv.driver. Upstream CI hides it via
+            # `-n auto --dist loadscope`. Which specific tests fail depends
+            # on collection order (we saw different subsets on linux-64 vs
+            # win-64 across runs), so we deselect the union of all tests
+            # #135 lists as vulnerable + test_fortran_contiguous (observed
+            # to hit the same contamination in our runs).
             #
             # test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn:
             # subprocess-invokes `cuobjdump`, not on PATH in the base
-            # ubuntu:24.04 container. (No upstream fix yet — pending a
-            # skip-guard bug to be filed against NVIDIA/numba-cuda-mlir.)
+            # ubuntu:24.04 container. (Linux-only; Windows runners ship
+            # cuobjdump with the local CTK. No upstream fix yet — pending
+            # a skip-guard bug to be filed against NVIDIA/numba-cuda-mlir.)
             DESELECTS+=(
+              --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_default_stream'
+              --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_supplied_stream'
+              --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_sync'
               --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_consume_no_sync'
               --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_consume_sync'
               --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_no_sync'

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -436,16 +436,44 @@ jobs:
         if: ${{ inputs.test-mode == 'nightly-numba-cuda' }}
         run: python -m numba.runtests numba.cuda.tests
 
+      - name: Checkout numba-cuda-mlir tests at matching tag
+        if: ${{ inputs.test-mode == 'nightly-numba-cuda-mlir' && env.NUMBA_CUDA_MLIR_VER != '' }}
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          repository: NVIDIA/numba-cuda-mlir
+          ref: v${{ env.NUMBA_CUDA_MLIR_VER }}
+          path: numba-cuda-mlir-released
+
       - name: Run numba-cuda-mlir tests
-        if: ${{ inputs.test-mode == 'nightly-numba-cuda-mlir' && env.NUMBA_CUDA_MLIR_TESTS_DIR != '' }}
+        if: ${{ inputs.test-mode == 'nightly-numba-cuda-mlir' && env.NUMBA_CUDA_MLIR_VER != '' }}
         run: |
-          pushd "${NUMBA_CUDA_MLIR_TESTS_DIR}"
-          pytest -rxXs -v --durations=0 tests/
+          pushd numba-cuda-mlir-released
+          # Install this tag's test deps (pytest + plugins + ml-dtypes + ...).
+          pip install --upgrade "pip>=25.1"
+          pip install --group test
+          # Skip tests/benchmarks/ and tests/doc_examples/ — they import the
+          # numba package at collection time, which cuSIMT intentionally does
+          # not depend on. See NVIDIA/numba-cuda-mlir#136.
+          pytest -rxXs -v --durations=0 \
+            --ignore=tests/benchmarks \
+            --ignore=tests/doc_examples \
+            tests/
           popd
 
+      - name: Checkout released cuda-core tests at matching tag
+        if: ${{ inputs.test-mode == 'nightly-cuda-core' && env.CUDA_CORE_RELEASED_VER != '' }}
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: cuda-core-v${{ env.CUDA_CORE_RELEASED_VER }}
+          path: cuda-core-released
+
       - name: Run released cuda-core tests
-        if: ${{ inputs.test-mode == 'nightly-cuda-core' && env.CUDA_CORE_RELEASED_TESTS_DIR != '' }}
+        if: ${{ inputs.test-mode == 'nightly-cuda-core' && env.CUDA_CORE_RELEASED_VER != '' }}
         run: |
-          pushd "${CUDA_CORE_RELEASED_TESTS_DIR}/cuda_core"
+          pushd cuda-core-released/cuda_core
+          # Install the released tag's test group so we exercise the exact deps
+          # that cuda-core version shipped with.
+          pip install --upgrade "pip>=25.1"
+          pip install --group "${CUDA_CORE_TEST_GROUP}"
           pytest -rxXs -v --durations=0 --randomly-dont-reorganize tests/
           popd

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -434,11 +434,21 @@ jobs:
           pushd numba-cuda-mlir-released
           pip install --upgrade "pip>=25.1"
           pip install --group test
-          # Skip tests/benchmarks/ and tests/doc_examples/ — see
-          # NVIDIA/numba-cuda-mlir#136.
+          # Deselects — see comments on the equivalent Linux step and
+          # NVIDIA/numba-cuda-mlir#135, #136.
           pytest -rxXs -v --durations=0 \
             --ignore=tests/benchmarks \
             --ignore=tests/doc_examples \
+            --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_default_stream' \
+            --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_supplied_stream' \
+            --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_sync' \
+            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_consume_no_sync' \
+            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_consume_sync' \
+            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_no_sync' \
+            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_sync' \
+            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_sync_two_streams' \
+            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_fortran_contiguous' \
+            --deselect 'tests/numba_cuda_tests/cudadrv/test_nvjitlink.py::TestLinkerDumpAssembly::test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn' \
             tests/
           popd
 
@@ -459,5 +469,10 @@ jobs:
           # Cap pytest below 9.1 — released cuda-core <=1.0.1 has parametrize
           # patterns that pytest 9.1 rejects (see #2212).
           pip install "pytest<9.1"
-          pytest -rxXs -v --durations=0 --randomly-dont-reorganize tests/
+          # Deselects — see comments on the equivalent Linux step.
+          pytest -rxXs -v --durations=0 --randomly-dont-reorganize \
+            --deselect 'tests/test_enum_coverage.py::test_wrapper_covers_all_binding_members[NvlinkVersion]' \
+            --deselect 'tests/test_rlcompleter_patch.py::test_opt_out_env_var_disables_patch_even_when_interactive' \
+            --deselect 'tests/test_memory.py::test_non_managed_resources_report_not_managed[pinned]' \
+            tests/
           popd

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -434,21 +434,16 @@ jobs:
           pushd numba-cuda-mlir-released
           pip install --upgrade "pip>=25.1"
           pip install --group test
-          # Deselects — see comments on the equivalent Linux step and
-          # NVIDIA/numba-cuda-mlir#135, #136.
+          # Deselects observed to fail on win-64 only (subset of the
+          # NVIDIA/numba-cuda-mlir#135 tests; different serial-pytest
+          # ordering surfaces different tests on Linux vs Windows).
           pytest -rxXs -v --durations=0 \
             --ignore=tests/benchmarks \
             --ignore=tests/doc_examples \
             --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_default_stream' \
             --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_supplied_stream' \
             --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_sync' \
-            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_consume_no_sync' \
-            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_consume_sync' \
-            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_no_sync' \
-            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_sync' \
-            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_sync_two_streams' \
             --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_fortran_contiguous' \
-            --deselect 'tests/numba_cuda_tests/cudadrv/test_nvjitlink.py::TestLinkerDumpAssembly::test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn' \
             tests/
           popd
 
@@ -469,7 +464,15 @@ jobs:
           # Cap pytest below 9.1 — released cuda-core <=1.0.1 has parametrize
           # patterns that pytest 9.1 rejects (see #2212).
           pip install "pytest<9.1"
-          # Deselects — see comments on the equivalent Linux step.
+          # NvlinkVersion: same expected drift as Linux (bindings adds
+          #   VERSION_6_0 unknown to v1.0.1's wrapper mapping).
+          # rlcompleter opt-out: env-dependent assertion that only fails on
+          #   Windows MCDM — passes on Linux.
+          # test_non_managed_resources_report_not_managed[pinned]: same
+          #   MCDM mempool OOM that v1.0.1 already xfails in sibling
+          #   test_pinned_memory_resource_initialization (TODO(#9999)).
+          #   Main fixed the parametrized case via #2139 but v1.0.1 doesn't
+          #   have the fix.
           pytest -rxXs -v --durations=0 --randomly-dont-reorganize \
             --deselect 'tests/test_enum_coverage.py::test_wrapper_covers_all_binding_members[NvlinkVersion]' \
             --deselect 'tests/test_rlcompleter_patch.py::test_opt_out_env_var_disables_patch_even_when_interactive' \

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -456,5 +456,8 @@ jobs:
           pushd cuda-core-released/cuda_core
           pip install --upgrade "pip>=25.1"
           pip install --group "${CUDA_CORE_TEST_GROUP}"
+          # Cap pytest below 9.1 — released cuda-core <=1.0.1 has parametrize
+          # patterns that pytest 9.1 rejects (see #2212).
+          pip install "pytest<9.1"
           pytest -rxXs -v --durations=0 --randomly-dont-reorganize tests/
           popd

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -37,8 +37,8 @@ on:
         default: ''
       test-mode:
         description: >
-          Test mode: 'standard' (default), 'nightly-pytorch', or
-          'nightly-numba-cuda'.
+          Test mode: 'standard' (default), 'nightly-pytorch',
+          'nightly-numba-cuda', or 'nightly-cuda-core'.
         type: string
         default: 'standard'
       sha:
@@ -388,6 +388,14 @@ jobs:
         shell: bash --noprofile --norc -xeuo pipefail {0}
         run: run-tests nightly-numba-cuda
 
+      - name: Install main pathfinder/bindings + released cuda-core
+        if: ${{ inputs.test-mode == 'nightly-cuda-core' }}
+        env:
+          CUDA_VER: ${{ matrix.CUDA_VER }}
+          LOCAL_CTK: ${{ matrix.LOCAL_CTK }}
+        shell: bash --noprofile --norc -xeuo pipefail {0}
+        run: run-tests nightly-cuda-core
+
       # ── Nightly: run tests ──
       - name: Run PyTorch interop tests
         if: ${{ inputs.test-mode == 'nightly-pytorch' }}
@@ -401,3 +409,11 @@ jobs:
         if: ${{ inputs.test-mode == 'nightly-numba-cuda' }}
         shell: bash --noprofile --norc -xeuo pipefail {0}
         run: python -m numba.runtests numba.cuda.tests
+
+      - name: Run released cuda-core tests
+        if: ${{ inputs.test-mode == 'nightly-cuda-core' && env.CUDA_CORE_RELEASED_TESTS_DIR != '' }}
+        shell: bash --noprofile --norc -xeuo pipefail {0}
+        run: |
+          pushd "${CUDA_CORE_RELEASED_TESTS_DIR}/cuda_core"
+          pytest -rxXs -v --durations=0 --randomly-dont-reorganize tests/
+          popd

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -436,14 +436,21 @@ jobs:
           pip install --group test
           # Version-gated deselects — dropped automatically when newer
           # cuSIMT release ships. See linux step for full rationale.
+          # NVIDIA/numba-cuda-mlir#135 poisons a subset of tests that
+          # varies across runs based on collection order, so we deselect
+          # the full union rather than trying to enumerate what happened
+          # to fail on the most recent nightly.
           DESELECTS=()
           if python -c "from packaging.version import Version; import sys; sys.exit(0 if Version('${NUMBA_CUDA_MLIR_VER}') <= Version('0.4.0') else 1)"; then
-            # Subset of NVIDIA/numba-cuda-mlir#135 tests that surface on
-            # win-64 (different serial-pytest ordering than Linux).
             DESELECTS+=(
               --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_default_stream'
               --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_supplied_stream'
               --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_sync'
+              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_consume_no_sync'
+              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_consume_sync'
+              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_no_sync'
+              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_sync'
+              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_sync_two_streams'
               --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_fortran_contiguous'
             )
           fi

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -38,7 +38,8 @@ on:
       test-mode:
         description: >
           Test mode: 'standard' (default), 'nightly-pytorch',
-          'nightly-numba-cuda', or 'nightly-cuda-core'.
+          'nightly-numba-cuda', 'nightly-numba-cuda-mlir', or
+          'nightly-cuda-core'.
         type: string
         default: 'standard'
       sha:
@@ -388,6 +389,14 @@ jobs:
         shell: bash --noprofile --norc -xeuo pipefail {0}
         run: run-tests nightly-numba-cuda
 
+      - name: Install cuda-python wheels + numba-cuda-mlir
+        if: ${{ inputs.test-mode == 'nightly-numba-cuda-mlir' }}
+        env:
+          CUDA_VER: ${{ matrix.CUDA_VER }}
+          LOCAL_CTK: ${{ matrix.LOCAL_CTK }}
+        shell: bash --noprofile --norc -xeuo pipefail {0}
+        run: run-tests nightly-numba-cuda-mlir
+
       - name: Install main pathfinder/bindings + released cuda-core
         if: ${{ inputs.test-mode == 'nightly-cuda-core' }}
         env:
@@ -409,6 +418,14 @@ jobs:
         if: ${{ inputs.test-mode == 'nightly-numba-cuda' }}
         shell: bash --noprofile --norc -xeuo pipefail {0}
         run: python -m numba.runtests numba.cuda.tests
+
+      - name: Run numba-cuda-mlir tests
+        if: ${{ inputs.test-mode == 'nightly-numba-cuda-mlir' && env.NUMBA_CUDA_MLIR_TESTS_DIR != '' }}
+        shell: bash --noprofile --norc -xeuo pipefail {0}
+        run: |
+          pushd "${NUMBA_CUDA_MLIR_TESTS_DIR}"
+          pytest -rxXs -v --durations=0 tests/
+          popd
 
       - name: Run released cuda-core tests
         if: ${{ inputs.test-mode == 'nightly-cuda-core' && env.CUDA_CORE_RELEASED_TESTS_DIR != '' }}

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -419,18 +419,42 @@ jobs:
         shell: bash --noprofile --norc -xeuo pipefail {0}
         run: python -m numba.runtests numba.cuda.tests
 
+      - name: Checkout numba-cuda-mlir tests at matching tag
+        if: ${{ inputs.test-mode == 'nightly-numba-cuda-mlir' && env.NUMBA_CUDA_MLIR_VER != '' }}
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          repository: NVIDIA/numba-cuda-mlir
+          ref: v${{ env.NUMBA_CUDA_MLIR_VER }}
+          path: numba-cuda-mlir-released
+
       - name: Run numba-cuda-mlir tests
-        if: ${{ inputs.test-mode == 'nightly-numba-cuda-mlir' && env.NUMBA_CUDA_MLIR_TESTS_DIR != '' }}
+        if: ${{ inputs.test-mode == 'nightly-numba-cuda-mlir' && env.NUMBA_CUDA_MLIR_VER != '' }}
         shell: bash --noprofile --norc -xeuo pipefail {0}
         run: |
-          pushd "${NUMBA_CUDA_MLIR_TESTS_DIR}"
-          pytest -rxXs -v --durations=0 tests/
+          pushd numba-cuda-mlir-released
+          pip install --upgrade "pip>=25.1"
+          pip install --group test
+          # Skip tests/benchmarks/ and tests/doc_examples/ — see
+          # NVIDIA/numba-cuda-mlir#136.
+          pytest -rxXs -v --durations=0 \
+            --ignore=tests/benchmarks \
+            --ignore=tests/doc_examples \
+            tests/
           popd
 
+      - name: Checkout released cuda-core tests at matching tag
+        if: ${{ inputs.test-mode == 'nightly-cuda-core' && env.CUDA_CORE_RELEASED_VER != '' }}
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: cuda-core-v${{ env.CUDA_CORE_RELEASED_VER }}
+          path: cuda-core-released
+
       - name: Run released cuda-core tests
-        if: ${{ inputs.test-mode == 'nightly-cuda-core' && env.CUDA_CORE_RELEASED_TESTS_DIR != '' }}
+        if: ${{ inputs.test-mode == 'nightly-cuda-core' && env.CUDA_CORE_RELEASED_VER != '' }}
         shell: bash --noprofile --norc -xeuo pipefail {0}
         run: |
-          pushd "${CUDA_CORE_RELEASED_TESTS_DIR}/cuda_core"
+          pushd cuda-core-released/cuda_core
+          pip install --upgrade "pip>=25.1"
+          pip install --group "${CUDA_CORE_TEST_GROUP}"
           pytest -rxXs -v --durations=0 --randomly-dont-reorganize tests/
           popd

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -434,16 +434,23 @@ jobs:
           pushd numba-cuda-mlir-released
           pip install --upgrade "pip>=25.1"
           pip install --group test
-          # Deselects observed to fail on win-64 only (subset of the
-          # NVIDIA/numba-cuda-mlir#135 tests; different serial-pytest
-          # ordering surfaces different tests on Linux vs Windows).
+          # Version-gated deselects — dropped automatically when newer
+          # cuSIMT release ships. See linux step for full rationale.
+          DESELECTS=()
+          if python -c "from packaging.version import Version; import sys; sys.exit(0 if Version('${NUMBA_CUDA_MLIR_VER}') <= Version('0.4.0') else 1)"; then
+            # Subset of NVIDIA/numba-cuda-mlir#135 tests that surface on
+            # win-64 (different serial-pytest ordering than Linux).
+            DESELECTS+=(
+              --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_default_stream'
+              --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_supplied_stream'
+              --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_sync'
+              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_fortran_contiguous'
+            )
+          fi
           pytest -rxXs -v --durations=0 \
             --ignore=tests/benchmarks \
             --ignore=tests/doc_examples \
-            --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_default_stream' \
-            --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_supplied_stream' \
-            --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_sync' \
-            --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_fortran_contiguous' \
+            "${DESELECTS[@]}" \
             tests/
           popd
 
@@ -464,18 +471,25 @@ jobs:
           # Cap pytest below 9.1 — released cuda-core <=1.0.1 has parametrize
           # patterns that pytest 9.1 rejects (see #2212).
           pip install "pytest<9.1"
-          # NvlinkVersion: same expected drift as Linux (bindings adds
-          #   VERSION_6_0 unknown to v1.0.1's wrapper mapping).
-          # rlcompleter opt-out: env-dependent assertion that only fails on
-          #   Windows MCDM — passes on Linux.
-          # test_non_managed_resources_report_not_managed[pinned]: same
-          #   MCDM mempool OOM that v1.0.1 already xfails in sibling
-          #   test_pinned_memory_resource_initialization (TODO(#9999)).
-          #   Main fixed the parametrized case via #2139 but v1.0.1 doesn't
-          #   have the fix.
+          # Version-gated deselects — dropped automatically when a newer
+          # cuda-core release ships. See linux step for full rationale on
+          # NvlinkVersion. The Windows-only tests are:
+          # - test_rlcompleter_patch: env-dependent expectation that
+          #   passes on Linux, fails on Windows MCDM.
+          # - test_non_managed_resources_report_not_managed[pinned]: same
+          #   MCDM mempool OOM v1.0.1 already xfails in
+          #   test_pinned_memory_resource_initialization (TODO(#9999));
+          #   main fixed the parametrized case via #2139 but v1.0.1 lacks
+          #   the fix.
+          DESELECTS=()
+          if python -c "from packaging.version import Version; import sys; sys.exit(0 if Version('${CUDA_CORE_RELEASED_VER}') <= Version('1.0.1') else 1)"; then
+            DESELECTS+=(
+              --deselect 'tests/test_enum_coverage.py::test_wrapper_covers_all_binding_members[NvlinkVersion]'
+              --deselect 'tests/test_rlcompleter_patch.py::test_opt_out_env_var_disables_patch_even_when_interactive'
+              --deselect 'tests/test_memory.py::test_non_managed_resources_report_not_managed[pinned]'
+            )
+          fi
           pytest -rxXs -v --durations=0 --randomly-dont-reorganize \
-            --deselect 'tests/test_enum_coverage.py::test_wrapper_covers_all_binding_members[NvlinkVersion]' \
-            --deselect 'tests/test_rlcompleter_patch.py::test_opt_out_env_var_disables_patch_even_when_interactive' \
-            --deselect 'tests/test_memory.py::test_non_managed_resources_report_not_managed[pinned]' \
+            "${DESELECTS[@]}" \
             tests/
           popd

--- a/ci/test-matrix.yml
+++ b/ci/test-matrix.yml
@@ -29,7 +29,7 @@
 #         subsequent steps (including the cuda.bindings and cuda.core test
 #         steps). Nightly rows also use ENV.MODE as a matrix-filter tag (see
 #         ci-nightly.yml). Examples:
-#           ENV: { CUDA_PYTHON_PER_THREAD_DEFAULT_STREAM: '1' }
+#           ENV: { CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM: '1' }
 #           ENV: { MODE: 'nightly-pytorch', TORCH_VER: '2.12.1', TORCH_CUDA: 'cu126' }
 
 linux:
@@ -41,7 +41,7 @@ linux:
     - { ARCH: 'amd64', PY_VER: '3.11',  CUDA_VER: '12.9.1', LOCAL_CTK: '0', GPU: 'rtxpro6000', GPU_COUNT: '1', DRIVER: 'latest' }
     - { ARCH: 'amd64', PY_VER: '3.11',  CUDA_VER: '13.0.2', LOCAL_CTK: '1', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest' }
     - { ARCH: 'amd64', PY_VER: '3.11',  CUDA_VER: '13.3.0', LOCAL_CTK: '1', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest' }
-    - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '12.9.1', LOCAL_CTK: '1', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest', ENV: { CUDA_PYTHON_PER_THREAD_DEFAULT_STREAM: '1' } }
+    - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '12.9.1', LOCAL_CTK: '1', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest', ENV: { CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM: '1' } }
     - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '13.0.2', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest' }
     - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest' }
     - { ARCH: 'amd64', PY_VER: '3.13',  CUDA_VER: '12.9.1', LOCAL_CTK: '0', GPU: 'v100',       GPU_COUNT: '1', DRIVER: 'latest' }
@@ -124,7 +124,7 @@ windows:
     - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '13.3.0', LOCAL_CTK: '1', GPU: 'a100',       GPU_COUNT: '1', DRIVER: 'latest', DRIVER_MODE: 'TCC' }
     - { ARCH: 'amd64', PY_VER: '3.13',  CUDA_VER: '12.9.1', LOCAL_CTK: '1', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest', DRIVER_MODE: 'TCC' }
     - { ARCH: 'amd64', PY_VER: '3.13',  CUDA_VER: '13.0.2', LOCAL_CTK: '0', GPU: 'rtxpro6000', GPU_COUNT: '1', DRIVER: 'latest', DRIVER_MODE: 'MCDM' }
-    - { ARCH: 'amd64', PY_VER: '3.13',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'rtxpro6000', GPU_COUNT: '1', DRIVER: 'latest', DRIVER_MODE: 'MCDM', ENV: { CUDA_PYTHON_PER_THREAD_DEFAULT_STREAM: '1' } }
+    - { ARCH: 'amd64', PY_VER: '3.13',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'rtxpro6000', GPU_COUNT: '1', DRIVER: 'latest', DRIVER_MODE: 'MCDM', ENV: { CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM: '1' } }
     - { ARCH: 'amd64', PY_VER: '3.14',  CUDA_VER: '12.9.1', LOCAL_CTK: '0', GPU: 'v100',       GPU_COUNT: '1', DRIVER: 'latest', DRIVER_MODE: 'TCC' }
     - { ARCH: 'amd64', PY_VER: '3.14',  CUDA_VER: '13.0.2', LOCAL_CTK: '1', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest', DRIVER_MODE: 'MCDM' }
     - { ARCH: 'amd64', PY_VER: '3.14',  CUDA_VER: '13.3.0', LOCAL_CTK: '1', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest', DRIVER_MODE: 'MCDM' }

--- a/ci/test-matrix.yml
+++ b/ci/test-matrix.yml
@@ -96,11 +96,9 @@ linux:
     - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: '580.65.06', ENV: { MODE: 'nightly-numba-cuda' } }
     - { ARCH: 'arm64', PY_VER: '3.12',  CUDA_VER: '12.9.1', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest',     ENV: { MODE: 'nightly-numba-cuda' } }
     - { ARCH: 'arm64', PY_VER: '3.12',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest',     ENV: { MODE: 'nightly-numba-cuda' } }
-    # nightly-numba-cuda-mlir (MLIR backend, mirrors nightly-numba-cuda coverage)
-    - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '12.9.1', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest',     ENV: { MODE: 'nightly-numba-cuda-mlir' } }
-    - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest',     ENV: { MODE: 'nightly-numba-cuda-mlir' } }
-    - { ARCH: 'arm64', PY_VER: '3.12',  CUDA_VER: '12.9.1', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest',     ENV: { MODE: 'nightly-numba-cuda-mlir' } }
-    - { ARCH: 'arm64', PY_VER: '3.12',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest',     ENV: { MODE: 'nightly-numba-cuda-mlir' } }
+    # nightly-numba-cuda-mlir (MLIR backend, linux-64 only)
+    - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '12.9.1', LOCAL_CTK: '0', GPU: 'rtxpro6000', GPU_COUNT: '1', DRIVER: 'latest',     ENV: { MODE: 'nightly-numba-cuda-mlir' } }
+    - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'rtxpro6000', GPU_COUNT: '1', DRIVER: 'latest',     ENV: { MODE: 'nightly-numba-cuda-mlir' } }
     # nightly-cuda-core (released cuda-core from PyPI against main pathfinder/bindings)
     - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'a100',       GPU_COUNT: '1', DRIVER: 'latest',     ENV: { MODE: 'nightly-cuda-core' } }
     # nightly-standard (arm64 nightly-only runners — per runner team request)
@@ -143,5 +141,8 @@ windows:
     # nightly-numba-cuda
     - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '12.9.1', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest',  DRIVER_MODE: 'TCC', ENV: { MODE: 'nightly-numba-cuda' } }
     - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: '596.36',  DRIVER_MODE: 'TCC', ENV: { MODE: 'nightly-numba-cuda' } }
+    # nightly-numba-cuda-mlir (MLIR backend, win-64)
+    - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '12.9.1', LOCAL_CTK: '0', GPU: 'rtxpro6000', GPU_COUNT: '1', DRIVER: 'latest',  DRIVER_MODE: 'MCDM', ENV: { MODE: 'nightly-numba-cuda-mlir' } }
+    - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'rtxpro6000', GPU_COUNT: '1', DRIVER: 'latest',  DRIVER_MODE: 'MCDM', ENV: { MODE: 'nightly-numba-cuda-mlir' } }
     # nightly-cuda-core (released cuda-core from PyPI against main pathfinder/bindings)
     - { ARCH: 'amd64', PY_VER: '3.14',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'a100',       GPU_COUNT: '1', DRIVER: 'latest',  DRIVER_MODE: 'MCDM', ENV: { MODE: 'nightly-cuda-core' } }

--- a/ci/test-matrix.yml
+++ b/ci/test-matrix.yml
@@ -96,6 +96,13 @@ linux:
     - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: '580.65.06', ENV: { MODE: 'nightly-numba-cuda' } }
     - { ARCH: 'arm64', PY_VER: '3.12',  CUDA_VER: '12.9.1', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest',     ENV: { MODE: 'nightly-numba-cuda' } }
     - { ARCH: 'arm64', PY_VER: '3.12',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest',     ENV: { MODE: 'nightly-numba-cuda' } }
+    # nightly-numba-cuda-mlir (MLIR backend, mirrors nightly-numba-cuda coverage)
+    - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '12.9.1', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest',     ENV: { MODE: 'nightly-numba-cuda-mlir' } }
+    - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest',     ENV: { MODE: 'nightly-numba-cuda-mlir' } }
+    - { ARCH: 'arm64', PY_VER: '3.12',  CUDA_VER: '12.9.1', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest',     ENV: { MODE: 'nightly-numba-cuda-mlir' } }
+    - { ARCH: 'arm64', PY_VER: '3.12',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest',     ENV: { MODE: 'nightly-numba-cuda-mlir' } }
+    # nightly-cuda-core (released cuda-core from PyPI against main pathfinder/bindings)
+    - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'a100',       GPU_COUNT: '1', DRIVER: 'latest',     ENV: { MODE: 'nightly-cuda-core' } }
     # nightly-standard (arm64 nightly-only runners — per runner team request)
     # TODO: gh200 row disabled — currently hangs on stream-ordered memory
     #       allocator (cudaMallocAsync); runner pool needs fixing first.
@@ -136,3 +143,5 @@ windows:
     # nightly-numba-cuda
     - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '12.9.1', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest',  DRIVER_MODE: 'TCC', ENV: { MODE: 'nightly-numba-cuda' } }
     - { ARCH: 'amd64', PY_VER: '3.12',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: '596.36',  DRIVER_MODE: 'TCC', ENV: { MODE: 'nightly-numba-cuda' } }
+    # nightly-cuda-core (released cuda-core from PyPI against main pathfinder/bindings)
+    - { ARCH: 'amd64', PY_VER: '3.14',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'a100',       GPU_COUNT: '1', DRIVER: 'latest',  DRIVER_MODE: 'MCDM', ENV: { MODE: 'nightly-cuda-core' } }

--- a/ci/tools/run-tests
+++ b/ci/tools/run-tests
@@ -114,32 +114,16 @@ elif [[ "${test_module}" == "core" || "${test_module}" == nightly-* ]]; then
     popd
   elif [[ "${test_module}" == "nightly-cuda-core" ]]; then
     # Test the *released* cuda-core (from PyPI) against *main*-built pathfinder
-    # and cuda-bindings. Fetches the released cuda-core's own test suite from
-    # the matching git tag so we exercise its full compiled surface, not the
-    # current main tests (which may reference APIs the released core doesn't
-    # have).
+    # and cuda-bindings. The workflow follows up with an actions/checkout of the
+    # matching cuda-core-v<X.Y.Z> tag so the released version's own test suite
+    # (which is not shipped in the wheel) can be exercised.
     echo "Installing pathfinder + bindings from main + released cuda-core from PyPI"
     pip install "${PATHFINDER_WHL[@]}" "${BINDINGS_ARGS[@]}" "cuda-core[cu${TEST_CUDA_MAJOR}]"
 
     released_ver=$(pip show cuda-core | awk '/^Version:/{print $2}')
-    tag="cuda-core-v${released_ver}"
-    tests_dir="${TMPDIR:-/tmp}/cuda-core-released-${released_ver}"
-    echo "Fetching cuda-core tests from tag ${tag}"
-    if ! git fetch origin --tags "+refs/tags/${tag}:refs/tags/${tag}" >/dev/null 2>&1; then
-      echo "Warning: tag ${tag} not fetchable; skipping released cuda-core tests"
-      exit 0
-    fi
-    mkdir -p "${tests_dir}"
-    git archive "${tag}" cuda_core | tar -x -C "${tests_dir}"
-
-    # Install test deps from the released tag's pyproject.toml, not main's.
-    pushd "${tests_dir}/cuda_core"
-    echo "Installing cuda-core test deps from tag ${tag}"
-    pip install --group "test-cu${TEST_CUDA_MAJOR}${FREE_THREADING}"
-    popd
-
     if [[ -n "${GITHUB_ENV:-}" ]]; then
-      echo "CUDA_CORE_RELEASED_TESTS_DIR=${tests_dir}" >> "${GITHUB_ENV}"
+      echo "CUDA_CORE_RELEASED_VER=${released_ver}" >> "${GITHUB_ENV}"
+      echo "CUDA_CORE_TEST_GROUP=test-cu${TEST_CUDA_MAJOR}${FREE_THREADING}" >> "${GITHUB_ENV}"
     fi
     echo "Installed packages before released cuda-core tests:"
     pip list
@@ -188,23 +172,12 @@ elif [[ "${test_module}" == "core" || "${test_module}" == nightly-* ]]; then
     popd
 
     if [[ "${test_module}" == "nightly-numba-cuda-mlir" ]]; then
-      # Fetch numba-cuda-mlir's own test suite from the matching git tag —
-      # the wheel does not ship test_*.py files.
+      # Expose the installed numba-cuda-mlir version so the workflow can
+      # actions/checkout the matching v<X.Y.Z> tag from NVIDIA/numba-cuda-mlir
+      # (the wheel does not ship test_*.py files).
       installed_ver=$(pip show numba-cuda-mlir | awk '/^Version:/{print $2}')
-      tag="v${installed_ver}"
-      tests_dir="${TMPDIR:-/tmp}/numba-cuda-mlir-${installed_ver}"
-      echo "Cloning numba-cuda-mlir tests at tag ${tag}"
-      if git clone --depth 1 --branch "${tag}" https://github.com/NVIDIA/numba-cuda-mlir "${tests_dir}"; then
-        pushd "${tests_dir}"
-        # --group requires pip 25.1+; Ubuntu 24.04 stock ships older.
-        pip install --upgrade "pip>=25.1"
-        pip install --group test
-        popd
-        if [[ -n "${GITHUB_ENV:-}" ]]; then
-          echo "NUMBA_CUDA_MLIR_TESTS_DIR=${tests_dir}" >> "${GITHUB_ENV}"
-        fi
-      else
-        echo "Warning: numba-cuda-mlir tag ${tag} not clonable; skipping tests"
+      if [[ -n "${GITHUB_ENV:-}" ]]; then
+        echo "NUMBA_CUDA_MLIR_VER=${installed_ver}" >> "${GITHUB_ENV}"
       fi
     fi
   fi

--- a/ci/tools/run-tests
+++ b/ci/tools/run-tests
@@ -93,10 +93,9 @@ elif [[ "${test_module}" == "core" || "${test_module}" == nightly-* ]]; then
     PATHFINDER_WHL=($(realpath ./cuda_pathfinder/*.whl))
   fi
 
-  # pushd so --group reads test dependency groups from cuda_core/pyproject.toml.
-  pushd ./cuda_core
-
   if [[ "${test_module}" == "core" ]]; then
+    # pushd so --group reads test dependency groups from cuda_core/pyproject.toml.
+    pushd ./cuda_core
     echo "Installing bindings (source: ${BINDINGS_SOURCE})"
     pip install "${BINDINGS_ARGS[@]}"
     echo "Installing core wheel"
@@ -112,10 +111,44 @@ elif [[ "${test_module}" == "core" || "${test_module}" == nightly-* ]]; then
     if [[ "${SKIP_CYTHON_TEST}" == 0 ]]; then
       ${SANITIZER_CMD} pytest -rxXs -v --durations=0 --randomly-dont-reorganize tests/cython
     fi
+    popd
+  elif [[ "${test_module}" == "nightly-cuda-core" ]]; then
+    # Test the *released* cuda-core (from PyPI) against *main*-built pathfinder
+    # and cuda-bindings. Fetches the released cuda-core's own test suite from
+    # the matching git tag so we exercise its full compiled surface, not the
+    # current main tests (which may reference APIs the released core doesn't
+    # have).
+    echo "Installing pathfinder + bindings from main + released cuda-core from PyPI"
+    pip install "${PATHFINDER_WHL[@]}" "${BINDINGS_ARGS[@]}" "cuda-core[cu${TEST_CUDA_MAJOR}]"
+
+    released_ver=$(pip show cuda-core | awk '/^Version:/{print $2}')
+    tag="cuda-core-v${released_ver}"
+    tests_dir="${TMPDIR:-/tmp}/cuda-core-released-${released_ver}"
+    echo "Fetching cuda-core tests from tag ${tag}"
+    if ! git fetch origin --tags "+refs/tags/${tag}:refs/tags/${tag}" >/dev/null 2>&1; then
+      echo "Warning: tag ${tag} not fetchable; skipping released cuda-core tests"
+      exit 0
+    fi
+    mkdir -p "${tests_dir}"
+    git archive "${tag}" cuda_core | tar -x -C "${tests_dir}"
+
+    # Install test deps from the released tag's pyproject.toml, not main's.
+    pushd "${tests_dir}/cuda_core"
+    echo "Installing cuda-core test deps from tag ${tag}"
+    pip install --group "test-cu${TEST_CUDA_MAJOR}${FREE_THREADING}"
+    popd
+
+    if [[ -n "${GITHUB_ENV:-}" ]]; then
+      echo "CUDA_CORE_RELEASED_TESTS_DIR=${tests_dir}" >> "${GITHUB_ENV}"
+    fi
+    echo "Installed packages before released cuda-core tests:"
+    pip list
   else
-    # Nightly optional-dependency testing.
-    # Install ALL wheels (pathfinder + bindings + core) and the optional dep
-    # in a single pip call so pip resolves version constraints in one shot.
+    # Nightly optional-dependency testing: nightly-pytorch, nightly-numba-cuda,
+    # nightly-numba-cuda-mlir. Install ALL cuda-python wheels (pathfinder +
+    # bindings + core) and the optional dep in a single pip call so pip resolves
+    # version constraints in one shot.
+    pushd ./cuda_core
     PIP_ARGS=(
       "${PATHFINDER_WHL[@]}"
       "${BINDINGS_ARGS[@]}"
@@ -144,12 +177,35 @@ elif [[ "${test_module}" == "core" || "${test_module}" == nightly-* ]]; then
         "cupy-cuda${TEST_CUDA_MAJOR}x"
         psutil cffi pytest-xdist pytest-benchmark filecheck ml_dtypes statistics
       )
+    elif [[ "${test_module}" == "nightly-numba-cuda-mlir" ]]; then
+      echo "Installing pathfinder + bindings + core + numba-cuda-mlir"
+      PIP_ARGS+=("numba-cuda-mlir[cu${TEST_CUDA_MAJOR}]")
     fi
 
     pip install "${PIP_ARGS[@]}"
     echo "Nightly install complete — installed packages:"
     pip list
-  fi
+    popd
 
-  popd
+    if [[ "${test_module}" == "nightly-numba-cuda-mlir" ]]; then
+      # Fetch numba-cuda-mlir's own test suite from the matching git tag —
+      # the wheel does not ship test_*.py files.
+      installed_ver=$(pip show numba-cuda-mlir | awk '/^Version:/{print $2}')
+      tag="v${installed_ver}"
+      tests_dir="${TMPDIR:-/tmp}/numba-cuda-mlir-${installed_ver}"
+      echo "Cloning numba-cuda-mlir tests at tag ${tag}"
+      if git clone --depth 1 --branch "${tag}" https://github.com/NVIDIA/numba-cuda-mlir "${tests_dir}"; then
+        pushd "${tests_dir}"
+        # --group requires pip 25.1+; Ubuntu 24.04 stock ships older.
+        pip install --upgrade "pip>=25.1"
+        pip install --group test
+        popd
+        if [[ -n "${GITHUB_ENV:-}" ]]; then
+          echo "NUMBA_CUDA_MLIR_TESTS_DIR=${tests_dir}" >> "${GITHUB_ENV}"
+        fi
+      else
+        echo "Warning: numba-cuda-mlir tag ${tag} not clonable; skipping tests"
+      fi
+    fi
+  fi
 fi

--- a/ci/tools/run-tests
+++ b/ci/tools/run-tests
@@ -163,7 +163,9 @@ elif [[ "${test_module}" == "core" || "${test_module}" == nightly-* ]]; then
       )
     elif [[ "${test_module}" == "nightly-numba-cuda-mlir" ]]; then
       echo "Installing pathfinder + bindings + core + numba-cuda-mlir"
-      PIP_ARGS+=("numba-cuda-mlir[cu${TEST_CUDA_MAJOR}]")
+      # numpy<2.5: numba-cuda-mlir 0.4.0 registers np.row_stack, which was
+      # removed in NumPy 2.5. See NVIDIA/numba-cuda-mlir#154.
+      PIP_ARGS+=("numba-cuda-mlir[cu${TEST_CUDA_MAJOR}]" "numpy<2.5")
     fi
 
     pip install "${PIP_ARGS[@]}"

--- a/cuda_pathfinder/pyproject.toml
+++ b/cuda_pathfinder/pyproject.toml
@@ -29,7 +29,7 @@ cu12 = [
     "nvidia-cusparselt-cu12",
     "nvidia-libmathdx-cu12",
     "nvidia-nccl-cu12; sys_platform != 'win32'",
-    "nvidia-nvshmem-cu12!=3.7.0; sys_platform != 'win32'",
+    "nvidia-nvshmem-cu12<3.7; sys_platform != 'win32'",
 ]
 cu13 = [
     "cuda-toolkit[nvcc,cublas,nvrtc,cudart,cufft,curand,cusolver,cusparse,npp,nvfatbin,nvjitlink,nvjpeg,cccl,cupti,profiler,nvvm]==13.*",
@@ -43,7 +43,7 @@ cu13 = [
     "nvidia-cusparselt-cu13",
     "nvidia-libmathdx-cu13",
     "nvidia-nccl-cu13; sys_platform != 'win32'",
-    "nvidia-nvshmem-cu13!=3.7.0; sys_platform != 'win32'",
+    "nvidia-nvshmem-cu13<3.7; sys_platform != 'win32'",
 ]
 host = [
     # TODO: remove the Python 3.15 guard once 3.15 is officially supported

--- a/cuda_pathfinder/pyproject.toml
+++ b/cuda_pathfinder/pyproject.toml
@@ -29,7 +29,7 @@ cu12 = [
     "nvidia-cusparselt-cu12",
     "nvidia-libmathdx-cu12",
     "nvidia-nccl-cu12; sys_platform != 'win32'",
-    "nvidia-nvshmem-cu12<3.7; sys_platform != 'win32'",
+    "nvidia-nvshmem-cu12!=3.7.0; sys_platform != 'win32'",
 ]
 cu13 = [
     "cuda-toolkit[nvcc,cublas,nvrtc,cudart,cufft,curand,cusolver,cusparse,npp,nvfatbin,nvjitlink,nvjpeg,cccl,cupti,profiler,nvvm]==13.*",
@@ -43,7 +43,7 @@ cu13 = [
     "nvidia-cusparselt-cu13",
     "nvidia-libmathdx-cu13",
     "nvidia-nccl-cu13; sys_platform != 'win32'",
-    "nvidia-nvshmem-cu13<3.7; sys_platform != 'win32'",
+    "nvidia-nvshmem-cu13!=3.7.0; sys_platform != 'win32'",
 ]
 host = [
     # TODO: remove the Python 3.15 guard once 3.15 is officially supported


### PR DESCRIPTION
## Summary

- Add `nightly-cuda-core`: released cuda-core from PyPI against main-built pathfinder + bindings. Fills the "core released x bindings main" quadrant discussed here (https://github.com/NVIDIA/cuda-python/issues/1955#issuecomment-4296771068).
- Add `nightly-numba-cuda-mlir`: MLIR-backend companion to `nightly-numba-cuda`.
- Both fetch the release tag's test suite from git — neither wheel ships `test_*.py`.
- Fix `CUDA_PYTHON_PER_THREAD_DEFAULT_STREAM` → `CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM` typo in `ci/test-matrix.yml` (https://github.com/NVIDIA/cuda-python/issues/971#issuecomment-4849789246).

Refs #971, #1955.