### PR TITLE
[no-ci] expand context7.json

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,32 @@
 {
+  "$schema": "https://context7.com/schema/context7.json",
   "url": "https://context7.com/nvidia/cuda-python",
-  "public_key": "pk_gupaHhsdvsuT1j3BZpb7i"
+  "public_key": "pk_gupaHhsdvsuT1j3BZpb7i",
+  "folders": [
+    "cuda_python/docs/source",
+    "cuda_bindings/docs/source",
+    "cuda_core/docs/source",
+    "cuda_pathfinder/docs/source"
+  ],
+  "excludeFolders": [
+    "**/_templates"
+  ],
+  "excludeFiles": [
+    "AGENTS.md",
+    "CLAUDE.md",
+    "CHANGELOG.md",
+    "CHANGELOG.mdx",
+    "changelog.md",
+    "changelog.mdx",
+    "CONTRIBUTING.md",
+    "LICENSE.md",
+    "license.md",
+    "CODE_OF_CONDUCT.md",
+    "code_of_conduct.md",
+    "SECURITY.md",
+    "api_private.rst",
+    "conduct.rst",
+    "contribute.rst",
+    "license.rst"
+  ]
 }


### PR DESCRIPTION
Summary

Adds context7.json so Context7 can use CUDA Python docs from the repository.

This sets up:

- docs folders for indexing
- exclusions for non-user-facing docs content

After merge, we should refresh/check the Context7 page to confirm the expected documentation is available.
