### PR TITLE
Refresh generated cuDLA Windows bindings

### DIFF
--- a/cuda_bindings/cuda/bindings/_internal/cudla_windows.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/cudla_windows.pyx
@@ -1,8 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# This code was automatically generated across versions from 1.5.0 to 13.3.0, generator version 0.3.1.dev1465+gc5c5c8652. Do not modify it directly.
+# This code was automatically generated across versions from 1.5.0 to 13.3.0. Do not modify it directly.
 
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=43403925d332dc0474938eb5f6b5d58c648884b9f056c1b319a515281b36757e
 from libc.stdint cimport intptr_t
 
 import threading


### PR DESCRIPTION
## Summary

Refresh `cudla_windows.pyx` so it uses the current generated-file metadata format.

There are no binding implementation changes.

## Validation

- `pre-commit run --all-files`
