### PR TITLE
cuda.core: update PyTorch example to use native __cuda_stream__

### DIFF
--- a/cuda_core/examples/pytorch_example.py
+++ b/cuda_core/examples/pytorch_example.py
@@ -32,16 +32,6 @@ __global__ void saxpy_kernel(const T* a, const T* x, const T* y, T* out, size_t 
 """
 
 
-# Create a wrapper class that implements __cuda_stream__
-class PyTorchStreamWrapper:
-    def __init__(self, pt_stream):
-        self.pt_stream = pt_stream
-
-    def __cuda_stream__(self):
-        stream_id = self.pt_stream.cuda_stream
-        return (0, stream_id)  # Return format required by CUDA Python
-
-
 def main():
     dev = Device()
     dev.set_current()
@@ -49,7 +39,7 @@ def main():
     pt_stream = torch.cuda.current_stream()
     print(f"PyTorch stream: {pt_stream}", file=sys.stderr)
 
-    stream = dev.create_stream(PyTorchStreamWrapper(pt_stream))
+    stream = dev.create_stream(pt_stream)
 
     try:
         # prepare program

--- a/cuda_core/examples/pytorch_example.py
+++ b/cuda_core/examples/pytorch_example.py
@@ -32,9 +32,21 @@ __global__ void saxpy_kernel(const T* a, const T* x, const T* y, T* out, size_t 
 """
 
 
+def torch_version() -> tuple[int, int, int]:
+    v = torch.__version__
+    v = v.split("+")[0].split(".")
+    return tuple(int(x) for x in v)
+
+
 def main():
     dev = Device()
     dev.set_current()
+
+    print(f"PyTorch version: {torch_version()}", file=sys.stderr)
+    if torch_version() < (2, 10, 0):
+        # Need support for the __cuda_stream__ method.
+        print("PyTorch version 2.10 or later required, skipping example", file=sys.stderr)
+        return
 
     pt_stream = torch.cuda.current_stream()
     print(f"PyTorch stream: {pt_stream}", file=sys.stderr)


### PR DESCRIPTION
Signed-off-by: Ralf Juengling <rjuengling@nvidia.com>

## Description

closes #1083

Drop the `PyTorchStreamWrapper` helper and pass the PyTorch stream
directly to `Device.create_stream()` now that PyTorch implements
`__cuda_stream__` natively.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.