### PR TITLE
Use cuda.pathfinder to locate nvcc for object-code fixture

### DIFF
--- a/cuda_core/tests/test_binaries/build_test_binaries.sh
+++ b/cuda_core/tests/test_binaries/build_test_binaries.sh
@@ -14,7 +14,9 @@ if [[ "${OS:-}" == "Windows_NT" ]]; then
     NVCC_EXTRA_FLAGS+=(-Xcompiler /Zc:preprocessor)
 fi
 
-nvcc -dc "${NVCC_EXTRA_FLAGS[@]}" -arch=all-major \
+NVCC="${NVCC:-nvcc}"
+
+"${NVCC}" -dc "${NVCC_EXTRA_FLAGS[@]}" -arch=all-major \
     -o "${SCRIPTPATH}/saxpy.o" "${SCRIPTPATH}/saxpy.cu"
 
 ls -lah "${SCRIPTPATH}/saxpy.o"

--- a/cuda_core/tests/test_module.py
+++ b/cuda_core/tests/test_module.py
@@ -189,15 +189,18 @@ def get_saxpy_object():
     obj_path = binaries_dir / "saxpy.o"
 
     if not obj_path.is_file():
-        if find_nvidia_binary_utility("nvcc") is None:
+        nvcc_path = find_nvidia_binary_utility("nvcc")
+        if nvcc_path is None:
             pytest.skip(
                 f"saxpy.o not found at {obj_path} and nvcc is unavailable. "
                 "In CI this is downloaded from the build stage."
             )
+        env = os.environ.copy()
+        env["NVCC"] = nvcc_path
         subprocess.run(  # noqa: S603
             ["bash", str(binaries_dir / "build_test_binaries.sh")],  # noqa: S607
             check=True,
-            env=os.environ,
+            env=env,
         )
 
     return obj_path.read_bytes()


### PR DESCRIPTION
## Description

This fixes the cuda.core object-code test fixture in environments where `nvcc` is available through `cuda.pathfinder`, but is not directly on `PATH`.

Previously, `get_saxpy_object()` checked whether `cuda.pathfinder` could locate `nvcc`, but then invoked `build_test_binaries.sh` without passing that resolved path through. The shell script still called bare `nvcc`, so the fallback build failed when `nvcc` was discoverable but not on `PATH`.

This PR:

- resolves `nvcc` once with `find_nvidia_binary_utility("nvcc")`;
- passes the resolved path to `build_test_binaries.sh` through `NVCC`;
- keeps the shell script usable by hand by defaulting `NVCC` to `nvcc`.