### PR TITLE
cuda.core: expose wqConcurrencyLimit on WorkqueueResource

### DIFF
--- a/cuda_core/cuda/core/_device_resources.pyi
+++ b/cuda_core/cuda/core/_device_resources.pyi
@@ -125,18 +125,6 @@ class WorkqueueResource:
     def handle(self) -> int:
         """Return the address of the underlying config ``CUdevResource`` struct."""
 
-    @property
-    def concurrency_limit(self) -> int:
-        """Expected maximum concurrent stream-ordered workloads.
-
-        Reflects the ``wqConcurrencyLimit`` field of the underlying
-        workqueue-config struct. When first queried, this matches
-        the driver-populated cap (typically
-        ``CUDA_DEVICE_MAX_CONNECTIONS``). It can be updated via
-        :meth:`configure` with
-        :attr:`WorkqueueResourceOptions.concurrency_limit`.
-        """
-
     def configure(self, options: WorkqueueResourceOptions) -> None:
         """Configure the workqueue resource in place.
 

--- a/cuda_core/cuda/core/_device_resources.pyi
+++ b/cuda_core/cuda/core/_device_resources.pyi
@@ -47,8 +47,19 @@ class WorkqueueResourceOptions:
     sharing_scope : str, optional
         Workqueue sharing scope. Accepted values: ``"device_ctx"``
         or ``"green_ctx_balanced"``. (Default to ``None``)
+    concurrency_limit : int, optional
+        Expected maximum number of concurrent stream-ordered
+        workloads. Must be ``>= 1`` when set. The effective
+        driver-side cap is ``CUDA_DEVICE_MAX_CONNECTIONS``
+        (typically ``[1, 32]``); configurations may exceed
+        this cap, but the driver will not guarantee that work
+        submission remains non-overlapping. (Default to ``None``)
     """
     sharing_scope: str | None = None
+    concurrency_limit: int | None = None
+
+    def __post_init__(self):
+        ...
 
 class SMResource:
     """Represent an SM (streaming multiprocessor) resource partition.
@@ -114,13 +125,25 @@ class WorkqueueResource:
     def handle(self) -> int:
         """Return the address of the underlying config ``CUdevResource`` struct."""
 
+    @property
+    def concurrency_limit(self) -> int:
+        """Expected maximum concurrent stream-ordered workloads.
+
+        Reflects the ``wqConcurrencyLimit`` field of the underlying
+        workqueue-config struct. When first queried, this matches
+        the driver-populated cap (typically
+        ``CUDA_DEVICE_MAX_CONNECTIONS``). It can be updated via
+        :meth:`configure` with
+        :attr:`WorkqueueResourceOptions.concurrency_limit`.
+        """
+
     def configure(self, options: WorkqueueResourceOptions) -> None:
         """Configure the workqueue resource in place.
 
         Parameters
         ----------
         options : :obj:`WorkqueueResourceOptions`
-            Configuration options (sharing scope, etc.).
+            Configuration options (sharing scope, concurrency limit).
         """
 
 class DeviceResources:

--- a/cuda_core/cuda/core/_device_resources.pyx
+++ b/cuda_core/cuda/core/_device_resources.pyx
@@ -554,24 +554,6 @@ cdef class WorkqueueResource:
         """Return the address of the underlying config ``CUdevResource`` struct."""
         return <intptr_t>(&self._wq_config_resource)
 
-    @property
-    def concurrency_limit(self) -> int:
-        """Expected maximum concurrent stream-ordered workloads.
-
-        Reflects the ``wqConcurrencyLimit`` field of the underlying
-        workqueue-config struct. When first queried, this matches
-        the driver-populated cap (typically
-        ``CUDA_DEVICE_MAX_CONNECTIONS``). It can be updated via
-        :meth:`configure` with
-        :attr:`WorkqueueResourceOptions.concurrency_limit`.
-        """
-        IF CUDA_CORE_BUILD_MAJOR >= 13:
-            return self._wq_config_resource.wqConfig.wqConcurrencyLimit
-        ELSE:
-            raise RuntimeError(
-                "WorkqueueResource requires cuda.core to be built with CUDA 13.x bindings"
-            )
-
     def configure(self, options: WorkqueueResourceOptions) -> None:
         """Configure the workqueue resource in place.
 

