### PR TITLE
cuda_pathfinder: pin nvshmem to <3.7 (was previously excluding only 3.7.0)

### DIFF
--- a/cuda_pathfinder/pyproject.toml
+++ b/cuda_pathfinder/pyproject.toml
@@ -29,7 +29,7 @@ cu12 = [
     "nvidia-cusparselt-cu12",
     "nvidia-libmathdx-cu12",
     "nvidia-nccl-cu12; sys_platform != 'win32'",
-    "nvidia-nvshmem-cu12!=3.7.0; sys_platform != 'win32'",
+    "nvidia-nvshmem-cu12<3.7; sys_platform != 'win32'",
 ]
 cu13 = [
     "cuda-toolkit[nvcc,cublas,nvrtc,cudart,cufft,curand,cusolver,cusparse,npp,nvfatbin,nvjitlink,nvjpeg,cccl,cupti,profiler,nvvm]==13.*",
@@ -43,7 +43,7 @@ cu13 = [
     "nvidia-cusparselt-cu13",
     "nvidia-libmathdx-cu13",
     "nvidia-nccl-cu13; sys_platform != 'win32'",
-    "nvidia-nvshmem-cu13!=3.7.0; sys_platform != 'win32'",
+    "nvidia-nvshmem-cu13<3.7; sys_platform != 'win32'",
 ]
 host = [
     # TODO: remove the Python 3.15 guard once 3.15 is officially supported


### PR DESCRIPTION
## Summary

`nvidia-nvshmem-cu{12,13}` 3.7.x is breaking main, not just 3.7.0. Widen the exclusion from `\!=3.7.0` to `<3.7` so all 3.7.x versions are avoided until we can move forward.

Extracted from #2283 to unblock CI ASAP.

See issue #2200 (and PR #2201) for related discussions.