### PR TITLE
Revert SMResource splitting fix, the problem was the test

### DIFF
--- a/cuda_core/cuda/core/_device_resources.pxd
+++ b/cuda_core/cuda/core/_device_resources.pxd
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-cimport cython
-
 from cuda.bindings cimport cydriver
 from cuda.core._resource_handles cimport ContextHandle, GreenCtxHandle
 
@@ -17,7 +15,6 @@ cdef class SMResource:
         unsigned int _flags
         bint _is_usable
         object __weakref__
-        cython.pymutex _split_mutex
 
     @staticmethod
     cdef SMResource _from_dev_resource(cydriver.CUdevResource res, int device_id)

--- a/cuda_core/cuda/core/_device_resources.pyx
+++ b/cuda_core/cuda/core/_device_resources.pyx
@@ -498,11 +498,10 @@ cdef class SMResource:
         )
         _resolve_group_count(opts)
         _check_green_ctx_support()
-        with self._split_mutex:
-            if _can_use_structured_sm_split():
-                return _split_with_general_api(self, opts, dry_run)
-            # SplitByCount requires the same 12.4+ as green ctx support (already checked above)
-            return _split_with_count_api(self, opts, dry_run)
+        if _can_use_structured_sm_split():
+            return _split_with_general_api(self, opts, dry_run)
+        # SplitByCount requires the same 12.4+ as green ctx support (already checked above)
+        return _split_with_count_api(self, opts, dry_run)
 
 
 cdef class WorkqueueResource:

--- a/cuda_core/tests/conftest.py
+++ b/cuda_core/tests/conftest.py
@@ -131,6 +131,18 @@ def _wrap_worker_cuda_test(func):
                 kwargs["mempool_device_x2"] = _mempool_device_impl(2)
             if "mempool_device_x3" in kwargs:
                 kwargs["mempool_device_x3"] = _mempool_device_impl(3)
+
+            # These are used by test_green_context.py.  The original fixtures include
+            # pytest.skip() but that should have correctly fired by this time.
+            if "sm_resource" in kwargs:
+                kwargs["sm_resource"] = device.resources.sm
+            if "wq_resource" in kwargs:
+                kwargs["wq_resource"] = device.resources.workqueue
+            if "green_ctx" in kwargs:
+                from cuda.core import ContextOptions, SMResourceOptions
+
+                groups, _ = device.resources.sm.split(SMResourceOptions(count=None))
+                kwargs["green_ctx"] = device.create_context(ContextOptions(resources=[groups[0]]))
             return func(*args, **kwargs)
 
     wrapper._cuda_core_worker_cuda_wrapped = True

--- a/cuda_core/tests/test_green_context.py
+++ b/cuda_core/tests/test_green_context.py
@@ -40,6 +40,8 @@ extern "C" __global__ void fill(int* out, int value, int n) {
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+# Note that the following fixtures (except fill_kernel) require per-thread setup
+# and are currently special cased to work with pytest-run-parallel in conftest.
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

I got things wrong, I think.  While completely harmless to have the lock, I think we can consider `SMResource` as thread-unsafe as it is based of `Device()` and the green-context where `Device()` is thread-local and green-contexts are by definition thread unsafe to share.

There is probably some documentation that would be good that sharing device objects across threads is unsafe (to the point of crashes).  But I now think the correct fix, at least for now, is to just fix the test and I have included that here.

@Andy-Jost sorry about this but FYI since you merged the other PR for me.