--- a/cuda_core/cuda/core/_device_resources.pyx
+++ b/cuda_core/cuda/core/_device_resources.pyx
@@ -129,9 +129,17 @@ cdef class WorkqueueResourceOptions:
     sharing_scope : str, optional
         Workqueue sharing scope. Accepted values: ``"device_ctx"``
         or ``"green_ctx_balanced"``. (Default to ``None``)
+    concurrency_limit : int, optional
+        Expected maximum number of concurrent stream-ordered
+        workloads. Must be ``>= 1`` when set. The effective
+        driver-side cap is ``CUDA_DEVICE_MAX_CONNECTIONS``
+        (typically ``[1, 32]``); configurations may exceed
+        this cap, but the driver will not guarantee that work
+        submission remains non-overlapping. (Default to ``None``)
     """
 
     sharing_scope: str | None = None
+    concurrency_limit: int | None = None
 
 
 cdef inline int _validate_split_field_length(
@@ -535,23 +543,49 @@ cdef class WorkqueueResource:
         """Return the address of the underlying config ``CUdevResource`` struct."""
         return <intptr_t>(&self._wq_config_resource)
 
+    @property
+    def concurrency_limit(self) -> int:
+        """Expected maximum concurrent stream-ordered workloads.
+
+        Reflects the ``wqConcurrencyLimit`` field of the underlying
+        workqueue-config struct. When first queried, this matches
+        the driver-populated cap (typically
+        ``CUDA_DEVICE_MAX_CONNECTIONS``). It can be updated via
+        :meth:`configure` with
+        :attr:`WorkqueueResourceOptions.concurrency_limit`.
+        """
+        IF CUDA_CORE_BUILD_MAJOR >= 13:
+            return self._wq_config_resource.wqConfig.wqConcurrencyLimit
+        ELSE:
+            raise RuntimeError(
+                "WorkqueueResource requires cuda.core to be built with CUDA 13.x bindings"
+            )
+
     def configure(self, options: WorkqueueResourceOptions) -> None:
         """Configure the workqueue resource in place.
 
         Parameters
         ----------
         options : :obj:`WorkqueueResourceOptions`
