### PR TITLE
docs: fix NVML wording

### DIFF
--- a/cuda_core/cuda/core/_device.pyi
+++ b/cuda_core/cuda/core/_device.pyi
@@ -654,7 +654,7 @@ class Device:
     def to_system_device(self) -> 'cuda.core.system.Device':
         """
         Get the corresponding :class:`cuda.core.system.Device` (which is used
-        for NVIDIA Machine Library (NVML) access) for this
+        for NVIDIA Management Library (NVML) access) for this
         :class:`cuda.core.Device` (which is used for CUDA access).
 
         The devices are mapped to one another by their UUID.

--- a/cuda_core/cuda/core/_device.pyx
+++ b/cuda_core/cuda/core/_device.pyx
@@ -1016,7 +1016,7 @@ class Device:
     def to_system_device(self) -> 'cuda.core.system.Device':
         """
         Get the corresponding :class:`cuda.core.system.Device` (which is used
-        for NVIDIA Machine Library (NVML) access) for this
+        for NVIDIA Management Library (NVML) access) for this
         :class:`cuda.core.Device` (which is used for CUDA access).
 
         The devices are mapped to one another by their UUID.
@@ -1030,7 +1030,7 @@ class Device:
 
         if not CUDA_BINDINGS_NVML_IS_COMPATIBLE:
             raise RuntimeError(
-                "cuda.core.system.Device requires cuda_bindings 13.1.2+ or 12.9.6+"
+                "cuda.core.system.Device requires cuda-bindings 12.9.6+ for CUDA 12.x, or cuda-bindings 13.2.0+ for CUDA 13.x"
             )
 
         from cuda.core.system import Device as SystemDevice

--- a/cuda_core/cuda/core/system/_device.pyi
+++ b/cuda_core/cuda/core/system/_device.pyi
@@ -1382,7 +1382,7 @@ class Device:
         """
         Get the corresponding :class:`cuda.core.Device` (which is used for CUDA
         access) for this :class:`cuda.core.system.Device` (which is used for
-        NVIDIA machine library (NVML) access).
+        NVIDIA Management Library (NVML) access).
 
         The devices are mapped to one another by their UUID.
 

--- a/cuda_core/cuda/core/system/_device.pyx
+++ b/cuda_core/cuda/core/system/_device.pyx
@@ -372,7 +372,7 @@ cdef class Device:
         """
         Get the corresponding :class:`cuda.core.Device` (which is used for CUDA
         access) for this :class:`cuda.core.system.Device` (which is used for
-        NVIDIA machine library (NVML) access).
+        NVIDIA Management Library (NVML) access).
 
         The devices are mapped to one another by their UUID.
 

--- a/cuda_core/cuda/core/system/_nvml_context.pxd
+++ b/cuda_core/cuda/core/system/_nvml_context.pxd
@@ -33,7 +33,7 @@ cpdef void _initialize() except *
 
 cpdef inline initialize():
     """
-    Initializes Nvidia Management Library (NVML), ensuring it only happens once per process.
+    Initializes NVIDIA Management Library (NVML), ensuring it only happens once per process.
     """
     if _NVML_STATE == _NVMLState.DISABLED_LIBRARY_NOT_FOUND or (
         _NVML_STATE == _NVMLState.INITIALIZED and getpid() == _NVML_OWNER_PID

--- a/cuda_core/cuda/core/system/_nvml_context.pyi
+++ b/cuda_core/cuda/core/system/_nvml_context.pyi
@@ -9,7 +9,7 @@ _lock = threading.Lock()
 
 def _initialize() -> None:
     """
-    Initializes Nvidia Management Library (NVML), ensuring it only happens once per process.
+    Initializes NVIDIA Management Library (NVML), ensuring it only happens once per process.
     """
 
 def validate() -> None:

--- a/cuda_core/cuda/core/system/_nvml_context.pyx
+++ b/cuda_core/cuda/core/system/_nvml_context.pyx
@@ -25,7 +25,7 @@ def _get_nvml_state() -> _NVMLState:
 
 cpdef void _initialize() except *:
     """
-    Initializes Nvidia Management Library (NVML), ensuring it only happens once per process.
+    Initializes NVIDIA Management Library (NVML), ensuring it only happens once per process.
     """
     global _NVML_STATE, _NVML_OWNER_PID
 

--- a/cuda_core/docs/source/api_nvml.rst
+++ b/cuda_core/docs/source/api_nvml.rst
@@ -10,7 +10,7 @@ This is the API reference for Pythonic access to CUDA system information,
 through the NVIDIA Management Library (NVML).
 
 .. note::
-   ``cuda.core.system`` support requires ``cuda_bindings`` 12.9.6 or later, or 13.2.0 or later.
+   ``cuda.core.system`` support requires ``cuda-bindings`` 12.9.6 or later for CUDA 12.x, or ``cuda-bindings`` 13.2.0 or later for CUDA 13.x.
 
 Basic functions
 ---------------

--- a/cuda_core/tests/system/conftest.py
+++ b/cuda_core/tests/system/conftest.py
@@ -18,7 +18,7 @@ if system.CUDA_BINDINGS_NVML_IS_COMPATIBLE:
 
 skip_if_nvml_unsupported = pytest.mark.skipif(
     SHOULD_SKIP_NVML_TESTS,
-    reason="NVML support requires cuda.bindings version 12.9.6+ or 13.1.2+, and hardware that supports NVML",
+    reason="NVML support requires cuda.bindings version 12.9.6+ for CUDA 12.x or 13.2.0+ for CUDA 13.x, and hardware that supports NVML",
 )
 
 

--- a/cuda_core/tests/test_device.py
+++ b/cuda_core/tests/test_device.py
@@ -25,7 +25,7 @@ def test_to_system_device(deinit_cuda):
     if not _system.CUDA_BINDINGS_NVML_IS_COMPATIBLE:
         with pytest.raises(RuntimeError):
             device.to_system_device()
-        pytest.skip("NVML support requires cuda.bindings version 12.9.6+ or 13.1.2+")
+        pytest.skip("NVML support requires cuda.bindings version 12.9.6+ for CUDA 12.x or 13.2.0+ for CUDA 13.x")
 
     from cuda.bindings._test_helpers.arch_check import hardware_supports_nvml
 


### PR DESCRIPTION
## Summary

Fixes the incorrect NVML expansion and clarifies the `cuda.core.system` `cuda-bindings` version requirement.

This updates:
- incorrect NVML references to `NVIDIA Management Library (NVML)`
- `cuda.core.system` support wording for CUDA 12.x and CUDA 13.x `cuda-bindings` versions
- matching docs, stubs, runtime message, and test skip text