### PR TITLE
Add griffe API checking to cuda_core

### DIFF
--- a/.github/actions/griffe-api-check/action.yml
+++ b/.github/actions/griffe-api-check/action.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: griffe API check
+
+description: >-
+  Check a package's public API (as defined by `__all__`) for changes using
+  griffe.
+
+inputs:
+  package-name:
+    description: "Importable package name to check, e.g. cuda.core"
+    required: true
+  package-dir:
+    description: "Directory to search for the package sources, e.g. cuda_core"
+    required: true
+  merge-base:
+    description: >-
+      Git ref/sha to compare the current code against, typically the PR's
+      merge-base with its target branch.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+      with:
+        enable-cache: false
+
+    - name: Check API
+      shell: bash --noprofile --norc -euo pipefail {0}
+      env:
+        PACKAGE_NAME: ${{ inputs.package-name }}
+        PACKAGE_DIR: ${{ inputs.package-dir }}
+        MERGE_BASE: ${{ inputs.merge-base }}
+      run: |
+        uvx griffe check "$PACKAGE_NAME" \
+          --search "$PACKAGE_DIR" \
+          --find-stubs-packages \
+          --against "$MERGE_BASE" \
+          --format github \
+          2>&1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
       test_bindings: ${{ steps.compose.outputs.test_bindings }}
       test_core: ${{ steps.compose.outputs.test_core }}
       test_pathfinder: ${{ steps.compose.outputs.test_pathfinder }}
+      pr_merge_base: ${{ steps.filter.outputs.merge_base }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -156,6 +157,7 @@ jobs:
             echo "python_meta=$(has_match '^cuda_python/')"
             echo "test_helpers=$(has_match '^cuda_python_test_helpers/')"
             echo "shared=$(has_match '^(\.github/|ci/|scripts/|toolshed/|conftest\.py$|pyproject\.toml$|pixi\.(toml|lock)$|pytest\.ini$|ruff\.toml$)')"
+            echo "merge_base=${base}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Compose gating outputs
@@ -227,6 +229,89 @@ jobs:
             echo "test_core=${test_core}"
             echo "test_pathfinder=${test_pathfinder}"
           } >> "$GITHUB_OUTPUT"
+
+  api-check-core-vs-release:
+    name: API check (cuda_core vs. latest release)
+    if: >-
+      ${{ !fromJSON(needs.should-skip.outputs.skip) &&
+          fromJSON(needs.detect-changes.outputs.core) }}
+    runs-on: ubuntu-latest
+    needs:
+      - should-skip
+      - detect-changes
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 1
+          filter: blob:none
+
+      - name: Find latest release tag
+        id: latest-tag
+        shell: bash --noprofile --norc -euo pipefail {0}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # --paginate fetches all pages; jq outputs one name per line per page;
+          # head -1 takes the first (newest) match since GitHub returns tags
+          # newest-first. Fails hard if no cuda-core-v* tag is found.
+          tag="$(gh api "repos/$GITHUB_REPOSITORY/tags" --paginate \
+            --jq '.[] | select(.name | startswith("cuda-core-v")) | .name' \
+            | head -1)"
+          if [[ -z "${tag}" ]]; then
+            echo "::error::No cuda-core-v* tag found in the repository." >&2
+            exit 1
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch release tag
+        shell: bash --noprofile --norc -euo pipefail {0}
+        run: |
+          git fetch --depth=1 --filter=blob:none origin \
+            "refs/tags/${{ steps.latest-tag.outputs.tag }}:refs/tags/${{ steps.latest-tag.outputs.tag }}"
+
+      - name: Check cuda_core public API
+        id: griffe
+        uses: ./.github/actions/griffe-api-check
+        with:
+          package-name: cuda.core
+          package-dir: cuda_core
+          merge-base: ${{ steps.latest-tag.outputs.tag }}
+
+  api-check-core-vs-base:
+    name: API check (cuda_core vs. merge base)
+    if: >-
+      ${{ startsWith(github.ref_name, 'pull-request/') &&
+          !fromJSON(needs.should-skip.outputs.skip) &&
+          fromJSON(needs.detect-changes.outputs.core) }}
+    runs-on: ubuntu-latest
+    needs:
+      - should-skip
+      - detect-changes
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 1
+          filter: blob:none
+
+      - name: Fetch merge base commit
+        shell: bash --noprofile --norc -euo pipefail {0}
+        run: |
+          git fetch --depth=1 --filter=blob:none origin \
+            "${{ needs.detect-changes.outputs.pr_merge_base }}"
+
+      - name: Check cuda_core public API
+        id: griffe
+        uses: ./.github/actions/griffe-api-check
+        with:
+          package-name: cuda.core
+          package-dir: cuda_core
+          merge-base: ${{ needs.detect-changes.outputs.pr_merge_base }}
 
   # NOTE: Build jobs are intentionally split by platform rather than using a single
   # matrix. This allows each test job to depend only on its corresponding build,


### PR DESCRIPTION
This adds a CI job to run `griffe` over `cuda_core` to detect API breakage.

It checks both against the merge base of the PR and against the latest `cuda-core` tag.

~This PR also deliberately makes an API breakage (the same one found in #2280) so we can confirm it's working.~

One side effect of this is that griffe /requires/ the top-level `__init__.py` to have an `__all__` so it's explicit about what the public API is.  This is a minor ongoing maintenance burden, but probably worth the effort.