-            Configuration options (sharing scope, etc.).
+            Configuration options (sharing scope, concurrency limit).
         """
         cdef WorkqueueResourceOptions opts = check_or_create_options(
             WorkqueueResourceOptions, options, "Workqueue resource options"
         )
         _check_green_ctx_support()
         _check_workqueue_support()
-        if opts.sharing_scope is None:
+        if opts.sharing_scope is None and opts.concurrency_limit is None:
             return None
 
         IF CUDA_CORE_BUILD_MAJOR >= 13:
+            if opts.concurrency_limit is not None:
+                if opts.concurrency_limit < 1:
+                    raise ValueError(
+                        f"concurrency_limit must be >= 1, got {opts.concurrency_limit}"
+                    )
+                self._wq_config_resource.wqConfig.wqConcurrencyLimit = (
+                    <unsigned int>opts.concurrency_limit
+                )
             if opts.sharing_scope == "device_ctx":
                 self._wq_config_resource.wqConfig.sharingScope = (
                     cydriver.CUdevWorkqueueConfigScope.CU_WORKQUEUE_SCOPE_DEVICE_CTX
@@ -560,7 +594,7 @@ cdef class WorkqueueResource:
                 self._wq_config_resource.wqConfig.sharingScope = (
                     cydriver.CUdevWorkqueueConfigScope.CU_WORKQUEUE_SCOPE_GREEN_CTX_BALANCED
                 )
-            else:
+            elif opts.sharing_scope is not None:
                 raise ValueError(
                     f"Unknown sharing_scope: {opts.sharing_scope!r}. "
                     "Expected 'device_ctx' or 'green_ctx_balanced'."

--- a/cuda_core/cuda/core/_device_resources.pyx
+++ b/cuda_core/cuda/core/_device_resources.pyx
@@ -141,6 +141,17 @@ cdef class WorkqueueResourceOptions:
     sharing_scope: str | None = None
     concurrency_limit: int | None = None
 
+    def __post_init__(self):
+        if self.sharing_scope not in (None, "device_ctx", "green_ctx_balanced"):
+            raise ValueError(
+                f"Unknown sharing_scope: {self.sharing_scope!r}. "
+                "Expected 'device_ctx' or 'green_ctx_balanced'."
+            )
+        if self.concurrency_limit is not None and self.concurrency_limit < 1:
+            raise ValueError(
+                f"concurrency_limit must be >= 1, got {self.concurrency_limit}"
+            )
+
 
 cdef inline int _validate_split_field_length(
     object value, str field_name, int n_groups, bint count_is_scalar
@@ -579,10 +590,6 @@ cdef class WorkqueueResource:
 
         IF CUDA_CORE_BUILD_MAJOR >= 13:
             if opts.concurrency_limit is not None:
-                if opts.concurrency_limit < 1:
-                    raise ValueError(
-                        f"concurrency_limit must be >= 1, got {opts.concurrency_limit}"
-                    )
                 self._wq_config_resource.wqConfig.wqConcurrencyLimit = (
                     <unsigned int>opts.concurrency_limit
                 )
@@ -593,11 +600,6 @@ cdef class WorkqueueResource:
             elif opts.sharing_scope == "green_ctx_balanced":
                 self._wq_config_resource.wqConfig.sharingScope = (
                     cydriver.CUdevWorkqueueConfigScope.CU_WORKQUEUE_SCOPE_GREEN_CTX_BALANCED
-                )
-            elif opts.sharing_scope is not None:
-                raise ValueError(
-                    f"Unknown sharing_scope: {opts.sharing_scope!r}. "
-                    "Expected 'device_ctx' or 'green_ctx_balanced'."
                 )
         ELSE:
             raise RuntimeError(

--- a/cuda_core/docs/source/release/1.1.0-notes.rst
+++ b/cuda_core/docs/source/release/1.1.0-notes.rst
@@ -106,6 +106,13 @@ New features
   (`#2068 <https://github.com/NVIDIA/cuda-python/pull/2068>`__,
   closes `#2049 <https://github.com/NVIDIA/cuda-python/issues/2049>`__)
 
+- Added ``concurrency_limit`` to :class:`WorkqueueResourceOptions` and a
+  read-only :attr:`WorkqueueResource.concurrency_limit` property, mirroring
+  the ``wqConcurrencyLimit`` field of the driver's workqueue-config struct.
+  This is the driver's "expected maximum concurrent stream-ordered
+  workloads" hint, bounded in practice by ``CUDA_DEVICE_MAX_CONNECTIONS``.
+  (`#2329 <https://github.com/NVIDIA/cuda-python/pull/2329>`__)
+
 Fixes and enhancements
 ----------------------
 

--- a/cuda_core/docs/source/release/1.1.0-notes.rst
+++ b/cuda_core/docs/source/release/1.1.0-notes.rst
@@ -107,10 +107,8 @@ New features
   closes `#2049 <https://github.com/NVIDIA/cuda-python/issues/2049>`__)
 
 - Added ``concurrency_limit`` to :class:`WorkqueueResourceOptions` and a
-  read-only :attr:`WorkqueueResource.concurrency_limit` property, mirroring
-  the ``wqConcurrencyLimit`` field of the driver's workqueue-config struct.
-  This is the driver's "expected maximum concurrent stream-ordered
-  workloads" hint, bounded in practice by ``CUDA_DEVICE_MAX_CONNECTIONS``.
+  read-only :attr:`WorkqueueResource.concurrency_limit` property to
+  configure the expected maximum concurrent stream-ordered workloads.
   (`#2329 <https://github.com/NVIDIA/cuda-python/pull/2329>`__)
 
 Fixes and enhancements

--- a/cuda_core/docs/source/release/1.1.0-notes.rst
+++ b/cuda_core/docs/source/release/1.1.0-notes.rst
@@ -106,8 +106,7 @@ New features
   (`#2068 <https://github.com/NVIDIA/cuda-python/pull/2068>`__,
   closes `#2049 <https://github.com/NVIDIA/cuda-python/issues/2049>`__)
 
-- Added ``concurrency_limit`` to :class:`WorkqueueResourceOptions` and a
-  read-only :attr:`WorkqueueResource.concurrency_limit` property to
+- Added ``concurrency_limit`` to :class:`WorkqueueResourceOptions` to
   configure the expected maximum concurrent stream-ordered workloads.
   (`#2329 <https://github.com/NVIDIA/cuda-python/pull/2329>`__)
 

--- a/cuda_core/tests/test_green_context.py
+++ b/cuda_core/tests/test_green_context.py
@@ -216,9 +216,9 @@ class TestWorkqueueResource:
     def test_configure_valid_scope(self, wq_resource):
         wq_resource.configure(WorkqueueResourceOptions(sharing_scope="green_ctx_balanced"))
 
-    def test_configure_invalid_scope_raises(self, wq_resource):
+    def test_invalid_scope_raises_at_construction(self):
         with pytest.raises(ValueError, match="Unknown sharing_scope"):
-            wq_resource.configure(WorkqueueResourceOptions(sharing_scope="bogus"))
+            WorkqueueResourceOptions(sharing_scope="bogus")
 
     def test_query_concurrency_limit_nonzero(self, wq_resource):
         # driver populates from CUDA_DEVICE_MAX_CONNECTIONS
@@ -235,13 +235,13 @@ class TestWorkqueueResource:
         ))
         assert wq_resource.concurrency_limit == 2
 
-    def test_configure_concurrency_limit_zero_raises(self, wq_resource):
+    def test_concurrency_limit_zero_raises_at_construction(self):
         with pytest.raises(ValueError, match="concurrency_limit must be >= 1"):
-            wq_resource.configure(WorkqueueResourceOptions(concurrency_limit=0))
+            WorkqueueResourceOptions(concurrency_limit=0)
 
-    def test_configure_concurrency_limit_negative_raises(self, wq_resource):
+    def test_concurrency_limit_negative_raises_at_construction(self):
         with pytest.raises(ValueError, match="concurrency_limit must be >= 1"):
-            wq_resource.configure(WorkqueueResourceOptions(concurrency_limit=-3))
+            WorkqueueResourceOptions(concurrency_limit=-3)
 
 
 # ---------------------------------------------------------------------------

--- a/cuda_core/tests/test_green_context.py
+++ b/cuda_core/tests/test_green_context.py
@@ -220,13 +220,8 @@ class TestWorkqueueResource:
         with pytest.raises(ValueError, match="Unknown sharing_scope"):
             WorkqueueResourceOptions(sharing_scope="bogus")
 
-    def test_query_concurrency_limit_nonzero(self, wq_resource):
-        # driver populates from CUDA_DEVICE_MAX_CONNECTIONS
-        assert wq_resource.concurrency_limit >= 1
-
     def test_configure_concurrency_limit(self, wq_resource):
         wq_resource.configure(WorkqueueResourceOptions(concurrency_limit=4))
-        assert wq_resource.concurrency_limit == 4
 
     def test_configure_concurrency_and_scope(self, wq_resource):
         wq_resource.configure(
@@ -235,7 +230,6 @@ class TestWorkqueueResource:
                 concurrency_limit=2,
             )
         )
-        assert wq_resource.concurrency_limit == 2
 
     def test_concurrency_limit_zero_raises_at_construction(self):
         with pytest.raises(ValueError, match="concurrency_limit must be >= 1"):

--- a/cuda_core/tests/test_green_context.py
+++ b/cuda_core/tests/test_green_context.py
@@ -518,9 +518,13 @@ class TestGreenContextKernelLaunch:
                 ctx_a.close()
 
     def test_with_workqueue_resource(self, init_cuda, sm_resource, wq_resource, fill_kernel):
-        """Green context with SM + workqueue resources can launch a kernel."""
+        """Green context with SM + configured workqueue can launch a kernel."""
         dev = init_cuda
         groups, _ = sm_resource.split(SMResourceOptions(count=None))
+        wq_resource.configure(WorkqueueResourceOptions(
+            sharing_scope="green_ctx_balanced",
+            concurrency_limit=4,
+        ))
 
         try:
             ctx = dev.create_context(ContextOptions(resources=[groups[0], wq_resource]))

--- a/cuda_core/tests/test_green_context.py
+++ b/cuda_core/tests/test_green_context.py
@@ -229,10 +229,12 @@ class TestWorkqueueResource:
         assert wq_resource.concurrency_limit == 4
 
     def test_configure_concurrency_and_scope(self, wq_resource):
-        wq_resource.configure(WorkqueueResourceOptions(
-            sharing_scope="green_ctx_balanced",
-            concurrency_limit=2,
-        ))
+        wq_resource.configure(
+            WorkqueueResourceOptions(
+                sharing_scope="green_ctx_balanced",
+                concurrency_limit=2,
+            )
+        )
         assert wq_resource.concurrency_limit == 2
 
     def test_concurrency_limit_zero_raises_at_construction(self):
@@ -521,10 +523,12 @@ class TestGreenContextKernelLaunch:
         """Green context with SM + configured workqueue can launch a kernel."""
         dev = init_cuda
         groups, _ = sm_resource.split(SMResourceOptions(count=None))
-        wq_resource.configure(WorkqueueResourceOptions(
-            sharing_scope="green_ctx_balanced",
-            concurrency_limit=4,
-        ))
+        wq_resource.configure(
+            WorkqueueResourceOptions(
+                sharing_scope="green_ctx_balanced",
+                concurrency_limit=4,
+            )
+        )
 
         try:
             ctx = dev.create_context(ContextOptions(resources=[groups[0], wq_resource]))

--- a/cuda_core/tests/test_green_context.py
+++ b/cuda_core/tests/test_green_context.py
@@ -220,6 +220,29 @@ class TestWorkqueueResource:
         with pytest.raises(ValueError, match="Unknown sharing_scope"):
             wq_resource.configure(WorkqueueResourceOptions(sharing_scope="bogus"))
 
+    def test_query_concurrency_limit_nonzero(self, wq_resource):
+        # driver populates from CUDA_DEVICE_MAX_CONNECTIONS
+        assert wq_resource.concurrency_limit >= 1
+
+    def test_configure_concurrency_limit(self, wq_resource):
+        wq_resource.configure(WorkqueueResourceOptions(concurrency_limit=4))
+        assert wq_resource.concurrency_limit == 4
+
+    def test_configure_concurrency_and_scope(self, wq_resource):
+        wq_resource.configure(WorkqueueResourceOptions(
+            sharing_scope="green_ctx_balanced",
+            concurrency_limit=2,
+        ))
+        assert wq_resource.concurrency_limit == 2
+
+    def test_configure_concurrency_limit_zero_raises(self, wq_resource):
+        with pytest.raises(ValueError, match="concurrency_limit must be >= 1"):
+            wq_resource.configure(WorkqueueResourceOptions(concurrency_limit=0))
+
+    def test_configure_concurrency_limit_negative_raises(self, wq_resource):
+        with pytest.raises(ValueError, match="concurrency_limit must be >= 1"):
+            wq_resource.configure(WorkqueueResourceOptions(concurrency_limit=-3))
+
 
 # ---------------------------------------------------------------------------
 # SM resource split — validation


### PR DESCRIPTION
## Summary

Add `concurrency_limit` to `WorkqueueResourceOptions`, so the user-facing options for `WorkqueueResource.configure()` mirror the driver's user-writable fields on the workqueue config (`sharing_scope` + `concurrency_limit`).

Also fixes `WorkqueueResource.configure()` where the `sharing_scope is None` early return silently dropped any other option that might be set, and moves both `sharing_scope` and `concurrency_limit` validation to `WorkqueueResourceOptions.__post_init__` so bad options fail at construction and are caught on any build (not just CUDA 13.x).

Following the "no speculative sugar" principle, no query-side property is added — `configure()` is the only user-facing setter, symmetric with how `sharing_scope` works today.

## Semantics

An input hint to the driver — "expected maximum number of concurrent stream-ordered workloads" — bounded in practice by `CUDA_DEVICE_MAX_CONNECTIONS` (see [CUDA docs](https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/environment-variables.html#cuda-device-max-connections)). Values `>= 1` accepted; per the [green contexts docs](https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/green-contexts.html), configurations may exceed the driver-reported cap at the cost of the non-overlap guarantee, so no upper cap is enforced.

## Test coverage

Extended `TestWorkqueueResource` in `test_green_context.py`:
- `configure(concurrency_limit=N)` accepted on valid values
- combined `sharing_scope` + `concurrency_limit` in one `configure()` call
- `WorkqueueResourceOptions(concurrency_limit=0)` and negative values raise `ValueError` at construction
- `WorkqueueResourceOptions(sharing_scope="bogus")` raises `ValueError` at construction (was: at `configure()`)

Extended `TestGreenContextKernelLaunch::test_with_workqueue_resource` to configure the workqueue with both `sharing_scope="green_ctx_balanced"` and `concurrency_limit=4` before green ctx creation + kernel launch, so the end-to-end path is exercised.

Full `test_green_context.py` locally: 35 passed, 2 skipped (arch), zero regressions.

Release notes entry added under 1.1.0 "New features".

Related: #1976 (green context support).

-- Leo's bot