### PR TITLE
Migrate MSVC toolchain setup to step-security/msvc-dev-cmd fork

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Set up MSVC
         if: ${{ startsWith(inputs.host-platform, 'win') }}
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756  # v1
+        uses: step-security/msvc-dev-cmd@22c98154b708dbd743e6f27a933cf6ceba3305c4  # v1.13.1
 
       - name: Set up yq
         # GitHub made an unprofessional decision to not provide it in their Windows VMs,

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -212,7 +212,7 @@ jobs:
           python-version: ${{ env.PY_VER }}
 
       - name: Set up MSVC
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: step-security/msvc-dev-cmd@22c98154b708dbd743e6f27a933cf6ceba3305c4  # v1.13.1
 
       - name: Set up mini CTK
         uses: ./.github/actions/fetch_ctk

--- a/.github/workflows/test-sdist-windows.yml
+++ b/.github/workflows/test-sdist-windows.yml
@@ -45,7 +45,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up MSVC
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756  # v1
+        uses: step-security/msvc-dev-cmd@22c98154b708dbd743e6f27a933cf6ceba3305c4  # v1.13.1
 
       - name: Install build tools
         run: pip install build


### PR DESCRIPTION
## Summary

Migrates the Windows MSVC-toolchain setup step from
[`ilammy/msvc-dev-cmd`](https://github.com/ilammy/msvc-dev-cmd) to the
maintained fork
[`step-security/msvc-dev-cmd@v1.13.1`](https://github.com/step-security/msvc-dev-cmd/releases/tag/v1.13.1).

## Motivation

The upstream `ilammy/msvc-dev-cmd` still runs on Node.js 20, which GitHub
Actions is deprecating:

> Actions will be forced to run with Node.js 24 by default starting June 16th, 2026.
> Node.js 20 will be removed from the runner on September 16th, 2026.

The `step-security` fork has been upgraded to Node.js 24.

## Test plan

- [ ] Windows build/wheel workflows pass on the PR
- [ ] Coverage workflow completes on Windows