### PR TITLE
Generator changes

### DIFF
--- a/cuda_bindings/cuda/bindings/_internal/_fast_enum.py
+++ b/cuda_bindings/cuda/bindings/_internal/_fast_enum.py
@@ -1,10 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-#
-# This code was automatically generated across versions from 12.0.1 to 13.3.0. Do not modify it directly.
 
 
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=5791f341ee9bb6573f42300fbed50cc52fc5e808c1d6bb9156e6aabb9db29b17
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=581469c1fadb5f72c43b478d73f2b905562136c8723a25e2f4240b5b681e2894
 """
 This is a replacement for the stdlib enum.IntEnum.
 

--- a/cuda_bindings/cuda/bindings/_internal/cudla_linux.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/cudla_linux.pyx
@@ -2,62 +2,34 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # This code was automatically generated across versions from 1.5.0 to 13.3.0. Do not modify it directly.
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=a7e70bc7234821ae1f02306321604d7605aee20e0fde536def5edd52263be5de
 
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=2b56e5f08b7806fe10648817d36d96ce420cb5a8329615fb283f71119128d090
-from libc.stdint cimport intptr_t, uintptr_t
 
-import threading
+# <<<< PREAMBLE CONTENT >>>>
+
+cdef extern from "<dlfcn.h>":
+    void* _cyb_dlsym "dlsym"(void*, const char*) nogil
+    const void * _cyb_RTLD_DEFAULT "RTLD_DEFAULT"
+
+from libc.stdint cimport intptr_t as _cyb_intptr_t
+
+import threading as _cyb_threading
+
+cdef bint _cyb___py_cudla_init = False
+cdef dict _cyb_func_ptrs = None
+cdef object _cyb_symbol_lock = _cyb_threading.Lock()
+
+# <<<< END OF PREAMBLE CONTENT >>>>
+
+from libc.stdint cimport uintptr_t
+
 from .utils import FunctionNotFoundError, NotSupportedError
-
 from cuda.pathfinder import load_nvidia_dynamic_lib
-
-
-###############################################################################
-# Extern
-###############################################################################
-
-# You must 'from .utils import NotSupportedError' before using this template
-
-cdef extern from "<dlfcn.h>" nogil:
-    void* dlopen(const char*, int)
-    char* dlerror()
-    void* dlsym(void*, const char*)
-    int dlclose(void*)
-
-    enum:
-        RTLD_LAZY
-        RTLD_NOW
-        RTLD_GLOBAL
-        RTLD_LOCAL
-
-    const void* RTLD_DEFAULT 'RTLD_DEFAULT'
-
-cdef int get_cuda_version():
-    cdef void* handle = NULL
-    cdef int err, driver_ver = 0
-
-    # Load driver to check version
-    handle = dlopen('libcuda.so.1', RTLD_NOW | RTLD_GLOBAL)
-    if handle == NULL:
-        err_msg = dlerror()
-        raise NotSupportedError(f'CUDA driver is not found ({err_msg.decode()})')
-    cuDriverGetVersion = dlsym(handle, "cuDriverGetVersion")
-    if cuDriverGetVersion == NULL:
-        raise RuntimeError('Did not find cuDriverGetVersion symbol in libcuda.so.1')
-    err = (<int (*)(int*) noexcept nogil>cuDriverGetVersion)(&driver_ver)
-    if err != 0:
-        raise RuntimeError(f'cuDriverGetVersion returned error code {err}')
-
-    return driver_ver
-
 
 
 ###############################################################################
 # Wrapper init
 ###############################################################################
-
-cdef object __symbol_lock = threading.Lock()
-cdef bint __py_cudla_init = False
 
 cdef void* __cudlaGetVersion = NULL
 cdef void* __cudlaDeviceGetCount = NULL
@@ -73,183 +45,174 @@ cdef void* __cudlaGetLastError = NULL
 cdef void* __cudlaDestroyDevice = NULL
 cdef void* __cudlaSetTaskTimeoutInMs = NULL
 
-
-cdef void* load_library() except* with gil:
-    cdef uintptr_t handle = load_nvidia_dynamic_lib("cudla")._handle_uint
-    return <void*>handle
-
-
 cdef int _init_cudla() except -1 nogil:
-    global __py_cudla_init
+    global _cyb___py_cudla_init
     cdef void* handle = NULL
+    with gil, _cyb_symbol_lock:
+        if _cyb___py_cudla_init: return 0
 
-    with gil, __symbol_lock:
-        # Recheck the flag after obtaining the locks
-        if __py_cudla_init:
-            return 0
-
-        # Load function
         global __cudlaGetVersion
-        __cudlaGetVersion = dlsym(RTLD_DEFAULT, 'cudlaGetVersion')
+        __cudlaGetVersion = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cudlaGetVersion')
         if __cudlaGetVersion == NULL:
             if handle == NULL:
                 handle = load_library()
-            __cudlaGetVersion = dlsym(handle, 'cudlaGetVersion')
+            __cudlaGetVersion = _cyb_dlsym(handle, 'cudlaGetVersion')
 
         global __cudlaDeviceGetCount
-        __cudlaDeviceGetCount = dlsym(RTLD_DEFAULT, 'cudlaDeviceGetCount')
+        __cudlaDeviceGetCount = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cudlaDeviceGetCount')
         if __cudlaDeviceGetCount == NULL:
             if handle == NULL:
                 handle = load_library()
-            __cudlaDeviceGetCount = dlsym(handle, 'cudlaDeviceGetCount')
+            __cudlaDeviceGetCount = _cyb_dlsym(handle, 'cudlaDeviceGetCount')
 
         global __cudlaCreateDevice
-        __cudlaCreateDevice = dlsym(RTLD_DEFAULT, 'cudlaCreateDevice')
+        __cudlaCreateDevice = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cudlaCreateDevice')
         if __cudlaCreateDevice == NULL:
             if handle == NULL:
                 handle = load_library()
-            __cudlaCreateDevice = dlsym(handle, 'cudlaCreateDevice')
+            __cudlaCreateDevice = _cyb_dlsym(handle, 'cudlaCreateDevice')
 
         global __cudlaMemRegister
-        __cudlaMemRegister = dlsym(RTLD_DEFAULT, 'cudlaMemRegister')
+        __cudlaMemRegister = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cudlaMemRegister')
         if __cudlaMemRegister == NULL:
             if handle == NULL:
                 handle = load_library()
-            __cudlaMemRegister = dlsym(handle, 'cudlaMemRegister')
+            __cudlaMemRegister = _cyb_dlsym(handle, 'cudlaMemRegister')
 
         global __cudlaModuleLoadFromMemory
-        __cudlaModuleLoadFromMemory = dlsym(RTLD_DEFAULT, 'cudlaModuleLoadFromMemory')
+        __cudlaModuleLoadFromMemory = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cudlaModuleLoadFromMemory')
         if __cudlaModuleLoadFromMemory == NULL:
             if handle == NULL:
                 handle = load_library()
-            __cudlaModuleLoadFromMemory = dlsym(handle, 'cudlaModuleLoadFromMemory')
+            __cudlaModuleLoadFromMemory = _cyb_dlsym(handle, 'cudlaModuleLoadFromMemory')
 
         global __cudlaModuleGetAttributes
-        __cudlaModuleGetAttributes = dlsym(RTLD_DEFAULT, 'cudlaModuleGetAttributes')
+        __cudlaModuleGetAttributes = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cudlaModuleGetAttributes')
         if __cudlaModuleGetAttributes == NULL:
             if handle == NULL:
                 handle = load_library()
-            __cudlaModuleGetAttributes = dlsym(handle, 'cudlaModuleGetAttributes')
+            __cudlaModuleGetAttributes = _cyb_dlsym(handle, 'cudlaModuleGetAttributes')
 
         global __cudlaModuleUnload
-        __cudlaModuleUnload = dlsym(RTLD_DEFAULT, 'cudlaModuleUnload')
+        __cudlaModuleUnload = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cudlaModuleUnload')
         if __cudlaModuleUnload == NULL:
             if handle == NULL:
                 handle = load_library()
-            __cudlaModuleUnload = dlsym(handle, 'cudlaModuleUnload')
+            __cudlaModuleUnload = _cyb_dlsym(handle, 'cudlaModuleUnload')
 
         global __cudlaSubmitTask
-        __cudlaSubmitTask = dlsym(RTLD_DEFAULT, 'cudlaSubmitTask')
+        __cudlaSubmitTask = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cudlaSubmitTask')
         if __cudlaSubmitTask == NULL:
             if handle == NULL:
                 handle = load_library()
-            __cudlaSubmitTask = dlsym(handle, 'cudlaSubmitTask')
+            __cudlaSubmitTask = _cyb_dlsym(handle, 'cudlaSubmitTask')
 
         global __cudlaDeviceGetAttribute
-        __cudlaDeviceGetAttribute = dlsym(RTLD_DEFAULT, 'cudlaDeviceGetAttribute')
+        __cudlaDeviceGetAttribute = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cudlaDeviceGetAttribute')
         if __cudlaDeviceGetAttribute == NULL:
             if handle == NULL:
                 handle = load_library()
-            __cudlaDeviceGetAttribute = dlsym(handle, 'cudlaDeviceGetAttribute')
+            __cudlaDeviceGetAttribute = _cyb_dlsym(handle, 'cudlaDeviceGetAttribute')
 
         global __cudlaMemUnregister
-        __cudlaMemUnregister = dlsym(RTLD_DEFAULT, 'cudlaMemUnregister')
+        __cudlaMemUnregister = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cudlaMemUnregister')
         if __cudlaMemUnregister == NULL:
             if handle == NULL:
                 handle = load_library()
-            __cudlaMemUnregister = dlsym(handle, 'cudlaMemUnregister')
+            __cudlaMemUnregister = _cyb_dlsym(handle, 'cudlaMemUnregister')
 
         global __cudlaGetLastError
-        __cudlaGetLastError = dlsym(RTLD_DEFAULT, 'cudlaGetLastError')
+        __cudlaGetLastError = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cudlaGetLastError')
         if __cudlaGetLastError == NULL:
             if handle == NULL:
                 handle = load_library()
-            __cudlaGetLastError = dlsym(handle, 'cudlaGetLastError')
+            __cudlaGetLastError = _cyb_dlsym(handle, 'cudlaGetLastError')
 
         global __cudlaDestroyDevice
-        __cudlaDestroyDevice = dlsym(RTLD_DEFAULT, 'cudlaDestroyDevice')
+        __cudlaDestroyDevice = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cudlaDestroyDevice')
         if __cudlaDestroyDevice == NULL:
             if handle == NULL:
                 handle = load_library()
-            __cudlaDestroyDevice = dlsym(handle, 'cudlaDestroyDevice')
+            __cudlaDestroyDevice = _cyb_dlsym(handle, 'cudlaDestroyDevice')
 
         global __cudlaSetTaskTimeoutInMs
-        __cudlaSetTaskTimeoutInMs = dlsym(RTLD_DEFAULT, 'cudlaSetTaskTimeoutInMs')
+        __cudlaSetTaskTimeoutInMs = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cudlaSetTaskTimeoutInMs')
         if __cudlaSetTaskTimeoutInMs == NULL:
             if handle == NULL:
                 handle = load_library()
-            __cudlaSetTaskTimeoutInMs = dlsym(handle, 'cudlaSetTaskTimeoutInMs')
+            __cudlaSetTaskTimeoutInMs = _cyb_dlsym(handle, 'cudlaSetTaskTimeoutInMs')
 
-        __py_cudla_init = True
+        _cyb___py_cudla_init = True
         return 0
 
-
 cdef inline int _check_or_init_cudla() except -1 nogil:
-    if __py_cudla_init:
+    if _cyb___py_cudla_init:
         return 0
 
     return _init_cudla()
 
 
-cdef dict func_ptrs = None
-
-
 cpdef dict _inspect_function_pointers():
-    global func_ptrs
-    if func_ptrs is not None:
-        return func_ptrs
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is not None:
+        return _cyb_func_ptrs
 
     _check_or_init_cudla()
     cdef dict data = {}
-
     global __cudlaGetVersion
-    data["__cudlaGetVersion"] = <intptr_t>__cudlaGetVersion
+    data["__cudlaGetVersion"] = <_cyb_intptr_t>__cudlaGetVersion
 
     global __cudlaDeviceGetCount
-    data["__cudlaDeviceGetCount"] = <intptr_t>__cudlaDeviceGetCount
+    data["__cudlaDeviceGetCount"] = <_cyb_intptr_t>__cudlaDeviceGetCount
 
     global __cudlaCreateDevice
-    data["__cudlaCreateDevice"] = <intptr_t>__cudlaCreateDevice
+    data["__cudlaCreateDevice"] = <_cyb_intptr_t>__cudlaCreateDevice
 
     global __cudlaMemRegister
-    data["__cudlaMemRegister"] = <intptr_t>__cudlaMemRegister
+    data["__cudlaMemRegister"] = <_cyb_intptr_t>__cudlaMemRegister
 
     global __cudlaModuleLoadFromMemory
-    data["__cudlaModuleLoadFromMemory"] = <intptr_t>__cudlaModuleLoadFromMemory
+    data["__cudlaModuleLoadFromMemory"] = <_cyb_intptr_t>__cudlaModuleLoadFromMemory
 
     global __cudlaModuleGetAttributes
-    data["__cudlaModuleGetAttributes"] = <intptr_t>__cudlaModuleGetAttributes
+    data["__cudlaModuleGetAttributes"] = <_cyb_intptr_t>__cudlaModuleGetAttributes
 
     global __cudlaModuleUnload
-    data["__cudlaModuleUnload"] = <intptr_t>__cudlaModuleUnload
+    data["__cudlaModuleUnload"] = <_cyb_intptr_t>__cudlaModuleUnload
 
     global __cudlaSubmitTask
-    data["__cudlaSubmitTask"] = <intptr_t>__cudlaSubmitTask
+    data["__cudlaSubmitTask"] = <_cyb_intptr_t>__cudlaSubmitTask
 
     global __cudlaDeviceGetAttribute
-    data["__cudlaDeviceGetAttribute"] = <intptr_t>__cudlaDeviceGetAttribute
+    data["__cudlaDeviceGetAttribute"] = <_cyb_intptr_t>__cudlaDeviceGetAttribute
 
     global __cudlaMemUnregister
-    data["__cudlaMemUnregister"] = <intptr_t>__cudlaMemUnregister
+    data["__cudlaMemUnregister"] = <_cyb_intptr_t>__cudlaMemUnregister
 
     global __cudlaGetLastError
-    data["__cudlaGetLastError"] = <intptr_t>__cudlaGetLastError
+    data["__cudlaGetLastError"] = <_cyb_intptr_t>__cudlaGetLastError
 
     global __cudlaDestroyDevice
-    data["__cudlaDestroyDevice"] = <intptr_t>__cudlaDestroyDevice
+    data["__cudlaDestroyDevice"] = <_cyb_intptr_t>__cudlaDestroyDevice
 
     global __cudlaSetTaskTimeoutInMs
-    data["__cudlaSetTaskTimeoutInMs"] = <intptr_t>__cudlaSetTaskTimeoutInMs
-
-    func_ptrs = data
+    data["__cudlaSetTaskTimeoutInMs"] = <_cyb_intptr_t>__cudlaSetTaskTimeoutInMs
+    _cyb_func_ptrs = data
     return data
 
 
 cpdef _inspect_function_pointer(str name):
-    global func_ptrs
-    if func_ptrs is None:
-        func_ptrs = _inspect_function_pointers()
-    return func_ptrs[name]
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is None:
+        _cyb_func_ptrs = _inspect_function_pointers()
+    return _cyb_func_ptrs[name]
+
+
+
+
+cdef void* load_library() except* with gil:
+    cdef uintptr_t handle = load_nvidia_dynamic_lib("cudla")._handle_uint
+    return <void*>handle
 
 
 ###############################################################################

--- a/cuda_bindings/cuda/bindings/_internal/cudla_windows.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/cudla_windows.pyx
@@ -2,80 +2,36 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # This code was automatically generated across versions from 1.5.0 to 13.3.0. Do not modify it directly.
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=2f2d196de722c29b044dff6aed4e22bd72347a0890d30c885d35780882c6800f
 
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=43403925d332dc0474938eb5f6b5d58c648884b9f056c1b319a515281b36757e
-from libc.stdint cimport intptr_t
 
-import threading
+# <<<< PREAMBLE CONTENT >>>>
+
+cdef extern from "<windows.h>":
+    ctypedef void* HMODULE
+    void* _cyb_GetProcAddress "GetProcAddress"(HMODULE, const char*) nogil
+
+from libc.stdint cimport intptr_t as _cyb_intptr_t
+
+import threading as _cyb_threading
+
+cdef bint _cyb___py_cudla_init = False
+cdef dict _cyb_func_ptrs = None
+cdef object _cyb_symbol_lock = _cyb_threading.Lock()
+
+# <<<< END OF PREAMBLE CONTENT >>>>
+
+from libc.stdint cimport uintptr_t
+
 from .utils import FunctionNotFoundError, NotSupportedError
 
 from cuda.pathfinder import load_nvidia_dynamic_lib
-
-from libc.stddef cimport wchar_t
-from libc.stdint cimport uintptr_t
-from cpython cimport PyUnicode_AsWideCharString, PyMem_Free
-
-# You must 'from .utils import NotSupportedError' before using this template
-
-cdef extern from "windows.h" nogil:
-    ctypedef void* HMODULE
-    ctypedef void* HANDLE
-    ctypedef void* FARPROC
-    ctypedef unsigned long DWORD
-    ctypedef const wchar_t *LPCWSTR
-    ctypedef const char *LPCSTR
-
-    cdef DWORD LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800
-    cdef DWORD LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000
-    cdef DWORD LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR = 0x00000100
-
-    HMODULE _LoadLibraryExW "LoadLibraryExW"(
-        LPCWSTR lpLibFileName,
-        HANDLE hFile,
-        DWORD dwFlags
-    )
-
-    FARPROC _GetProcAddress "GetProcAddress"(HMODULE hModule, LPCSTR lpProcName)
-
-cdef inline uintptr_t LoadLibraryExW(str path, HANDLE hFile, DWORD dwFlags):
-    cdef uintptr_t result
-    cdef wchar_t* wpath = PyUnicode_AsWideCharString(path, NULL)
-    with nogil:
-        result = <uintptr_t>_LoadLibraryExW(
-            wpath,
-            hFile,
-            dwFlags
-        )
-    PyMem_Free(wpath)
-    return result
-
-cdef inline void *GetProcAddress(uintptr_t hModule, const char* lpProcName) nogil:
-    return _GetProcAddress(<HMODULE>hModule, lpProcName)
-
-cdef int get_cuda_version():
-    cdef int err, driver_ver = 0
-
-    # Load driver to check version
-    handle = LoadLibraryExW("nvcuda.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32)
-    if handle == 0:
-        raise NotSupportedError('CUDA driver is not found')
-    cuDriverGetVersion = GetProcAddress(handle, 'cuDriverGetVersion')
-    if cuDriverGetVersion == NULL:
-        raise RuntimeError('Did not find cuDriverGetVersion symbol in nvcuda.dll')
-    err = (<int (*)(int*) noexcept nogil>cuDriverGetVersion)(&driver_ver)
-    if err != 0:
-        raise RuntimeError(f'cuDriverGetVersion returned error code {err}')
-
-    return driver_ver
-
 
 
 ###############################################################################
 # Wrapper init
 ###############################################################################
 
-cdef object __symbol_lock = threading.Lock()
-cdef bint __py_cudla_init = False
 
 cdef void* __cudlaGetVersion = NULL
 cdef void* __cudlaDeviceGetCount = NULL
@@ -91,128 +47,124 @@ cdef void* __cudlaGetLastError = NULL
 cdef void* __cudlaDestroyDevice = NULL
 cdef void* __cudlaSetTaskTimeoutInMs = NULL
 
-
 cdef int _init_cudla() except -1 nogil:
-    global __py_cudla_init
+    global _cyb___py_cudla_init
 
-    with gil, __symbol_lock:
-        # Recheck the flag after obtaining the locks
-        if __py_cudla_init:
-            return 0
+    cdef int err
+    cdef uintptr_t handle
+    with gil, _cyb_symbol_lock:
+        if _cyb___py_cudla_init: return 0
 
-        # Load library
-        handle = load_nvidia_dynamic_lib("cudla")._handle_uint
-
-        # Load function
+        handle = load_library()
         global __cudlaGetVersion
-        __cudlaGetVersion = GetProcAddress(handle, 'cudlaGetVersion')
+        __cudlaGetVersion = _cyb_GetProcAddress(<HMODULE>handle, 'cudlaGetVersion')
 
         global __cudlaDeviceGetCount
-        __cudlaDeviceGetCount = GetProcAddress(handle, 'cudlaDeviceGetCount')
+        __cudlaDeviceGetCount = _cyb_GetProcAddress(<HMODULE>handle, 'cudlaDeviceGetCount')
 
         global __cudlaCreateDevice
-        __cudlaCreateDevice = GetProcAddress(handle, 'cudlaCreateDevice')
+        __cudlaCreateDevice = _cyb_GetProcAddress(<HMODULE>handle, 'cudlaCreateDevice')
 
         global __cudlaMemRegister
-        __cudlaMemRegister = GetProcAddress(handle, 'cudlaMemRegister')
+        __cudlaMemRegister = _cyb_GetProcAddress(<HMODULE>handle, 'cudlaMemRegister')
 
         global __cudlaModuleLoadFromMemory
-        __cudlaModuleLoadFromMemory = GetProcAddress(handle, 'cudlaModuleLoadFromMemory')
+        __cudlaModuleLoadFromMemory = _cyb_GetProcAddress(<HMODULE>handle, 'cudlaModuleLoadFromMemory')
 
         global __cudlaModuleGetAttributes
-        __cudlaModuleGetAttributes = GetProcAddress(handle, 'cudlaModuleGetAttributes')
+        __cudlaModuleGetAttributes = _cyb_GetProcAddress(<HMODULE>handle, 'cudlaModuleGetAttributes')
 
         global __cudlaModuleUnload
-        __cudlaModuleUnload = GetProcAddress(handle, 'cudlaModuleUnload')
+        __cudlaModuleUnload = _cyb_GetProcAddress(<HMODULE>handle, 'cudlaModuleUnload')
 
         global __cudlaSubmitTask
-        __cudlaSubmitTask = GetProcAddress(handle, 'cudlaSubmitTask')
+        __cudlaSubmitTask = _cyb_GetProcAddress(<HMODULE>handle, 'cudlaSubmitTask')
 
         global __cudlaDeviceGetAttribute
-        __cudlaDeviceGetAttribute = GetProcAddress(handle, 'cudlaDeviceGetAttribute')
+        __cudlaDeviceGetAttribute = _cyb_GetProcAddress(<HMODULE>handle, 'cudlaDeviceGetAttribute')
 
         global __cudlaMemUnregister
-        __cudlaMemUnregister = GetProcAddress(handle, 'cudlaMemUnregister')
+        __cudlaMemUnregister = _cyb_GetProcAddress(<HMODULE>handle, 'cudlaMemUnregister')
 
         global __cudlaGetLastError
-        __cudlaGetLastError = GetProcAddress(handle, 'cudlaGetLastError')
+        __cudlaGetLastError = _cyb_GetProcAddress(<HMODULE>handle, 'cudlaGetLastError')
 
         global __cudlaDestroyDevice
-        __cudlaDestroyDevice = GetProcAddress(handle, 'cudlaDestroyDevice')
+        __cudlaDestroyDevice = _cyb_GetProcAddress(<HMODULE>handle, 'cudlaDestroyDevice')
 
         global __cudlaSetTaskTimeoutInMs
-        __cudlaSetTaskTimeoutInMs = GetProcAddress(handle, 'cudlaSetTaskTimeoutInMs')
+        __cudlaSetTaskTimeoutInMs = _cyb_GetProcAddress(<HMODULE>handle, 'cudlaSetTaskTimeoutInMs')
 
-        __py_cudla_init = True
+        _cyb___py_cudla_init = True
         return 0
 
-
 cdef inline int _check_or_init_cudla() except -1 nogil:
-    if __py_cudla_init:
+    if _cyb___py_cudla_init:
         return 0
 
     return _init_cudla()
 
 
-cdef dict func_ptrs = None
-
-
 cpdef dict _inspect_function_pointers():
-    global func_ptrs
-    if func_ptrs is not None:
-        return func_ptrs
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is not None:
+        return _cyb_func_ptrs
 
     _check_or_init_cudla()
     cdef dict data = {}
-
     global __cudlaGetVersion
-    data["__cudlaGetVersion"] = <intptr_t>__cudlaGetVersion
+    data["__cudlaGetVersion"] = <_cyb_intptr_t>__cudlaGetVersion
 
     global __cudlaDeviceGetCount
-    data["__cudlaDeviceGetCount"] = <intptr_t>__cudlaDeviceGetCount
+    data["__cudlaDeviceGetCount"] = <_cyb_intptr_t>__cudlaDeviceGetCount
 
     global __cudlaCreateDevice
-    data["__cudlaCreateDevice"] = <intptr_t>__cudlaCreateDevice
+    data["__cudlaCreateDevice"] = <_cyb_intptr_t>__cudlaCreateDevice
 
     global __cudlaMemRegister
-    data["__cudlaMemRegister"] = <intptr_t>__cudlaMemRegister
+    data["__cudlaMemRegister"] = <_cyb_intptr_t>__cudlaMemRegister
 
     global __cudlaModuleLoadFromMemory
-    data["__cudlaModuleLoadFromMemory"] = <intptr_t>__cudlaModuleLoadFromMemory
+    data["__cudlaModuleLoadFromMemory"] = <_cyb_intptr_t>__cudlaModuleLoadFromMemory
 
     global __cudlaModuleGetAttributes
-    data["__cudlaModuleGetAttributes"] = <intptr_t>__cudlaModuleGetAttributes
+    data["__cudlaModuleGetAttributes"] = <_cyb_intptr_t>__cudlaModuleGetAttributes
 
     global __cudlaModuleUnload
-    data["__cudlaModuleUnload"] = <intptr_t>__cudlaModuleUnload
+    data["__cudlaModuleUnload"] = <_cyb_intptr_t>__cudlaModuleUnload
 
     global __cudlaSubmitTask
-    data["__cudlaSubmitTask"] = <intptr_t>__cudlaSubmitTask
+    data["__cudlaSubmitTask"] = <_cyb_intptr_t>__cudlaSubmitTask
 
     global __cudlaDeviceGetAttribute
-    data["__cudlaDeviceGetAttribute"] = <intptr_t>__cudlaDeviceGetAttribute
+    data["__cudlaDeviceGetAttribute"] = <_cyb_intptr_t>__cudlaDeviceGetAttribute
 
     global __cudlaMemUnregister
-    data["__cudlaMemUnregister"] = <intptr_t>__cudlaMemUnregister
+    data["__cudlaMemUnregister"] = <_cyb_intptr_t>__cudlaMemUnregister
 
     global __cudlaGetLastError
-    data["__cudlaGetLastError"] = <intptr_t>__cudlaGetLastError
+    data["__cudlaGetLastError"] = <_cyb_intptr_t>__cudlaGetLastError
 
     global __cudlaDestroyDevice
-    data["__cudlaDestroyDevice"] = <intptr_t>__cudlaDestroyDevice
+    data["__cudlaDestroyDevice"] = <_cyb_intptr_t>__cudlaDestroyDevice
 
     global __cudlaSetTaskTimeoutInMs
-    data["__cudlaSetTaskTimeoutInMs"] = <intptr_t>__cudlaSetTaskTimeoutInMs
-
-    func_ptrs = data
+    data["__cudlaSetTaskTimeoutInMs"] = <_cyb_intptr_t>__cudlaSetTaskTimeoutInMs
+    _cyb_func_ptrs = data
     return data
 
 
 cpdef _inspect_function_pointer(str name):
-    global func_ptrs
-    if func_ptrs is None:
-        func_ptrs = _inspect_function_pointers()
-    return func_ptrs[name]
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is None:
+        _cyb_func_ptrs = _inspect_function_pointers()
+    return _cyb_func_ptrs[name]
+
+
+
+
+cdef uintptr_t load_library() except* with gil:
+    return load_nvidia_dynamic_lib("cudla")._handle_uint
 
 
 ###############################################################################

--- a/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx
@@ -3,64 +3,36 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.9.1 to 13.3.0. Do not modify it directly.
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=ae15aefcbc4ccf2d415fb5d6436ae854690559f5561704523ba7d6f45abfc592
 
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=b43946a1b7b010b7d9ee95ed67723e3dfc54b46a6dc68829e936ffad6ba852dc
-from libc.stdint cimport intptr_t, uintptr_t
-import threading
+
+# <<<< PREAMBLE CONTENT >>>>
+
+cdef extern from "<dlfcn.h>":
+    void* _cyb_dlsym "dlsym"(void*, const char*) nogil
+    const void * _cyb_RTLD_DEFAULT "RTLD_DEFAULT"
+
+cimport cython as _cyb_cython
+from libc.stdint cimport intptr_t as _cyb_intptr_t
+
+import threading as _cyb_threading
+
+cdef bint _cyb___py_cufile_init = False
+cdef dict _cyb_func_ptrs = None
+cdef object _cyb_symbol_lock = _cyb_threading.Lock()
+
+# <<<< END OF PREAMBLE CONTENT >>>>
+
+from libc.stdint cimport uintptr_t
 
 from .utils import FunctionNotFoundError, NotSupportedError
-
 from cuda.pathfinder import load_nvidia_dynamic_lib
-
-import cython
-
-
-###############################################################################
-# Extern
-###############################################################################
-
-# You must 'from .utils import NotSupportedError' before using this template
-
-cdef extern from "<dlfcn.h>" nogil:
-    void* dlopen(const char*, int)
-    char* dlerror()
-    void* dlsym(void*, const char*)
-    int dlclose(void*)
-
-    enum:
-        RTLD_LAZY
-        RTLD_NOW
-        RTLD_GLOBAL
-        RTLD_LOCAL
-
-    const void* RTLD_DEFAULT 'RTLD_DEFAULT'
-
-cdef int get_cuda_version():
-    cdef void* handle = NULL
-    cdef int err, driver_ver = 0
-
-    # Load driver to check version
-    handle = dlopen('libcuda.so.1', RTLD_NOW | RTLD_GLOBAL)
-    if handle == NULL:
-        err_msg = dlerror()
-        raise NotSupportedError(f'CUDA driver is not found ({err_msg.decode()})')
-    cuDriverGetVersion = dlsym(handle, "cuDriverGetVersion")
-    if cuDriverGetVersion == NULL:
-        raise RuntimeError('Did not find cuDriverGetVersion symbol in libcuda.so.1')
-    err = (<int (*)(int*) noexcept nogil>cuDriverGetVersion)(&driver_ver)
-    if err != 0:
-        raise RuntimeError(f'cuDriverGetVersion returned error code {err}')
-
-    return driver_ver
-
 
 
 ###############################################################################
 # Wrapper init
 ###############################################################################
 
-cdef object __symbol_lock = threading.Lock()
-cdef bint __py_cufile_init = False
 
 cdef void* __cuFileHandleRegister = NULL
 cdef void* __cuFileHandleDeregister = NULL
@@ -106,488 +78,478 @@ cdef void* __cuFileGetBARSizeInKB = NULL
 cdef void* __cuFileSetParameterPosixPoolSlabArray = NULL
 cdef void* __cuFileGetParameterPosixPoolSlabArray = NULL
 
+cdef int _init_cufile() except -1 nogil:
+    global _cyb___py_cufile_init
+    cdef void* handle = NULL
+    with gil, _cyb_symbol_lock:
+        if _cyb___py_cufile_init: return 0
+
+        global __cuFileHandleRegister
+        __cuFileHandleRegister = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileHandleRegister')
+        if __cuFileHandleRegister == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileHandleRegister = _cyb_dlsym(handle, 'cuFileHandleRegister')
+
+        global __cuFileHandleDeregister
+        __cuFileHandleDeregister = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileHandleDeregister')
+        if __cuFileHandleDeregister == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileHandleDeregister = _cyb_dlsym(handle, 'cuFileHandleDeregister')
+
+        global __cuFileBufRegister
+        __cuFileBufRegister = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileBufRegister')
+        if __cuFileBufRegister == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileBufRegister = _cyb_dlsym(handle, 'cuFileBufRegister')
+
+        global __cuFileBufDeregister
+        __cuFileBufDeregister = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileBufDeregister')
+        if __cuFileBufDeregister == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileBufDeregister = _cyb_dlsym(handle, 'cuFileBufDeregister')
+
+        global __cuFileRead
+        __cuFileRead = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileRead')
+        if __cuFileRead == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileRead = _cyb_dlsym(handle, 'cuFileRead')
+
+        global __cuFileWrite
+        __cuFileWrite = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileWrite')
+        if __cuFileWrite == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileWrite = _cyb_dlsym(handle, 'cuFileWrite')
+
+        global __cuFileDriverOpen
+        __cuFileDriverOpen = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileDriverOpen')
+        if __cuFileDriverOpen == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileDriverOpen = _cyb_dlsym(handle, 'cuFileDriverOpen')
+
+        global __cuFileDriverClose
+        __cuFileDriverClose = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileDriverClose')
+        if __cuFileDriverClose == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileDriverClose = _cyb_dlsym(handle, 'cuFileDriverClose')
+
+        global __cuFileDriverClose_v2
+        __cuFileDriverClose_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileDriverClose_v2')
+        if __cuFileDriverClose_v2 == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileDriverClose_v2 = _cyb_dlsym(handle, 'cuFileDriverClose_v2')
+
+        global __cuFileUseCount
+        __cuFileUseCount = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileUseCount')
+        if __cuFileUseCount == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileUseCount = _cyb_dlsym(handle, 'cuFileUseCount')
+
+        global __cuFileDriverGetProperties
+        __cuFileDriverGetProperties = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileDriverGetProperties')
+        if __cuFileDriverGetProperties == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileDriverGetProperties = _cyb_dlsym(handle, 'cuFileDriverGetProperties')
+
+        global __cuFileDriverSetPollMode
+        __cuFileDriverSetPollMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileDriverSetPollMode')
+        if __cuFileDriverSetPollMode == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileDriverSetPollMode = _cyb_dlsym(handle, 'cuFileDriverSetPollMode')
+
+        global __cuFileDriverSetMaxDirectIOSize
+        __cuFileDriverSetMaxDirectIOSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileDriverSetMaxDirectIOSize')
+        if __cuFileDriverSetMaxDirectIOSize == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileDriverSetMaxDirectIOSize = _cyb_dlsym(handle, 'cuFileDriverSetMaxDirectIOSize')
+
+        global __cuFileDriverSetMaxCacheSize
+        __cuFileDriverSetMaxCacheSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileDriverSetMaxCacheSize')
+        if __cuFileDriverSetMaxCacheSize == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileDriverSetMaxCacheSize = _cyb_dlsym(handle, 'cuFileDriverSetMaxCacheSize')
+
+        global __cuFileDriverSetMaxPinnedMemSize
+        __cuFileDriverSetMaxPinnedMemSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileDriverSetMaxPinnedMemSize')
+        if __cuFileDriverSetMaxPinnedMemSize == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileDriverSetMaxPinnedMemSize = _cyb_dlsym(handle, 'cuFileDriverSetMaxPinnedMemSize')
+
+        global __cuFileBatchIOSetUp
+        __cuFileBatchIOSetUp = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileBatchIOSetUp')
+        if __cuFileBatchIOSetUp == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileBatchIOSetUp = _cyb_dlsym(handle, 'cuFileBatchIOSetUp')
+
+        global __cuFileBatchIOSubmit
+        __cuFileBatchIOSubmit = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileBatchIOSubmit')
+        if __cuFileBatchIOSubmit == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileBatchIOSubmit = _cyb_dlsym(handle, 'cuFileBatchIOSubmit')
+
+        global __cuFileBatchIOGetStatus
+        __cuFileBatchIOGetStatus = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileBatchIOGetStatus')
+        if __cuFileBatchIOGetStatus == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileBatchIOGetStatus = _cyb_dlsym(handle, 'cuFileBatchIOGetStatus')
+
+        global __cuFileBatchIOCancel
+        __cuFileBatchIOCancel = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileBatchIOCancel')
+        if __cuFileBatchIOCancel == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileBatchIOCancel = _cyb_dlsym(handle, 'cuFileBatchIOCancel')
+
+        global __cuFileBatchIODestroy
+        __cuFileBatchIODestroy = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileBatchIODestroy')
+        if __cuFileBatchIODestroy == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileBatchIODestroy = _cyb_dlsym(handle, 'cuFileBatchIODestroy')
+
+        global __cuFileReadAsync
+        __cuFileReadAsync = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileReadAsync')
+        if __cuFileReadAsync == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileReadAsync = _cyb_dlsym(handle, 'cuFileReadAsync')
+
+        global __cuFileWriteAsync
+        __cuFileWriteAsync = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileWriteAsync')
+        if __cuFileWriteAsync == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileWriteAsync = _cyb_dlsym(handle, 'cuFileWriteAsync')
+
+        global __cuFileStreamRegister
+        __cuFileStreamRegister = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileStreamRegister')
+        if __cuFileStreamRegister == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileStreamRegister = _cyb_dlsym(handle, 'cuFileStreamRegister')
+
+        global __cuFileStreamDeregister
+        __cuFileStreamDeregister = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileStreamDeregister')
+        if __cuFileStreamDeregister == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileStreamDeregister = _cyb_dlsym(handle, 'cuFileStreamDeregister')
+
+        global __cuFileGetVersion
+        __cuFileGetVersion = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileGetVersion')
+        if __cuFileGetVersion == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileGetVersion = _cyb_dlsym(handle, 'cuFileGetVersion')
+
+        global __cuFileGetParameterSizeT
+        __cuFileGetParameterSizeT = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileGetParameterSizeT')
+        if __cuFileGetParameterSizeT == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileGetParameterSizeT = _cyb_dlsym(handle, 'cuFileGetParameterSizeT')
+
+        global __cuFileGetParameterBool
+        __cuFileGetParameterBool = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileGetParameterBool')
+        if __cuFileGetParameterBool == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileGetParameterBool = _cyb_dlsym(handle, 'cuFileGetParameterBool')
+
+        global __cuFileGetParameterString
+        __cuFileGetParameterString = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileGetParameterString')
+        if __cuFileGetParameterString == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileGetParameterString = _cyb_dlsym(handle, 'cuFileGetParameterString')
+
+        global __cuFileSetParameterSizeT
+        __cuFileSetParameterSizeT = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileSetParameterSizeT')
+        if __cuFileSetParameterSizeT == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileSetParameterSizeT = _cyb_dlsym(handle, 'cuFileSetParameterSizeT')
+
+        global __cuFileSetParameterBool
+        __cuFileSetParameterBool = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileSetParameterBool')
+        if __cuFileSetParameterBool == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileSetParameterBool = _cyb_dlsym(handle, 'cuFileSetParameterBool')
+
+        global __cuFileSetParameterString
+        __cuFileSetParameterString = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileSetParameterString')
+        if __cuFileSetParameterString == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileSetParameterString = _cyb_dlsym(handle, 'cuFileSetParameterString')
+
+        global __cuFileGetParameterMinMaxValue
+        __cuFileGetParameterMinMaxValue = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileGetParameterMinMaxValue')
+        if __cuFileGetParameterMinMaxValue == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileGetParameterMinMaxValue = _cyb_dlsym(handle, 'cuFileGetParameterMinMaxValue')
+
+        global __cuFileSetStatsLevel
+        __cuFileSetStatsLevel = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileSetStatsLevel')
+        if __cuFileSetStatsLevel == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileSetStatsLevel = _cyb_dlsym(handle, 'cuFileSetStatsLevel')
+
+        global __cuFileGetStatsLevel
+        __cuFileGetStatsLevel = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileGetStatsLevel')
+        if __cuFileGetStatsLevel == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileGetStatsLevel = _cyb_dlsym(handle, 'cuFileGetStatsLevel')
+
+        global __cuFileStatsStart
+        __cuFileStatsStart = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileStatsStart')
+        if __cuFileStatsStart == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileStatsStart = _cyb_dlsym(handle, 'cuFileStatsStart')
+
+        global __cuFileStatsStop
+        __cuFileStatsStop = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileStatsStop')
+        if __cuFileStatsStop == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileStatsStop = _cyb_dlsym(handle, 'cuFileStatsStop')
+
+        global __cuFileStatsReset
+        __cuFileStatsReset = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileStatsReset')
+        if __cuFileStatsReset == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileStatsReset = _cyb_dlsym(handle, 'cuFileStatsReset')
+
+        global __cuFileGetStatsL1
+        __cuFileGetStatsL1 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileGetStatsL1')
+        if __cuFileGetStatsL1 == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileGetStatsL1 = _cyb_dlsym(handle, 'cuFileGetStatsL1')
+
+        global __cuFileGetStatsL2
+        __cuFileGetStatsL2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileGetStatsL2')
+        if __cuFileGetStatsL2 == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileGetStatsL2 = _cyb_dlsym(handle, 'cuFileGetStatsL2')
+
+        global __cuFileGetStatsL3
+        __cuFileGetStatsL3 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileGetStatsL3')
+        if __cuFileGetStatsL3 == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileGetStatsL3 = _cyb_dlsym(handle, 'cuFileGetStatsL3')
+
+        global __cuFileGetBARSizeInKB
+        __cuFileGetBARSizeInKB = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileGetBARSizeInKB')
+        if __cuFileGetBARSizeInKB == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileGetBARSizeInKB = _cyb_dlsym(handle, 'cuFileGetBARSizeInKB')
+
+        global __cuFileSetParameterPosixPoolSlabArray
+        __cuFileSetParameterPosixPoolSlabArray = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileSetParameterPosixPoolSlabArray')
+        if __cuFileSetParameterPosixPoolSlabArray == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileSetParameterPosixPoolSlabArray = _cyb_dlsym(handle, 'cuFileSetParameterPosixPoolSlabArray')
+
+        global __cuFileGetParameterPosixPoolSlabArray
+        __cuFileGetParameterPosixPoolSlabArray = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'cuFileGetParameterPosixPoolSlabArray')
+        if __cuFileGetParameterPosixPoolSlabArray == NULL:
+            if handle == NULL:
+                handle = load_library()
+            __cuFileGetParameterPosixPoolSlabArray = _cyb_dlsym(handle, 'cuFileGetParameterPosixPoolSlabArray')
+
+        _cyb___py_cufile_init = True
+        return 0
+
+cdef inline int _check_or_init_cufile() except -1 nogil:
+    if _cyb___py_cufile_init:
+        return 0
+
+    return _init_cufile()
+
+
+cpdef dict _inspect_function_pointers():
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is not None:
+        return _cyb_func_ptrs
+
+    _check_or_init_cufile()
+    cdef dict data = {}
+    global __cuFileHandleRegister
+    data["__cuFileHandleRegister"] = <_cyb_intptr_t>__cuFileHandleRegister
+
+    global __cuFileHandleDeregister
+    data["__cuFileHandleDeregister"] = <_cyb_intptr_t>__cuFileHandleDeregister
+
+    global __cuFileBufRegister
+    data["__cuFileBufRegister"] = <_cyb_intptr_t>__cuFileBufRegister
+
+    global __cuFileBufDeregister
+    data["__cuFileBufDeregister"] = <_cyb_intptr_t>__cuFileBufDeregister
+
+    global __cuFileRead
+    data["__cuFileRead"] = <_cyb_intptr_t>__cuFileRead
+
+    global __cuFileWrite
+    data["__cuFileWrite"] = <_cyb_intptr_t>__cuFileWrite
+
+    global __cuFileDriverOpen
+    data["__cuFileDriverOpen"] = <_cyb_intptr_t>__cuFileDriverOpen
+
+    global __cuFileDriverClose
+    data["__cuFileDriverClose"] = <_cyb_intptr_t>__cuFileDriverClose
+
+    global __cuFileDriverClose_v2
+    data["__cuFileDriverClose_v2"] = <_cyb_intptr_t>__cuFileDriverClose_v2
+
+    global __cuFileUseCount
+    data["__cuFileUseCount"] = <_cyb_intptr_t>__cuFileUseCount
+
+    global __cuFileDriverGetProperties
+    data["__cuFileDriverGetProperties"] = <_cyb_intptr_t>__cuFileDriverGetProperties
+
+    global __cuFileDriverSetPollMode
+    data["__cuFileDriverSetPollMode"] = <_cyb_intptr_t>__cuFileDriverSetPollMode
+
+    global __cuFileDriverSetMaxDirectIOSize
+    data["__cuFileDriverSetMaxDirectIOSize"] = <_cyb_intptr_t>__cuFileDriverSetMaxDirectIOSize
+
+    global __cuFileDriverSetMaxCacheSize
+    data["__cuFileDriverSetMaxCacheSize"] = <_cyb_intptr_t>__cuFileDriverSetMaxCacheSize
+
+    global __cuFileDriverSetMaxPinnedMemSize
+    data["__cuFileDriverSetMaxPinnedMemSize"] = <_cyb_intptr_t>__cuFileDriverSetMaxPinnedMemSize
+
+    global __cuFileBatchIOSetUp
+    data["__cuFileBatchIOSetUp"] = <_cyb_intptr_t>__cuFileBatchIOSetUp
+
+    global __cuFileBatchIOSubmit
+    data["__cuFileBatchIOSubmit"] = <_cyb_intptr_t>__cuFileBatchIOSubmit
+
+    global __cuFileBatchIOGetStatus
+    data["__cuFileBatchIOGetStatus"] = <_cyb_intptr_t>__cuFileBatchIOGetStatus
+
+    global __cuFileBatchIOCancel
+    data["__cuFileBatchIOCancel"] = <_cyb_intptr_t>__cuFileBatchIOCancel
+
+    global __cuFileBatchIODestroy
+    data["__cuFileBatchIODestroy"] = <_cyb_intptr_t>__cuFileBatchIODestroy
+
+    global __cuFileReadAsync
+    data["__cuFileReadAsync"] = <_cyb_intptr_t>__cuFileReadAsync
+
+    global __cuFileWriteAsync
+    data["__cuFileWriteAsync"] = <_cyb_intptr_t>__cuFileWriteAsync
+
+    global __cuFileStreamRegister
+    data["__cuFileStreamRegister"] = <_cyb_intptr_t>__cuFileStreamRegister
+
+    global __cuFileStreamDeregister
+    data["__cuFileStreamDeregister"] = <_cyb_intptr_t>__cuFileStreamDeregister
+
+    global __cuFileGetVersion
+    data["__cuFileGetVersion"] = <_cyb_intptr_t>__cuFileGetVersion
+
+    global __cuFileGetParameterSizeT
+    data["__cuFileGetParameterSizeT"] = <_cyb_intptr_t>__cuFileGetParameterSizeT
+
+    global __cuFileGetParameterBool
+    data["__cuFileGetParameterBool"] = <_cyb_intptr_t>__cuFileGetParameterBool
+
+    global __cuFileGetParameterString
+    data["__cuFileGetParameterString"] = <_cyb_intptr_t>__cuFileGetParameterString
+
+    global __cuFileSetParameterSizeT
+    data["__cuFileSetParameterSizeT"] = <_cyb_intptr_t>__cuFileSetParameterSizeT
+
+    global __cuFileSetParameterBool
+    data["__cuFileSetParameterBool"] = <_cyb_intptr_t>__cuFileSetParameterBool
+
+    global __cuFileSetParameterString
+    data["__cuFileSetParameterString"] = <_cyb_intptr_t>__cuFileSetParameterString
+
+    global __cuFileGetParameterMinMaxValue
+    data["__cuFileGetParameterMinMaxValue"] = <_cyb_intptr_t>__cuFileGetParameterMinMaxValue
+
+    global __cuFileSetStatsLevel
+    data["__cuFileSetStatsLevel"] = <_cyb_intptr_t>__cuFileSetStatsLevel
+
+    global __cuFileGetStatsLevel
+    data["__cuFileGetStatsLevel"] = <_cyb_intptr_t>__cuFileGetStatsLevel
+
+    global __cuFileStatsStart
+    data["__cuFileStatsStart"] = <_cyb_intptr_t>__cuFileStatsStart
+
+    global __cuFileStatsStop
+    data["__cuFileStatsStop"] = <_cyb_intptr_t>__cuFileStatsStop
+
+    global __cuFileStatsReset
+    data["__cuFileStatsReset"] = <_cyb_intptr_t>__cuFileStatsReset
+
+    global __cuFileGetStatsL1
+    data["__cuFileGetStatsL1"] = <_cyb_intptr_t>__cuFileGetStatsL1
+
+    global __cuFileGetStatsL2
+    data["__cuFileGetStatsL2"] = <_cyb_intptr_t>__cuFileGetStatsL2
+
+    global __cuFileGetStatsL3
+    data["__cuFileGetStatsL3"] = <_cyb_intptr_t>__cuFileGetStatsL3
+
+    global __cuFileGetBARSizeInKB
+    data["__cuFileGetBARSizeInKB"] = <_cyb_intptr_t>__cuFileGetBARSizeInKB
+
+    global __cuFileSetParameterPosixPoolSlabArray
+    data["__cuFileSetParameterPosixPoolSlabArray"] = <_cyb_intptr_t>__cuFileSetParameterPosixPoolSlabArray
+
+    global __cuFileGetParameterPosixPoolSlabArray
+    data["__cuFileGetParameterPosixPoolSlabArray"] = <_cyb_intptr_t>__cuFileGetParameterPosixPoolSlabArray
+    _cyb_func_ptrs = data
+    return data
+
+
+cpdef _inspect_function_pointer(str name):
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is None:
+        _cyb_func_ptrs = _inspect_function_pointers()
+    return _cyb_func_ptrs[name]
+
+
+
 
 cdef void* load_library() except* with gil:
     cdef uintptr_t handle = load_nvidia_dynamic_lib("cufile")._handle_uint
     return <void*>handle
 
 
-cdef int _init_cufile() except -1 nogil:
-    global __py_cufile_init
-
-    cdef void* handle = NULL
-
-    with gil, __symbol_lock:
-        # Recheck the flag after obtaining the locks
-        if __py_cufile_init:
-            return 0
-        # Load function
-        global __cuFileHandleRegister
-        __cuFileHandleRegister = dlsym(RTLD_DEFAULT, 'cuFileHandleRegister')
-        if __cuFileHandleRegister == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileHandleRegister = dlsym(handle, 'cuFileHandleRegister')
-
-        global __cuFileHandleDeregister
-        __cuFileHandleDeregister = dlsym(RTLD_DEFAULT, 'cuFileHandleDeregister')
-        if __cuFileHandleDeregister == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileHandleDeregister = dlsym(handle, 'cuFileHandleDeregister')
-
-        global __cuFileBufRegister
-        __cuFileBufRegister = dlsym(RTLD_DEFAULT, 'cuFileBufRegister')
-        if __cuFileBufRegister == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileBufRegister = dlsym(handle, 'cuFileBufRegister')
-
-        global __cuFileBufDeregister
-        __cuFileBufDeregister = dlsym(RTLD_DEFAULT, 'cuFileBufDeregister')
-        if __cuFileBufDeregister == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileBufDeregister = dlsym(handle, 'cuFileBufDeregister')
-
-        global __cuFileRead
-        __cuFileRead = dlsym(RTLD_DEFAULT, 'cuFileRead')
-        if __cuFileRead == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileRead = dlsym(handle, 'cuFileRead')
-
-        global __cuFileWrite
-        __cuFileWrite = dlsym(RTLD_DEFAULT, 'cuFileWrite')
-        if __cuFileWrite == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileWrite = dlsym(handle, 'cuFileWrite')
-
-        global __cuFileDriverOpen
-        __cuFileDriverOpen = dlsym(RTLD_DEFAULT, 'cuFileDriverOpen')
-        if __cuFileDriverOpen == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileDriverOpen = dlsym(handle, 'cuFileDriverOpen')
-
-        global __cuFileDriverClose
-        __cuFileDriverClose = dlsym(RTLD_DEFAULT, 'cuFileDriverClose')
-        if __cuFileDriverClose == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileDriverClose = dlsym(handle, 'cuFileDriverClose')
-
-        global __cuFileDriverClose_v2
-        __cuFileDriverClose_v2 = dlsym(RTLD_DEFAULT, 'cuFileDriverClose_v2')
-        if __cuFileDriverClose_v2 == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileDriverClose_v2 = dlsym(handle, 'cuFileDriverClose_v2')
-
-        global __cuFileUseCount
-        __cuFileUseCount = dlsym(RTLD_DEFAULT, 'cuFileUseCount')
-        if __cuFileUseCount == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileUseCount = dlsym(handle, 'cuFileUseCount')
-
-        global __cuFileDriverGetProperties
-        __cuFileDriverGetProperties = dlsym(RTLD_DEFAULT, 'cuFileDriverGetProperties')
-        if __cuFileDriverGetProperties == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileDriverGetProperties = dlsym(handle, 'cuFileDriverGetProperties')
-
-        global __cuFileDriverSetPollMode
-        __cuFileDriverSetPollMode = dlsym(RTLD_DEFAULT, 'cuFileDriverSetPollMode')
-        if __cuFileDriverSetPollMode == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileDriverSetPollMode = dlsym(handle, 'cuFileDriverSetPollMode')
-
-        global __cuFileDriverSetMaxDirectIOSize
-        __cuFileDriverSetMaxDirectIOSize = dlsym(RTLD_DEFAULT, 'cuFileDriverSetMaxDirectIOSize')
-        if __cuFileDriverSetMaxDirectIOSize == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileDriverSetMaxDirectIOSize = dlsym(handle, 'cuFileDriverSetMaxDirectIOSize')
-
-        global __cuFileDriverSetMaxCacheSize
-        __cuFileDriverSetMaxCacheSize = dlsym(RTLD_DEFAULT, 'cuFileDriverSetMaxCacheSize')
-        if __cuFileDriverSetMaxCacheSize == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileDriverSetMaxCacheSize = dlsym(handle, 'cuFileDriverSetMaxCacheSize')
-
-        global __cuFileDriverSetMaxPinnedMemSize
-        __cuFileDriverSetMaxPinnedMemSize = dlsym(RTLD_DEFAULT, 'cuFileDriverSetMaxPinnedMemSize')
-        if __cuFileDriverSetMaxPinnedMemSize == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileDriverSetMaxPinnedMemSize = dlsym(handle, 'cuFileDriverSetMaxPinnedMemSize')
-
-        global __cuFileBatchIOSetUp
-        __cuFileBatchIOSetUp = dlsym(RTLD_DEFAULT, 'cuFileBatchIOSetUp')
-        if __cuFileBatchIOSetUp == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileBatchIOSetUp = dlsym(handle, 'cuFileBatchIOSetUp')
-
-        global __cuFileBatchIOSubmit
-        __cuFileBatchIOSubmit = dlsym(RTLD_DEFAULT, 'cuFileBatchIOSubmit')
-        if __cuFileBatchIOSubmit == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileBatchIOSubmit = dlsym(handle, 'cuFileBatchIOSubmit')
-
-        global __cuFileBatchIOGetStatus
-        __cuFileBatchIOGetStatus = dlsym(RTLD_DEFAULT, 'cuFileBatchIOGetStatus')
-        if __cuFileBatchIOGetStatus == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileBatchIOGetStatus = dlsym(handle, 'cuFileBatchIOGetStatus')
-
-        global __cuFileBatchIOCancel
-        __cuFileBatchIOCancel = dlsym(RTLD_DEFAULT, 'cuFileBatchIOCancel')
-        if __cuFileBatchIOCancel == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileBatchIOCancel = dlsym(handle, 'cuFileBatchIOCancel')
-
-        global __cuFileBatchIODestroy
-        __cuFileBatchIODestroy = dlsym(RTLD_DEFAULT, 'cuFileBatchIODestroy')
-        if __cuFileBatchIODestroy == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileBatchIODestroy = dlsym(handle, 'cuFileBatchIODestroy')
-
-        global __cuFileReadAsync
-        __cuFileReadAsync = dlsym(RTLD_DEFAULT, 'cuFileReadAsync')
-        if __cuFileReadAsync == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileReadAsync = dlsym(handle, 'cuFileReadAsync')
-
-        global __cuFileWriteAsync
-        __cuFileWriteAsync = dlsym(RTLD_DEFAULT, 'cuFileWriteAsync')
-        if __cuFileWriteAsync == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileWriteAsync = dlsym(handle, 'cuFileWriteAsync')
-
-        global __cuFileStreamRegister
-        __cuFileStreamRegister = dlsym(RTLD_DEFAULT, 'cuFileStreamRegister')
-        if __cuFileStreamRegister == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileStreamRegister = dlsym(handle, 'cuFileStreamRegister')
-
-        global __cuFileStreamDeregister
-        __cuFileStreamDeregister = dlsym(RTLD_DEFAULT, 'cuFileStreamDeregister')
-        if __cuFileStreamDeregister == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileStreamDeregister = dlsym(handle, 'cuFileStreamDeregister')
-
-        global __cuFileGetVersion
-        __cuFileGetVersion = dlsym(RTLD_DEFAULT, 'cuFileGetVersion')
-        if __cuFileGetVersion == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileGetVersion = dlsym(handle, 'cuFileGetVersion')
-
-        global __cuFileGetParameterSizeT
-        __cuFileGetParameterSizeT = dlsym(RTLD_DEFAULT, 'cuFileGetParameterSizeT')
-        if __cuFileGetParameterSizeT == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileGetParameterSizeT = dlsym(handle, 'cuFileGetParameterSizeT')
-
-        global __cuFileGetParameterBool
-        __cuFileGetParameterBool = dlsym(RTLD_DEFAULT, 'cuFileGetParameterBool')
-        if __cuFileGetParameterBool == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileGetParameterBool = dlsym(handle, 'cuFileGetParameterBool')
-
-        global __cuFileGetParameterString
-        __cuFileGetParameterString = dlsym(RTLD_DEFAULT, 'cuFileGetParameterString')
-        if __cuFileGetParameterString == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileGetParameterString = dlsym(handle, 'cuFileGetParameterString')
-
-        global __cuFileSetParameterSizeT
-        __cuFileSetParameterSizeT = dlsym(RTLD_DEFAULT, 'cuFileSetParameterSizeT')
-        if __cuFileSetParameterSizeT == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileSetParameterSizeT = dlsym(handle, 'cuFileSetParameterSizeT')
-
-        global __cuFileSetParameterBool
-        __cuFileSetParameterBool = dlsym(RTLD_DEFAULT, 'cuFileSetParameterBool')
-        if __cuFileSetParameterBool == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileSetParameterBool = dlsym(handle, 'cuFileSetParameterBool')
-
-        global __cuFileSetParameterString
-        __cuFileSetParameterString = dlsym(RTLD_DEFAULT, 'cuFileSetParameterString')
-        if __cuFileSetParameterString == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileSetParameterString = dlsym(handle, 'cuFileSetParameterString')
-
-        global __cuFileGetParameterMinMaxValue
-        __cuFileGetParameterMinMaxValue = dlsym(RTLD_DEFAULT, 'cuFileGetParameterMinMaxValue')
-        if __cuFileGetParameterMinMaxValue == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileGetParameterMinMaxValue = dlsym(handle, 'cuFileGetParameterMinMaxValue')
-
-        global __cuFileSetStatsLevel
-        __cuFileSetStatsLevel = dlsym(RTLD_DEFAULT, 'cuFileSetStatsLevel')
-        if __cuFileSetStatsLevel == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileSetStatsLevel = dlsym(handle, 'cuFileSetStatsLevel')
-
-        global __cuFileGetStatsLevel
-        __cuFileGetStatsLevel = dlsym(RTLD_DEFAULT, 'cuFileGetStatsLevel')
-        if __cuFileGetStatsLevel == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileGetStatsLevel = dlsym(handle, 'cuFileGetStatsLevel')
-
-        global __cuFileStatsStart
-        __cuFileStatsStart = dlsym(RTLD_DEFAULT, 'cuFileStatsStart')
-        if __cuFileStatsStart == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileStatsStart = dlsym(handle, 'cuFileStatsStart')
-
-        global __cuFileStatsStop
-        __cuFileStatsStop = dlsym(RTLD_DEFAULT, 'cuFileStatsStop')
-        if __cuFileStatsStop == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileStatsStop = dlsym(handle, 'cuFileStatsStop')
-
-        global __cuFileStatsReset
-        __cuFileStatsReset = dlsym(RTLD_DEFAULT, 'cuFileStatsReset')
-        if __cuFileStatsReset == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileStatsReset = dlsym(handle, 'cuFileStatsReset')
-
-        global __cuFileGetStatsL1
-        __cuFileGetStatsL1 = dlsym(RTLD_DEFAULT, 'cuFileGetStatsL1')
-        if __cuFileGetStatsL1 == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileGetStatsL1 = dlsym(handle, 'cuFileGetStatsL1')
-
-        global __cuFileGetStatsL2
-        __cuFileGetStatsL2 = dlsym(RTLD_DEFAULT, 'cuFileGetStatsL2')
-        if __cuFileGetStatsL2 == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileGetStatsL2 = dlsym(handle, 'cuFileGetStatsL2')
-
-        global __cuFileGetStatsL3
-        __cuFileGetStatsL3 = dlsym(RTLD_DEFAULT, 'cuFileGetStatsL3')
-        if __cuFileGetStatsL3 == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileGetStatsL3 = dlsym(handle, 'cuFileGetStatsL3')
-
-        global __cuFileGetBARSizeInKB
-        __cuFileGetBARSizeInKB = dlsym(RTLD_DEFAULT, 'cuFileGetBARSizeInKB')
-        if __cuFileGetBARSizeInKB == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileGetBARSizeInKB = dlsym(handle, 'cuFileGetBARSizeInKB')
-
-        global __cuFileSetParameterPosixPoolSlabArray
-        __cuFileSetParameterPosixPoolSlabArray = dlsym(RTLD_DEFAULT, 'cuFileSetParameterPosixPoolSlabArray')
-        if __cuFileSetParameterPosixPoolSlabArray == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileSetParameterPosixPoolSlabArray = dlsym(handle, 'cuFileSetParameterPosixPoolSlabArray')
-
-        global __cuFileGetParameterPosixPoolSlabArray
-        __cuFileGetParameterPosixPoolSlabArray = dlsym(RTLD_DEFAULT, 'cuFileGetParameterPosixPoolSlabArray')
-        if __cuFileGetParameterPosixPoolSlabArray == NULL:
-            if handle == NULL:
-                handle = load_library()
-            __cuFileGetParameterPosixPoolSlabArray = dlsym(handle, 'cuFileGetParameterPosixPoolSlabArray')
-
-        __py_cufile_init = True
-        return 0
-
-
-cdef inline int _check_or_init_cufile() except -1 nogil:
-    if __py_cufile_init:
-        return 0
-
-    return _init_cufile()
-
-
-cdef dict func_ptrs = None
-
-
-cpdef dict _inspect_function_pointers():
-    global func_ptrs
-    if func_ptrs is not None:
-        return func_ptrs
-
-    _check_or_init_cufile()
-    cdef dict data = {}
-
-    global __cuFileHandleRegister
-    data["__cuFileHandleRegister"] = <intptr_t>__cuFileHandleRegister
-
-    global __cuFileHandleDeregister
-    data["__cuFileHandleDeregister"] = <intptr_t>__cuFileHandleDeregister
-
-    global __cuFileBufRegister
-    data["__cuFileBufRegister"] = <intptr_t>__cuFileBufRegister
-
-    global __cuFileBufDeregister
-    data["__cuFileBufDeregister"] = <intptr_t>__cuFileBufDeregister
-
-    global __cuFileRead
-    data["__cuFileRead"] = <intptr_t>__cuFileRead
-
-    global __cuFileWrite
-    data["__cuFileWrite"] = <intptr_t>__cuFileWrite
-
-    global __cuFileDriverOpen
-    data["__cuFileDriverOpen"] = <intptr_t>__cuFileDriverOpen
-
-    global __cuFileDriverClose
-    data["__cuFileDriverClose"] = <intptr_t>__cuFileDriverClose
-
-    global __cuFileDriverClose_v2
-    data["__cuFileDriverClose_v2"] = <intptr_t>__cuFileDriverClose_v2
-
-    global __cuFileUseCount
-    data["__cuFileUseCount"] = <intptr_t>__cuFileUseCount
-
-    global __cuFileDriverGetProperties
-    data["__cuFileDriverGetProperties"] = <intptr_t>__cuFileDriverGetProperties
-
-    global __cuFileDriverSetPollMode
-    data["__cuFileDriverSetPollMode"] = <intptr_t>__cuFileDriverSetPollMode
-
-    global __cuFileDriverSetMaxDirectIOSize
-    data["__cuFileDriverSetMaxDirectIOSize"] = <intptr_t>__cuFileDriverSetMaxDirectIOSize
-
-    global __cuFileDriverSetMaxCacheSize
-    data["__cuFileDriverSetMaxCacheSize"] = <intptr_t>__cuFileDriverSetMaxCacheSize
-
-    global __cuFileDriverSetMaxPinnedMemSize
-    data["__cuFileDriverSetMaxPinnedMemSize"] = <intptr_t>__cuFileDriverSetMaxPinnedMemSize
-
-    global __cuFileBatchIOSetUp
-    data["__cuFileBatchIOSetUp"] = <intptr_t>__cuFileBatchIOSetUp
-
-    global __cuFileBatchIOSubmit
-    data["__cuFileBatchIOSubmit"] = <intptr_t>__cuFileBatchIOSubmit
-
-    global __cuFileBatchIOGetStatus
-    data["__cuFileBatchIOGetStatus"] = <intptr_t>__cuFileBatchIOGetStatus
-
-    global __cuFileBatchIOCancel
-    data["__cuFileBatchIOCancel"] = <intptr_t>__cuFileBatchIOCancel
-
-    global __cuFileBatchIODestroy
-    data["__cuFileBatchIODestroy"] = <intptr_t>__cuFileBatchIODestroy
-
-    global __cuFileReadAsync
-    data["__cuFileReadAsync"] = <intptr_t>__cuFileReadAsync
-
-    global __cuFileWriteAsync
-    data["__cuFileWriteAsync"] = <intptr_t>__cuFileWriteAsync
-
-    global __cuFileStreamRegister
-    data["__cuFileStreamRegister"] = <intptr_t>__cuFileStreamRegister
-
-    global __cuFileStreamDeregister
-    data["__cuFileStreamDeregister"] = <intptr_t>__cuFileStreamDeregister
-
-    global __cuFileGetVersion
-    data["__cuFileGetVersion"] = <intptr_t>__cuFileGetVersion
-
-    global __cuFileGetParameterSizeT
-    data["__cuFileGetParameterSizeT"] = <intptr_t>__cuFileGetParameterSizeT
-
-    global __cuFileGetParameterBool
-    data["__cuFileGetParameterBool"] = <intptr_t>__cuFileGetParameterBool
-
-    global __cuFileGetParameterString
-    data["__cuFileGetParameterString"] = <intptr_t>__cuFileGetParameterString
-
-    global __cuFileSetParameterSizeT
-    data["__cuFileSetParameterSizeT"] = <intptr_t>__cuFileSetParameterSizeT
-
-    global __cuFileSetParameterBool
-    data["__cuFileSetParameterBool"] = <intptr_t>__cuFileSetParameterBool
-
-    global __cuFileSetParameterString
-    data["__cuFileSetParameterString"] = <intptr_t>__cuFileSetParameterString
-
-    global __cuFileGetParameterMinMaxValue
-    data["__cuFileGetParameterMinMaxValue"] = <intptr_t>__cuFileGetParameterMinMaxValue
-
-    global __cuFileSetStatsLevel
-    data["__cuFileSetStatsLevel"] = <intptr_t>__cuFileSetStatsLevel
-
-    global __cuFileGetStatsLevel
-    data["__cuFileGetStatsLevel"] = <intptr_t>__cuFileGetStatsLevel
-
-    global __cuFileStatsStart
-    data["__cuFileStatsStart"] = <intptr_t>__cuFileStatsStart
-
-    global __cuFileStatsStop
-    data["__cuFileStatsStop"] = <intptr_t>__cuFileStatsStop
-
-    global __cuFileStatsReset
-    data["__cuFileStatsReset"] = <intptr_t>__cuFileStatsReset
-
-    global __cuFileGetStatsL1
-    data["__cuFileGetStatsL1"] = <intptr_t>__cuFileGetStatsL1
-
-    global __cuFileGetStatsL2
-    data["__cuFileGetStatsL2"] = <intptr_t>__cuFileGetStatsL2
-
-    global __cuFileGetStatsL3
-    data["__cuFileGetStatsL3"] = <intptr_t>__cuFileGetStatsL3
-
-    global __cuFileGetBARSizeInKB
-    data["__cuFileGetBARSizeInKB"] = <intptr_t>__cuFileGetBARSizeInKB
-
-    global __cuFileSetParameterPosixPoolSlabArray
-    data["__cuFileSetParameterPosixPoolSlabArray"] = <intptr_t>__cuFileSetParameterPosixPoolSlabArray
-
-    global __cuFileGetParameterPosixPoolSlabArray
-    data["__cuFileGetParameterPosixPoolSlabArray"] = <intptr_t>__cuFileGetParameterPosixPoolSlabArray
-
-    func_ptrs = data
-    return data
-
-
-cpdef _inspect_function_pointer(str name):
-    global func_ptrs
-    if func_ptrs is None:
-        func_ptrs = _inspect_function_pointers()
-    return func_ptrs[name]
-
-
 ###############################################################################
 # Wrapper functions
-###############################################################################
 
 cdef CUfileError_t _cuFileHandleRegister(CUfileHandle_t* fh, CUfileDescr_t* descr) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
     global __cuFileHandleRegister
@@ -599,7 +561,7 @@ cdef CUfileError_t _cuFileHandleRegister(CUfileHandle_t* fh, CUfileDescr_t* desc
         fh, descr)
 
 
-@cython.show_performance_hints(False)
+@_cyb_cython.show_performance_hints(False)
 cdef void _cuFileHandleDeregister(CUfileHandle_t fh) except* nogil:
     global __cuFileHandleDeregister
     _check_or_init_cufile()
@@ -780,7 +742,7 @@ cdef CUfileError_t _cuFileBatchIOCancel(CUfileBatchHandle_t batch_idp) except?<C
         batch_idp)
 
 
-@cython.show_performance_hints(False)
+@_cyb_cython.show_performance_hints(False)
 cdef void _cuFileBatchIODestroy(CUfileBatchHandle_t batch_idp) except* nogil:
     global __cuFileBatchIODestroy
     _check_or_init_cufile()

--- a/cuda_bindings/cuda/bindings/_internal/driver_linux.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/driver_linux.pyx
@@ -3,63 +3,37 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.9.0 to 13.3.0. Do not modify it directly.
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=644e8be3cdcaddb497db76bdc5912df43457a11696b5b7f710d46cba991d0d0b
 
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=5707b0fec0518992a2e1a55400a030c3921e5443dc65094af083b8845b41b0e5
-from libc.stdint cimport intptr_t, uintptr_t
 
-import os
-import threading
+# <<<< PREAMBLE CONTENT >>>>
+
+cdef extern from "<dlfcn.h>":
+    void* _cyb_dlsym "dlsym"(void*, const char*) nogil
+
+from libc.stdint cimport intptr_t as _cyb_intptr_t
+
+from os import getenv as _cyb_getenv
+import threading as _cyb_threading
+
+ctypedef int (*_cyb_cuGetProcAddress_v2_T)(const char *, void **, int, cuuint64_t, CUdriverProcAddressQueryResult *)except?CUDA_ERROR_NOT_FOUND nogil
+
+cdef bint _cyb___py_driver_init = False
+cdef dict _cyb_func_ptrs = None
+cdef object _cyb_symbol_lock = _cyb_threading.Lock()
+
+# <<<< END OF PREAMBLE CONTENT >>>>
+
+from libc.stdint cimport uintptr_t
+
 from .utils import FunctionNotFoundError, NotSupportedError
-
 from cuda.pathfinder import load_nvidia_dynamic_lib
-
-
-###############################################################################
-# Extern
-###############################################################################
-
-# You must 'from .utils import NotSupportedError' before using this template
-
-cdef extern from "<dlfcn.h>" nogil:
-    void* dlopen(const char*, int)
-    char* dlerror()
-    void* dlsym(void*, const char*)
-    int dlclose(void*)
-
-    enum:
-        RTLD_LAZY
-        RTLD_NOW
-        RTLD_GLOBAL
-        RTLD_LOCAL
-
-    const void* RTLD_DEFAULT 'RTLD_DEFAULT'
-
-cdef int get_cuda_version():
-    cdef void* handle = NULL
-    cdef int err, driver_ver = 0
-
-    # Load driver to check version
-    handle = dlopen('libcuda.so.1', RTLD_NOW | RTLD_GLOBAL)
-    if handle == NULL:
-        err_msg = dlerror()
-        raise NotSupportedError(f'CUDA driver is not found ({err_msg.decode()})')
-    cuDriverGetVersion = dlsym(handle, "cuDriverGetVersion")
-    if cuDriverGetVersion == NULL:
-        raise RuntimeError('Did not find cuDriverGetVersion symbol in libcuda.so.1')
-    err = (<int (*)(int*) noexcept nogil>cuDriverGetVersion)(&driver_ver)
-    if err != 0:
-        raise RuntimeError(f'cuDriverGetVersion returned error code {err}')
-
-    return driver_ver
-
 
 
 ###############################################################################
 # Wrapper init
 ###############################################################################
 
-cdef object __symbol_lock = threading.Lock()
-cdef bint __py_driver_init = False
 
 cdef void* __cuGetErrorString = NULL
 cdef void* __cuGetErrorName = NULL
@@ -579,3177 +553,3159 @@ cdef void* __cuLogicalEndpointGetLimits = NULL
 cdef void* __cuLogicalEndpointQuery = NULL
 cdef void* __cuStreamBeginRecaptureToGraph = NULL
 
+cdef int _init_driver() except -1 nogil:
+    global _cyb___py_driver_init
+    cdef void* handle = NULL
+    cdef int ptds_mode
+    cdef _cyb_cuGetProcAddress_v2_T cuGetProcAddress_v2
+    with gil, _cyb_symbol_lock:
+        if _cyb___py_driver_init: return 0
+
+        handle = load_library()
+        if handle == NULL:
+            raise RuntimeError('Failed to open cuda')
+        # Get latest cuGetProcAddress_v2
+        cuGetProcAddress_v2 = <_cyb_cuGetProcAddress_v2_T>_cyb_dlsym(handle, 'cuGetProcAddress_v2')
+        if cuGetProcAddress_v2 == NULL:
+            raise RuntimeError("Failed to get cuGetProcAddress_v2")
+        if bool(int(_cyb_getenv('CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM', default=0))):
+            ptds_mode = CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM
+        else:
+            ptds_mode = CU_GET_PROC_ADDRESS_DEFAULT
+        global __cuGetErrorString
+        cuGetProcAddress_v2('cuGetErrorString', <void **>&__cuGetErrorString, 6000, ptds_mode, NULL)
+
+        global __cuGetErrorName
+        cuGetProcAddress_v2('cuGetErrorName', <void **>&__cuGetErrorName, 6000, ptds_mode, NULL)
+
+        global __cuInit
+        cuGetProcAddress_v2('cuInit', <void **>&__cuInit, 2000, ptds_mode, NULL)
+
+        global __cuDriverGetVersion
+        cuGetProcAddress_v2('cuDriverGetVersion', <void **>&__cuDriverGetVersion, 2020, ptds_mode, NULL)
+
+        global __cuDeviceGet
+        cuGetProcAddress_v2('cuDeviceGet', <void **>&__cuDeviceGet, 2000, ptds_mode, NULL)
+
+        global __cuDeviceGetCount
+        cuGetProcAddress_v2('cuDeviceGetCount', <void **>&__cuDeviceGetCount, 2000, ptds_mode, NULL)
+
+        global __cuDeviceGetName
+        cuGetProcAddress_v2('cuDeviceGetName', <void **>&__cuDeviceGetName, 2000, ptds_mode, NULL)
+
+        global __cuDeviceGetUuid_v2
+        cuGetProcAddress_v2('cuDeviceGetUuid', <void **>&__cuDeviceGetUuid_v2, 11040, ptds_mode, NULL)
+
+        global __cuDeviceGetLuid
+        cuGetProcAddress_v2('cuDeviceGetLuid', <void **>&__cuDeviceGetLuid, 10000, ptds_mode, NULL)
+
+        global __cuDeviceTotalMem_v2
+        cuGetProcAddress_v2('cuDeviceTotalMem', <void **>&__cuDeviceTotalMem_v2, 3020, ptds_mode, NULL)
+
+        global __cuDeviceGetTexture1DLinearMaxWidth
+        cuGetProcAddress_v2('cuDeviceGetTexture1DLinearMaxWidth', <void **>&__cuDeviceGetTexture1DLinearMaxWidth, 11010, ptds_mode, NULL)
+
+        global __cuDeviceGetAttribute
+        cuGetProcAddress_v2('cuDeviceGetAttribute', <void **>&__cuDeviceGetAttribute, 2000, ptds_mode, NULL)
+
+        global __cuDeviceGetNvSciSyncAttributes
+        cuGetProcAddress_v2('cuDeviceGetNvSciSyncAttributes', <void **>&__cuDeviceGetNvSciSyncAttributes, 10020, ptds_mode, NULL)
+
+        global __cuDeviceSetMemPool
+        cuGetProcAddress_v2('cuDeviceSetMemPool', <void **>&__cuDeviceSetMemPool, 11020, ptds_mode, NULL)
+
+        global __cuDeviceGetMemPool
+        cuGetProcAddress_v2('cuDeviceGetMemPool', <void **>&__cuDeviceGetMemPool, 11020, ptds_mode, NULL)
+
+        global __cuDeviceGetDefaultMemPool
+        cuGetProcAddress_v2('cuDeviceGetDefaultMemPool', <void **>&__cuDeviceGetDefaultMemPool, 11020, ptds_mode, NULL)
+
+        global __cuDeviceGetExecAffinitySupport
+        cuGetProcAddress_v2('cuDeviceGetExecAffinitySupport', <void **>&__cuDeviceGetExecAffinitySupport, 11040, ptds_mode, NULL)
+
+        global __cuFlushGPUDirectRDMAWrites
+        cuGetProcAddress_v2('cuFlushGPUDirectRDMAWrites', <void **>&__cuFlushGPUDirectRDMAWrites, 11030, ptds_mode, NULL)
+
+        global __cuDeviceGetProperties
+        cuGetProcAddress_v2('cuDeviceGetProperties', <void **>&__cuDeviceGetProperties, 2000, ptds_mode, NULL)
+
+        global __cuDeviceComputeCapability
+        cuGetProcAddress_v2('cuDeviceComputeCapability', <void **>&__cuDeviceComputeCapability, 2000, ptds_mode, NULL)
+
+        global __cuDevicePrimaryCtxRetain
+        cuGetProcAddress_v2('cuDevicePrimaryCtxRetain', <void **>&__cuDevicePrimaryCtxRetain, 7000, ptds_mode, NULL)
+
+        global __cuDevicePrimaryCtxRelease_v2
+        cuGetProcAddress_v2('cuDevicePrimaryCtxRelease', <void **>&__cuDevicePrimaryCtxRelease_v2, 11000, ptds_mode, NULL)
+
+        global __cuDevicePrimaryCtxSetFlags_v2
+        cuGetProcAddress_v2('cuDevicePrimaryCtxSetFlags', <void **>&__cuDevicePrimaryCtxSetFlags_v2, 11000, ptds_mode, NULL)
+
+        global __cuDevicePrimaryCtxGetState
+        cuGetProcAddress_v2('cuDevicePrimaryCtxGetState', <void **>&__cuDevicePrimaryCtxGetState, 7000, ptds_mode, NULL)
+
+        global __cuDevicePrimaryCtxReset_v2
+        cuGetProcAddress_v2('cuDevicePrimaryCtxReset', <void **>&__cuDevicePrimaryCtxReset_v2, 11000, ptds_mode, NULL)
+
+        global __cuCtxCreate_v2
+        cuGetProcAddress_v2('cuCtxCreate', <void **>&__cuCtxCreate_v2, 3020, ptds_mode, NULL)
+
+        global __cuCtxCreate_v3
+        cuGetProcAddress_v2('cuCtxCreate', <void **>&__cuCtxCreate_v3, 11040, ptds_mode, NULL)
+
+        global __cuCtxCreate_v4
+        cuGetProcAddress_v2('cuCtxCreate', <void **>&__cuCtxCreate_v4, 12050, ptds_mode, NULL)
+
+        global __cuCtxDestroy_v2
+        cuGetProcAddress_v2('cuCtxDestroy', <void **>&__cuCtxDestroy_v2, 4000, ptds_mode, NULL)
+
+        global __cuCtxPushCurrent_v2
+        cuGetProcAddress_v2('cuCtxPushCurrent', <void **>&__cuCtxPushCurrent_v2, 4000, ptds_mode, NULL)
+
+        global __cuCtxPopCurrent_v2
+        cuGetProcAddress_v2('cuCtxPopCurrent', <void **>&__cuCtxPopCurrent_v2, 4000, ptds_mode, NULL)
+
+        global __cuCtxSetCurrent
+        cuGetProcAddress_v2('cuCtxSetCurrent', <void **>&__cuCtxSetCurrent, 4000, ptds_mode, NULL)
+
+        global __cuCtxGetCurrent
+        cuGetProcAddress_v2('cuCtxGetCurrent', <void **>&__cuCtxGetCurrent, 4000, ptds_mode, NULL)
+
+        global __cuCtxGetDevice
+        cuGetProcAddress_v2('cuCtxGetDevice', <void **>&__cuCtxGetDevice, 2000, ptds_mode, NULL)
+
+        global __cuCtxGetFlags
+        cuGetProcAddress_v2('cuCtxGetFlags', <void **>&__cuCtxGetFlags, 7000, ptds_mode, NULL)
+
+        global __cuCtxSetFlags
+        cuGetProcAddress_v2('cuCtxSetFlags', <void **>&__cuCtxSetFlags, 12010, ptds_mode, NULL)
+
+        global __cuCtxGetId
+        cuGetProcAddress_v2('cuCtxGetId', <void **>&__cuCtxGetId, 12000, ptds_mode, NULL)
+
+        global __cuCtxSynchronize
+        cuGetProcAddress_v2('cuCtxSynchronize', <void **>&__cuCtxSynchronize, 2000, ptds_mode, NULL)
+
+        global __cuCtxSetLimit
+        cuGetProcAddress_v2('cuCtxSetLimit', <void **>&__cuCtxSetLimit, 3010, ptds_mode, NULL)
+
+        global __cuCtxGetLimit
+        cuGetProcAddress_v2('cuCtxGetLimit', <void **>&__cuCtxGetLimit, 3010, ptds_mode, NULL)
+
+        global __cuCtxGetCacheConfig
+        cuGetProcAddress_v2('cuCtxGetCacheConfig', <void **>&__cuCtxGetCacheConfig, 3020, ptds_mode, NULL)
+
+        global __cuCtxSetCacheConfig
+        cuGetProcAddress_v2('cuCtxSetCacheConfig', <void **>&__cuCtxSetCacheConfig, 3020, ptds_mode, NULL)
+
+        global __cuCtxGetApiVersion
+        cuGetProcAddress_v2('cuCtxGetApiVersion', <void **>&__cuCtxGetApiVersion, 3020, ptds_mode, NULL)
+
+        global __cuCtxGetStreamPriorityRange
+        cuGetProcAddress_v2('cuCtxGetStreamPriorityRange', <void **>&__cuCtxGetStreamPriorityRange, 5050, ptds_mode, NULL)
+
+        global __cuCtxResetPersistingL2Cache
+        cuGetProcAddress_v2('cuCtxResetPersistingL2Cache', <void **>&__cuCtxResetPersistingL2Cache, 11000, ptds_mode, NULL)
+
+        global __cuCtxGetExecAffinity
+        cuGetProcAddress_v2('cuCtxGetExecAffinity', <void **>&__cuCtxGetExecAffinity, 11040, ptds_mode, NULL)
+
+        global __cuCtxRecordEvent
+        cuGetProcAddress_v2('cuCtxRecordEvent', <void **>&__cuCtxRecordEvent, 12050, ptds_mode, NULL)
+
+        global __cuCtxWaitEvent
+        cuGetProcAddress_v2('cuCtxWaitEvent', <void **>&__cuCtxWaitEvent, 12050, ptds_mode, NULL)
+
+        global __cuCtxAttach
+        cuGetProcAddress_v2('cuCtxAttach', <void **>&__cuCtxAttach, 2000, ptds_mode, NULL)
+
+        global __cuCtxDetach
+        cuGetProcAddress_v2('cuCtxDetach', <void **>&__cuCtxDetach, 2000, ptds_mode, NULL)
+
+        global __cuCtxGetSharedMemConfig
+        cuGetProcAddress_v2('cuCtxGetSharedMemConfig', <void **>&__cuCtxGetSharedMemConfig, 4020, ptds_mode, NULL)
+
+        global __cuCtxSetSharedMemConfig
+        cuGetProcAddress_v2('cuCtxSetSharedMemConfig', <void **>&__cuCtxSetSharedMemConfig, 4020, ptds_mode, NULL)
+
+        global __cuModuleLoad
+        cuGetProcAddress_v2('cuModuleLoad', <void **>&__cuModuleLoad, 2000, ptds_mode, NULL)
+
+        global __cuModuleLoadData
+        cuGetProcAddress_v2('cuModuleLoadData', <void **>&__cuModuleLoadData, 2000, ptds_mode, NULL)
+
+        global __cuModuleLoadDataEx
+        cuGetProcAddress_v2('cuModuleLoadDataEx', <void **>&__cuModuleLoadDataEx, 2010, ptds_mode, NULL)
+
+        global __cuModuleLoadFatBinary
+        cuGetProcAddress_v2('cuModuleLoadFatBinary', <void **>&__cuModuleLoadFatBinary, 2000, ptds_mode, NULL)
+
+        global __cuModuleUnload
+        cuGetProcAddress_v2('cuModuleUnload', <void **>&__cuModuleUnload, 2000, ptds_mode, NULL)
+
+        global __cuModuleGetLoadingMode
+        cuGetProcAddress_v2('cuModuleGetLoadingMode', <void **>&__cuModuleGetLoadingMode, 11070, ptds_mode, NULL)
+
+        global __cuModuleGetFunction
+        cuGetProcAddress_v2('cuModuleGetFunction', <void **>&__cuModuleGetFunction, 2000, ptds_mode, NULL)
+
+        global __cuModuleGetFunctionCount
+        cuGetProcAddress_v2('cuModuleGetFunctionCount', <void **>&__cuModuleGetFunctionCount, 12040, ptds_mode, NULL)
+
+        global __cuModuleEnumerateFunctions
+        cuGetProcAddress_v2('cuModuleEnumerateFunctions', <void **>&__cuModuleEnumerateFunctions, 12040, ptds_mode, NULL)
+
+        global __cuModuleGetGlobal_v2
+        cuGetProcAddress_v2('cuModuleGetGlobal', <void **>&__cuModuleGetGlobal_v2, 3020, ptds_mode, NULL)
+
+        global __cuLinkCreate_v2
+        cuGetProcAddress_v2('cuLinkCreate', <void **>&__cuLinkCreate_v2, 6050, ptds_mode, NULL)
+
+        global __cuLinkAddData_v2
+        cuGetProcAddress_v2('cuLinkAddData', <void **>&__cuLinkAddData_v2, 6050, ptds_mode, NULL)
+
+        global __cuLinkAddFile_v2
+        cuGetProcAddress_v2('cuLinkAddFile', <void **>&__cuLinkAddFile_v2, 6050, ptds_mode, NULL)
+
+        global __cuLinkComplete
+        cuGetProcAddress_v2('cuLinkComplete', <void **>&__cuLinkComplete, 5050, ptds_mode, NULL)
+
+        global __cuLinkDestroy
+        cuGetProcAddress_v2('cuLinkDestroy', <void **>&__cuLinkDestroy, 5050, ptds_mode, NULL)
+
+        global __cuModuleGetTexRef
+        cuGetProcAddress_v2('cuModuleGetTexRef', <void **>&__cuModuleGetTexRef, 2000, ptds_mode, NULL)
+
+        global __cuModuleGetSurfRef
+        cuGetProcAddress_v2('cuModuleGetSurfRef', <void **>&__cuModuleGetSurfRef, 3000, ptds_mode, NULL)
+
+        global __cuLibraryLoadData
+        cuGetProcAddress_v2('cuLibraryLoadData', <void **>&__cuLibraryLoadData, 12000, ptds_mode, NULL)
+
+        global __cuLibraryLoadFromFile
+        cuGetProcAddress_v2('cuLibraryLoadFromFile', <void **>&__cuLibraryLoadFromFile, 12000, ptds_mode, NULL)
+
+        global __cuLibraryUnload
+        cuGetProcAddress_v2('cuLibraryUnload', <void **>&__cuLibraryUnload, 12000, ptds_mode, NULL)
+
+        global __cuLibraryGetKernel
+        cuGetProcAddress_v2('cuLibraryGetKernel', <void **>&__cuLibraryGetKernel, 12000, ptds_mode, NULL)
+
+        global __cuLibraryGetKernelCount
+        cuGetProcAddress_v2('cuLibraryGetKernelCount', <void **>&__cuLibraryGetKernelCount, 12040, ptds_mode, NULL)
+
+        global __cuLibraryEnumerateKernels
+        cuGetProcAddress_v2('cuLibraryEnumerateKernels', <void **>&__cuLibraryEnumerateKernels, 12040, ptds_mode, NULL)
+
+        global __cuLibraryGetModule
+        cuGetProcAddress_v2('cuLibraryGetModule', <void **>&__cuLibraryGetModule, 12000, ptds_mode, NULL)
+
+        global __cuKernelGetFunction
+        cuGetProcAddress_v2('cuKernelGetFunction', <void **>&__cuKernelGetFunction, 12000, ptds_mode, NULL)
+
+        global __cuKernelGetLibrary
+        cuGetProcAddress_v2('cuKernelGetLibrary', <void **>&__cuKernelGetLibrary, 12050, ptds_mode, NULL)
+
+        global __cuLibraryGetGlobal
+        cuGetProcAddress_v2('cuLibraryGetGlobal', <void **>&__cuLibraryGetGlobal, 12000, ptds_mode, NULL)
+
+        global __cuLibraryGetManaged
+        cuGetProcAddress_v2('cuLibraryGetManaged', <void **>&__cuLibraryGetManaged, 12000, ptds_mode, NULL)
+
+        global __cuLibraryGetUnifiedFunction
+        cuGetProcAddress_v2('cuLibraryGetUnifiedFunction', <void **>&__cuLibraryGetUnifiedFunction, 12000, ptds_mode, NULL)
+
+        global __cuKernelGetAttribute
+        cuGetProcAddress_v2('cuKernelGetAttribute', <void **>&__cuKernelGetAttribute, 12000, ptds_mode, NULL)
+
+        global __cuKernelSetAttribute
+        cuGetProcAddress_v2('cuKernelSetAttribute', <void **>&__cuKernelSetAttribute, 12000, ptds_mode, NULL)
+
+        global __cuKernelSetCacheConfig
+        cuGetProcAddress_v2('cuKernelSetCacheConfig', <void **>&__cuKernelSetCacheConfig, 12000, ptds_mode, NULL)
+
+        global __cuKernelGetName
+        cuGetProcAddress_v2('cuKernelGetName', <void **>&__cuKernelGetName, 12030, ptds_mode, NULL)
+
+        global __cuKernelGetParamInfo
+        cuGetProcAddress_v2('cuKernelGetParamInfo', <void **>&__cuKernelGetParamInfo, 12040, ptds_mode, NULL)
+
+        global __cuMemGetInfo_v2
+        cuGetProcAddress_v2('cuMemGetInfo', <void **>&__cuMemGetInfo_v2, 3020, ptds_mode, NULL)
+
+        global __cuMemAlloc_v2
+        cuGetProcAddress_v2('cuMemAlloc', <void **>&__cuMemAlloc_v2, 3020, ptds_mode, NULL)
+
+        global __cuMemAllocPitch_v2
+        cuGetProcAddress_v2('cuMemAllocPitch', <void **>&__cuMemAllocPitch_v2, 3020, ptds_mode, NULL)
+
+        global __cuMemFree_v2
+        cuGetProcAddress_v2('cuMemFree', <void **>&__cuMemFree_v2, 3020, ptds_mode, NULL)
+
+        global __cuMemGetAddressRange_v2
+        cuGetProcAddress_v2('cuMemGetAddressRange', <void **>&__cuMemGetAddressRange_v2, 3020, ptds_mode, NULL)
+
+        global __cuMemAllocHost_v2
+        cuGetProcAddress_v2('cuMemAllocHost', <void **>&__cuMemAllocHost_v2, 3020, ptds_mode, NULL)
+
+        global __cuMemFreeHost
+        cuGetProcAddress_v2('cuMemFreeHost', <void **>&__cuMemFreeHost, 2000, ptds_mode, NULL)
+
+        global __cuMemHostAlloc
+        cuGetProcAddress_v2('cuMemHostAlloc', <void **>&__cuMemHostAlloc, 2020, ptds_mode, NULL)
+
+        global __cuMemHostGetDevicePointer_v2
+        cuGetProcAddress_v2('cuMemHostGetDevicePointer', <void **>&__cuMemHostGetDevicePointer_v2, 3020, ptds_mode, NULL)
+
+        global __cuMemHostGetFlags
+        cuGetProcAddress_v2('cuMemHostGetFlags', <void **>&__cuMemHostGetFlags, 2030, ptds_mode, NULL)
+
+        global __cuMemAllocManaged
+        cuGetProcAddress_v2('cuMemAllocManaged', <void **>&__cuMemAllocManaged, 6000, ptds_mode, NULL)
+
+        global __cuDeviceRegisterAsyncNotification
+        cuGetProcAddress_v2('cuDeviceRegisterAsyncNotification', <void **>&__cuDeviceRegisterAsyncNotification, 12040, ptds_mode, NULL)
+
+        global __cuDeviceUnregisterAsyncNotification
+        cuGetProcAddress_v2('cuDeviceUnregisterAsyncNotification', <void **>&__cuDeviceUnregisterAsyncNotification, 12040, ptds_mode, NULL)
+
+        global __cuDeviceGetByPCIBusId
+        cuGetProcAddress_v2('cuDeviceGetByPCIBusId', <void **>&__cuDeviceGetByPCIBusId, 4010, ptds_mode, NULL)
+
+        global __cuDeviceGetPCIBusId
+        cuGetProcAddress_v2('cuDeviceGetPCIBusId', <void **>&__cuDeviceGetPCIBusId, 4010, ptds_mode, NULL)
+
+        global __cuIpcGetEventHandle
+        cuGetProcAddress_v2('cuIpcGetEventHandle', <void **>&__cuIpcGetEventHandle, 4010, ptds_mode, NULL)
+
+        global __cuIpcOpenEventHandle
+        cuGetProcAddress_v2('cuIpcOpenEventHandle', <void **>&__cuIpcOpenEventHandle, 4010, ptds_mode, NULL)
+
+        global __cuIpcGetMemHandle
+        cuGetProcAddress_v2('cuIpcGetMemHandle', <void **>&__cuIpcGetMemHandle, 4010, ptds_mode, NULL)
+
+        global __cuIpcOpenMemHandle_v2
+        cuGetProcAddress_v2('cuIpcOpenMemHandle', <void **>&__cuIpcOpenMemHandle_v2, 11000, ptds_mode, NULL)
+
+        global __cuIpcCloseMemHandle
+        cuGetProcAddress_v2('cuIpcCloseMemHandle', <void **>&__cuIpcCloseMemHandle, 4010, ptds_mode, NULL)
+
+        global __cuMemHostRegister_v2
+        cuGetProcAddress_v2('cuMemHostRegister', <void **>&__cuMemHostRegister_v2, 6050, ptds_mode, NULL)
+
+        global __cuMemHostUnregister
+        cuGetProcAddress_v2('cuMemHostUnregister', <void **>&__cuMemHostUnregister, 4000, ptds_mode, NULL)
+
+        global __cuMemcpy
+        cuGetProcAddress_v2('cuMemcpy', <void **>&__cuMemcpy, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
+
+        global __cuMemcpyPeer
+        cuGetProcAddress_v2('cuMemcpyPeer', <void **>&__cuMemcpyPeer, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
+
+        global __cuMemcpyHtoD_v2
+        cuGetProcAddress_v2('cuMemcpyHtoD', <void **>&__cuMemcpyHtoD_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemcpyDtoH_v2
+        cuGetProcAddress_v2('cuMemcpyDtoH', <void **>&__cuMemcpyDtoH_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemcpyDtoD_v2
+        cuGetProcAddress_v2('cuMemcpyDtoD', <void **>&__cuMemcpyDtoD_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemcpyDtoA_v2
+        cuGetProcAddress_v2('cuMemcpyDtoA', <void **>&__cuMemcpyDtoA_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemcpyAtoD_v2
+        cuGetProcAddress_v2('cuMemcpyAtoD', <void **>&__cuMemcpyAtoD_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemcpyHtoA_v2
+        cuGetProcAddress_v2('cuMemcpyHtoA', <void **>&__cuMemcpyHtoA_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemcpyAtoH_v2
+        cuGetProcAddress_v2('cuMemcpyAtoH', <void **>&__cuMemcpyAtoH_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemcpyAtoA_v2
+        cuGetProcAddress_v2('cuMemcpyAtoA', <void **>&__cuMemcpyAtoA_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemcpy2D_v2
+        cuGetProcAddress_v2('cuMemcpy2D', <void **>&__cuMemcpy2D_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemcpy2DUnaligned_v2
+        cuGetProcAddress_v2('cuMemcpy2DUnaligned', <void **>&__cuMemcpy2DUnaligned_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemcpy3D_v2
+        cuGetProcAddress_v2('cuMemcpy3D', <void **>&__cuMemcpy3D_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemcpy3DPeer
+        cuGetProcAddress_v2('cuMemcpy3DPeer', <void **>&__cuMemcpy3DPeer, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
+
+        global __cuMemcpyAsync
+        cuGetProcAddress_v2('cuMemcpyAsync', <void **>&__cuMemcpyAsync, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
+
+        global __cuMemcpyPeerAsync
+        cuGetProcAddress_v2('cuMemcpyPeerAsync', <void **>&__cuMemcpyPeerAsync, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
+
+        global __cuMemcpyHtoDAsync_v2
+        cuGetProcAddress_v2('cuMemcpyHtoDAsync', <void **>&__cuMemcpyHtoDAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemcpyDtoHAsync_v2
+        cuGetProcAddress_v2('cuMemcpyDtoHAsync', <void **>&__cuMemcpyDtoHAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemcpyDtoDAsync_v2
+        cuGetProcAddress_v2('cuMemcpyDtoDAsync', <void **>&__cuMemcpyDtoDAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemcpyHtoAAsync_v2
+        cuGetProcAddress_v2('cuMemcpyHtoAAsync', <void **>&__cuMemcpyHtoAAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemcpyAtoHAsync_v2
+        cuGetProcAddress_v2('cuMemcpyAtoHAsync', <void **>&__cuMemcpyAtoHAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemcpy2DAsync_v2
+        cuGetProcAddress_v2('cuMemcpy2DAsync', <void **>&__cuMemcpy2DAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemcpy3DAsync_v2
+        cuGetProcAddress_v2('cuMemcpy3DAsync', <void **>&__cuMemcpy3DAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemcpy3DPeerAsync
+        cuGetProcAddress_v2('cuMemcpy3DPeerAsync', <void **>&__cuMemcpy3DPeerAsync, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
+
+        global __cuMemsetD8_v2
+        cuGetProcAddress_v2('cuMemsetD8', <void **>&__cuMemsetD8_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemsetD16_v2
+        cuGetProcAddress_v2('cuMemsetD16', <void **>&__cuMemsetD16_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemsetD32_v2
+        cuGetProcAddress_v2('cuMemsetD32', <void **>&__cuMemsetD32_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemsetD2D8_v2
+        cuGetProcAddress_v2('cuMemsetD2D8', <void **>&__cuMemsetD2D8_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemsetD2D16_v2
+        cuGetProcAddress_v2('cuMemsetD2D16', <void **>&__cuMemsetD2D16_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemsetD2D32_v2
+        cuGetProcAddress_v2('cuMemsetD2D32', <void **>&__cuMemsetD2D32_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemsetD8Async
+        cuGetProcAddress_v2('cuMemsetD8Async', <void **>&__cuMemsetD8Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemsetD16Async
+        cuGetProcAddress_v2('cuMemsetD16Async', <void **>&__cuMemsetD16Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemsetD32Async
+        cuGetProcAddress_v2('cuMemsetD32Async', <void **>&__cuMemsetD32Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemsetD2D8Async
+        cuGetProcAddress_v2('cuMemsetD2D8Async', <void **>&__cuMemsetD2D8Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemsetD2D16Async
+        cuGetProcAddress_v2('cuMemsetD2D16Async', <void **>&__cuMemsetD2D16Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuMemsetD2D32Async
+        cuGetProcAddress_v2('cuMemsetD2D32Async', <void **>&__cuMemsetD2D32Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuArrayCreate_v2
+        cuGetProcAddress_v2('cuArrayCreate', <void **>&__cuArrayCreate_v2, 3020, ptds_mode, NULL)
+
+        global __cuArrayGetDescriptor_v2
+        cuGetProcAddress_v2('cuArrayGetDescriptor', <void **>&__cuArrayGetDescriptor_v2, 3020, ptds_mode, NULL)
+
+        global __cuArrayGetSparseProperties
+        cuGetProcAddress_v2('cuArrayGetSparseProperties', <void **>&__cuArrayGetSparseProperties, 11010, ptds_mode, NULL)
+
+        global __cuMipmappedArrayGetSparseProperties
+        cuGetProcAddress_v2('cuMipmappedArrayGetSparseProperties', <void **>&__cuMipmappedArrayGetSparseProperties, 11010, ptds_mode, NULL)
+
+        global __cuArrayGetMemoryRequirements
+        cuGetProcAddress_v2('cuArrayGetMemoryRequirements', <void **>&__cuArrayGetMemoryRequirements, 11060, ptds_mode, NULL)
+
+        global __cuMipmappedArrayGetMemoryRequirements
+        cuGetProcAddress_v2('cuMipmappedArrayGetMemoryRequirements', <void **>&__cuMipmappedArrayGetMemoryRequirements, 11060, ptds_mode, NULL)
+
+        global __cuArrayGetPlane
+        cuGetProcAddress_v2('cuArrayGetPlane', <void **>&__cuArrayGetPlane, 11020, ptds_mode, NULL)
+
+        global __cuArrayDestroy
+        cuGetProcAddress_v2('cuArrayDestroy', <void **>&__cuArrayDestroy, 2000, ptds_mode, NULL)
+
+        global __cuArray3DCreate_v2
+        cuGetProcAddress_v2('cuArray3DCreate', <void **>&__cuArray3DCreate_v2, 3020, ptds_mode, NULL)
+
+        global __cuArray3DGetDescriptor_v2
+        cuGetProcAddress_v2('cuArray3DGetDescriptor', <void **>&__cuArray3DGetDescriptor_v2, 3020, ptds_mode, NULL)
+
+        global __cuMipmappedArrayCreate
+        cuGetProcAddress_v2('cuMipmappedArrayCreate', <void **>&__cuMipmappedArrayCreate, 5000, ptds_mode, NULL)
+
+        global __cuMipmappedArrayGetLevel
+        cuGetProcAddress_v2('cuMipmappedArrayGetLevel', <void **>&__cuMipmappedArrayGetLevel, 5000, ptds_mode, NULL)
+
+        global __cuMipmappedArrayDestroy
+        cuGetProcAddress_v2('cuMipmappedArrayDestroy', <void **>&__cuMipmappedArrayDestroy, 5000, ptds_mode, NULL)
+
+        global __cuMemGetHandleForAddressRange
+        cuGetProcAddress_v2('cuMemGetHandleForAddressRange', <void **>&__cuMemGetHandleForAddressRange, 11070, ptds_mode, NULL)
+
+        global __cuMemBatchDecompressAsync
+        cuGetProcAddress_v2('cuMemBatchDecompressAsync', <void **>&__cuMemBatchDecompressAsync, 12060, ptds_mode, NULL)
+
+        global __cuMemAddressReserve
+        cuGetProcAddress_v2('cuMemAddressReserve', <void **>&__cuMemAddressReserve, 10020, ptds_mode, NULL)
+
+        global __cuMemAddressFree
+        cuGetProcAddress_v2('cuMemAddressFree', <void **>&__cuMemAddressFree, 10020, ptds_mode, NULL)
+
+        global __cuMemCreate
+        cuGetProcAddress_v2('cuMemCreate', <void **>&__cuMemCreate, 10020, ptds_mode, NULL)
+
+        global __cuMemRelease
+        cuGetProcAddress_v2('cuMemRelease', <void **>&__cuMemRelease, 10020, ptds_mode, NULL)
+
+        global __cuMemMap
+        cuGetProcAddress_v2('cuMemMap', <void **>&__cuMemMap, 10020, ptds_mode, NULL)
+
+        global __cuMemMapArrayAsync
+        cuGetProcAddress_v2('cuMemMapArrayAsync', <void **>&__cuMemMapArrayAsync, 11010, ptds_mode, NULL)
+
+        global __cuMemUnmap
+        cuGetProcAddress_v2('cuMemUnmap', <void **>&__cuMemUnmap, 10020, ptds_mode, NULL)
+
+        global __cuMemSetAccess
+        cuGetProcAddress_v2('cuMemSetAccess', <void **>&__cuMemSetAccess, 10020, ptds_mode, NULL)
+
+        global __cuMemGetAccess
+        cuGetProcAddress_v2('cuMemGetAccess', <void **>&__cuMemGetAccess, 10020, ptds_mode, NULL)
+
+        global __cuMemExportToShareableHandle
+        cuGetProcAddress_v2('cuMemExportToShareableHandle', <void **>&__cuMemExportToShareableHandle, 10020, ptds_mode, NULL)
+
+        global __cuMemImportFromShareableHandle
+        cuGetProcAddress_v2('cuMemImportFromShareableHandle', <void **>&__cuMemImportFromShareableHandle, 10020, ptds_mode, NULL)
+
+        global __cuMemGetAllocationGranularity
+        cuGetProcAddress_v2('cuMemGetAllocationGranularity', <void **>&__cuMemGetAllocationGranularity, 10020, ptds_mode, NULL)
+
+        global __cuMemGetAllocationPropertiesFromHandle
+        cuGetProcAddress_v2('cuMemGetAllocationPropertiesFromHandle', <void **>&__cuMemGetAllocationPropertiesFromHandle, 10020, ptds_mode, NULL)
+
+        global __cuMemRetainAllocationHandle
+        cuGetProcAddress_v2('cuMemRetainAllocationHandle', <void **>&__cuMemRetainAllocationHandle, 11000, ptds_mode, NULL)
+
+        global __cuMemFreeAsync
+        cuGetProcAddress_v2('cuMemFreeAsync', <void **>&__cuMemFreeAsync, 11020, ptds_mode, NULL)
+
+        global __cuMemAllocAsync
+        cuGetProcAddress_v2('cuMemAllocAsync', <void **>&__cuMemAllocAsync, 11020, ptds_mode, NULL)
+
+        global __cuMemPoolTrimTo
+        cuGetProcAddress_v2('cuMemPoolTrimTo', <void **>&__cuMemPoolTrimTo, 11020, ptds_mode, NULL)
+
+        global __cuMemPoolSetAttribute
+        cuGetProcAddress_v2('cuMemPoolSetAttribute', <void **>&__cuMemPoolSetAttribute, 11020, ptds_mode, NULL)
+
+        global __cuMemPoolGetAttribute
+        cuGetProcAddress_v2('cuMemPoolGetAttribute', <void **>&__cuMemPoolGetAttribute, 11020, ptds_mode, NULL)
+
+        global __cuMemPoolSetAccess
+        cuGetProcAddress_v2('cuMemPoolSetAccess', <void **>&__cuMemPoolSetAccess, 11020, ptds_mode, NULL)
+
+        global __cuMemPoolGetAccess
+        cuGetProcAddress_v2('cuMemPoolGetAccess', <void **>&__cuMemPoolGetAccess, 11020, ptds_mode, NULL)
+
+        global __cuMemPoolCreate
+        cuGetProcAddress_v2('cuMemPoolCreate', <void **>&__cuMemPoolCreate, 11020, ptds_mode, NULL)
+
+        global __cuMemPoolDestroy
+        cuGetProcAddress_v2('cuMemPoolDestroy', <void **>&__cuMemPoolDestroy, 11020, ptds_mode, NULL)
+
+        global __cuMemAllocFromPoolAsync
+        cuGetProcAddress_v2('cuMemAllocFromPoolAsync', <void **>&__cuMemAllocFromPoolAsync, 11020, ptds_mode, NULL)
+
+        global __cuMemPoolExportToShareableHandle
+        cuGetProcAddress_v2('cuMemPoolExportToShareableHandle', <void **>&__cuMemPoolExportToShareableHandle, 11020, ptds_mode, NULL)
+
+        global __cuMemPoolImportFromShareableHandle
+        cuGetProcAddress_v2('cuMemPoolImportFromShareableHandle', <void **>&__cuMemPoolImportFromShareableHandle, 11020, ptds_mode, NULL)
+
+        global __cuMemPoolExportPointer
+        cuGetProcAddress_v2('cuMemPoolExportPointer', <void **>&__cuMemPoolExportPointer, 11020, ptds_mode, NULL)
+
+        global __cuMemPoolImportPointer
+        cuGetProcAddress_v2('cuMemPoolImportPointer', <void **>&__cuMemPoolImportPointer, 11020, ptds_mode, NULL)
+
+        global __cuMulticastCreate
+        cuGetProcAddress_v2('cuMulticastCreate', <void **>&__cuMulticastCreate, 12010, ptds_mode, NULL)
+
+        global __cuMulticastAddDevice
+        cuGetProcAddress_v2('cuMulticastAddDevice', <void **>&__cuMulticastAddDevice, 12010, ptds_mode, NULL)
+
+        global __cuMulticastBindMem
+        cuGetProcAddress_v2('cuMulticastBindMem', <void **>&__cuMulticastBindMem, 12010, ptds_mode, NULL)
+
+        global __cuMulticastBindAddr
+        cuGetProcAddress_v2('cuMulticastBindAddr', <void **>&__cuMulticastBindAddr, 12010, ptds_mode, NULL)
+
+        global __cuMulticastUnbind
+        cuGetProcAddress_v2('cuMulticastUnbind', <void **>&__cuMulticastUnbind, 12010, ptds_mode, NULL)
+
+        global __cuMulticastGetGranularity
+        cuGetProcAddress_v2('cuMulticastGetGranularity', <void **>&__cuMulticastGetGranularity, 12010, ptds_mode, NULL)
+
+        global __cuPointerGetAttribute
+        cuGetProcAddress_v2('cuPointerGetAttribute', <void **>&__cuPointerGetAttribute, 4000, ptds_mode, NULL)
+
+        global __cuMemPrefetchAsync_v2
+        cuGetProcAddress_v2('cuMemPrefetchAsync', <void **>&__cuMemPrefetchAsync_v2, 12020, ptds_mode, NULL)
+
+        global __cuMemAdvise_v2
+        cuGetProcAddress_v2('cuMemAdvise', <void **>&__cuMemAdvise_v2, 12020, ptds_mode, NULL)
+
+        global __cuMemRangeGetAttribute
+        cuGetProcAddress_v2('cuMemRangeGetAttribute', <void **>&__cuMemRangeGetAttribute, 8000, ptds_mode, NULL)
+
+        global __cuMemRangeGetAttributes
+        cuGetProcAddress_v2('cuMemRangeGetAttributes', <void **>&__cuMemRangeGetAttributes, 8000, ptds_mode, NULL)
+
+        global __cuPointerSetAttribute
+        cuGetProcAddress_v2('cuPointerSetAttribute', <void **>&__cuPointerSetAttribute, 6000, ptds_mode, NULL)
+
+        global __cuPointerGetAttributes
+        cuGetProcAddress_v2('cuPointerGetAttributes', <void **>&__cuPointerGetAttributes, 7000, ptds_mode, NULL)
+
+        global __cuStreamCreate
+        cuGetProcAddress_v2('cuStreamCreate', <void **>&__cuStreamCreate, 2000, ptds_mode, NULL)
+
+        global __cuStreamCreateWithPriority
+        cuGetProcAddress_v2('cuStreamCreateWithPriority', <void **>&__cuStreamCreateWithPriority, 5050, ptds_mode, NULL)
+
+        global __cuStreamGetPriority
+        cuGetProcAddress_v2('cuStreamGetPriority', <void **>&__cuStreamGetPriority, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 5050, ptds_mode, NULL)
+
+        global __cuStreamGetDevice
+        cuGetProcAddress_v2('cuStreamGetDevice', <void **>&__cuStreamGetDevice, 12080, ptds_mode, NULL)
+
+        global __cuStreamGetFlags
+        cuGetProcAddress_v2('cuStreamGetFlags', <void **>&__cuStreamGetFlags, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 5050, ptds_mode, NULL)
+
+        global __cuStreamGetId
+        cuGetProcAddress_v2('cuStreamGetId', <void **>&__cuStreamGetId, 12000, ptds_mode, NULL)
+
+        global __cuStreamGetCtx
+        cuGetProcAddress_v2('cuStreamGetCtx', <void **>&__cuStreamGetCtx, 9020, ptds_mode, NULL)
+
+        global __cuStreamGetCtx_v2
+        cuGetProcAddress_v2('cuStreamGetCtx', <void **>&__cuStreamGetCtx_v2, 12050, ptds_mode, NULL)
+
+        global __cuStreamWaitEvent
+        cuGetProcAddress_v2('cuStreamWaitEvent', <void **>&__cuStreamWaitEvent, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuStreamAddCallback
+        cuGetProcAddress_v2('cuStreamAddCallback', <void **>&__cuStreamAddCallback, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 5000, ptds_mode, NULL)
+
+        global __cuStreamBeginCapture_v2
+        cuGetProcAddress_v2('cuStreamBeginCapture', <void **>&__cuStreamBeginCapture_v2, 10010, ptds_mode, NULL)
+
+        global __cuStreamBeginCaptureToGraph
+        cuGetProcAddress_v2('cuStreamBeginCaptureToGraph', <void **>&__cuStreamBeginCaptureToGraph, 12030, ptds_mode, NULL)
+
+        global __cuThreadExchangeStreamCaptureMode
+        cuGetProcAddress_v2('cuThreadExchangeStreamCaptureMode', <void **>&__cuThreadExchangeStreamCaptureMode, 10010, ptds_mode, NULL)
+
+        global __cuStreamEndCapture
+        cuGetProcAddress_v2('cuStreamEndCapture', <void **>&__cuStreamEndCapture, 10000, ptds_mode, NULL)
+
+        global __cuStreamIsCapturing
+        cuGetProcAddress_v2('cuStreamIsCapturing', <void **>&__cuStreamIsCapturing, 10000, ptds_mode, NULL)
+
+        global __cuStreamGetCaptureInfo_v2
+        cuGetProcAddress_v2('cuStreamGetCaptureInfo', <void **>&__cuStreamGetCaptureInfo_v2, 11030, ptds_mode, NULL)
+
+        global __cuStreamGetCaptureInfo_v3
+        cuGetProcAddress_v2('cuStreamGetCaptureInfo', <void **>&__cuStreamGetCaptureInfo_v3, 12030, ptds_mode, NULL)
+
+        global __cuStreamUpdateCaptureDependencies_v2
+        cuGetProcAddress_v2('cuStreamUpdateCaptureDependencies', <void **>&__cuStreamUpdateCaptureDependencies_v2, 12030, ptds_mode, NULL)
+
+        global __cuStreamAttachMemAsync
+        cuGetProcAddress_v2('cuStreamAttachMemAsync', <void **>&__cuStreamAttachMemAsync, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 6000, ptds_mode, NULL)
+
+        global __cuStreamQuery
+        cuGetProcAddress_v2('cuStreamQuery', <void **>&__cuStreamQuery, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 2000, ptds_mode, NULL)
+
+        global __cuStreamSynchronize
+        cuGetProcAddress_v2('cuStreamSynchronize', <void **>&__cuStreamSynchronize, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 2000, ptds_mode, NULL)
+
+        global __cuStreamDestroy_v2
+        cuGetProcAddress_v2('cuStreamDestroy', <void **>&__cuStreamDestroy_v2, 4000, ptds_mode, NULL)
+
+        global __cuStreamCopyAttributes
+        cuGetProcAddress_v2('cuStreamCopyAttributes', <void **>&__cuStreamCopyAttributes, 11000, ptds_mode, NULL)
+
+        global __cuStreamGetAttribute
+        cuGetProcAddress_v2('cuStreamGetAttribute', <void **>&__cuStreamGetAttribute, 11000, ptds_mode, NULL)
+
+        global __cuStreamSetAttribute
+        cuGetProcAddress_v2('cuStreamSetAttribute', <void **>&__cuStreamSetAttribute, 11000, ptds_mode, NULL)
+
+        global __cuEventCreate
+        cuGetProcAddress_v2('cuEventCreate', <void **>&__cuEventCreate, 2000, ptds_mode, NULL)
+
+        global __cuEventRecord
+        cuGetProcAddress_v2('cuEventRecord', <void **>&__cuEventRecord, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 2000, ptds_mode, NULL)
+
+        global __cuEventRecordWithFlags
+        cuGetProcAddress_v2('cuEventRecordWithFlags', <void **>&__cuEventRecordWithFlags, 11010, ptds_mode, NULL)
+
+        global __cuEventQuery
+        cuGetProcAddress_v2('cuEventQuery', <void **>&__cuEventQuery, 2000, ptds_mode, NULL)
+
+        global __cuEventSynchronize
+        cuGetProcAddress_v2('cuEventSynchronize', <void **>&__cuEventSynchronize, 2000, ptds_mode, NULL)
+
+        global __cuEventDestroy_v2
+        cuGetProcAddress_v2('cuEventDestroy', <void **>&__cuEventDestroy_v2, 4000, ptds_mode, NULL)
+
+        global __cuEventElapsedTime_v2
+        cuGetProcAddress_v2('cuEventElapsedTime', <void **>&__cuEventElapsedTime_v2, 12080, ptds_mode, NULL)
+
+        global __cuImportExternalMemory
+        cuGetProcAddress_v2('cuImportExternalMemory', <void **>&__cuImportExternalMemory, 10000, ptds_mode, NULL)
+
+        global __cuExternalMemoryGetMappedBuffer
+        cuGetProcAddress_v2('cuExternalMemoryGetMappedBuffer', <void **>&__cuExternalMemoryGetMappedBuffer, 10000, ptds_mode, NULL)
+
+        global __cuExternalMemoryGetMappedMipmappedArray
+        cuGetProcAddress_v2('cuExternalMemoryGetMappedMipmappedArray', <void **>&__cuExternalMemoryGetMappedMipmappedArray, 10000, ptds_mode, NULL)
+
+        global __cuDestroyExternalMemory
+        cuGetProcAddress_v2('cuDestroyExternalMemory', <void **>&__cuDestroyExternalMemory, 10000, ptds_mode, NULL)
+
+        global __cuImportExternalSemaphore
+        cuGetProcAddress_v2('cuImportExternalSemaphore', <void **>&__cuImportExternalSemaphore, 10000, ptds_mode, NULL)
+
+        global __cuSignalExternalSemaphoresAsync
+        cuGetProcAddress_v2('cuSignalExternalSemaphoresAsync', <void **>&__cuSignalExternalSemaphoresAsync, 10000, ptds_mode, NULL)
+
+        global __cuWaitExternalSemaphoresAsync
+        cuGetProcAddress_v2('cuWaitExternalSemaphoresAsync', <void **>&__cuWaitExternalSemaphoresAsync, 10000, ptds_mode, NULL)
+
+        global __cuDestroyExternalSemaphore
+        cuGetProcAddress_v2('cuDestroyExternalSemaphore', <void **>&__cuDestroyExternalSemaphore, 10000, ptds_mode, NULL)
+
+        global __cuStreamWaitValue32_v2
+        cuGetProcAddress_v2('cuStreamWaitValue32', <void **>&__cuStreamWaitValue32_v2, 11070, ptds_mode, NULL)
+
+        global __cuStreamWaitValue64_v2
+        cuGetProcAddress_v2('cuStreamWaitValue64', <void **>&__cuStreamWaitValue64_v2, 11070, ptds_mode, NULL)
+
+        global __cuStreamWriteValue32_v2
+        cuGetProcAddress_v2('cuStreamWriteValue32', <void **>&__cuStreamWriteValue32_v2, 11070, ptds_mode, NULL)
+
+        global __cuStreamWriteValue64_v2
+        cuGetProcAddress_v2('cuStreamWriteValue64', <void **>&__cuStreamWriteValue64_v2, 11070, ptds_mode, NULL)
+
+        global __cuStreamBatchMemOp_v2
+        cuGetProcAddress_v2('cuStreamBatchMemOp', <void **>&__cuStreamBatchMemOp_v2, 11070, ptds_mode, NULL)
+
+        global __cuFuncGetAttribute
+        cuGetProcAddress_v2('cuFuncGetAttribute', <void **>&__cuFuncGetAttribute, 2020, ptds_mode, NULL)
+
+        global __cuFuncSetAttribute
+        cuGetProcAddress_v2('cuFuncSetAttribute', <void **>&__cuFuncSetAttribute, 9000, ptds_mode, NULL)
+
+        global __cuFuncSetCacheConfig
+        cuGetProcAddress_v2('cuFuncSetCacheConfig', <void **>&__cuFuncSetCacheConfig, 3000, ptds_mode, NULL)
+
+        global __cuFuncGetModule
+        cuGetProcAddress_v2('cuFuncGetModule', <void **>&__cuFuncGetModule, 11000, ptds_mode, NULL)
+
+        global __cuFuncGetName
+        cuGetProcAddress_v2('cuFuncGetName', <void **>&__cuFuncGetName, 12030, ptds_mode, NULL)
+
+        global __cuFuncGetParamInfo
+        cuGetProcAddress_v2('cuFuncGetParamInfo', <void **>&__cuFuncGetParamInfo, 12040, ptds_mode, NULL)
+
+        global __cuFuncIsLoaded
+        cuGetProcAddress_v2('cuFuncIsLoaded', <void **>&__cuFuncIsLoaded, 12040, ptds_mode, NULL)
+
+        global __cuFuncLoad
+        cuGetProcAddress_v2('cuFuncLoad', <void **>&__cuFuncLoad, 12040, ptds_mode, NULL)
+
+        global __cuLaunchKernel
+        cuGetProcAddress_v2('cuLaunchKernel', <void **>&__cuLaunchKernel, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
+
+        global __cuLaunchKernelEx
+        cuGetProcAddress_v2('cuLaunchKernelEx', <void **>&__cuLaunchKernelEx, 11060, ptds_mode, NULL)
+
+        global __cuLaunchCooperativeKernel
+        cuGetProcAddress_v2('cuLaunchCooperativeKernel', <void **>&__cuLaunchCooperativeKernel, 9000, ptds_mode, NULL)
+
+        global __cuLaunchCooperativeKernelMultiDevice
+        cuGetProcAddress_v2('cuLaunchCooperativeKernelMultiDevice', <void **>&__cuLaunchCooperativeKernelMultiDevice, 9000, ptds_mode, NULL)
+
+        global __cuLaunchHostFunc
+        cuGetProcAddress_v2('cuLaunchHostFunc', <void **>&__cuLaunchHostFunc, 10000, ptds_mode, NULL)
+
+        global __cuFuncSetBlockShape
+        cuGetProcAddress_v2('cuFuncSetBlockShape', <void **>&__cuFuncSetBlockShape, 2000, ptds_mode, NULL)
+
+        global __cuFuncSetSharedSize
+        cuGetProcAddress_v2('cuFuncSetSharedSize', <void **>&__cuFuncSetSharedSize, 2000, ptds_mode, NULL)
+
+        global __cuParamSetSize
+        cuGetProcAddress_v2('cuParamSetSize', <void **>&__cuParamSetSize, 2000, ptds_mode, NULL)
+
+        global __cuParamSeti
+        cuGetProcAddress_v2('cuParamSeti', <void **>&__cuParamSeti, 2000, ptds_mode, NULL)
+
+        global __cuParamSetf
+        cuGetProcAddress_v2('cuParamSetf', <void **>&__cuParamSetf, 2000, ptds_mode, NULL)
+
+        global __cuParamSetv
+        cuGetProcAddress_v2('cuParamSetv', <void **>&__cuParamSetv, 2000, ptds_mode, NULL)
+
+        global __cuLaunch
+        cuGetProcAddress_v2('cuLaunch', <void **>&__cuLaunch, 2000, ptds_mode, NULL)
+
+        global __cuLaunchGrid
+        cuGetProcAddress_v2('cuLaunchGrid', <void **>&__cuLaunchGrid, 2000, ptds_mode, NULL)
+
+        global __cuLaunchGridAsync
+        cuGetProcAddress_v2('cuLaunchGridAsync', <void **>&__cuLaunchGridAsync, 2000, ptds_mode, NULL)
+
+        global __cuParamSetTexRef
+        cuGetProcAddress_v2('cuParamSetTexRef', <void **>&__cuParamSetTexRef, 2000, ptds_mode, NULL)
+
+        global __cuFuncSetSharedMemConfig
+        cuGetProcAddress_v2('cuFuncSetSharedMemConfig', <void **>&__cuFuncSetSharedMemConfig, 4020, ptds_mode, NULL)
+
+        global __cuGraphCreate
+        cuGetProcAddress_v2('cuGraphCreate', <void **>&__cuGraphCreate, 10000, ptds_mode, NULL)
+
+        global __cuGraphAddKernelNode_v2
+        cuGetProcAddress_v2('cuGraphAddKernelNode', <void **>&__cuGraphAddKernelNode_v2, 12000, ptds_mode, NULL)
+
+        global __cuGraphKernelNodeGetParams_v2
+        cuGetProcAddress_v2('cuGraphKernelNodeGetParams', <void **>&__cuGraphKernelNodeGetParams_v2, 12000, ptds_mode, NULL)
+
+        global __cuGraphKernelNodeSetParams_v2
+        cuGetProcAddress_v2('cuGraphKernelNodeSetParams', <void **>&__cuGraphKernelNodeSetParams_v2, 12000, ptds_mode, NULL)
+
+        global __cuGraphAddMemcpyNode
+        cuGetProcAddress_v2('cuGraphAddMemcpyNode', <void **>&__cuGraphAddMemcpyNode, 10000, ptds_mode, NULL)
+
+        global __cuGraphMemcpyNodeGetParams
+        cuGetProcAddress_v2('cuGraphMemcpyNodeGetParams', <void **>&__cuGraphMemcpyNodeGetParams, 10000, ptds_mode, NULL)
+
+        global __cuGraphMemcpyNodeSetParams
+        cuGetProcAddress_v2('cuGraphMemcpyNodeSetParams', <void **>&__cuGraphMemcpyNodeSetParams, 10000, ptds_mode, NULL)
+
+        global __cuGraphAddMemsetNode
+        cuGetProcAddress_v2('cuGraphAddMemsetNode', <void **>&__cuGraphAddMemsetNode, 10000, ptds_mode, NULL)
+
+        global __cuGraphMemsetNodeGetParams
+        cuGetProcAddress_v2('cuGraphMemsetNodeGetParams', <void **>&__cuGraphMemsetNodeGetParams, 10000, ptds_mode, NULL)
+
+        global __cuGraphMemsetNodeSetParams
+        cuGetProcAddress_v2('cuGraphMemsetNodeSetParams', <void **>&__cuGraphMemsetNodeSetParams, 10000, ptds_mode, NULL)
+
+        global __cuGraphAddHostNode
+        cuGetProcAddress_v2('cuGraphAddHostNode', <void **>&__cuGraphAddHostNode, 10000, ptds_mode, NULL)
+
+        global __cuGraphHostNodeGetParams
+        cuGetProcAddress_v2('cuGraphHostNodeGetParams', <void **>&__cuGraphHostNodeGetParams, 10000, ptds_mode, NULL)
+
+        global __cuGraphHostNodeSetParams
+        cuGetProcAddress_v2('cuGraphHostNodeSetParams', <void **>&__cuGraphHostNodeSetParams, 10000, ptds_mode, NULL)
+
+        global __cuGraphAddChildGraphNode
+        cuGetProcAddress_v2('cuGraphAddChildGraphNode', <void **>&__cuGraphAddChildGraphNode, 10000, ptds_mode, NULL)
+
+        global __cuGraphChildGraphNodeGetGraph
+        cuGetProcAddress_v2('cuGraphChildGraphNodeGetGraph', <void **>&__cuGraphChildGraphNodeGetGraph, 10000, ptds_mode, NULL)
+
+        global __cuGraphAddEmptyNode
+        cuGetProcAddress_v2('cuGraphAddEmptyNode', <void **>&__cuGraphAddEmptyNode, 10000, ptds_mode, NULL)
+
+        global __cuGraphAddEventRecordNode
+        cuGetProcAddress_v2('cuGraphAddEventRecordNode', <void **>&__cuGraphAddEventRecordNode, 11010, ptds_mode, NULL)
+
+        global __cuGraphEventRecordNodeGetEvent
+        cuGetProcAddress_v2('cuGraphEventRecordNodeGetEvent', <void **>&__cuGraphEventRecordNodeGetEvent, 11010, ptds_mode, NULL)
+
+        global __cuGraphEventRecordNodeSetEvent
+        cuGetProcAddress_v2('cuGraphEventRecordNodeSetEvent', <void **>&__cuGraphEventRecordNodeSetEvent, 11010, ptds_mode, NULL)
+
+        global __cuGraphAddEventWaitNode
+        cuGetProcAddress_v2('cuGraphAddEventWaitNode', <void **>&__cuGraphAddEventWaitNode, 11010, ptds_mode, NULL)
+
+        global __cuGraphEventWaitNodeGetEvent
+        cuGetProcAddress_v2('cuGraphEventWaitNodeGetEvent', <void **>&__cuGraphEventWaitNodeGetEvent, 11010, ptds_mode, NULL)
+
+        global __cuGraphEventWaitNodeSetEvent
+        cuGetProcAddress_v2('cuGraphEventWaitNodeSetEvent', <void **>&__cuGraphEventWaitNodeSetEvent, 11010, ptds_mode, NULL)
+
+        global __cuGraphAddExternalSemaphoresSignalNode
+        cuGetProcAddress_v2('cuGraphAddExternalSemaphoresSignalNode', <void **>&__cuGraphAddExternalSemaphoresSignalNode, 11020, ptds_mode, NULL)
+
+        global __cuGraphExternalSemaphoresSignalNodeGetParams
+        cuGetProcAddress_v2('cuGraphExternalSemaphoresSignalNodeGetParams', <void **>&__cuGraphExternalSemaphoresSignalNodeGetParams, 11020, ptds_mode, NULL)
+
+        global __cuGraphExternalSemaphoresSignalNodeSetParams
+        cuGetProcAddress_v2('cuGraphExternalSemaphoresSignalNodeSetParams', <void **>&__cuGraphExternalSemaphoresSignalNodeSetParams, 11020, ptds_mode, NULL)
+
+        global __cuGraphAddExternalSemaphoresWaitNode
+        cuGetProcAddress_v2('cuGraphAddExternalSemaphoresWaitNode', <void **>&__cuGraphAddExternalSemaphoresWaitNode, 11020, ptds_mode, NULL)
+
+        global __cuGraphExternalSemaphoresWaitNodeGetParams
+        cuGetProcAddress_v2('cuGraphExternalSemaphoresWaitNodeGetParams', <void **>&__cuGraphExternalSemaphoresWaitNodeGetParams, 11020, ptds_mode, NULL)
+
+        global __cuGraphExternalSemaphoresWaitNodeSetParams
+        cuGetProcAddress_v2('cuGraphExternalSemaphoresWaitNodeSetParams', <void **>&__cuGraphExternalSemaphoresWaitNodeSetParams, 11020, ptds_mode, NULL)
+
+        global __cuGraphAddBatchMemOpNode
+        cuGetProcAddress_v2('cuGraphAddBatchMemOpNode', <void **>&__cuGraphAddBatchMemOpNode, 11070, ptds_mode, NULL)
+
+        global __cuGraphBatchMemOpNodeGetParams
+        cuGetProcAddress_v2('cuGraphBatchMemOpNodeGetParams', <void **>&__cuGraphBatchMemOpNodeGetParams, 11070, ptds_mode, NULL)
+
+        global __cuGraphBatchMemOpNodeSetParams
+        cuGetProcAddress_v2('cuGraphBatchMemOpNodeSetParams', <void **>&__cuGraphBatchMemOpNodeSetParams, 11070, ptds_mode, NULL)
+
+        global __cuGraphExecBatchMemOpNodeSetParams
+        cuGetProcAddress_v2('cuGraphExecBatchMemOpNodeSetParams', <void **>&__cuGraphExecBatchMemOpNodeSetParams, 11070, ptds_mode, NULL)
+
+        global __cuGraphAddMemAllocNode
+        cuGetProcAddress_v2('cuGraphAddMemAllocNode', <void **>&__cuGraphAddMemAllocNode, 11040, ptds_mode, NULL)
+
+        global __cuGraphMemAllocNodeGetParams
+        cuGetProcAddress_v2('cuGraphMemAllocNodeGetParams', <void **>&__cuGraphMemAllocNodeGetParams, 11040, ptds_mode, NULL)
+
+        global __cuGraphAddMemFreeNode
+        cuGetProcAddress_v2('cuGraphAddMemFreeNode', <void **>&__cuGraphAddMemFreeNode, 11040, ptds_mode, NULL)
+
+        global __cuGraphMemFreeNodeGetParams
+        cuGetProcAddress_v2('cuGraphMemFreeNodeGetParams', <void **>&__cuGraphMemFreeNodeGetParams, 11040, ptds_mode, NULL)
+
+        global __cuDeviceGraphMemTrim
+        cuGetProcAddress_v2('cuDeviceGraphMemTrim', <void **>&__cuDeviceGraphMemTrim, 11040, ptds_mode, NULL)
+
+        global __cuDeviceGetGraphMemAttribute
+        cuGetProcAddress_v2('cuDeviceGetGraphMemAttribute', <void **>&__cuDeviceGetGraphMemAttribute, 11040, ptds_mode, NULL)
+
+        global __cuDeviceSetGraphMemAttribute
+        cuGetProcAddress_v2('cuDeviceSetGraphMemAttribute', <void **>&__cuDeviceSetGraphMemAttribute, 11040, ptds_mode, NULL)
+
+        global __cuGraphClone
+        cuGetProcAddress_v2('cuGraphClone', <void **>&__cuGraphClone, 10000, ptds_mode, NULL)
+
+        global __cuGraphNodeFindInClone
+        cuGetProcAddress_v2('cuGraphNodeFindInClone', <void **>&__cuGraphNodeFindInClone, 10000, ptds_mode, NULL)
+
+        global __cuGraphNodeGetType
+        cuGetProcAddress_v2('cuGraphNodeGetType', <void **>&__cuGraphNodeGetType, 10000, ptds_mode, NULL)
+
+        global __cuGraphGetNodes
+        cuGetProcAddress_v2('cuGraphGetNodes', <void **>&__cuGraphGetNodes, 10000, ptds_mode, NULL)
+
+        global __cuGraphGetRootNodes
+        cuGetProcAddress_v2('cuGraphGetRootNodes', <void **>&__cuGraphGetRootNodes, 10000, ptds_mode, NULL)
+
+        global __cuGraphGetEdges_v2
+        cuGetProcAddress_v2('cuGraphGetEdges', <void **>&__cuGraphGetEdges_v2, 12030, ptds_mode, NULL)
+
+        global __cuGraphNodeGetDependencies_v2
+        cuGetProcAddress_v2('cuGraphNodeGetDependencies', <void **>&__cuGraphNodeGetDependencies_v2, 12030, ptds_mode, NULL)
+
+        global __cuGraphNodeGetDependentNodes_v2
+        cuGetProcAddress_v2('cuGraphNodeGetDependentNodes', <void **>&__cuGraphNodeGetDependentNodes_v2, 12030, ptds_mode, NULL)
+
+        global __cuGraphAddDependencies_v2
+        cuGetProcAddress_v2('cuGraphAddDependencies', <void **>&__cuGraphAddDependencies_v2, 12030, ptds_mode, NULL)
+
+        global __cuGraphRemoveDependencies_v2
+        cuGetProcAddress_v2('cuGraphRemoveDependencies', <void **>&__cuGraphRemoveDependencies_v2, 12030, ptds_mode, NULL)
+
+        global __cuGraphDestroyNode
+        cuGetProcAddress_v2('cuGraphDestroyNode', <void **>&__cuGraphDestroyNode, 10000, ptds_mode, NULL)
+
+        global __cuGraphInstantiateWithFlags
+        cuGetProcAddress_v2('cuGraphInstantiateWithFlags', <void **>&__cuGraphInstantiateWithFlags, 11040, ptds_mode, NULL)
+
+        global __cuGraphInstantiateWithParams
+        cuGetProcAddress_v2('cuGraphInstantiateWithParams', <void **>&__cuGraphInstantiateWithParams, 12000, ptds_mode, NULL)
+
+        global __cuGraphExecGetFlags
+        cuGetProcAddress_v2('cuGraphExecGetFlags', <void **>&__cuGraphExecGetFlags, 12000, ptds_mode, NULL)
+
+        global __cuGraphExecKernelNodeSetParams_v2
+        cuGetProcAddress_v2('cuGraphExecKernelNodeSetParams', <void **>&__cuGraphExecKernelNodeSetParams_v2, 12000, ptds_mode, NULL)
+
+        global __cuGraphExecMemcpyNodeSetParams
+        cuGetProcAddress_v2('cuGraphExecMemcpyNodeSetParams', <void **>&__cuGraphExecMemcpyNodeSetParams, 10020, ptds_mode, NULL)
+
+        global __cuGraphExecMemsetNodeSetParams
+        cuGetProcAddress_v2('cuGraphExecMemsetNodeSetParams', <void **>&__cuGraphExecMemsetNodeSetParams, 10020, ptds_mode, NULL)
+
+        global __cuGraphExecHostNodeSetParams
+        cuGetProcAddress_v2('cuGraphExecHostNodeSetParams', <void **>&__cuGraphExecHostNodeSetParams, 10020, ptds_mode, NULL)
+
+        global __cuGraphExecChildGraphNodeSetParams
+        cuGetProcAddress_v2('cuGraphExecChildGraphNodeSetParams', <void **>&__cuGraphExecChildGraphNodeSetParams, 11010, ptds_mode, NULL)
+
+        global __cuGraphExecEventRecordNodeSetEvent
+        cuGetProcAddress_v2('cuGraphExecEventRecordNodeSetEvent', <void **>&__cuGraphExecEventRecordNodeSetEvent, 11010, ptds_mode, NULL)
+
+        global __cuGraphExecEventWaitNodeSetEvent
+        cuGetProcAddress_v2('cuGraphExecEventWaitNodeSetEvent', <void **>&__cuGraphExecEventWaitNodeSetEvent, 11010, ptds_mode, NULL)
+
+        global __cuGraphExecExternalSemaphoresSignalNodeSetParams
+        cuGetProcAddress_v2('cuGraphExecExternalSemaphoresSignalNodeSetParams', <void **>&__cuGraphExecExternalSemaphoresSignalNodeSetParams, 11020, ptds_mode, NULL)
+
+        global __cuGraphExecExternalSemaphoresWaitNodeSetParams
+        cuGetProcAddress_v2('cuGraphExecExternalSemaphoresWaitNodeSetParams', <void **>&__cuGraphExecExternalSemaphoresWaitNodeSetParams, 11020, ptds_mode, NULL)
+
+        global __cuGraphNodeSetEnabled
+        cuGetProcAddress_v2('cuGraphNodeSetEnabled', <void **>&__cuGraphNodeSetEnabled, 11060, ptds_mode, NULL)
+
+        global __cuGraphNodeGetEnabled
+        cuGetProcAddress_v2('cuGraphNodeGetEnabled', <void **>&__cuGraphNodeGetEnabled, 11060, ptds_mode, NULL)
+
+        global __cuGraphUpload
+        cuGetProcAddress_v2('cuGraphUpload', <void **>&__cuGraphUpload, 11010, ptds_mode, NULL)
+
+        global __cuGraphLaunch
+        cuGetProcAddress_v2('cuGraphLaunch', <void **>&__cuGraphLaunch, 10000, ptds_mode, NULL)
+
+        global __cuGraphExecDestroy
+        cuGetProcAddress_v2('cuGraphExecDestroy', <void **>&__cuGraphExecDestroy, 10000, ptds_mode, NULL)
+
+        global __cuGraphDestroy
+        cuGetProcAddress_v2('cuGraphDestroy', <void **>&__cuGraphDestroy, 10000, ptds_mode, NULL)
+
+        global __cuGraphExecUpdate_v2
+        cuGetProcAddress_v2('cuGraphExecUpdate', <void **>&__cuGraphExecUpdate_v2, 12000, ptds_mode, NULL)
+
+        global __cuGraphKernelNodeCopyAttributes
+        cuGetProcAddress_v2('cuGraphKernelNodeCopyAttributes', <void **>&__cuGraphKernelNodeCopyAttributes, 11000, ptds_mode, NULL)
+
+        global __cuGraphKernelNodeGetAttribute
+        cuGetProcAddress_v2('cuGraphKernelNodeGetAttribute', <void **>&__cuGraphKernelNodeGetAttribute, 11000, ptds_mode, NULL)
+
+        global __cuGraphKernelNodeSetAttribute
+        cuGetProcAddress_v2('cuGraphKernelNodeSetAttribute', <void **>&__cuGraphKernelNodeSetAttribute, 11000, ptds_mode, NULL)
+
+        global __cuGraphDebugDotPrint
+        cuGetProcAddress_v2('cuGraphDebugDotPrint', <void **>&__cuGraphDebugDotPrint, 11030, ptds_mode, NULL)
+
+        global __cuUserObjectCreate
+        cuGetProcAddress_v2('cuUserObjectCreate', <void **>&__cuUserObjectCreate, 11030, ptds_mode, NULL)
+
+        global __cuUserObjectRetain
+        cuGetProcAddress_v2('cuUserObjectRetain', <void **>&__cuUserObjectRetain, 11030, ptds_mode, NULL)
+
+        global __cuUserObjectRelease
+        cuGetProcAddress_v2('cuUserObjectRelease', <void **>&__cuUserObjectRelease, 11030, ptds_mode, NULL)
+
+        global __cuGraphRetainUserObject
+        cuGetProcAddress_v2('cuGraphRetainUserObject', <void **>&__cuGraphRetainUserObject, 11030, ptds_mode, NULL)
+
+        global __cuGraphReleaseUserObject
+        cuGetProcAddress_v2('cuGraphReleaseUserObject', <void **>&__cuGraphReleaseUserObject, 11030, ptds_mode, NULL)
+
+        global __cuGraphAddNode_v2
+        cuGetProcAddress_v2('cuGraphAddNode', <void **>&__cuGraphAddNode_v2, 12030, ptds_mode, NULL)
+
+        global __cuGraphNodeSetParams
+        cuGetProcAddress_v2('cuGraphNodeSetParams', <void **>&__cuGraphNodeSetParams, 12020, ptds_mode, NULL)
+
+        global __cuGraphExecNodeSetParams
+        cuGetProcAddress_v2('cuGraphExecNodeSetParams', <void **>&__cuGraphExecNodeSetParams, 12020, ptds_mode, NULL)
+
+        global __cuGraphConditionalHandleCreate
+        cuGetProcAddress_v2('cuGraphConditionalHandleCreate', <void **>&__cuGraphConditionalHandleCreate, 12030, ptds_mode, NULL)
+
+        global __cuOccupancyMaxActiveBlocksPerMultiprocessor
+        cuGetProcAddress_v2('cuOccupancyMaxActiveBlocksPerMultiprocessor', <void **>&__cuOccupancyMaxActiveBlocksPerMultiprocessor, 6050, ptds_mode, NULL)
+
+        global __cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags
+        cuGetProcAddress_v2('cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags', <void **>&__cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags, 7000, ptds_mode, NULL)
+
+        global __cuOccupancyMaxPotentialBlockSize
+        cuGetProcAddress_v2('cuOccupancyMaxPotentialBlockSize', <void **>&__cuOccupancyMaxPotentialBlockSize, 6050, ptds_mode, NULL)
+
+        global __cuOccupancyMaxPotentialBlockSizeWithFlags
+        cuGetProcAddress_v2('cuOccupancyMaxPotentialBlockSizeWithFlags', <void **>&__cuOccupancyMaxPotentialBlockSizeWithFlags, 7000, ptds_mode, NULL)
+
+        global __cuOccupancyAvailableDynamicSMemPerBlock
+        cuGetProcAddress_v2('cuOccupancyAvailableDynamicSMemPerBlock', <void **>&__cuOccupancyAvailableDynamicSMemPerBlock, 10020, ptds_mode, NULL)
+
+        global __cuOccupancyMaxPotentialClusterSize
+        cuGetProcAddress_v2('cuOccupancyMaxPotentialClusterSize', <void **>&__cuOccupancyMaxPotentialClusterSize, 11070, ptds_mode, NULL)
+
+        global __cuOccupancyMaxActiveClusters
+        cuGetProcAddress_v2('cuOccupancyMaxActiveClusters', <void **>&__cuOccupancyMaxActiveClusters, 11070, ptds_mode, NULL)
+
+        global __cuTexRefSetArray
+        cuGetProcAddress_v2('cuTexRefSetArray', <void **>&__cuTexRefSetArray, 2000, ptds_mode, NULL)
+
+        global __cuTexRefSetMipmappedArray
+        cuGetProcAddress_v2('cuTexRefSetMipmappedArray', <void **>&__cuTexRefSetMipmappedArray, 5000, ptds_mode, NULL)
+
+        global __cuTexRefSetAddress_v2
+        cuGetProcAddress_v2('cuTexRefSetAddress', <void **>&__cuTexRefSetAddress_v2, 3020, ptds_mode, NULL)
+
+        global __cuTexRefSetAddress2D_v3
+        cuGetProcAddress_v2('cuTexRefSetAddress2D', <void **>&__cuTexRefSetAddress2D_v3, 4010, ptds_mode, NULL)
+
+        global __cuTexRefSetFormat
+        cuGetProcAddress_v2('cuTexRefSetFormat', <void **>&__cuTexRefSetFormat, 2000, ptds_mode, NULL)
+
+        global __cuTexRefSetAddressMode
+        cuGetProcAddress_v2('cuTexRefSetAddressMode', <void **>&__cuTexRefSetAddressMode, 2000, ptds_mode, NULL)
+
+        global __cuTexRefSetFilterMode
+        cuGetProcAddress_v2('cuTexRefSetFilterMode', <void **>&__cuTexRefSetFilterMode, 2000, ptds_mode, NULL)
+
+        global __cuTexRefSetMipmapFilterMode
+        cuGetProcAddress_v2('cuTexRefSetMipmapFilterMode', <void **>&__cuTexRefSetMipmapFilterMode, 5000, ptds_mode, NULL)
+
+        global __cuTexRefSetMipmapLevelBias
+        cuGetProcAddress_v2('cuTexRefSetMipmapLevelBias', <void **>&__cuTexRefSetMipmapLevelBias, 5000, ptds_mode, NULL)
+
+        global __cuTexRefSetMipmapLevelClamp
+        cuGetProcAddress_v2('cuTexRefSetMipmapLevelClamp', <void **>&__cuTexRefSetMipmapLevelClamp, 5000, ptds_mode, NULL)
+
+        global __cuTexRefSetMaxAnisotropy
+        cuGetProcAddress_v2('cuTexRefSetMaxAnisotropy', <void **>&__cuTexRefSetMaxAnisotropy, 5000, ptds_mode, NULL)
+
+        global __cuTexRefSetBorderColor
+        cuGetProcAddress_v2('cuTexRefSetBorderColor', <void **>&__cuTexRefSetBorderColor, 8000, ptds_mode, NULL)
+
+        global __cuTexRefSetFlags
+        cuGetProcAddress_v2('cuTexRefSetFlags', <void **>&__cuTexRefSetFlags, 2000, ptds_mode, NULL)
+
+        global __cuTexRefGetAddress_v2
+        cuGetProcAddress_v2('cuTexRefGetAddress', <void **>&__cuTexRefGetAddress_v2, 3020, ptds_mode, NULL)
+
+        global __cuTexRefGetArray
+        cuGetProcAddress_v2('cuTexRefGetArray', <void **>&__cuTexRefGetArray, 2000, ptds_mode, NULL)
+
+        global __cuTexRefGetMipmappedArray
+        cuGetProcAddress_v2('cuTexRefGetMipmappedArray', <void **>&__cuTexRefGetMipmappedArray, 5000, ptds_mode, NULL)
+
+        global __cuTexRefGetAddressMode
+        cuGetProcAddress_v2('cuTexRefGetAddressMode', <void **>&__cuTexRefGetAddressMode, 2000, ptds_mode, NULL)
+
+        global __cuTexRefGetFilterMode
+        cuGetProcAddress_v2('cuTexRefGetFilterMode', <void **>&__cuTexRefGetFilterMode, 2000, ptds_mode, NULL)
+
+        global __cuTexRefGetFormat
+        cuGetProcAddress_v2('cuTexRefGetFormat', <void **>&__cuTexRefGetFormat, 2000, ptds_mode, NULL)
+
+        global __cuTexRefGetMipmapFilterMode
+        cuGetProcAddress_v2('cuTexRefGetMipmapFilterMode', <void **>&__cuTexRefGetMipmapFilterMode, 5000, ptds_mode, NULL)
+
+        global __cuTexRefGetMipmapLevelBias
+        cuGetProcAddress_v2('cuTexRefGetMipmapLevelBias', <void **>&__cuTexRefGetMipmapLevelBias, 5000, ptds_mode, NULL)
+
+        global __cuTexRefGetMipmapLevelClamp
+        cuGetProcAddress_v2('cuTexRefGetMipmapLevelClamp', <void **>&__cuTexRefGetMipmapLevelClamp, 5000, ptds_mode, NULL)
+
+        global __cuTexRefGetMaxAnisotropy
+        cuGetProcAddress_v2('cuTexRefGetMaxAnisotropy', <void **>&__cuTexRefGetMaxAnisotropy, 5000, ptds_mode, NULL)
+
+        global __cuTexRefGetBorderColor
+        cuGetProcAddress_v2('cuTexRefGetBorderColor', <void **>&__cuTexRefGetBorderColor, 8000, ptds_mode, NULL)
+
+        global __cuTexRefGetFlags
+        cuGetProcAddress_v2('cuTexRefGetFlags', <void **>&__cuTexRefGetFlags, 2000, ptds_mode, NULL)
+
+        global __cuTexRefCreate
+        cuGetProcAddress_v2('cuTexRefCreate', <void **>&__cuTexRefCreate, 2000, ptds_mode, NULL)
+
+        global __cuTexRefDestroy
+        cuGetProcAddress_v2('cuTexRefDestroy', <void **>&__cuTexRefDestroy, 2000, ptds_mode, NULL)
+
+        global __cuSurfRefSetArray
+        cuGetProcAddress_v2('cuSurfRefSetArray', <void **>&__cuSurfRefSetArray, 3000, ptds_mode, NULL)
+
+        global __cuSurfRefGetArray
+        cuGetProcAddress_v2('cuSurfRefGetArray', <void **>&__cuSurfRefGetArray, 3000, ptds_mode, NULL)
+
+        global __cuTexObjectCreate
+        cuGetProcAddress_v2('cuTexObjectCreate', <void **>&__cuTexObjectCreate, 5000, ptds_mode, NULL)
+
+        global __cuTexObjectDestroy
+        cuGetProcAddress_v2('cuTexObjectDestroy', <void **>&__cuTexObjectDestroy, 5000, ptds_mode, NULL)
+
+        global __cuTexObjectGetResourceDesc
+        cuGetProcAddress_v2('cuTexObjectGetResourceDesc', <void **>&__cuTexObjectGetResourceDesc, 5000, ptds_mode, NULL)
+
+        global __cuTexObjectGetTextureDesc
+        cuGetProcAddress_v2('cuTexObjectGetTextureDesc', <void **>&__cuTexObjectGetTextureDesc, 5000, ptds_mode, NULL)
+
+        global __cuTexObjectGetResourceViewDesc
+        cuGetProcAddress_v2('cuTexObjectGetResourceViewDesc', <void **>&__cuTexObjectGetResourceViewDesc, 5000, ptds_mode, NULL)
+
+        global __cuSurfObjectCreate
+        cuGetProcAddress_v2('cuSurfObjectCreate', <void **>&__cuSurfObjectCreate, 5000, ptds_mode, NULL)
+
+        global __cuSurfObjectDestroy
+        cuGetProcAddress_v2('cuSurfObjectDestroy', <void **>&__cuSurfObjectDestroy, 5000, ptds_mode, NULL)
+
+        global __cuSurfObjectGetResourceDesc
+        cuGetProcAddress_v2('cuSurfObjectGetResourceDesc', <void **>&__cuSurfObjectGetResourceDesc, 5000, ptds_mode, NULL)
+
+        global __cuTensorMapEncodeTiled
+        cuGetProcAddress_v2('cuTensorMapEncodeTiled', <void **>&__cuTensorMapEncodeTiled, 12000, ptds_mode, NULL)
+
+        global __cuTensorMapEncodeIm2col
+        cuGetProcAddress_v2('cuTensorMapEncodeIm2col', <void **>&__cuTensorMapEncodeIm2col, 12000, ptds_mode, NULL)
+
+        global __cuTensorMapEncodeIm2colWide
+        cuGetProcAddress_v2('cuTensorMapEncodeIm2colWide', <void **>&__cuTensorMapEncodeIm2colWide, 12080, ptds_mode, NULL)
+
+        global __cuTensorMapReplaceAddress
+        cuGetProcAddress_v2('cuTensorMapReplaceAddress', <void **>&__cuTensorMapReplaceAddress, 12000, ptds_mode, NULL)
+
+        global __cuDeviceCanAccessPeer
+        cuGetProcAddress_v2('cuDeviceCanAccessPeer', <void **>&__cuDeviceCanAccessPeer, 4000, ptds_mode, NULL)
+
+        global __cuCtxEnablePeerAccess
+        cuGetProcAddress_v2('cuCtxEnablePeerAccess', <void **>&__cuCtxEnablePeerAccess, 4000, ptds_mode, NULL)
+
+        global __cuCtxDisablePeerAccess
+        cuGetProcAddress_v2('cuCtxDisablePeerAccess', <void **>&__cuCtxDisablePeerAccess, 4000, ptds_mode, NULL)
+
+        global __cuDeviceGetP2PAttribute
+        cuGetProcAddress_v2('cuDeviceGetP2PAttribute', <void **>&__cuDeviceGetP2PAttribute, 8000, ptds_mode, NULL)
+
+        global __cuGraphicsUnregisterResource
+        cuGetProcAddress_v2('cuGraphicsUnregisterResource', <void **>&__cuGraphicsUnregisterResource, 3000, ptds_mode, NULL)
+
+        global __cuGraphicsSubResourceGetMappedArray
+        cuGetProcAddress_v2('cuGraphicsSubResourceGetMappedArray', <void **>&__cuGraphicsSubResourceGetMappedArray, 3000, ptds_mode, NULL)
+
+        global __cuGraphicsResourceGetMappedMipmappedArray
+        cuGetProcAddress_v2('cuGraphicsResourceGetMappedMipmappedArray', <void **>&__cuGraphicsResourceGetMappedMipmappedArray, 5000, ptds_mode, NULL)
+
+        global __cuGraphicsResourceGetMappedPointer_v2
+        cuGetProcAddress_v2('cuGraphicsResourceGetMappedPointer', <void **>&__cuGraphicsResourceGetMappedPointer_v2, 3020, ptds_mode, NULL)
+
+        global __cuGraphicsResourceSetMapFlags_v2
+        cuGetProcAddress_v2('cuGraphicsResourceSetMapFlags', <void **>&__cuGraphicsResourceSetMapFlags_v2, 6050, ptds_mode, NULL)
+
+        global __cuGraphicsMapResources
+        cuGetProcAddress_v2('cuGraphicsMapResources', <void **>&__cuGraphicsMapResources, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3000, ptds_mode, NULL)
+
+        global __cuGraphicsUnmapResources
+        cuGetProcAddress_v2('cuGraphicsUnmapResources', <void **>&__cuGraphicsUnmapResources, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3000, ptds_mode, NULL)
+
+        global __cuGetProcAddress_v2
+        cuGetProcAddress_v2('cuGetProcAddress', <void **>&__cuGetProcAddress_v2, 12000, ptds_mode, NULL)
+
+        global __cuCoredumpGetAttribute
+        cuGetProcAddress_v2('cuCoredumpGetAttribute', <void **>&__cuCoredumpGetAttribute, 12010, ptds_mode, NULL)
+
+        global __cuCoredumpGetAttributeGlobal
+        cuGetProcAddress_v2('cuCoredumpGetAttributeGlobal', <void **>&__cuCoredumpGetAttributeGlobal, 12010, ptds_mode, NULL)
+
+        global __cuCoredumpSetAttribute
+        cuGetProcAddress_v2('cuCoredumpSetAttribute', <void **>&__cuCoredumpSetAttribute, 12010, ptds_mode, NULL)
+
+        global __cuCoredumpSetAttributeGlobal
+        cuGetProcAddress_v2('cuCoredumpSetAttributeGlobal', <void **>&__cuCoredumpSetAttributeGlobal, 12010, ptds_mode, NULL)
+
+        global __cuGetExportTable
+        cuGetProcAddress_v2('cuGetExportTable', <void **>&__cuGetExportTable, 3000, ptds_mode, NULL)
+
+        global __cuGreenCtxCreate
+        cuGetProcAddress_v2('cuGreenCtxCreate', <void **>&__cuGreenCtxCreate, 12040, ptds_mode, NULL)
+
+        global __cuGreenCtxDestroy
+        cuGetProcAddress_v2('cuGreenCtxDestroy', <void **>&__cuGreenCtxDestroy, 12040, ptds_mode, NULL)
+
+        global __cuCtxFromGreenCtx
+        cuGetProcAddress_v2('cuCtxFromGreenCtx', <void **>&__cuCtxFromGreenCtx, 12040, ptds_mode, NULL)
+
+        global __cuDeviceGetDevResource
+        cuGetProcAddress_v2('cuDeviceGetDevResource', <void **>&__cuDeviceGetDevResource, 12040, ptds_mode, NULL)
+
+        global __cuCtxGetDevResource
+        cuGetProcAddress_v2('cuCtxGetDevResource', <void **>&__cuCtxGetDevResource, 12040, ptds_mode, NULL)
+
+        global __cuGreenCtxGetDevResource
+        cuGetProcAddress_v2('cuGreenCtxGetDevResource', <void **>&__cuGreenCtxGetDevResource, 12040, ptds_mode, NULL)
+
+        global __cuDevSmResourceSplitByCount
+        cuGetProcAddress_v2('cuDevSmResourceSplitByCount', <void **>&__cuDevSmResourceSplitByCount, 12040, ptds_mode, NULL)
+
+        global __cuDevResourceGenerateDesc
+        cuGetProcAddress_v2('cuDevResourceGenerateDesc', <void **>&__cuDevResourceGenerateDesc, 12040, ptds_mode, NULL)
+
+        global __cuGreenCtxRecordEvent
+        cuGetProcAddress_v2('cuGreenCtxRecordEvent', <void **>&__cuGreenCtxRecordEvent, 12040, ptds_mode, NULL)
+
+        global __cuGreenCtxWaitEvent
+        cuGetProcAddress_v2('cuGreenCtxWaitEvent', <void **>&__cuGreenCtxWaitEvent, 12040, ptds_mode, NULL)
+
+        global __cuStreamGetGreenCtx
+        cuGetProcAddress_v2('cuStreamGetGreenCtx', <void **>&__cuStreamGetGreenCtx, 12040, ptds_mode, NULL)
+
+        global __cuGreenCtxStreamCreate
+        cuGetProcAddress_v2('cuGreenCtxStreamCreate', <void **>&__cuGreenCtxStreamCreate, 12050, ptds_mode, NULL)
+
+        global __cuLogsRegisterCallback
+        cuGetProcAddress_v2('cuLogsRegisterCallback', <void **>&__cuLogsRegisterCallback, 12080, ptds_mode, NULL)
+
+        global __cuLogsUnregisterCallback
+        cuGetProcAddress_v2('cuLogsUnregisterCallback', <void **>&__cuLogsUnregisterCallback, 12080, ptds_mode, NULL)
+
+        global __cuLogsCurrent
+        cuGetProcAddress_v2('cuLogsCurrent', <void **>&__cuLogsCurrent, 12080, ptds_mode, NULL)
+
+        global __cuLogsDumpToFile
+        cuGetProcAddress_v2('cuLogsDumpToFile', <void **>&__cuLogsDumpToFile, 12080, ptds_mode, NULL)
+
+        global __cuLogsDumpToMemory
+        cuGetProcAddress_v2('cuLogsDumpToMemory', <void **>&__cuLogsDumpToMemory, 12080, ptds_mode, NULL)
+
+        global __cuCheckpointProcessGetRestoreThreadId
+        cuGetProcAddress_v2('cuCheckpointProcessGetRestoreThreadId', <void **>&__cuCheckpointProcessGetRestoreThreadId, 12080, ptds_mode, NULL)
+
+        global __cuCheckpointProcessGetState
+        cuGetProcAddress_v2('cuCheckpointProcessGetState', <void **>&__cuCheckpointProcessGetState, 12080, ptds_mode, NULL)
+
+        global __cuCheckpointProcessLock
+        cuGetProcAddress_v2('cuCheckpointProcessLock', <void **>&__cuCheckpointProcessLock, 12080, ptds_mode, NULL)
+
+        global __cuCheckpointProcessCheckpoint
+        cuGetProcAddress_v2('cuCheckpointProcessCheckpoint', <void **>&__cuCheckpointProcessCheckpoint, 12080, ptds_mode, NULL)
+
+        global __cuCheckpointProcessRestore
+        cuGetProcAddress_v2('cuCheckpointProcessRestore', <void **>&__cuCheckpointProcessRestore, 12080, ptds_mode, NULL)
+
+        global __cuCheckpointProcessUnlock
+        cuGetProcAddress_v2('cuCheckpointProcessUnlock', <void **>&__cuCheckpointProcessUnlock, 12080, ptds_mode, NULL)
+
+        global __cuGraphicsEGLRegisterImage
+        cuGetProcAddress_v2('cuGraphicsEGLRegisterImage', <void **>&__cuGraphicsEGLRegisterImage, 7000, ptds_mode, NULL)
+
+        global __cuEGLStreamConsumerConnect
+        cuGetProcAddress_v2('cuEGLStreamConsumerConnect', <void **>&__cuEGLStreamConsumerConnect, 7000, ptds_mode, NULL)
+
+        global __cuEGLStreamConsumerConnectWithFlags
+        cuGetProcAddress_v2('cuEGLStreamConsumerConnectWithFlags', <void **>&__cuEGLStreamConsumerConnectWithFlags, 8000, ptds_mode, NULL)
+
+        global __cuEGLStreamConsumerDisconnect
+        cuGetProcAddress_v2('cuEGLStreamConsumerDisconnect', <void **>&__cuEGLStreamConsumerDisconnect, 7000, ptds_mode, NULL)
+
+        global __cuEGLStreamConsumerAcquireFrame
+        cuGetProcAddress_v2('cuEGLStreamConsumerAcquireFrame', <void **>&__cuEGLStreamConsumerAcquireFrame, 7000, ptds_mode, NULL)
+
+        global __cuEGLStreamConsumerReleaseFrame
+        cuGetProcAddress_v2('cuEGLStreamConsumerReleaseFrame', <void **>&__cuEGLStreamConsumerReleaseFrame, 7000, ptds_mode, NULL)
+
+        global __cuEGLStreamProducerConnect
+        cuGetProcAddress_v2('cuEGLStreamProducerConnect', <void **>&__cuEGLStreamProducerConnect, 7000, ptds_mode, NULL)
+
+        global __cuEGLStreamProducerDisconnect
+        cuGetProcAddress_v2('cuEGLStreamProducerDisconnect', <void **>&__cuEGLStreamProducerDisconnect, 7000, ptds_mode, NULL)
+
+        global __cuEGLStreamProducerPresentFrame
+        cuGetProcAddress_v2('cuEGLStreamProducerPresentFrame', <void **>&__cuEGLStreamProducerPresentFrame, 7000, ptds_mode, NULL)
+
+        global __cuEGLStreamProducerReturnFrame
+        cuGetProcAddress_v2('cuEGLStreamProducerReturnFrame', <void **>&__cuEGLStreamProducerReturnFrame, 7000, ptds_mode, NULL)
+
+        global __cuGraphicsResourceGetMappedEglFrame
+        cuGetProcAddress_v2('cuGraphicsResourceGetMappedEglFrame', <void **>&__cuGraphicsResourceGetMappedEglFrame, 7000, ptds_mode, NULL)
+
+        global __cuEventCreateFromEGLSync
+        cuGetProcAddress_v2('cuEventCreateFromEGLSync', <void **>&__cuEventCreateFromEGLSync, 9000, ptds_mode, NULL)
+
+        global __cuGraphicsGLRegisterBuffer
+        cuGetProcAddress_v2('cuGraphicsGLRegisterBuffer', <void **>&__cuGraphicsGLRegisterBuffer, 3000, ptds_mode, NULL)
+
+        global __cuGraphicsGLRegisterImage
+        cuGetProcAddress_v2('cuGraphicsGLRegisterImage', <void **>&__cuGraphicsGLRegisterImage, 3000, ptds_mode, NULL)
+
+        global __cuGLGetDevices_v2
+        cuGetProcAddress_v2('cuGLGetDevices', <void **>&__cuGLGetDevices_v2, 6050, ptds_mode, NULL)
+
+        global __cuGLCtxCreate_v2
+        cuGetProcAddress_v2('cuGLCtxCreate', <void **>&__cuGLCtxCreate_v2, 3020, ptds_mode, NULL)
+
+        global __cuGLInit
+        cuGetProcAddress_v2('cuGLInit', <void **>&__cuGLInit, 2000, ptds_mode, NULL)
+
+        global __cuGLRegisterBufferObject
+        cuGetProcAddress_v2('cuGLRegisterBufferObject', <void **>&__cuGLRegisterBufferObject, 2000, ptds_mode, NULL)
+
+        global __cuGLMapBufferObject_v2
+        cuGetProcAddress_v2('cuGLMapBufferObject', <void **>&__cuGLMapBufferObject_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuGLUnmapBufferObject
+        cuGetProcAddress_v2('cuGLUnmapBufferObject', <void **>&__cuGLUnmapBufferObject, 2000, ptds_mode, NULL)
+
+        global __cuGLUnregisterBufferObject
+        cuGetProcAddress_v2('cuGLUnregisterBufferObject', <void **>&__cuGLUnregisterBufferObject, 2000, ptds_mode, NULL)
+
+        global __cuGLSetBufferObjectMapFlags
+        cuGetProcAddress_v2('cuGLSetBufferObjectMapFlags', <void **>&__cuGLSetBufferObjectMapFlags, 2030, ptds_mode, NULL)
+
+        global __cuGLMapBufferObjectAsync_v2
+        cuGetProcAddress_v2('cuGLMapBufferObjectAsync', <void **>&__cuGLMapBufferObjectAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+
+        global __cuGLUnmapBufferObjectAsync
+        cuGetProcAddress_v2('cuGLUnmapBufferObjectAsync', <void **>&__cuGLUnmapBufferObjectAsync, 2030, ptds_mode, NULL)
+
+        global __cuProfilerInitialize
+        cuGetProcAddress_v2('cuProfilerInitialize', <void **>&__cuProfilerInitialize, 4000, ptds_mode, NULL)
+
+        global __cuProfilerStart
+        cuGetProcAddress_v2('cuProfilerStart', <void **>&__cuProfilerStart, 4000, ptds_mode, NULL)
+
+        global __cuProfilerStop
+        cuGetProcAddress_v2('cuProfilerStop', <void **>&__cuProfilerStop, 4000, ptds_mode, NULL)
+
+        global __cuVDPAUGetDevice
+        cuGetProcAddress_v2('cuVDPAUGetDevice', <void **>&__cuVDPAUGetDevice, 3010, ptds_mode, NULL)
+
+        global __cuVDPAUCtxCreate_v2
+        cuGetProcAddress_v2('cuVDPAUCtxCreate', <void **>&__cuVDPAUCtxCreate_v2, 3020, ptds_mode, NULL)
+
+        global __cuGraphicsVDPAURegisterVideoSurface
+        cuGetProcAddress_v2('cuGraphicsVDPAURegisterVideoSurface', <void **>&__cuGraphicsVDPAURegisterVideoSurface, 3010, ptds_mode, NULL)
+
+        global __cuGraphicsVDPAURegisterOutputSurface
+        cuGetProcAddress_v2('cuGraphicsVDPAURegisterOutputSurface', <void **>&__cuGraphicsVDPAURegisterOutputSurface, 3010, ptds_mode, NULL)
+
+        global __cuDeviceGetHostAtomicCapabilities
+        cuGetProcAddress_v2('cuDeviceGetHostAtomicCapabilities', <void **>&__cuDeviceGetHostAtomicCapabilities, 13000, ptds_mode, NULL)
+
+        global __cuCtxGetDevice_v2
+        cuGetProcAddress_v2('cuCtxGetDevice', <void **>&__cuCtxGetDevice_v2, 13000, ptds_mode, NULL)
+
+        global __cuCtxSynchronize_v2
+        cuGetProcAddress_v2('cuCtxSynchronize', <void **>&__cuCtxSynchronize_v2, 13000, ptds_mode, NULL)
+
+        global __cuMemcpyBatchAsync_v2
+        cuGetProcAddress_v2('cuMemcpyBatchAsync', <void **>&__cuMemcpyBatchAsync_v2, 13000, ptds_mode, NULL)
+
+        global __cuMemcpy3DBatchAsync_v2
+        cuGetProcAddress_v2('cuMemcpy3DBatchAsync', <void **>&__cuMemcpy3DBatchAsync_v2, 13000, ptds_mode, NULL)
+
+        global __cuMemGetDefaultMemPool
+        cuGetProcAddress_v2('cuMemGetDefaultMemPool', <void **>&__cuMemGetDefaultMemPool, 13000, ptds_mode, NULL)
+
+        global __cuMemGetMemPool
+        cuGetProcAddress_v2('cuMemGetMemPool', <void **>&__cuMemGetMemPool, 13000, ptds_mode, NULL)
+
+        global __cuMemSetMemPool
+        cuGetProcAddress_v2('cuMemSetMemPool', <void **>&__cuMemSetMemPool, 13000, ptds_mode, NULL)
+
+        global __cuMemPrefetchBatchAsync
+        cuGetProcAddress_v2('cuMemPrefetchBatchAsync', <void **>&__cuMemPrefetchBatchAsync, 13000, ptds_mode, NULL)
+
+        global __cuMemDiscardBatchAsync
+        cuGetProcAddress_v2('cuMemDiscardBatchAsync', <void **>&__cuMemDiscardBatchAsync, 13000, ptds_mode, NULL)
+
+        global __cuMemDiscardAndPrefetchBatchAsync
+        cuGetProcAddress_v2('cuMemDiscardAndPrefetchBatchAsync', <void **>&__cuMemDiscardAndPrefetchBatchAsync, 13000, ptds_mode, NULL)
+
+        global __cuDeviceGetP2PAtomicCapabilities
+        cuGetProcAddress_v2('cuDeviceGetP2PAtomicCapabilities', <void **>&__cuDeviceGetP2PAtomicCapabilities, 13000, ptds_mode, NULL)
+
+        global __cuGreenCtxGetId
+        cuGetProcAddress_v2('cuGreenCtxGetId', <void **>&__cuGreenCtxGetId, 13000, ptds_mode, NULL)
+
+        global __cuMulticastBindMem_v2
+        cuGetProcAddress_v2('cuMulticastBindMem', <void **>&__cuMulticastBindMem_v2, 13010, ptds_mode, NULL)
+
+        global __cuMulticastBindAddr_v2
+        cuGetProcAddress_v2('cuMulticastBindAddr', <void **>&__cuMulticastBindAddr_v2, 13010, ptds_mode, NULL)
+
+        global __cuGraphNodeGetContainingGraph
+        cuGetProcAddress_v2('cuGraphNodeGetContainingGraph', <void **>&__cuGraphNodeGetContainingGraph, 13010, ptds_mode, NULL)
+
+        global __cuGraphNodeGetLocalId
+        cuGetProcAddress_v2('cuGraphNodeGetLocalId', <void **>&__cuGraphNodeGetLocalId, 13010, ptds_mode, NULL)
+
+        global __cuGraphNodeGetToolsId
+        cuGetProcAddress_v2('cuGraphNodeGetToolsId', <void **>&__cuGraphNodeGetToolsId, 13010, ptds_mode, NULL)
+
+        global __cuGraphGetId
+        cuGetProcAddress_v2('cuGraphGetId', <void **>&__cuGraphGetId, 13010, ptds_mode, NULL)
+
+        global __cuGraphExecGetId
+        cuGetProcAddress_v2('cuGraphExecGetId', <void **>&__cuGraphExecGetId, 13010, ptds_mode, NULL)
+
+        global __cuDevSmResourceSplit
+        cuGetProcAddress_v2('cuDevSmResourceSplit', <void **>&__cuDevSmResourceSplit, 13010, ptds_mode, NULL)
+
+        global __cuStreamGetDevResource
+        cuGetProcAddress_v2('cuStreamGetDevResource', <void **>&__cuStreamGetDevResource, 13010, ptds_mode, NULL)
+
+        global __cuKernelGetParamCount
+        cuGetProcAddress_v2('cuKernelGetParamCount', <void **>&__cuKernelGetParamCount, 13020, ptds_mode, NULL)
+
+        global __cuMemcpyWithAttributesAsync
+        cuGetProcAddress_v2('cuMemcpyWithAttributesAsync', <void **>&__cuMemcpyWithAttributesAsync, 13020, ptds_mode, NULL)
+
+        global __cuMemcpy3DWithAttributesAsync
+        cuGetProcAddress_v2('cuMemcpy3DWithAttributesAsync', <void **>&__cuMemcpy3DWithAttributesAsync, 13020, ptds_mode, NULL)
+
+        global __cuStreamBeginCaptureToCig
+        cuGetProcAddress_v2('cuStreamBeginCaptureToCig', <void **>&__cuStreamBeginCaptureToCig, 13020, ptds_mode, NULL)
+
+        global __cuStreamEndCaptureToCig
+        cuGetProcAddress_v2('cuStreamEndCaptureToCig', <void **>&__cuStreamEndCaptureToCig, 13020, ptds_mode, NULL)
+
+        global __cuFuncGetParamCount
+        cuGetProcAddress_v2('cuFuncGetParamCount', <void **>&__cuFuncGetParamCount, 13020, ptds_mode, NULL)
+
+        global __cuLaunchHostFunc_v2
+        cuGetProcAddress_v2('cuLaunchHostFunc', <void **>&__cuLaunchHostFunc_v2, 13020, ptds_mode, NULL)
+
+        global __cuGraphNodeGetParams
+        cuGetProcAddress_v2('cuGraphNodeGetParams', <void **>&__cuGraphNodeGetParams, 13020, ptds_mode, NULL)
+
+        global __cuCoredumpRegisterStartCallback
+        cuGetProcAddress_v2('cuCoredumpRegisterStartCallback', <void **>&__cuCoredumpRegisterStartCallback, 13020, ptds_mode, NULL)
+
+        global __cuCoredumpRegisterCompleteCallback
+        cuGetProcAddress_v2('cuCoredumpRegisterCompleteCallback', <void **>&__cuCoredumpRegisterCompleteCallback, 13020, ptds_mode, NULL)
+
+        global __cuCoredumpDeregisterStartCallback
+        cuGetProcAddress_v2('cuCoredumpDeregisterStartCallback', <void **>&__cuCoredumpDeregisterStartCallback, 13020, ptds_mode, NULL)
+
+        global __cuCoredumpDeregisterCompleteCallback
+        cuGetProcAddress_v2('cuCoredumpDeregisterCompleteCallback', <void **>&__cuCoredumpDeregisterCompleteCallback, 13020, ptds_mode, NULL)
+
+        global __cuLogicalEndpointIdReserve
+        cuGetProcAddress_v2('cuLogicalEndpointIdReserve', <void **>&__cuLogicalEndpointIdReserve, 13030, ptds_mode, NULL)
+
+        global __cuLogicalEndpointIdRelease
+        cuGetProcAddress_v2('cuLogicalEndpointIdRelease', <void **>&__cuLogicalEndpointIdRelease, 13030, ptds_mode, NULL)
+
+        global __cuLogicalEndpointCreate
+        cuGetProcAddress_v2('cuLogicalEndpointCreate', <void **>&__cuLogicalEndpointCreate, 13030, ptds_mode, NULL)
+
+        global __cuLogicalEndpointAddDevice
+        cuGetProcAddress_v2('cuLogicalEndpointAddDevice', <void **>&__cuLogicalEndpointAddDevice, 13030, ptds_mode, NULL)
+
+        global __cuLogicalEndpointDestroy
+        cuGetProcAddress_v2('cuLogicalEndpointDestroy', <void **>&__cuLogicalEndpointDestroy, 13030, ptds_mode, NULL)
+
+        global __cuLogicalEndpointBindAddr
+        cuGetProcAddress_v2('cuLogicalEndpointBindAddr', <void **>&__cuLogicalEndpointBindAddr, 13030, ptds_mode, NULL)
+
+        global __cuLogicalEndpointBindMem
+        cuGetProcAddress_v2('cuLogicalEndpointBindMem', <void **>&__cuLogicalEndpointBindMem, 13030, ptds_mode, NULL)
+
+        global __cuLogicalEndpointUnbind
+        cuGetProcAddress_v2('cuLogicalEndpointUnbind', <void **>&__cuLogicalEndpointUnbind, 13030, ptds_mode, NULL)
+
+        global __cuLogicalEndpointExport
+        cuGetProcAddress_v2('cuLogicalEndpointExport', <void **>&__cuLogicalEndpointExport, 13030, ptds_mode, NULL)
+
+        global __cuLogicalEndpointImport
+        cuGetProcAddress_v2('cuLogicalEndpointImport', <void **>&__cuLogicalEndpointImport, 13030, ptds_mode, NULL)
+
+        global __cuLogicalEndpointGetLimits
+        cuGetProcAddress_v2('cuLogicalEndpointGetLimits', <void **>&__cuLogicalEndpointGetLimits, 13030, ptds_mode, NULL)
+
+        global __cuLogicalEndpointQuery
+        cuGetProcAddress_v2('cuLogicalEndpointQuery', <void **>&__cuLogicalEndpointQuery, 13030, ptds_mode, NULL)
+
+        global __cuStreamBeginRecaptureToGraph
+        cuGetProcAddress_v2('cuStreamBeginRecaptureToGraph', <void **>&__cuStreamBeginRecaptureToGraph, 13030, ptds_mode, NULL)
+
+        _cyb___py_driver_init = True
+        return 0
+
+cdef inline int _check_or_init_driver() except -1 nogil:
+    if _cyb___py_driver_init:
+        return 0
+
+    return _init_driver()
+
+
+cpdef dict _inspect_function_pointers():
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is not None:
+        return _cyb_func_ptrs
+
+    _check_or_init_driver()
+    cdef dict data = {}
+    global __cuGetErrorString
+    data["__cuGetErrorString"] = <_cyb_intptr_t>__cuGetErrorString
+
+    global __cuGetErrorName
+    data["__cuGetErrorName"] = <_cyb_intptr_t>__cuGetErrorName
+
+    global __cuInit
+    data["__cuInit"] = <_cyb_intptr_t>__cuInit
+
+    global __cuDriverGetVersion
+    data["__cuDriverGetVersion"] = <_cyb_intptr_t>__cuDriverGetVersion
+
+    global __cuDeviceGet
+    data["__cuDeviceGet"] = <_cyb_intptr_t>__cuDeviceGet
+
+    global __cuDeviceGetCount
+    data["__cuDeviceGetCount"] = <_cyb_intptr_t>__cuDeviceGetCount
+
+    global __cuDeviceGetName
+    data["__cuDeviceGetName"] = <_cyb_intptr_t>__cuDeviceGetName
+
+    global __cuDeviceGetUuid_v2
+    data["__cuDeviceGetUuid_v2"] = <_cyb_intptr_t>__cuDeviceGetUuid_v2
+
+    global __cuDeviceGetLuid
+    data["__cuDeviceGetLuid"] = <_cyb_intptr_t>__cuDeviceGetLuid
+
+    global __cuDeviceTotalMem_v2
+    data["__cuDeviceTotalMem_v2"] = <_cyb_intptr_t>__cuDeviceTotalMem_v2
+
+    global __cuDeviceGetTexture1DLinearMaxWidth
+    data["__cuDeviceGetTexture1DLinearMaxWidth"] = <_cyb_intptr_t>__cuDeviceGetTexture1DLinearMaxWidth
+
+    global __cuDeviceGetAttribute
+    data["__cuDeviceGetAttribute"] = <_cyb_intptr_t>__cuDeviceGetAttribute
+
+    global __cuDeviceGetNvSciSyncAttributes
+    data["__cuDeviceGetNvSciSyncAttributes"] = <_cyb_intptr_t>__cuDeviceGetNvSciSyncAttributes
+
+    global __cuDeviceSetMemPool
+    data["__cuDeviceSetMemPool"] = <_cyb_intptr_t>__cuDeviceSetMemPool
+
+    global __cuDeviceGetMemPool
+    data["__cuDeviceGetMemPool"] = <_cyb_intptr_t>__cuDeviceGetMemPool
+
+    global __cuDeviceGetDefaultMemPool
+    data["__cuDeviceGetDefaultMemPool"] = <_cyb_intptr_t>__cuDeviceGetDefaultMemPool
+
+    global __cuDeviceGetExecAffinitySupport
+    data["__cuDeviceGetExecAffinitySupport"] = <_cyb_intptr_t>__cuDeviceGetExecAffinitySupport
+
+    global __cuFlushGPUDirectRDMAWrites
+    data["__cuFlushGPUDirectRDMAWrites"] = <_cyb_intptr_t>__cuFlushGPUDirectRDMAWrites
+
+    global __cuDeviceGetProperties
+    data["__cuDeviceGetProperties"] = <_cyb_intptr_t>__cuDeviceGetProperties
+
+    global __cuDeviceComputeCapability
+    data["__cuDeviceComputeCapability"] = <_cyb_intptr_t>__cuDeviceComputeCapability
+
+    global __cuDevicePrimaryCtxRetain
+    data["__cuDevicePrimaryCtxRetain"] = <_cyb_intptr_t>__cuDevicePrimaryCtxRetain
+
+    global __cuDevicePrimaryCtxRelease_v2
+    data["__cuDevicePrimaryCtxRelease_v2"] = <_cyb_intptr_t>__cuDevicePrimaryCtxRelease_v2
+
+    global __cuDevicePrimaryCtxSetFlags_v2
+    data["__cuDevicePrimaryCtxSetFlags_v2"] = <_cyb_intptr_t>__cuDevicePrimaryCtxSetFlags_v2
+
+    global __cuDevicePrimaryCtxGetState
+    data["__cuDevicePrimaryCtxGetState"] = <_cyb_intptr_t>__cuDevicePrimaryCtxGetState
+
+    global __cuDevicePrimaryCtxReset_v2
+    data["__cuDevicePrimaryCtxReset_v2"] = <_cyb_intptr_t>__cuDevicePrimaryCtxReset_v2
+
+    global __cuCtxCreate_v2
+    data["__cuCtxCreate_v2"] = <_cyb_intptr_t>__cuCtxCreate_v2
+
+    global __cuCtxCreate_v3
+    data["__cuCtxCreate_v3"] = <_cyb_intptr_t>__cuCtxCreate_v3
+
+    global __cuCtxCreate_v4
+    data["__cuCtxCreate_v4"] = <_cyb_intptr_t>__cuCtxCreate_v4
+
+    global __cuCtxDestroy_v2
+    data["__cuCtxDestroy_v2"] = <_cyb_intptr_t>__cuCtxDestroy_v2
+
+    global __cuCtxPushCurrent_v2
+    data["__cuCtxPushCurrent_v2"] = <_cyb_intptr_t>__cuCtxPushCurrent_v2
+
+    global __cuCtxPopCurrent_v2
+    data["__cuCtxPopCurrent_v2"] = <_cyb_intptr_t>__cuCtxPopCurrent_v2
+
+    global __cuCtxSetCurrent
+    data["__cuCtxSetCurrent"] = <_cyb_intptr_t>__cuCtxSetCurrent
+
+    global __cuCtxGetCurrent
+    data["__cuCtxGetCurrent"] = <_cyb_intptr_t>__cuCtxGetCurrent
+
+    global __cuCtxGetDevice
+    data["__cuCtxGetDevice"] = <_cyb_intptr_t>__cuCtxGetDevice
+
+    global __cuCtxGetFlags
+    data["__cuCtxGetFlags"] = <_cyb_intptr_t>__cuCtxGetFlags
+
+    global __cuCtxSetFlags
+    data["__cuCtxSetFlags"] = <_cyb_intptr_t>__cuCtxSetFlags
+
+    global __cuCtxGetId
+    data["__cuCtxGetId"] = <_cyb_intptr_t>__cuCtxGetId
+
+    global __cuCtxSynchronize
+    data["__cuCtxSynchronize"] = <_cyb_intptr_t>__cuCtxSynchronize
+
+    global __cuCtxSetLimit
+    data["__cuCtxSetLimit"] = <_cyb_intptr_t>__cuCtxSetLimit
+
+    global __cuCtxGetLimit
+    data["__cuCtxGetLimit"] = <_cyb_intptr_t>__cuCtxGetLimit
+
+    global __cuCtxGetCacheConfig
+    data["__cuCtxGetCacheConfig"] = <_cyb_intptr_t>__cuCtxGetCacheConfig
+
+    global __cuCtxSetCacheConfig
+    data["__cuCtxSetCacheConfig"] = <_cyb_intptr_t>__cuCtxSetCacheConfig
+
+    global __cuCtxGetApiVersion
+    data["__cuCtxGetApiVersion"] = <_cyb_intptr_t>__cuCtxGetApiVersion
+
+    global __cuCtxGetStreamPriorityRange
+    data["__cuCtxGetStreamPriorityRange"] = <_cyb_intptr_t>__cuCtxGetStreamPriorityRange
+
+    global __cuCtxResetPersistingL2Cache
+    data["__cuCtxResetPersistingL2Cache"] = <_cyb_intptr_t>__cuCtxResetPersistingL2Cache
+
+    global __cuCtxGetExecAffinity
+    data["__cuCtxGetExecAffinity"] = <_cyb_intptr_t>__cuCtxGetExecAffinity
+
+    global __cuCtxRecordEvent
+    data["__cuCtxRecordEvent"] = <_cyb_intptr_t>__cuCtxRecordEvent
+
+    global __cuCtxWaitEvent
+    data["__cuCtxWaitEvent"] = <_cyb_intptr_t>__cuCtxWaitEvent
+
+    global __cuCtxAttach
+    data["__cuCtxAttach"] = <_cyb_intptr_t>__cuCtxAttach
+
+    global __cuCtxDetach
+    data["__cuCtxDetach"] = <_cyb_intptr_t>__cuCtxDetach
+
+    global __cuCtxGetSharedMemConfig
+    data["__cuCtxGetSharedMemConfig"] = <_cyb_intptr_t>__cuCtxGetSharedMemConfig
+
+    global __cuCtxSetSharedMemConfig
+    data["__cuCtxSetSharedMemConfig"] = <_cyb_intptr_t>__cuCtxSetSharedMemConfig
+
+    global __cuModuleLoad
+    data["__cuModuleLoad"] = <_cyb_intptr_t>__cuModuleLoad
+
+    global __cuModuleLoadData
+    data["__cuModuleLoadData"] = <_cyb_intptr_t>__cuModuleLoadData
+
+    global __cuModuleLoadDataEx
+    data["__cuModuleLoadDataEx"] = <_cyb_intptr_t>__cuModuleLoadDataEx
+
+    global __cuModuleLoadFatBinary
+    data["__cuModuleLoadFatBinary"] = <_cyb_intptr_t>__cuModuleLoadFatBinary
+
+    global __cuModuleUnload
+    data["__cuModuleUnload"] = <_cyb_intptr_t>__cuModuleUnload
+
+    global __cuModuleGetLoadingMode
+    data["__cuModuleGetLoadingMode"] = <_cyb_intptr_t>__cuModuleGetLoadingMode
+
+    global __cuModuleGetFunction
+    data["__cuModuleGetFunction"] = <_cyb_intptr_t>__cuModuleGetFunction
+
+    global __cuModuleGetFunctionCount
+    data["__cuModuleGetFunctionCount"] = <_cyb_intptr_t>__cuModuleGetFunctionCount
+
+    global __cuModuleEnumerateFunctions
+    data["__cuModuleEnumerateFunctions"] = <_cyb_intptr_t>__cuModuleEnumerateFunctions
+
+    global __cuModuleGetGlobal_v2
+    data["__cuModuleGetGlobal_v2"] = <_cyb_intptr_t>__cuModuleGetGlobal_v2
+
+    global __cuLinkCreate_v2
+    data["__cuLinkCreate_v2"] = <_cyb_intptr_t>__cuLinkCreate_v2
+
+    global __cuLinkAddData_v2
+    data["__cuLinkAddData_v2"] = <_cyb_intptr_t>__cuLinkAddData_v2
+
+    global __cuLinkAddFile_v2
+    data["__cuLinkAddFile_v2"] = <_cyb_intptr_t>__cuLinkAddFile_v2
+
+    global __cuLinkComplete
+    data["__cuLinkComplete"] = <_cyb_intptr_t>__cuLinkComplete
+
+    global __cuLinkDestroy
+    data["__cuLinkDestroy"] = <_cyb_intptr_t>__cuLinkDestroy
+
+    global __cuModuleGetTexRef
+    data["__cuModuleGetTexRef"] = <_cyb_intptr_t>__cuModuleGetTexRef
+
+    global __cuModuleGetSurfRef
+    data["__cuModuleGetSurfRef"] = <_cyb_intptr_t>__cuModuleGetSurfRef
+
+    global __cuLibraryLoadData
+    data["__cuLibraryLoadData"] = <_cyb_intptr_t>__cuLibraryLoadData
+
+    global __cuLibraryLoadFromFile
+    data["__cuLibraryLoadFromFile"] = <_cyb_intptr_t>__cuLibraryLoadFromFile
+
+    global __cuLibraryUnload
+    data["__cuLibraryUnload"] = <_cyb_intptr_t>__cuLibraryUnload
+
+    global __cuLibraryGetKernel
+    data["__cuLibraryGetKernel"] = <_cyb_intptr_t>__cuLibraryGetKernel
+
+    global __cuLibraryGetKernelCount
+    data["__cuLibraryGetKernelCount"] = <_cyb_intptr_t>__cuLibraryGetKernelCount
+
+    global __cuLibraryEnumerateKernels
+    data["__cuLibraryEnumerateKernels"] = <_cyb_intptr_t>__cuLibraryEnumerateKernels
+
+    global __cuLibraryGetModule
+    data["__cuLibraryGetModule"] = <_cyb_intptr_t>__cuLibraryGetModule
+
+    global __cuKernelGetFunction
+    data["__cuKernelGetFunction"] = <_cyb_intptr_t>__cuKernelGetFunction
+
+    global __cuKernelGetLibrary
+    data["__cuKernelGetLibrary"] = <_cyb_intptr_t>__cuKernelGetLibrary
+
+    global __cuLibraryGetGlobal
+    data["__cuLibraryGetGlobal"] = <_cyb_intptr_t>__cuLibraryGetGlobal
+
+    global __cuLibraryGetManaged
+    data["__cuLibraryGetManaged"] = <_cyb_intptr_t>__cuLibraryGetManaged
+
+    global __cuLibraryGetUnifiedFunction
+    data["__cuLibraryGetUnifiedFunction"] = <_cyb_intptr_t>__cuLibraryGetUnifiedFunction
+
+    global __cuKernelGetAttribute
+    data["__cuKernelGetAttribute"] = <_cyb_intptr_t>__cuKernelGetAttribute
+
+    global __cuKernelSetAttribute
+    data["__cuKernelSetAttribute"] = <_cyb_intptr_t>__cuKernelSetAttribute
+
+    global __cuKernelSetCacheConfig
+    data["__cuKernelSetCacheConfig"] = <_cyb_intptr_t>__cuKernelSetCacheConfig
+
+    global __cuKernelGetName
+    data["__cuKernelGetName"] = <_cyb_intptr_t>__cuKernelGetName
+
+    global __cuKernelGetParamInfo
+    data["__cuKernelGetParamInfo"] = <_cyb_intptr_t>__cuKernelGetParamInfo
+
+    global __cuMemGetInfo_v2
+    data["__cuMemGetInfo_v2"] = <_cyb_intptr_t>__cuMemGetInfo_v2
+
+    global __cuMemAlloc_v2
+    data["__cuMemAlloc_v2"] = <_cyb_intptr_t>__cuMemAlloc_v2
+
+    global __cuMemAllocPitch_v2
+    data["__cuMemAllocPitch_v2"] = <_cyb_intptr_t>__cuMemAllocPitch_v2
+
+    global __cuMemFree_v2
+    data["__cuMemFree_v2"] = <_cyb_intptr_t>__cuMemFree_v2
+
+    global __cuMemGetAddressRange_v2
+    data["__cuMemGetAddressRange_v2"] = <_cyb_intptr_t>__cuMemGetAddressRange_v2
+
+    global __cuMemAllocHost_v2
+    data["__cuMemAllocHost_v2"] = <_cyb_intptr_t>__cuMemAllocHost_v2
+
+    global __cuMemFreeHost
+    data["__cuMemFreeHost"] = <_cyb_intptr_t>__cuMemFreeHost
+
+    global __cuMemHostAlloc
+    data["__cuMemHostAlloc"] = <_cyb_intptr_t>__cuMemHostAlloc
+
+    global __cuMemHostGetDevicePointer_v2
+    data["__cuMemHostGetDevicePointer_v2"] = <_cyb_intptr_t>__cuMemHostGetDevicePointer_v2
+
+    global __cuMemHostGetFlags
+    data["__cuMemHostGetFlags"] = <_cyb_intptr_t>__cuMemHostGetFlags
+
+    global __cuMemAllocManaged
+    data["__cuMemAllocManaged"] = <_cyb_intptr_t>__cuMemAllocManaged
+
+    global __cuDeviceRegisterAsyncNotification
+    data["__cuDeviceRegisterAsyncNotification"] = <_cyb_intptr_t>__cuDeviceRegisterAsyncNotification
+
+    global __cuDeviceUnregisterAsyncNotification
+    data["__cuDeviceUnregisterAsyncNotification"] = <_cyb_intptr_t>__cuDeviceUnregisterAsyncNotification
+
+    global __cuDeviceGetByPCIBusId
+    data["__cuDeviceGetByPCIBusId"] = <_cyb_intptr_t>__cuDeviceGetByPCIBusId
+
+    global __cuDeviceGetPCIBusId
+    data["__cuDeviceGetPCIBusId"] = <_cyb_intptr_t>__cuDeviceGetPCIBusId
+
+    global __cuIpcGetEventHandle
+    data["__cuIpcGetEventHandle"] = <_cyb_intptr_t>__cuIpcGetEventHandle
+
+    global __cuIpcOpenEventHandle
+    data["__cuIpcOpenEventHandle"] = <_cyb_intptr_t>__cuIpcOpenEventHandle
+
+    global __cuIpcGetMemHandle
+    data["__cuIpcGetMemHandle"] = <_cyb_intptr_t>__cuIpcGetMemHandle
+
+    global __cuIpcOpenMemHandle_v2
+    data["__cuIpcOpenMemHandle_v2"] = <_cyb_intptr_t>__cuIpcOpenMemHandle_v2
+
+    global __cuIpcCloseMemHandle
+    data["__cuIpcCloseMemHandle"] = <_cyb_intptr_t>__cuIpcCloseMemHandle
+
+    global __cuMemHostRegister_v2
+    data["__cuMemHostRegister_v2"] = <_cyb_intptr_t>__cuMemHostRegister_v2
+
+    global __cuMemHostUnregister
+    data["__cuMemHostUnregister"] = <_cyb_intptr_t>__cuMemHostUnregister
+
+    global __cuMemcpy
+    data["__cuMemcpy"] = <_cyb_intptr_t>__cuMemcpy
+
+    global __cuMemcpyPeer
+    data["__cuMemcpyPeer"] = <_cyb_intptr_t>__cuMemcpyPeer
+
+    global __cuMemcpyHtoD_v2
+    data["__cuMemcpyHtoD_v2"] = <_cyb_intptr_t>__cuMemcpyHtoD_v2
+
+    global __cuMemcpyDtoH_v2
+    data["__cuMemcpyDtoH_v2"] = <_cyb_intptr_t>__cuMemcpyDtoH_v2
+
+    global __cuMemcpyDtoD_v2
+    data["__cuMemcpyDtoD_v2"] = <_cyb_intptr_t>__cuMemcpyDtoD_v2
+
+    global __cuMemcpyDtoA_v2
+    data["__cuMemcpyDtoA_v2"] = <_cyb_intptr_t>__cuMemcpyDtoA_v2
+
+    global __cuMemcpyAtoD_v2
+    data["__cuMemcpyAtoD_v2"] = <_cyb_intptr_t>__cuMemcpyAtoD_v2
+
+    global __cuMemcpyHtoA_v2
+    data["__cuMemcpyHtoA_v2"] = <_cyb_intptr_t>__cuMemcpyHtoA_v2
+
+    global __cuMemcpyAtoH_v2
+    data["__cuMemcpyAtoH_v2"] = <_cyb_intptr_t>__cuMemcpyAtoH_v2
+
+    global __cuMemcpyAtoA_v2
+    data["__cuMemcpyAtoA_v2"] = <_cyb_intptr_t>__cuMemcpyAtoA_v2
+
+    global __cuMemcpy2D_v2
+    data["__cuMemcpy2D_v2"] = <_cyb_intptr_t>__cuMemcpy2D_v2
+
+    global __cuMemcpy2DUnaligned_v2
+    data["__cuMemcpy2DUnaligned_v2"] = <_cyb_intptr_t>__cuMemcpy2DUnaligned_v2
+
+    global __cuMemcpy3D_v2
+    data["__cuMemcpy3D_v2"] = <_cyb_intptr_t>__cuMemcpy3D_v2
+
+    global __cuMemcpy3DPeer
+    data["__cuMemcpy3DPeer"] = <_cyb_intptr_t>__cuMemcpy3DPeer
+
+    global __cuMemcpyAsync
+    data["__cuMemcpyAsync"] = <_cyb_intptr_t>__cuMemcpyAsync
+
+    global __cuMemcpyPeerAsync
+    data["__cuMemcpyPeerAsync"] = <_cyb_intptr_t>__cuMemcpyPeerAsync
+
+    global __cuMemcpyHtoDAsync_v2
+    data["__cuMemcpyHtoDAsync_v2"] = <_cyb_intptr_t>__cuMemcpyHtoDAsync_v2
+
+    global __cuMemcpyDtoHAsync_v2
+    data["__cuMemcpyDtoHAsync_v2"] = <_cyb_intptr_t>__cuMemcpyDtoHAsync_v2
+
+    global __cuMemcpyDtoDAsync_v2
+    data["__cuMemcpyDtoDAsync_v2"] = <_cyb_intptr_t>__cuMemcpyDtoDAsync_v2
+
+    global __cuMemcpyHtoAAsync_v2
+    data["__cuMemcpyHtoAAsync_v2"] = <_cyb_intptr_t>__cuMemcpyHtoAAsync_v2
+
+    global __cuMemcpyAtoHAsync_v2
+    data["__cuMemcpyAtoHAsync_v2"] = <_cyb_intptr_t>__cuMemcpyAtoHAsync_v2
+
+    global __cuMemcpy2DAsync_v2
+    data["__cuMemcpy2DAsync_v2"] = <_cyb_intptr_t>__cuMemcpy2DAsync_v2
+
+    global __cuMemcpy3DAsync_v2
+    data["__cuMemcpy3DAsync_v2"] = <_cyb_intptr_t>__cuMemcpy3DAsync_v2
+
+    global __cuMemcpy3DPeerAsync
+    data["__cuMemcpy3DPeerAsync"] = <_cyb_intptr_t>__cuMemcpy3DPeerAsync
+
+    global __cuMemsetD8_v2
+    data["__cuMemsetD8_v2"] = <_cyb_intptr_t>__cuMemsetD8_v2
+
+    global __cuMemsetD16_v2
+    data["__cuMemsetD16_v2"] = <_cyb_intptr_t>__cuMemsetD16_v2
+
+    global __cuMemsetD32_v2
+    data["__cuMemsetD32_v2"] = <_cyb_intptr_t>__cuMemsetD32_v2
+
+    global __cuMemsetD2D8_v2
+    data["__cuMemsetD2D8_v2"] = <_cyb_intptr_t>__cuMemsetD2D8_v2
+
+    global __cuMemsetD2D16_v2
+    data["__cuMemsetD2D16_v2"] = <_cyb_intptr_t>__cuMemsetD2D16_v2
+
+    global __cuMemsetD2D32_v2
+    data["__cuMemsetD2D32_v2"] = <_cyb_intptr_t>__cuMemsetD2D32_v2
+
+    global __cuMemsetD8Async
+    data["__cuMemsetD8Async"] = <_cyb_intptr_t>__cuMemsetD8Async
+
+    global __cuMemsetD16Async
+    data["__cuMemsetD16Async"] = <_cyb_intptr_t>__cuMemsetD16Async
+
+    global __cuMemsetD32Async
+    data["__cuMemsetD32Async"] = <_cyb_intptr_t>__cuMemsetD32Async
+
+    global __cuMemsetD2D8Async
+    data["__cuMemsetD2D8Async"] = <_cyb_intptr_t>__cuMemsetD2D8Async
+
+    global __cuMemsetD2D16Async
+    data["__cuMemsetD2D16Async"] = <_cyb_intptr_t>__cuMemsetD2D16Async
+
+    global __cuMemsetD2D32Async
+    data["__cuMemsetD2D32Async"] = <_cyb_intptr_t>__cuMemsetD2D32Async
+
+    global __cuArrayCreate_v2
+    data["__cuArrayCreate_v2"] = <_cyb_intptr_t>__cuArrayCreate_v2
+
+    global __cuArrayGetDescriptor_v2
+    data["__cuArrayGetDescriptor_v2"] = <_cyb_intptr_t>__cuArrayGetDescriptor_v2
+
+    global __cuArrayGetSparseProperties
+    data["__cuArrayGetSparseProperties"] = <_cyb_intptr_t>__cuArrayGetSparseProperties
+
+    global __cuMipmappedArrayGetSparseProperties
+    data["__cuMipmappedArrayGetSparseProperties"] = <_cyb_intptr_t>__cuMipmappedArrayGetSparseProperties
+
+    global __cuArrayGetMemoryRequirements
+    data["__cuArrayGetMemoryRequirements"] = <_cyb_intptr_t>__cuArrayGetMemoryRequirements
+
+    global __cuMipmappedArrayGetMemoryRequirements
+    data["__cuMipmappedArrayGetMemoryRequirements"] = <_cyb_intptr_t>__cuMipmappedArrayGetMemoryRequirements
+
+    global __cuArrayGetPlane
+    data["__cuArrayGetPlane"] = <_cyb_intptr_t>__cuArrayGetPlane
+
+    global __cuArrayDestroy
+    data["__cuArrayDestroy"] = <_cyb_intptr_t>__cuArrayDestroy
+
+    global __cuArray3DCreate_v2
+    data["__cuArray3DCreate_v2"] = <_cyb_intptr_t>__cuArray3DCreate_v2
+
+    global __cuArray3DGetDescriptor_v2
+    data["__cuArray3DGetDescriptor_v2"] = <_cyb_intptr_t>__cuArray3DGetDescriptor_v2
+
+    global __cuMipmappedArrayCreate
+    data["__cuMipmappedArrayCreate"] = <_cyb_intptr_t>__cuMipmappedArrayCreate
+
+    global __cuMipmappedArrayGetLevel
+    data["__cuMipmappedArrayGetLevel"] = <_cyb_intptr_t>__cuMipmappedArrayGetLevel
+
+    global __cuMipmappedArrayDestroy
+    data["__cuMipmappedArrayDestroy"] = <_cyb_intptr_t>__cuMipmappedArrayDestroy
+
+    global __cuMemGetHandleForAddressRange
+    data["__cuMemGetHandleForAddressRange"] = <_cyb_intptr_t>__cuMemGetHandleForAddressRange
+
+    global __cuMemBatchDecompressAsync
+    data["__cuMemBatchDecompressAsync"] = <_cyb_intptr_t>__cuMemBatchDecompressAsync
+
+    global __cuMemAddressReserve
+    data["__cuMemAddressReserve"] = <_cyb_intptr_t>__cuMemAddressReserve
+
+    global __cuMemAddressFree
+    data["__cuMemAddressFree"] = <_cyb_intptr_t>__cuMemAddressFree
+
+    global __cuMemCreate
+    data["__cuMemCreate"] = <_cyb_intptr_t>__cuMemCreate
+
+    global __cuMemRelease
+    data["__cuMemRelease"] = <_cyb_intptr_t>__cuMemRelease
+
+    global __cuMemMap
+    data["__cuMemMap"] = <_cyb_intptr_t>__cuMemMap
+
+    global __cuMemMapArrayAsync
+    data["__cuMemMapArrayAsync"] = <_cyb_intptr_t>__cuMemMapArrayAsync
+
+    global __cuMemUnmap
+    data["__cuMemUnmap"] = <_cyb_intptr_t>__cuMemUnmap
+
+    global __cuMemSetAccess
+    data["__cuMemSetAccess"] = <_cyb_intptr_t>__cuMemSetAccess
+
+    global __cuMemGetAccess
+    data["__cuMemGetAccess"] = <_cyb_intptr_t>__cuMemGetAccess
+
+    global __cuMemExportToShareableHandle
+    data["__cuMemExportToShareableHandle"] = <_cyb_intptr_t>__cuMemExportToShareableHandle
+
+    global __cuMemImportFromShareableHandle
+    data["__cuMemImportFromShareableHandle"] = <_cyb_intptr_t>__cuMemImportFromShareableHandle
+
+    global __cuMemGetAllocationGranularity
+    data["__cuMemGetAllocationGranularity"] = <_cyb_intptr_t>__cuMemGetAllocationGranularity
+
+    global __cuMemGetAllocationPropertiesFromHandle
+    data["__cuMemGetAllocationPropertiesFromHandle"] = <_cyb_intptr_t>__cuMemGetAllocationPropertiesFromHandle
+
+    global __cuMemRetainAllocationHandle
+    data["__cuMemRetainAllocationHandle"] = <_cyb_intptr_t>__cuMemRetainAllocationHandle
+
+    global __cuMemFreeAsync
+    data["__cuMemFreeAsync"] = <_cyb_intptr_t>__cuMemFreeAsync
+
+    global __cuMemAllocAsync
+    data["__cuMemAllocAsync"] = <_cyb_intptr_t>__cuMemAllocAsync
+
+    global __cuMemPoolTrimTo
+    data["__cuMemPoolTrimTo"] = <_cyb_intptr_t>__cuMemPoolTrimTo
+
+    global __cuMemPoolSetAttribute
+    data["__cuMemPoolSetAttribute"] = <_cyb_intptr_t>__cuMemPoolSetAttribute
+
+    global __cuMemPoolGetAttribute
+    data["__cuMemPoolGetAttribute"] = <_cyb_intptr_t>__cuMemPoolGetAttribute
+
+    global __cuMemPoolSetAccess
+    data["__cuMemPoolSetAccess"] = <_cyb_intptr_t>__cuMemPoolSetAccess
+
+    global __cuMemPoolGetAccess
+    data["__cuMemPoolGetAccess"] = <_cyb_intptr_t>__cuMemPoolGetAccess
+
+    global __cuMemPoolCreate
+    data["__cuMemPoolCreate"] = <_cyb_intptr_t>__cuMemPoolCreate
+
+    global __cuMemPoolDestroy
+    data["__cuMemPoolDestroy"] = <_cyb_intptr_t>__cuMemPoolDestroy
+
+    global __cuMemAllocFromPoolAsync
+    data["__cuMemAllocFromPoolAsync"] = <_cyb_intptr_t>__cuMemAllocFromPoolAsync
+
+    global __cuMemPoolExportToShareableHandle
+    data["__cuMemPoolExportToShareableHandle"] = <_cyb_intptr_t>__cuMemPoolExportToShareableHandle
+
+    global __cuMemPoolImportFromShareableHandle
+    data["__cuMemPoolImportFromShareableHandle"] = <_cyb_intptr_t>__cuMemPoolImportFromShareableHandle
+
+    global __cuMemPoolExportPointer
+    data["__cuMemPoolExportPointer"] = <_cyb_intptr_t>__cuMemPoolExportPointer
+
+    global __cuMemPoolImportPointer
+    data["__cuMemPoolImportPointer"] = <_cyb_intptr_t>__cuMemPoolImportPointer
+
+    global __cuMulticastCreate
+    data["__cuMulticastCreate"] = <_cyb_intptr_t>__cuMulticastCreate
+
+    global __cuMulticastAddDevice
+    data["__cuMulticastAddDevice"] = <_cyb_intptr_t>__cuMulticastAddDevice
+
+    global __cuMulticastBindMem
+    data["__cuMulticastBindMem"] = <_cyb_intptr_t>__cuMulticastBindMem
+
+    global __cuMulticastBindAddr
+    data["__cuMulticastBindAddr"] = <_cyb_intptr_t>__cuMulticastBindAddr
+
+    global __cuMulticastUnbind
+    data["__cuMulticastUnbind"] = <_cyb_intptr_t>__cuMulticastUnbind
+
+    global __cuMulticastGetGranularity
+    data["__cuMulticastGetGranularity"] = <_cyb_intptr_t>__cuMulticastGetGranularity
+
+    global __cuPointerGetAttribute
+    data["__cuPointerGetAttribute"] = <_cyb_intptr_t>__cuPointerGetAttribute
+
+    global __cuMemPrefetchAsync_v2
+    data["__cuMemPrefetchAsync_v2"] = <_cyb_intptr_t>__cuMemPrefetchAsync_v2
+
+    global __cuMemAdvise_v2
+    data["__cuMemAdvise_v2"] = <_cyb_intptr_t>__cuMemAdvise_v2
+
+    global __cuMemRangeGetAttribute
+    data["__cuMemRangeGetAttribute"] = <_cyb_intptr_t>__cuMemRangeGetAttribute
+
+    global __cuMemRangeGetAttributes
+    data["__cuMemRangeGetAttributes"] = <_cyb_intptr_t>__cuMemRangeGetAttributes
+
+    global __cuPointerSetAttribute
+    data["__cuPointerSetAttribute"] = <_cyb_intptr_t>__cuPointerSetAttribute
+
+    global __cuPointerGetAttributes
+    data["__cuPointerGetAttributes"] = <_cyb_intptr_t>__cuPointerGetAttributes
+
+    global __cuStreamCreate
+    data["__cuStreamCreate"] = <_cyb_intptr_t>__cuStreamCreate
+
+    global __cuStreamCreateWithPriority
+    data["__cuStreamCreateWithPriority"] = <_cyb_intptr_t>__cuStreamCreateWithPriority
+
+    global __cuStreamGetPriority
+    data["__cuStreamGetPriority"] = <_cyb_intptr_t>__cuStreamGetPriority
+
+    global __cuStreamGetDevice
+    data["__cuStreamGetDevice"] = <_cyb_intptr_t>__cuStreamGetDevice
+
+    global __cuStreamGetFlags
+    data["__cuStreamGetFlags"] = <_cyb_intptr_t>__cuStreamGetFlags
+
+    global __cuStreamGetId
+    data["__cuStreamGetId"] = <_cyb_intptr_t>__cuStreamGetId
+
+    global __cuStreamGetCtx
+    data["__cuStreamGetCtx"] = <_cyb_intptr_t>__cuStreamGetCtx
+
+    global __cuStreamGetCtx_v2
+    data["__cuStreamGetCtx_v2"] = <_cyb_intptr_t>__cuStreamGetCtx_v2
+
+    global __cuStreamWaitEvent
+    data["__cuStreamWaitEvent"] = <_cyb_intptr_t>__cuStreamWaitEvent
+
+    global __cuStreamAddCallback
+    data["__cuStreamAddCallback"] = <_cyb_intptr_t>__cuStreamAddCallback
+
+    global __cuStreamBeginCapture_v2
+    data["__cuStreamBeginCapture_v2"] = <_cyb_intptr_t>__cuStreamBeginCapture_v2
+
+    global __cuStreamBeginCaptureToGraph
+    data["__cuStreamBeginCaptureToGraph"] = <_cyb_intptr_t>__cuStreamBeginCaptureToGraph
+
+    global __cuThreadExchangeStreamCaptureMode
+    data["__cuThreadExchangeStreamCaptureMode"] = <_cyb_intptr_t>__cuThreadExchangeStreamCaptureMode
+
+    global __cuStreamEndCapture
+    data["__cuStreamEndCapture"] = <_cyb_intptr_t>__cuStreamEndCapture
+
+    global __cuStreamIsCapturing
+    data["__cuStreamIsCapturing"] = <_cyb_intptr_t>__cuStreamIsCapturing
+
+    global __cuStreamGetCaptureInfo_v2
+    data["__cuStreamGetCaptureInfo_v2"] = <_cyb_intptr_t>__cuStreamGetCaptureInfo_v2
+
+    global __cuStreamGetCaptureInfo_v3
+    data["__cuStreamGetCaptureInfo_v3"] = <_cyb_intptr_t>__cuStreamGetCaptureInfo_v3
+
+    global __cuStreamUpdateCaptureDependencies_v2
+    data["__cuStreamUpdateCaptureDependencies_v2"] = <_cyb_intptr_t>__cuStreamUpdateCaptureDependencies_v2
+
+    global __cuStreamAttachMemAsync
+    data["__cuStreamAttachMemAsync"] = <_cyb_intptr_t>__cuStreamAttachMemAsync
+
+    global __cuStreamQuery
+    data["__cuStreamQuery"] = <_cyb_intptr_t>__cuStreamQuery
+
+    global __cuStreamSynchronize
+    data["__cuStreamSynchronize"] = <_cyb_intptr_t>__cuStreamSynchronize
+
+    global __cuStreamDestroy_v2
+    data["__cuStreamDestroy_v2"] = <_cyb_intptr_t>__cuStreamDestroy_v2
+
+    global __cuStreamCopyAttributes
+    data["__cuStreamCopyAttributes"] = <_cyb_intptr_t>__cuStreamCopyAttributes
+
+    global __cuStreamGetAttribute
+    data["__cuStreamGetAttribute"] = <_cyb_intptr_t>__cuStreamGetAttribute
+
+    global __cuStreamSetAttribute
+    data["__cuStreamSetAttribute"] = <_cyb_intptr_t>__cuStreamSetAttribute
+
+    global __cuEventCreate
+    data["__cuEventCreate"] = <_cyb_intptr_t>__cuEventCreate
+
+    global __cuEventRecord
+    data["__cuEventRecord"] = <_cyb_intptr_t>__cuEventRecord
+
+    global __cuEventRecordWithFlags
+    data["__cuEventRecordWithFlags"] = <_cyb_intptr_t>__cuEventRecordWithFlags
+
+    global __cuEventQuery
+    data["__cuEventQuery"] = <_cyb_intptr_t>__cuEventQuery
+
+    global __cuEventSynchronize
+    data["__cuEventSynchronize"] = <_cyb_intptr_t>__cuEventSynchronize
+
+    global __cuEventDestroy_v2
+    data["__cuEventDestroy_v2"] = <_cyb_intptr_t>__cuEventDestroy_v2
+
+    global __cuEventElapsedTime_v2
+    data["__cuEventElapsedTime_v2"] = <_cyb_intptr_t>__cuEventElapsedTime_v2
+
+    global __cuImportExternalMemory
+    data["__cuImportExternalMemory"] = <_cyb_intptr_t>__cuImportExternalMemory
+
+    global __cuExternalMemoryGetMappedBuffer
+    data["__cuExternalMemoryGetMappedBuffer"] = <_cyb_intptr_t>__cuExternalMemoryGetMappedBuffer
+
+    global __cuExternalMemoryGetMappedMipmappedArray
+    data["__cuExternalMemoryGetMappedMipmappedArray"] = <_cyb_intptr_t>__cuExternalMemoryGetMappedMipmappedArray
+
+    global __cuDestroyExternalMemory
+    data["__cuDestroyExternalMemory"] = <_cyb_intptr_t>__cuDestroyExternalMemory
+
+    global __cuImportExternalSemaphore
+    data["__cuImportExternalSemaphore"] = <_cyb_intptr_t>__cuImportExternalSemaphore
+
+    global __cuSignalExternalSemaphoresAsync
+    data["__cuSignalExternalSemaphoresAsync"] = <_cyb_intptr_t>__cuSignalExternalSemaphoresAsync
+
+    global __cuWaitExternalSemaphoresAsync
+    data["__cuWaitExternalSemaphoresAsync"] = <_cyb_intptr_t>__cuWaitExternalSemaphoresAsync
+
+    global __cuDestroyExternalSemaphore
+    data["__cuDestroyExternalSemaphore"] = <_cyb_intptr_t>__cuDestroyExternalSemaphore
+
+    global __cuStreamWaitValue32_v2
+    data["__cuStreamWaitValue32_v2"] = <_cyb_intptr_t>__cuStreamWaitValue32_v2
+
+    global __cuStreamWaitValue64_v2
+    data["__cuStreamWaitValue64_v2"] = <_cyb_intptr_t>__cuStreamWaitValue64_v2
+
+    global __cuStreamWriteValue32_v2
+    data["__cuStreamWriteValue32_v2"] = <_cyb_intptr_t>__cuStreamWriteValue32_v2
+
+    global __cuStreamWriteValue64_v2
+    data["__cuStreamWriteValue64_v2"] = <_cyb_intptr_t>__cuStreamWriteValue64_v2
+
+    global __cuStreamBatchMemOp_v2
+    data["__cuStreamBatchMemOp_v2"] = <_cyb_intptr_t>__cuStreamBatchMemOp_v2
+
+    global __cuFuncGetAttribute
+    data["__cuFuncGetAttribute"] = <_cyb_intptr_t>__cuFuncGetAttribute
+
+    global __cuFuncSetAttribute
+    data["__cuFuncSetAttribute"] = <_cyb_intptr_t>__cuFuncSetAttribute
+
+    global __cuFuncSetCacheConfig
+    data["__cuFuncSetCacheConfig"] = <_cyb_intptr_t>__cuFuncSetCacheConfig
+
+    global __cuFuncGetModule
+    data["__cuFuncGetModule"] = <_cyb_intptr_t>__cuFuncGetModule
+
+    global __cuFuncGetName
+    data["__cuFuncGetName"] = <_cyb_intptr_t>__cuFuncGetName
+
+    global __cuFuncGetParamInfo
+    data["__cuFuncGetParamInfo"] = <_cyb_intptr_t>__cuFuncGetParamInfo
+
+    global __cuFuncIsLoaded
+    data["__cuFuncIsLoaded"] = <_cyb_intptr_t>__cuFuncIsLoaded
+
+    global __cuFuncLoad
+    data["__cuFuncLoad"] = <_cyb_intptr_t>__cuFuncLoad
+
+    global __cuLaunchKernel
+    data["__cuLaunchKernel"] = <_cyb_intptr_t>__cuLaunchKernel
+
+    global __cuLaunchKernelEx
+    data["__cuLaunchKernelEx"] = <_cyb_intptr_t>__cuLaunchKernelEx
+
+    global __cuLaunchCooperativeKernel
+    data["__cuLaunchCooperativeKernel"] = <_cyb_intptr_t>__cuLaunchCooperativeKernel
+
+    global __cuLaunchCooperativeKernelMultiDevice
+    data["__cuLaunchCooperativeKernelMultiDevice"] = <_cyb_intptr_t>__cuLaunchCooperativeKernelMultiDevice
+
+    global __cuLaunchHostFunc
+    data["__cuLaunchHostFunc"] = <_cyb_intptr_t>__cuLaunchHostFunc
+
+    global __cuFuncSetBlockShape
+    data["__cuFuncSetBlockShape"] = <_cyb_intptr_t>__cuFuncSetBlockShape
+
+    global __cuFuncSetSharedSize
+    data["__cuFuncSetSharedSize"] = <_cyb_intptr_t>__cuFuncSetSharedSize
+
+    global __cuParamSetSize
+    data["__cuParamSetSize"] = <_cyb_intptr_t>__cuParamSetSize
+
+    global __cuParamSeti
+    data["__cuParamSeti"] = <_cyb_intptr_t>__cuParamSeti
+
+    global __cuParamSetf
+    data["__cuParamSetf"] = <_cyb_intptr_t>__cuParamSetf
+
+    global __cuParamSetv
+    data["__cuParamSetv"] = <_cyb_intptr_t>__cuParamSetv
+
+    global __cuLaunch
+    data["__cuLaunch"] = <_cyb_intptr_t>__cuLaunch
+
+    global __cuLaunchGrid
+    data["__cuLaunchGrid"] = <_cyb_intptr_t>__cuLaunchGrid
+
+    global __cuLaunchGridAsync
+    data["__cuLaunchGridAsync"] = <_cyb_intptr_t>__cuLaunchGridAsync
+
+    global __cuParamSetTexRef
+    data["__cuParamSetTexRef"] = <_cyb_intptr_t>__cuParamSetTexRef
+
+    global __cuFuncSetSharedMemConfig
+    data["__cuFuncSetSharedMemConfig"] = <_cyb_intptr_t>__cuFuncSetSharedMemConfig
+
+    global __cuGraphCreate
+    data["__cuGraphCreate"] = <_cyb_intptr_t>__cuGraphCreate
+
+    global __cuGraphAddKernelNode_v2
+    data["__cuGraphAddKernelNode_v2"] = <_cyb_intptr_t>__cuGraphAddKernelNode_v2
+
+    global __cuGraphKernelNodeGetParams_v2
+    data["__cuGraphKernelNodeGetParams_v2"] = <_cyb_intptr_t>__cuGraphKernelNodeGetParams_v2
+
+    global __cuGraphKernelNodeSetParams_v2
+    data["__cuGraphKernelNodeSetParams_v2"] = <_cyb_intptr_t>__cuGraphKernelNodeSetParams_v2
+
+    global __cuGraphAddMemcpyNode
+    data["__cuGraphAddMemcpyNode"] = <_cyb_intptr_t>__cuGraphAddMemcpyNode
+
+    global __cuGraphMemcpyNodeGetParams
+    data["__cuGraphMemcpyNodeGetParams"] = <_cyb_intptr_t>__cuGraphMemcpyNodeGetParams
+
+    global __cuGraphMemcpyNodeSetParams
+    data["__cuGraphMemcpyNodeSetParams"] = <_cyb_intptr_t>__cuGraphMemcpyNodeSetParams
+
+    global __cuGraphAddMemsetNode
+    data["__cuGraphAddMemsetNode"] = <_cyb_intptr_t>__cuGraphAddMemsetNode
+
+    global __cuGraphMemsetNodeGetParams
+    data["__cuGraphMemsetNodeGetParams"] = <_cyb_intptr_t>__cuGraphMemsetNodeGetParams
+
+    global __cuGraphMemsetNodeSetParams
+    data["__cuGraphMemsetNodeSetParams"] = <_cyb_intptr_t>__cuGraphMemsetNodeSetParams
+
+    global __cuGraphAddHostNode
+    data["__cuGraphAddHostNode"] = <_cyb_intptr_t>__cuGraphAddHostNode
+
+    global __cuGraphHostNodeGetParams
+    data["__cuGraphHostNodeGetParams"] = <_cyb_intptr_t>__cuGraphHostNodeGetParams
+
+    global __cuGraphHostNodeSetParams
+    data["__cuGraphHostNodeSetParams"] = <_cyb_intptr_t>__cuGraphHostNodeSetParams
+
+    global __cuGraphAddChildGraphNode
+    data["__cuGraphAddChildGraphNode"] = <_cyb_intptr_t>__cuGraphAddChildGraphNode
+
+    global __cuGraphChildGraphNodeGetGraph
+    data["__cuGraphChildGraphNodeGetGraph"] = <_cyb_intptr_t>__cuGraphChildGraphNodeGetGraph
+
+    global __cuGraphAddEmptyNode
+    data["__cuGraphAddEmptyNode"] = <_cyb_intptr_t>__cuGraphAddEmptyNode
+
+    global __cuGraphAddEventRecordNode
+    data["__cuGraphAddEventRecordNode"] = <_cyb_intptr_t>__cuGraphAddEventRecordNode
+
+    global __cuGraphEventRecordNodeGetEvent
+    data["__cuGraphEventRecordNodeGetEvent"] = <_cyb_intptr_t>__cuGraphEventRecordNodeGetEvent
+
+    global __cuGraphEventRecordNodeSetEvent
+    data["__cuGraphEventRecordNodeSetEvent"] = <_cyb_intptr_t>__cuGraphEventRecordNodeSetEvent
+
+    global __cuGraphAddEventWaitNode
+    data["__cuGraphAddEventWaitNode"] = <_cyb_intptr_t>__cuGraphAddEventWaitNode
+
+    global __cuGraphEventWaitNodeGetEvent
+    data["__cuGraphEventWaitNodeGetEvent"] = <_cyb_intptr_t>__cuGraphEventWaitNodeGetEvent
+
+    global __cuGraphEventWaitNodeSetEvent
+    data["__cuGraphEventWaitNodeSetEvent"] = <_cyb_intptr_t>__cuGraphEventWaitNodeSetEvent
+
+    global __cuGraphAddExternalSemaphoresSignalNode
+    data["__cuGraphAddExternalSemaphoresSignalNode"] = <_cyb_intptr_t>__cuGraphAddExternalSemaphoresSignalNode
+
+    global __cuGraphExternalSemaphoresSignalNodeGetParams
+    data["__cuGraphExternalSemaphoresSignalNodeGetParams"] = <_cyb_intptr_t>__cuGraphExternalSemaphoresSignalNodeGetParams
+
+    global __cuGraphExternalSemaphoresSignalNodeSetParams
+    data["__cuGraphExternalSemaphoresSignalNodeSetParams"] = <_cyb_intptr_t>__cuGraphExternalSemaphoresSignalNodeSetParams
+
+    global __cuGraphAddExternalSemaphoresWaitNode
+    data["__cuGraphAddExternalSemaphoresWaitNode"] = <_cyb_intptr_t>__cuGraphAddExternalSemaphoresWaitNode
+
+    global __cuGraphExternalSemaphoresWaitNodeGetParams
+    data["__cuGraphExternalSemaphoresWaitNodeGetParams"] = <_cyb_intptr_t>__cuGraphExternalSemaphoresWaitNodeGetParams
+
+    global __cuGraphExternalSemaphoresWaitNodeSetParams
+    data["__cuGraphExternalSemaphoresWaitNodeSetParams"] = <_cyb_intptr_t>__cuGraphExternalSemaphoresWaitNodeSetParams
+
+    global __cuGraphAddBatchMemOpNode
+    data["__cuGraphAddBatchMemOpNode"] = <_cyb_intptr_t>__cuGraphAddBatchMemOpNode
+
+    global __cuGraphBatchMemOpNodeGetParams
+    data["__cuGraphBatchMemOpNodeGetParams"] = <_cyb_intptr_t>__cuGraphBatchMemOpNodeGetParams
+
+    global __cuGraphBatchMemOpNodeSetParams
+    data["__cuGraphBatchMemOpNodeSetParams"] = <_cyb_intptr_t>__cuGraphBatchMemOpNodeSetParams
+
+    global __cuGraphExecBatchMemOpNodeSetParams
+    data["__cuGraphExecBatchMemOpNodeSetParams"] = <_cyb_intptr_t>__cuGraphExecBatchMemOpNodeSetParams
+
+    global __cuGraphAddMemAllocNode
+    data["__cuGraphAddMemAllocNode"] = <_cyb_intptr_t>__cuGraphAddMemAllocNode
+
+    global __cuGraphMemAllocNodeGetParams
+    data["__cuGraphMemAllocNodeGetParams"] = <_cyb_intptr_t>__cuGraphMemAllocNodeGetParams
+
+    global __cuGraphAddMemFreeNode
+    data["__cuGraphAddMemFreeNode"] = <_cyb_intptr_t>__cuGraphAddMemFreeNode
+
+    global __cuGraphMemFreeNodeGetParams
+    data["__cuGraphMemFreeNodeGetParams"] = <_cyb_intptr_t>__cuGraphMemFreeNodeGetParams
+
+    global __cuDeviceGraphMemTrim
+    data["__cuDeviceGraphMemTrim"] = <_cyb_intptr_t>__cuDeviceGraphMemTrim
+
+    global __cuDeviceGetGraphMemAttribute
+    data["__cuDeviceGetGraphMemAttribute"] = <_cyb_intptr_t>__cuDeviceGetGraphMemAttribute
+
+    global __cuDeviceSetGraphMemAttribute
+    data["__cuDeviceSetGraphMemAttribute"] = <_cyb_intptr_t>__cuDeviceSetGraphMemAttribute
+
+    global __cuGraphClone
+    data["__cuGraphClone"] = <_cyb_intptr_t>__cuGraphClone
+
+    global __cuGraphNodeFindInClone
+    data["__cuGraphNodeFindInClone"] = <_cyb_intptr_t>__cuGraphNodeFindInClone
+
+    global __cuGraphNodeGetType
+    data["__cuGraphNodeGetType"] = <_cyb_intptr_t>__cuGraphNodeGetType
+
+    global __cuGraphGetNodes
+    data["__cuGraphGetNodes"] = <_cyb_intptr_t>__cuGraphGetNodes
+
+    global __cuGraphGetRootNodes
+    data["__cuGraphGetRootNodes"] = <_cyb_intptr_t>__cuGraphGetRootNodes
+
+    global __cuGraphGetEdges_v2
+    data["__cuGraphGetEdges_v2"] = <_cyb_intptr_t>__cuGraphGetEdges_v2
+
+    global __cuGraphNodeGetDependencies_v2
+    data["__cuGraphNodeGetDependencies_v2"] = <_cyb_intptr_t>__cuGraphNodeGetDependencies_v2
+
+    global __cuGraphNodeGetDependentNodes_v2
+    data["__cuGraphNodeGetDependentNodes_v2"] = <_cyb_intptr_t>__cuGraphNodeGetDependentNodes_v2
+
+    global __cuGraphAddDependencies_v2
+    data["__cuGraphAddDependencies_v2"] = <_cyb_intptr_t>__cuGraphAddDependencies_v2
+
+    global __cuGraphRemoveDependencies_v2
+    data["__cuGraphRemoveDependencies_v2"] = <_cyb_intptr_t>__cuGraphRemoveDependencies_v2
+
+    global __cuGraphDestroyNode
+    data["__cuGraphDestroyNode"] = <_cyb_intptr_t>__cuGraphDestroyNode
+
+    global __cuGraphInstantiateWithFlags
+    data["__cuGraphInstantiateWithFlags"] = <_cyb_intptr_t>__cuGraphInstantiateWithFlags
+
+    global __cuGraphInstantiateWithParams
+    data["__cuGraphInstantiateWithParams"] = <_cyb_intptr_t>__cuGraphInstantiateWithParams
+
+    global __cuGraphExecGetFlags
+    data["__cuGraphExecGetFlags"] = <_cyb_intptr_t>__cuGraphExecGetFlags
+
+    global __cuGraphExecKernelNodeSetParams_v2
+    data["__cuGraphExecKernelNodeSetParams_v2"] = <_cyb_intptr_t>__cuGraphExecKernelNodeSetParams_v2
+
+    global __cuGraphExecMemcpyNodeSetParams
+    data["__cuGraphExecMemcpyNodeSetParams"] = <_cyb_intptr_t>__cuGraphExecMemcpyNodeSetParams
+
+    global __cuGraphExecMemsetNodeSetParams
+    data["__cuGraphExecMemsetNodeSetParams"] = <_cyb_intptr_t>__cuGraphExecMemsetNodeSetParams
+
+    global __cuGraphExecHostNodeSetParams
+    data["__cuGraphExecHostNodeSetParams"] = <_cyb_intptr_t>__cuGraphExecHostNodeSetParams
+
+    global __cuGraphExecChildGraphNodeSetParams
+    data["__cuGraphExecChildGraphNodeSetParams"] = <_cyb_intptr_t>__cuGraphExecChildGraphNodeSetParams
+
+    global __cuGraphExecEventRecordNodeSetEvent
+    data["__cuGraphExecEventRecordNodeSetEvent"] = <_cyb_intptr_t>__cuGraphExecEventRecordNodeSetEvent
+
+    global __cuGraphExecEventWaitNodeSetEvent
+    data["__cuGraphExecEventWaitNodeSetEvent"] = <_cyb_intptr_t>__cuGraphExecEventWaitNodeSetEvent
+
+    global __cuGraphExecExternalSemaphoresSignalNodeSetParams
+    data["__cuGraphExecExternalSemaphoresSignalNodeSetParams"] = <_cyb_intptr_t>__cuGraphExecExternalSemaphoresSignalNodeSetParams
+
+    global __cuGraphExecExternalSemaphoresWaitNodeSetParams
+    data["__cuGraphExecExternalSemaphoresWaitNodeSetParams"] = <_cyb_intptr_t>__cuGraphExecExternalSemaphoresWaitNodeSetParams
+
+    global __cuGraphNodeSetEnabled
+    data["__cuGraphNodeSetEnabled"] = <_cyb_intptr_t>__cuGraphNodeSetEnabled
+
+    global __cuGraphNodeGetEnabled
+    data["__cuGraphNodeGetEnabled"] = <_cyb_intptr_t>__cuGraphNodeGetEnabled
+
+    global __cuGraphUpload
+    data["__cuGraphUpload"] = <_cyb_intptr_t>__cuGraphUpload
+
+    global __cuGraphLaunch
+    data["__cuGraphLaunch"] = <_cyb_intptr_t>__cuGraphLaunch
+
+    global __cuGraphExecDestroy
+    data["__cuGraphExecDestroy"] = <_cyb_intptr_t>__cuGraphExecDestroy
+
+    global __cuGraphDestroy
+    data["__cuGraphDestroy"] = <_cyb_intptr_t>__cuGraphDestroy
+
+    global __cuGraphExecUpdate_v2
+    data["__cuGraphExecUpdate_v2"] = <_cyb_intptr_t>__cuGraphExecUpdate_v2
+
+    global __cuGraphKernelNodeCopyAttributes
+    data["__cuGraphKernelNodeCopyAttributes"] = <_cyb_intptr_t>__cuGraphKernelNodeCopyAttributes
+
+    global __cuGraphKernelNodeGetAttribute
+    data["__cuGraphKernelNodeGetAttribute"] = <_cyb_intptr_t>__cuGraphKernelNodeGetAttribute
+
+    global __cuGraphKernelNodeSetAttribute
+    data["__cuGraphKernelNodeSetAttribute"] = <_cyb_intptr_t>__cuGraphKernelNodeSetAttribute
+
+    global __cuGraphDebugDotPrint
+    data["__cuGraphDebugDotPrint"] = <_cyb_intptr_t>__cuGraphDebugDotPrint
+
+    global __cuUserObjectCreate
+    data["__cuUserObjectCreate"] = <_cyb_intptr_t>__cuUserObjectCreate
+
+    global __cuUserObjectRetain
+    data["__cuUserObjectRetain"] = <_cyb_intptr_t>__cuUserObjectRetain
+
+    global __cuUserObjectRelease
+    data["__cuUserObjectRelease"] = <_cyb_intptr_t>__cuUserObjectRelease
+
+    global __cuGraphRetainUserObject
+    data["__cuGraphRetainUserObject"] = <_cyb_intptr_t>__cuGraphRetainUserObject
+
+    global __cuGraphReleaseUserObject
+    data["__cuGraphReleaseUserObject"] = <_cyb_intptr_t>__cuGraphReleaseUserObject
+
+    global __cuGraphAddNode_v2
+    data["__cuGraphAddNode_v2"] = <_cyb_intptr_t>__cuGraphAddNode_v2
+
+    global __cuGraphNodeSetParams
+    data["__cuGraphNodeSetParams"] = <_cyb_intptr_t>__cuGraphNodeSetParams
+
+    global __cuGraphExecNodeSetParams
+    data["__cuGraphExecNodeSetParams"] = <_cyb_intptr_t>__cuGraphExecNodeSetParams
+
+    global __cuGraphConditionalHandleCreate
+    data["__cuGraphConditionalHandleCreate"] = <_cyb_intptr_t>__cuGraphConditionalHandleCreate
+
+    global __cuOccupancyMaxActiveBlocksPerMultiprocessor
+    data["__cuOccupancyMaxActiveBlocksPerMultiprocessor"] = <_cyb_intptr_t>__cuOccupancyMaxActiveBlocksPerMultiprocessor
+
+    global __cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags
+    data["__cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags"] = <_cyb_intptr_t>__cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags
+
+    global __cuOccupancyMaxPotentialBlockSize
+    data["__cuOccupancyMaxPotentialBlockSize"] = <_cyb_intptr_t>__cuOccupancyMaxPotentialBlockSize
+
+    global __cuOccupancyMaxPotentialBlockSizeWithFlags
+    data["__cuOccupancyMaxPotentialBlockSizeWithFlags"] = <_cyb_intptr_t>__cuOccupancyMaxPotentialBlockSizeWithFlags
+
+    global __cuOccupancyAvailableDynamicSMemPerBlock
+    data["__cuOccupancyAvailableDynamicSMemPerBlock"] = <_cyb_intptr_t>__cuOccupancyAvailableDynamicSMemPerBlock
+
+    global __cuOccupancyMaxPotentialClusterSize
+    data["__cuOccupancyMaxPotentialClusterSize"] = <_cyb_intptr_t>__cuOccupancyMaxPotentialClusterSize
+
+    global __cuOccupancyMaxActiveClusters
+    data["__cuOccupancyMaxActiveClusters"] = <_cyb_intptr_t>__cuOccupancyMaxActiveClusters
+
+    global __cuTexRefSetArray
+    data["__cuTexRefSetArray"] = <_cyb_intptr_t>__cuTexRefSetArray
+
+    global __cuTexRefSetMipmappedArray
+    data["__cuTexRefSetMipmappedArray"] = <_cyb_intptr_t>__cuTexRefSetMipmappedArray
+
+    global __cuTexRefSetAddress_v2
+    data["__cuTexRefSetAddress_v2"] = <_cyb_intptr_t>__cuTexRefSetAddress_v2
+
+    global __cuTexRefSetAddress2D_v3
+    data["__cuTexRefSetAddress2D_v3"] = <_cyb_intptr_t>__cuTexRefSetAddress2D_v3
+
+    global __cuTexRefSetFormat
+    data["__cuTexRefSetFormat"] = <_cyb_intptr_t>__cuTexRefSetFormat
+
+    global __cuTexRefSetAddressMode
+    data["__cuTexRefSetAddressMode"] = <_cyb_intptr_t>__cuTexRefSetAddressMode
+
+    global __cuTexRefSetFilterMode
+    data["__cuTexRefSetFilterMode"] = <_cyb_intptr_t>__cuTexRefSetFilterMode
+
+    global __cuTexRefSetMipmapFilterMode
+    data["__cuTexRefSetMipmapFilterMode"] = <_cyb_intptr_t>__cuTexRefSetMipmapFilterMode
+
+    global __cuTexRefSetMipmapLevelBias
+    data["__cuTexRefSetMipmapLevelBias"] = <_cyb_intptr_t>__cuTexRefSetMipmapLevelBias
+
+    global __cuTexRefSetMipmapLevelClamp
+    data["__cuTexRefSetMipmapLevelClamp"] = <_cyb_intptr_t>__cuTexRefSetMipmapLevelClamp
+
+    global __cuTexRefSetMaxAnisotropy
+    data["__cuTexRefSetMaxAnisotropy"] = <_cyb_intptr_t>__cuTexRefSetMaxAnisotropy
+
+    global __cuTexRefSetBorderColor
+    data["__cuTexRefSetBorderColor"] = <_cyb_intptr_t>__cuTexRefSetBorderColor
+
+    global __cuTexRefSetFlags
+    data["__cuTexRefSetFlags"] = <_cyb_intptr_t>__cuTexRefSetFlags
+
+    global __cuTexRefGetAddress_v2
+    data["__cuTexRefGetAddress_v2"] = <_cyb_intptr_t>__cuTexRefGetAddress_v2
+
+    global __cuTexRefGetArray
+    data["__cuTexRefGetArray"] = <_cyb_intptr_t>__cuTexRefGetArray
+
+    global __cuTexRefGetMipmappedArray
+    data["__cuTexRefGetMipmappedArray"] = <_cyb_intptr_t>__cuTexRefGetMipmappedArray
+
+    global __cuTexRefGetAddressMode
+    data["__cuTexRefGetAddressMode"] = <_cyb_intptr_t>__cuTexRefGetAddressMode
+
+    global __cuTexRefGetFilterMode
+    data["__cuTexRefGetFilterMode"] = <_cyb_intptr_t>__cuTexRefGetFilterMode
+
+    global __cuTexRefGetFormat
+    data["__cuTexRefGetFormat"] = <_cyb_intptr_t>__cuTexRefGetFormat
+
+    global __cuTexRefGetMipmapFilterMode
+    data["__cuTexRefGetMipmapFilterMode"] = <_cyb_intptr_t>__cuTexRefGetMipmapFilterMode
+
+    global __cuTexRefGetMipmapLevelBias
+    data["__cuTexRefGetMipmapLevelBias"] = <_cyb_intptr_t>__cuTexRefGetMipmapLevelBias
+
+    global __cuTexRefGetMipmapLevelClamp
+    data["__cuTexRefGetMipmapLevelClamp"] = <_cyb_intptr_t>__cuTexRefGetMipmapLevelClamp
+
+    global __cuTexRefGetMaxAnisotropy
+    data["__cuTexRefGetMaxAnisotropy"] = <_cyb_intptr_t>__cuTexRefGetMaxAnisotropy
+
+    global __cuTexRefGetBorderColor
+    data["__cuTexRefGetBorderColor"] = <_cyb_intptr_t>__cuTexRefGetBorderColor
+
+    global __cuTexRefGetFlags
+    data["__cuTexRefGetFlags"] = <_cyb_intptr_t>__cuTexRefGetFlags
+
+    global __cuTexRefCreate
+    data["__cuTexRefCreate"] = <_cyb_intptr_t>__cuTexRefCreate
+
+    global __cuTexRefDestroy
+    data["__cuTexRefDestroy"] = <_cyb_intptr_t>__cuTexRefDestroy
+
+    global __cuSurfRefSetArray
+    data["__cuSurfRefSetArray"] = <_cyb_intptr_t>__cuSurfRefSetArray
+
+    global __cuSurfRefGetArray
+    data["__cuSurfRefGetArray"] = <_cyb_intptr_t>__cuSurfRefGetArray
+
+    global __cuTexObjectCreate
+    data["__cuTexObjectCreate"] = <_cyb_intptr_t>__cuTexObjectCreate
+
+    global __cuTexObjectDestroy
+    data["__cuTexObjectDestroy"] = <_cyb_intptr_t>__cuTexObjectDestroy
+
+    global __cuTexObjectGetResourceDesc
+    data["__cuTexObjectGetResourceDesc"] = <_cyb_intptr_t>__cuTexObjectGetResourceDesc
+
+    global __cuTexObjectGetTextureDesc
+    data["__cuTexObjectGetTextureDesc"] = <_cyb_intptr_t>__cuTexObjectGetTextureDesc
+
+    global __cuTexObjectGetResourceViewDesc
+    data["__cuTexObjectGetResourceViewDesc"] = <_cyb_intptr_t>__cuTexObjectGetResourceViewDesc
+
+    global __cuSurfObjectCreate
+    data["__cuSurfObjectCreate"] = <_cyb_intptr_t>__cuSurfObjectCreate
+
+    global __cuSurfObjectDestroy
+    data["__cuSurfObjectDestroy"] = <_cyb_intptr_t>__cuSurfObjectDestroy
+
+    global __cuSurfObjectGetResourceDesc
+    data["__cuSurfObjectGetResourceDesc"] = <_cyb_intptr_t>__cuSurfObjectGetResourceDesc
+
+    global __cuTensorMapEncodeTiled
+    data["__cuTensorMapEncodeTiled"] = <_cyb_intptr_t>__cuTensorMapEncodeTiled
+
+    global __cuTensorMapEncodeIm2col
+    data["__cuTensorMapEncodeIm2col"] = <_cyb_intptr_t>__cuTensorMapEncodeIm2col
+
+    global __cuTensorMapEncodeIm2colWide
+    data["__cuTensorMapEncodeIm2colWide"] = <_cyb_intptr_t>__cuTensorMapEncodeIm2colWide
+
+    global __cuTensorMapReplaceAddress
+    data["__cuTensorMapReplaceAddress"] = <_cyb_intptr_t>__cuTensorMapReplaceAddress
+
+    global __cuDeviceCanAccessPeer
+    data["__cuDeviceCanAccessPeer"] = <_cyb_intptr_t>__cuDeviceCanAccessPeer
+
+    global __cuCtxEnablePeerAccess
+    data["__cuCtxEnablePeerAccess"] = <_cyb_intptr_t>__cuCtxEnablePeerAccess
+
+    global __cuCtxDisablePeerAccess
+    data["__cuCtxDisablePeerAccess"] = <_cyb_intptr_t>__cuCtxDisablePeerAccess
+
+    global __cuDeviceGetP2PAttribute
+    data["__cuDeviceGetP2PAttribute"] = <_cyb_intptr_t>__cuDeviceGetP2PAttribute
+
+    global __cuGraphicsUnregisterResource
+    data["__cuGraphicsUnregisterResource"] = <_cyb_intptr_t>__cuGraphicsUnregisterResource
+
+    global __cuGraphicsSubResourceGetMappedArray
+    data["__cuGraphicsSubResourceGetMappedArray"] = <_cyb_intptr_t>__cuGraphicsSubResourceGetMappedArray
+
+    global __cuGraphicsResourceGetMappedMipmappedArray
+    data["__cuGraphicsResourceGetMappedMipmappedArray"] = <_cyb_intptr_t>__cuGraphicsResourceGetMappedMipmappedArray
+
+    global __cuGraphicsResourceGetMappedPointer_v2
+    data["__cuGraphicsResourceGetMappedPointer_v2"] = <_cyb_intptr_t>__cuGraphicsResourceGetMappedPointer_v2
+
+    global __cuGraphicsResourceSetMapFlags_v2
+    data["__cuGraphicsResourceSetMapFlags_v2"] = <_cyb_intptr_t>__cuGraphicsResourceSetMapFlags_v2
+
+    global __cuGraphicsMapResources
+    data["__cuGraphicsMapResources"] = <_cyb_intptr_t>__cuGraphicsMapResources
+
+    global __cuGraphicsUnmapResources
+    data["__cuGraphicsUnmapResources"] = <_cyb_intptr_t>__cuGraphicsUnmapResources
+
+    global __cuGetProcAddress_v2
+    data["__cuGetProcAddress_v2"] = <_cyb_intptr_t>__cuGetProcAddress_v2
+
+    global __cuCoredumpGetAttribute
+    data["__cuCoredumpGetAttribute"] = <_cyb_intptr_t>__cuCoredumpGetAttribute
+
+    global __cuCoredumpGetAttributeGlobal
+    data["__cuCoredumpGetAttributeGlobal"] = <_cyb_intptr_t>__cuCoredumpGetAttributeGlobal
+
+    global __cuCoredumpSetAttribute
+    data["__cuCoredumpSetAttribute"] = <_cyb_intptr_t>__cuCoredumpSetAttribute
+
+    global __cuCoredumpSetAttributeGlobal
+    data["__cuCoredumpSetAttributeGlobal"] = <_cyb_intptr_t>__cuCoredumpSetAttributeGlobal
+
+    global __cuGetExportTable
+    data["__cuGetExportTable"] = <_cyb_intptr_t>__cuGetExportTable
+
+    global __cuGreenCtxCreate
+    data["__cuGreenCtxCreate"] = <_cyb_intptr_t>__cuGreenCtxCreate
+
+    global __cuGreenCtxDestroy
+    data["__cuGreenCtxDestroy"] = <_cyb_intptr_t>__cuGreenCtxDestroy
+
+    global __cuCtxFromGreenCtx
+    data["__cuCtxFromGreenCtx"] = <_cyb_intptr_t>__cuCtxFromGreenCtx
+
+    global __cuDeviceGetDevResource
+    data["__cuDeviceGetDevResource"] = <_cyb_intptr_t>__cuDeviceGetDevResource
+
+    global __cuCtxGetDevResource
+    data["__cuCtxGetDevResource"] = <_cyb_intptr_t>__cuCtxGetDevResource
+
+    global __cuGreenCtxGetDevResource
+    data["__cuGreenCtxGetDevResource"] = <_cyb_intptr_t>__cuGreenCtxGetDevResource
+
+    global __cuDevSmResourceSplitByCount
+    data["__cuDevSmResourceSplitByCount"] = <_cyb_intptr_t>__cuDevSmResourceSplitByCount
+
+    global __cuDevResourceGenerateDesc
+    data["__cuDevResourceGenerateDesc"] = <_cyb_intptr_t>__cuDevResourceGenerateDesc
+
+    global __cuGreenCtxRecordEvent
+    data["__cuGreenCtxRecordEvent"] = <_cyb_intptr_t>__cuGreenCtxRecordEvent
+
+    global __cuGreenCtxWaitEvent
+    data["__cuGreenCtxWaitEvent"] = <_cyb_intptr_t>__cuGreenCtxWaitEvent
+
+    global __cuStreamGetGreenCtx
+    data["__cuStreamGetGreenCtx"] = <_cyb_intptr_t>__cuStreamGetGreenCtx
+
+    global __cuGreenCtxStreamCreate
+    data["__cuGreenCtxStreamCreate"] = <_cyb_intptr_t>__cuGreenCtxStreamCreate
+
+    global __cuLogsRegisterCallback
+    data["__cuLogsRegisterCallback"] = <_cyb_intptr_t>__cuLogsRegisterCallback
+
+    global __cuLogsUnregisterCallback
+    data["__cuLogsUnregisterCallback"] = <_cyb_intptr_t>__cuLogsUnregisterCallback
+
+    global __cuLogsCurrent
+    data["__cuLogsCurrent"] = <_cyb_intptr_t>__cuLogsCurrent
+
+    global __cuLogsDumpToFile
+    data["__cuLogsDumpToFile"] = <_cyb_intptr_t>__cuLogsDumpToFile
+
+    global __cuLogsDumpToMemory
+    data["__cuLogsDumpToMemory"] = <_cyb_intptr_t>__cuLogsDumpToMemory
+
+    global __cuCheckpointProcessGetRestoreThreadId
+    data["__cuCheckpointProcessGetRestoreThreadId"] = <_cyb_intptr_t>__cuCheckpointProcessGetRestoreThreadId
+
+    global __cuCheckpointProcessGetState
+    data["__cuCheckpointProcessGetState"] = <_cyb_intptr_t>__cuCheckpointProcessGetState
+
+    global __cuCheckpointProcessLock
+    data["__cuCheckpointProcessLock"] = <_cyb_intptr_t>__cuCheckpointProcessLock
+
+    global __cuCheckpointProcessCheckpoint
+    data["__cuCheckpointProcessCheckpoint"] = <_cyb_intptr_t>__cuCheckpointProcessCheckpoint
+
+    global __cuCheckpointProcessRestore
+    data["__cuCheckpointProcessRestore"] = <_cyb_intptr_t>__cuCheckpointProcessRestore
+
+    global __cuCheckpointProcessUnlock
+    data["__cuCheckpointProcessUnlock"] = <_cyb_intptr_t>__cuCheckpointProcessUnlock
+
+    global __cuGraphicsEGLRegisterImage
+    data["__cuGraphicsEGLRegisterImage"] = <_cyb_intptr_t>__cuGraphicsEGLRegisterImage
+
+    global __cuEGLStreamConsumerConnect
+    data["__cuEGLStreamConsumerConnect"] = <_cyb_intptr_t>__cuEGLStreamConsumerConnect
+
+    global __cuEGLStreamConsumerConnectWithFlags
+    data["__cuEGLStreamConsumerConnectWithFlags"] = <_cyb_intptr_t>__cuEGLStreamConsumerConnectWithFlags
+
+    global __cuEGLStreamConsumerDisconnect
+    data["__cuEGLStreamConsumerDisconnect"] = <_cyb_intptr_t>__cuEGLStreamConsumerDisconnect
+
+    global __cuEGLStreamConsumerAcquireFrame
+    data["__cuEGLStreamConsumerAcquireFrame"] = <_cyb_intptr_t>__cuEGLStreamConsumerAcquireFrame
+
+    global __cuEGLStreamConsumerReleaseFrame
+    data["__cuEGLStreamConsumerReleaseFrame"] = <_cyb_intptr_t>__cuEGLStreamConsumerReleaseFrame
+
+    global __cuEGLStreamProducerConnect
+    data["__cuEGLStreamProducerConnect"] = <_cyb_intptr_t>__cuEGLStreamProducerConnect
+
+    global __cuEGLStreamProducerDisconnect
+    data["__cuEGLStreamProducerDisconnect"] = <_cyb_intptr_t>__cuEGLStreamProducerDisconnect
+
+    global __cuEGLStreamProducerPresentFrame
+    data["__cuEGLStreamProducerPresentFrame"] = <_cyb_intptr_t>__cuEGLStreamProducerPresentFrame
+
+    global __cuEGLStreamProducerReturnFrame
+    data["__cuEGLStreamProducerReturnFrame"] = <_cyb_intptr_t>__cuEGLStreamProducerReturnFrame
+
+    global __cuGraphicsResourceGetMappedEglFrame
+    data["__cuGraphicsResourceGetMappedEglFrame"] = <_cyb_intptr_t>__cuGraphicsResourceGetMappedEglFrame
+
+    global __cuEventCreateFromEGLSync
+    data["__cuEventCreateFromEGLSync"] = <_cyb_intptr_t>__cuEventCreateFromEGLSync
+
+    global __cuGraphicsGLRegisterBuffer
+    data["__cuGraphicsGLRegisterBuffer"] = <_cyb_intptr_t>__cuGraphicsGLRegisterBuffer
+
+    global __cuGraphicsGLRegisterImage
+    data["__cuGraphicsGLRegisterImage"] = <_cyb_intptr_t>__cuGraphicsGLRegisterImage
+
+    global __cuGLGetDevices_v2
+    data["__cuGLGetDevices_v2"] = <_cyb_intptr_t>__cuGLGetDevices_v2
+
+    global __cuGLCtxCreate_v2
+    data["__cuGLCtxCreate_v2"] = <_cyb_intptr_t>__cuGLCtxCreate_v2
+
+    global __cuGLInit
+    data["__cuGLInit"] = <_cyb_intptr_t>__cuGLInit
+
+    global __cuGLRegisterBufferObject
+    data["__cuGLRegisterBufferObject"] = <_cyb_intptr_t>__cuGLRegisterBufferObject
+
+    global __cuGLMapBufferObject_v2
+    data["__cuGLMapBufferObject_v2"] = <_cyb_intptr_t>__cuGLMapBufferObject_v2
+
+    global __cuGLUnmapBufferObject
+    data["__cuGLUnmapBufferObject"] = <_cyb_intptr_t>__cuGLUnmapBufferObject
+
+    global __cuGLUnregisterBufferObject
+    data["__cuGLUnregisterBufferObject"] = <_cyb_intptr_t>__cuGLUnregisterBufferObject
+
+    global __cuGLSetBufferObjectMapFlags
+    data["__cuGLSetBufferObjectMapFlags"] = <_cyb_intptr_t>__cuGLSetBufferObjectMapFlags
+
+    global __cuGLMapBufferObjectAsync_v2
+    data["__cuGLMapBufferObjectAsync_v2"] = <_cyb_intptr_t>__cuGLMapBufferObjectAsync_v2
+
+    global __cuGLUnmapBufferObjectAsync
+    data["__cuGLUnmapBufferObjectAsync"] = <_cyb_intptr_t>__cuGLUnmapBufferObjectAsync
+
+    global __cuProfilerInitialize
+    data["__cuProfilerInitialize"] = <_cyb_intptr_t>__cuProfilerInitialize
+
+    global __cuProfilerStart
+    data["__cuProfilerStart"] = <_cyb_intptr_t>__cuProfilerStart
+
+    global __cuProfilerStop
+    data["__cuProfilerStop"] = <_cyb_intptr_t>__cuProfilerStop
+
+    global __cuVDPAUGetDevice
+    data["__cuVDPAUGetDevice"] = <_cyb_intptr_t>__cuVDPAUGetDevice
+
+    global __cuVDPAUCtxCreate_v2
+    data["__cuVDPAUCtxCreate_v2"] = <_cyb_intptr_t>__cuVDPAUCtxCreate_v2
+
+    global __cuGraphicsVDPAURegisterVideoSurface
+    data["__cuGraphicsVDPAURegisterVideoSurface"] = <_cyb_intptr_t>__cuGraphicsVDPAURegisterVideoSurface
+
+    global __cuGraphicsVDPAURegisterOutputSurface
+    data["__cuGraphicsVDPAURegisterOutputSurface"] = <_cyb_intptr_t>__cuGraphicsVDPAURegisterOutputSurface
+
+    global __cuDeviceGetHostAtomicCapabilities
+    data["__cuDeviceGetHostAtomicCapabilities"] = <_cyb_intptr_t>__cuDeviceGetHostAtomicCapabilities
+
+    global __cuCtxGetDevice_v2
+    data["__cuCtxGetDevice_v2"] = <_cyb_intptr_t>__cuCtxGetDevice_v2
+
+    global __cuCtxSynchronize_v2
+    data["__cuCtxSynchronize_v2"] = <_cyb_intptr_t>__cuCtxSynchronize_v2
+
+    global __cuMemcpyBatchAsync_v2
+    data["__cuMemcpyBatchAsync_v2"] = <_cyb_intptr_t>__cuMemcpyBatchAsync_v2
+
+    global __cuMemcpy3DBatchAsync_v2
+    data["__cuMemcpy3DBatchAsync_v2"] = <_cyb_intptr_t>__cuMemcpy3DBatchAsync_v2
+
+    global __cuMemGetDefaultMemPool
+    data["__cuMemGetDefaultMemPool"] = <_cyb_intptr_t>__cuMemGetDefaultMemPool
+
+    global __cuMemGetMemPool
+    data["__cuMemGetMemPool"] = <_cyb_intptr_t>__cuMemGetMemPool
+
+    global __cuMemSetMemPool
+    data["__cuMemSetMemPool"] = <_cyb_intptr_t>__cuMemSetMemPool
+
+    global __cuMemPrefetchBatchAsync
+    data["__cuMemPrefetchBatchAsync"] = <_cyb_intptr_t>__cuMemPrefetchBatchAsync
+
+    global __cuMemDiscardBatchAsync
+    data["__cuMemDiscardBatchAsync"] = <_cyb_intptr_t>__cuMemDiscardBatchAsync
+
+    global __cuMemDiscardAndPrefetchBatchAsync
+    data["__cuMemDiscardAndPrefetchBatchAsync"] = <_cyb_intptr_t>__cuMemDiscardAndPrefetchBatchAsync
+
+    global __cuDeviceGetP2PAtomicCapabilities
+    data["__cuDeviceGetP2PAtomicCapabilities"] = <_cyb_intptr_t>__cuDeviceGetP2PAtomicCapabilities
+
+    global __cuGreenCtxGetId
+    data["__cuGreenCtxGetId"] = <_cyb_intptr_t>__cuGreenCtxGetId
+
+    global __cuMulticastBindMem_v2
+    data["__cuMulticastBindMem_v2"] = <_cyb_intptr_t>__cuMulticastBindMem_v2
+
+    global __cuMulticastBindAddr_v2
+    data["__cuMulticastBindAddr_v2"] = <_cyb_intptr_t>__cuMulticastBindAddr_v2
+
+    global __cuGraphNodeGetContainingGraph
+    data["__cuGraphNodeGetContainingGraph"] = <_cyb_intptr_t>__cuGraphNodeGetContainingGraph
+
+    global __cuGraphNodeGetLocalId
+    data["__cuGraphNodeGetLocalId"] = <_cyb_intptr_t>__cuGraphNodeGetLocalId
+
+    global __cuGraphNodeGetToolsId
+    data["__cuGraphNodeGetToolsId"] = <_cyb_intptr_t>__cuGraphNodeGetToolsId
+
+    global __cuGraphGetId
+    data["__cuGraphGetId"] = <_cyb_intptr_t>__cuGraphGetId
+
+    global __cuGraphExecGetId
+    data["__cuGraphExecGetId"] = <_cyb_intptr_t>__cuGraphExecGetId
+
+    global __cuDevSmResourceSplit
+    data["__cuDevSmResourceSplit"] = <_cyb_intptr_t>__cuDevSmResourceSplit
+
+    global __cuStreamGetDevResource
+    data["__cuStreamGetDevResource"] = <_cyb_intptr_t>__cuStreamGetDevResource
+
+    global __cuKernelGetParamCount
+    data["__cuKernelGetParamCount"] = <_cyb_intptr_t>__cuKernelGetParamCount
+
+    global __cuMemcpyWithAttributesAsync
+    data["__cuMemcpyWithAttributesAsync"] = <_cyb_intptr_t>__cuMemcpyWithAttributesAsync
+
+    global __cuMemcpy3DWithAttributesAsync
+    data["__cuMemcpy3DWithAttributesAsync"] = <_cyb_intptr_t>__cuMemcpy3DWithAttributesAsync
+
+    global __cuStreamBeginCaptureToCig
+    data["__cuStreamBeginCaptureToCig"] = <_cyb_intptr_t>__cuStreamBeginCaptureToCig
+
+    global __cuStreamEndCaptureToCig
+    data["__cuStreamEndCaptureToCig"] = <_cyb_intptr_t>__cuStreamEndCaptureToCig
+
+    global __cuFuncGetParamCount
+    data["__cuFuncGetParamCount"] = <_cyb_intptr_t>__cuFuncGetParamCount
+
+    global __cuLaunchHostFunc_v2
+    data["__cuLaunchHostFunc_v2"] = <_cyb_intptr_t>__cuLaunchHostFunc_v2
+
+    global __cuGraphNodeGetParams
+    data["__cuGraphNodeGetParams"] = <_cyb_intptr_t>__cuGraphNodeGetParams
+
+    global __cuCoredumpRegisterStartCallback
+    data["__cuCoredumpRegisterStartCallback"] = <_cyb_intptr_t>__cuCoredumpRegisterStartCallback
+
+    global __cuCoredumpRegisterCompleteCallback
+    data["__cuCoredumpRegisterCompleteCallback"] = <_cyb_intptr_t>__cuCoredumpRegisterCompleteCallback
+
+    global __cuCoredumpDeregisterStartCallback
+    data["__cuCoredumpDeregisterStartCallback"] = <_cyb_intptr_t>__cuCoredumpDeregisterStartCallback
+
+    global __cuCoredumpDeregisterCompleteCallback
+    data["__cuCoredumpDeregisterCompleteCallback"] = <_cyb_intptr_t>__cuCoredumpDeregisterCompleteCallback
+
+    global __cuLogicalEndpointIdReserve
+    data["__cuLogicalEndpointIdReserve"] = <_cyb_intptr_t>__cuLogicalEndpointIdReserve
+
+    global __cuLogicalEndpointIdRelease
+    data["__cuLogicalEndpointIdRelease"] = <_cyb_intptr_t>__cuLogicalEndpointIdRelease
+
+    global __cuLogicalEndpointCreate
+    data["__cuLogicalEndpointCreate"] = <_cyb_intptr_t>__cuLogicalEndpointCreate
+
+    global __cuLogicalEndpointAddDevice
+    data["__cuLogicalEndpointAddDevice"] = <_cyb_intptr_t>__cuLogicalEndpointAddDevice
+
+    global __cuLogicalEndpointDestroy
+    data["__cuLogicalEndpointDestroy"] = <_cyb_intptr_t>__cuLogicalEndpointDestroy
+
+    global __cuLogicalEndpointBindAddr
+    data["__cuLogicalEndpointBindAddr"] = <_cyb_intptr_t>__cuLogicalEndpointBindAddr
+
+    global __cuLogicalEndpointBindMem
+    data["__cuLogicalEndpointBindMem"] = <_cyb_intptr_t>__cuLogicalEndpointBindMem
+
+    global __cuLogicalEndpointUnbind
+    data["__cuLogicalEndpointUnbind"] = <_cyb_intptr_t>__cuLogicalEndpointUnbind
+
+    global __cuLogicalEndpointExport
+    data["__cuLogicalEndpointExport"] = <_cyb_intptr_t>__cuLogicalEndpointExport
+
+    global __cuLogicalEndpointImport
+    data["__cuLogicalEndpointImport"] = <_cyb_intptr_t>__cuLogicalEndpointImport
+
+    global __cuLogicalEndpointGetLimits
+    data["__cuLogicalEndpointGetLimits"] = <_cyb_intptr_t>__cuLogicalEndpointGetLimits
+
+    global __cuLogicalEndpointQuery
+    data["__cuLogicalEndpointQuery"] = <_cyb_intptr_t>__cuLogicalEndpointQuery
+
+    global __cuStreamBeginRecaptureToGraph
+    data["__cuStreamBeginRecaptureToGraph"] = <_cyb_intptr_t>__cuStreamBeginRecaptureToGraph
+    _cyb_func_ptrs = data
+    return data
+
+
+cpdef _inspect_function_pointer(str name):
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is None:
+        _cyb_func_ptrs = _inspect_function_pointers()
+    return _cyb_func_ptrs[name]
+
+
 
 
 cdef void* load_library() except* with gil:
     cdef uintptr_t handle = load_nvidia_dynamic_lib("cuda")._handle_uint
     return <void*>handle
-
-
-ctypedef CUresult (*__cuGetProcAddress_v2_T)(const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*) except?CUDA_ERROR_NOT_FOUND nogil
-cdef __cuGetProcAddress_v2_T _F_cuGetProcAddress_v2 = NULL
-
-
-cdef int _init_driver() except -1 nogil:
-    global __py_driver_init
-
-    cdef void* handle = NULL
-    cdef int ptds_mode
-
-    with gil, __symbol_lock:
-        # Recheck the flag after obtaining the locks
-        if __py_driver_init:
-            return 0
-
-        handle = load_library()
-        if handle == NULL:
-            raise RuntimeError('Failed to open cuda')
-
-        # Get latest __cuGetProcAddress_v2
-        global __cuGetProcAddress_v2
-        __cuGetProcAddress_v2 = dlsym(handle, 'cuGetProcAddress_v2')
-        if __cuGetProcAddress_v2 == NULL:
-            raise RuntimeError("Failed to get __cuGetProcAddress_v2")
-        _F_cuGetProcAddress_v2 = <__cuGetProcAddress_v2_T>__cuGetProcAddress_v2
-
-        if bool(int(os.getenv('CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM', default=0))):
-            ptds_mode = CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM
-        else:
-            ptds_mode = CU_GET_PROC_ADDRESS_DEFAULT
-
-        # Load function
-        global __cuGetErrorString
-        _F_cuGetProcAddress_v2('cuGetErrorString', <void **>&__cuGetErrorString, 6000, ptds_mode, NULL)
-
-        global __cuGetErrorName
-        _F_cuGetProcAddress_v2('cuGetErrorName', <void **>&__cuGetErrorName, 6000, ptds_mode, NULL)
-
-        global __cuInit
-        _F_cuGetProcAddress_v2('cuInit', <void **>&__cuInit, 2000, ptds_mode, NULL)
-
-        global __cuDriverGetVersion
-        _F_cuGetProcAddress_v2('cuDriverGetVersion', <void **>&__cuDriverGetVersion, 2020, ptds_mode, NULL)
-
-        global __cuDeviceGet
-        _F_cuGetProcAddress_v2('cuDeviceGet', <void **>&__cuDeviceGet, 2000, ptds_mode, NULL)
-
-        global __cuDeviceGetCount
-        _F_cuGetProcAddress_v2('cuDeviceGetCount', <void **>&__cuDeviceGetCount, 2000, ptds_mode, NULL)
-
-        global __cuDeviceGetName
-        _F_cuGetProcAddress_v2('cuDeviceGetName', <void **>&__cuDeviceGetName, 2000, ptds_mode, NULL)
-
-        global __cuDeviceGetUuid_v2
-        _F_cuGetProcAddress_v2('cuDeviceGetUuid', <void **>&__cuDeviceGetUuid_v2, 11040, ptds_mode, NULL)
-
-        global __cuDeviceGetLuid
-        _F_cuGetProcAddress_v2('cuDeviceGetLuid', <void **>&__cuDeviceGetLuid, 10000, ptds_mode, NULL)
-
-        global __cuDeviceTotalMem_v2
-        _F_cuGetProcAddress_v2('cuDeviceTotalMem', <void **>&__cuDeviceTotalMem_v2, 3020, ptds_mode, NULL)
-
-        global __cuDeviceGetTexture1DLinearMaxWidth
-        _F_cuGetProcAddress_v2('cuDeviceGetTexture1DLinearMaxWidth', <void **>&__cuDeviceGetTexture1DLinearMaxWidth, 11010, ptds_mode, NULL)
-
-        global __cuDeviceGetAttribute
-        _F_cuGetProcAddress_v2('cuDeviceGetAttribute', <void **>&__cuDeviceGetAttribute, 2000, ptds_mode, NULL)
-
-        global __cuDeviceGetNvSciSyncAttributes
-        _F_cuGetProcAddress_v2('cuDeviceGetNvSciSyncAttributes', <void **>&__cuDeviceGetNvSciSyncAttributes, 10020, ptds_mode, NULL)
-
-        global __cuDeviceSetMemPool
-        _F_cuGetProcAddress_v2('cuDeviceSetMemPool', <void **>&__cuDeviceSetMemPool, 11020, ptds_mode, NULL)
-
-        global __cuDeviceGetMemPool
-        _F_cuGetProcAddress_v2('cuDeviceGetMemPool', <void **>&__cuDeviceGetMemPool, 11020, ptds_mode, NULL)
-
-        global __cuDeviceGetDefaultMemPool
-        _F_cuGetProcAddress_v2('cuDeviceGetDefaultMemPool', <void **>&__cuDeviceGetDefaultMemPool, 11020, ptds_mode, NULL)
-
-        global __cuDeviceGetExecAffinitySupport
-        _F_cuGetProcAddress_v2('cuDeviceGetExecAffinitySupport', <void **>&__cuDeviceGetExecAffinitySupport, 11040, ptds_mode, NULL)
-
-        global __cuFlushGPUDirectRDMAWrites
-        _F_cuGetProcAddress_v2('cuFlushGPUDirectRDMAWrites', <void **>&__cuFlushGPUDirectRDMAWrites, 11030, ptds_mode, NULL)
-
-        global __cuDeviceGetProperties
-        _F_cuGetProcAddress_v2('cuDeviceGetProperties', <void **>&__cuDeviceGetProperties, 2000, ptds_mode, NULL)
-
-        global __cuDeviceComputeCapability
-        _F_cuGetProcAddress_v2('cuDeviceComputeCapability', <void **>&__cuDeviceComputeCapability, 2000, ptds_mode, NULL)
-
-        global __cuDevicePrimaryCtxRetain
-        _F_cuGetProcAddress_v2('cuDevicePrimaryCtxRetain', <void **>&__cuDevicePrimaryCtxRetain, 7000, ptds_mode, NULL)
-
-        global __cuDevicePrimaryCtxRelease_v2
-        _F_cuGetProcAddress_v2('cuDevicePrimaryCtxRelease', <void **>&__cuDevicePrimaryCtxRelease_v2, 11000, ptds_mode, NULL)
-
-        global __cuDevicePrimaryCtxSetFlags_v2
-        _F_cuGetProcAddress_v2('cuDevicePrimaryCtxSetFlags', <void **>&__cuDevicePrimaryCtxSetFlags_v2, 11000, ptds_mode, NULL)
-
-        global __cuDevicePrimaryCtxGetState
-        _F_cuGetProcAddress_v2('cuDevicePrimaryCtxGetState', <void **>&__cuDevicePrimaryCtxGetState, 7000, ptds_mode, NULL)
-
-        global __cuDevicePrimaryCtxReset_v2
-        _F_cuGetProcAddress_v2('cuDevicePrimaryCtxReset', <void **>&__cuDevicePrimaryCtxReset_v2, 11000, ptds_mode, NULL)
-
-        global __cuCtxCreate_v2
-        _F_cuGetProcAddress_v2('cuCtxCreate', <void **>&__cuCtxCreate_v2, 3020, ptds_mode, NULL)
-
-        global __cuCtxCreate_v3
-        _F_cuGetProcAddress_v2('cuCtxCreate', <void **>&__cuCtxCreate_v3, 11040, ptds_mode, NULL)
-
-        global __cuCtxCreate_v4
-        _F_cuGetProcAddress_v2('cuCtxCreate', <void **>&__cuCtxCreate_v4, 12050, ptds_mode, NULL)
-
-        global __cuCtxDestroy_v2
-        _F_cuGetProcAddress_v2('cuCtxDestroy', <void **>&__cuCtxDestroy_v2, 4000, ptds_mode, NULL)
-
-        global __cuCtxPushCurrent_v2
-        _F_cuGetProcAddress_v2('cuCtxPushCurrent', <void **>&__cuCtxPushCurrent_v2, 4000, ptds_mode, NULL)
-
-        global __cuCtxPopCurrent_v2
-        _F_cuGetProcAddress_v2('cuCtxPopCurrent', <void **>&__cuCtxPopCurrent_v2, 4000, ptds_mode, NULL)
-
-        global __cuCtxSetCurrent
-        _F_cuGetProcAddress_v2('cuCtxSetCurrent', <void **>&__cuCtxSetCurrent, 4000, ptds_mode, NULL)
-
-        global __cuCtxGetCurrent
-        _F_cuGetProcAddress_v2('cuCtxGetCurrent', <void **>&__cuCtxGetCurrent, 4000, ptds_mode, NULL)
-
-        global __cuCtxGetDevice
-        _F_cuGetProcAddress_v2('cuCtxGetDevice', <void **>&__cuCtxGetDevice, 2000, ptds_mode, NULL)
-
-        global __cuCtxGetFlags
-        _F_cuGetProcAddress_v2('cuCtxGetFlags', <void **>&__cuCtxGetFlags, 7000, ptds_mode, NULL)
-
-        global __cuCtxSetFlags
-        _F_cuGetProcAddress_v2('cuCtxSetFlags', <void **>&__cuCtxSetFlags, 12010, ptds_mode, NULL)
-
-        global __cuCtxGetId
-        _F_cuGetProcAddress_v2('cuCtxGetId', <void **>&__cuCtxGetId, 12000, ptds_mode, NULL)
-
-        global __cuCtxSynchronize
-        _F_cuGetProcAddress_v2('cuCtxSynchronize', <void **>&__cuCtxSynchronize, 2000, ptds_mode, NULL)
-
-        global __cuCtxSetLimit
-        _F_cuGetProcAddress_v2('cuCtxSetLimit', <void **>&__cuCtxSetLimit, 3010, ptds_mode, NULL)
-
-        global __cuCtxGetLimit
-        _F_cuGetProcAddress_v2('cuCtxGetLimit', <void **>&__cuCtxGetLimit, 3010, ptds_mode, NULL)
-
-        global __cuCtxGetCacheConfig
-        _F_cuGetProcAddress_v2('cuCtxGetCacheConfig', <void **>&__cuCtxGetCacheConfig, 3020, ptds_mode, NULL)
-
-        global __cuCtxSetCacheConfig
-        _F_cuGetProcAddress_v2('cuCtxSetCacheConfig', <void **>&__cuCtxSetCacheConfig, 3020, ptds_mode, NULL)
-
-        global __cuCtxGetApiVersion
-        _F_cuGetProcAddress_v2('cuCtxGetApiVersion', <void **>&__cuCtxGetApiVersion, 3020, ptds_mode, NULL)
-
-        global __cuCtxGetStreamPriorityRange
-        _F_cuGetProcAddress_v2('cuCtxGetStreamPriorityRange', <void **>&__cuCtxGetStreamPriorityRange, 5050, ptds_mode, NULL)
-
-        global __cuCtxResetPersistingL2Cache
-        _F_cuGetProcAddress_v2('cuCtxResetPersistingL2Cache', <void **>&__cuCtxResetPersistingL2Cache, 11000, ptds_mode, NULL)
-
-        global __cuCtxGetExecAffinity
-        _F_cuGetProcAddress_v2('cuCtxGetExecAffinity', <void **>&__cuCtxGetExecAffinity, 11040, ptds_mode, NULL)
-
-        global __cuCtxRecordEvent
-        _F_cuGetProcAddress_v2('cuCtxRecordEvent', <void **>&__cuCtxRecordEvent, 12050, ptds_mode, NULL)
-
-        global __cuCtxWaitEvent
-        _F_cuGetProcAddress_v2('cuCtxWaitEvent', <void **>&__cuCtxWaitEvent, 12050, ptds_mode, NULL)
-
-        global __cuCtxAttach
-        _F_cuGetProcAddress_v2('cuCtxAttach', <void **>&__cuCtxAttach, 2000, ptds_mode, NULL)
-
-        global __cuCtxDetach
-        _F_cuGetProcAddress_v2('cuCtxDetach', <void **>&__cuCtxDetach, 2000, ptds_mode, NULL)
-
-        global __cuCtxGetSharedMemConfig
-        _F_cuGetProcAddress_v2('cuCtxGetSharedMemConfig', <void **>&__cuCtxGetSharedMemConfig, 4020, ptds_mode, NULL)
-
-        global __cuCtxSetSharedMemConfig
-        _F_cuGetProcAddress_v2('cuCtxSetSharedMemConfig', <void **>&__cuCtxSetSharedMemConfig, 4020, ptds_mode, NULL)
-
-        global __cuModuleLoad
-        _F_cuGetProcAddress_v2('cuModuleLoad', <void **>&__cuModuleLoad, 2000, ptds_mode, NULL)
-
-        global __cuModuleLoadData
-        _F_cuGetProcAddress_v2('cuModuleLoadData', <void **>&__cuModuleLoadData, 2000, ptds_mode, NULL)
-
-        global __cuModuleLoadDataEx
-        _F_cuGetProcAddress_v2('cuModuleLoadDataEx', <void **>&__cuModuleLoadDataEx, 2010, ptds_mode, NULL)
-
-        global __cuModuleLoadFatBinary
-        _F_cuGetProcAddress_v2('cuModuleLoadFatBinary', <void **>&__cuModuleLoadFatBinary, 2000, ptds_mode, NULL)
-
-        global __cuModuleUnload
-        _F_cuGetProcAddress_v2('cuModuleUnload', <void **>&__cuModuleUnload, 2000, ptds_mode, NULL)
-
-        global __cuModuleGetLoadingMode
-        _F_cuGetProcAddress_v2('cuModuleGetLoadingMode', <void **>&__cuModuleGetLoadingMode, 11070, ptds_mode, NULL)
-
-        global __cuModuleGetFunction
-        _F_cuGetProcAddress_v2('cuModuleGetFunction', <void **>&__cuModuleGetFunction, 2000, ptds_mode, NULL)
-
-        global __cuModuleGetFunctionCount
-        _F_cuGetProcAddress_v2('cuModuleGetFunctionCount', <void **>&__cuModuleGetFunctionCount, 12040, ptds_mode, NULL)
-
-        global __cuModuleEnumerateFunctions
-        _F_cuGetProcAddress_v2('cuModuleEnumerateFunctions', <void **>&__cuModuleEnumerateFunctions, 12040, ptds_mode, NULL)
-
-        global __cuModuleGetGlobal_v2
-        _F_cuGetProcAddress_v2('cuModuleGetGlobal', <void **>&__cuModuleGetGlobal_v2, 3020, ptds_mode, NULL)
-
-        global __cuLinkCreate_v2
-        _F_cuGetProcAddress_v2('cuLinkCreate', <void **>&__cuLinkCreate_v2, 6050, ptds_mode, NULL)
-
-        global __cuLinkAddData_v2
-        _F_cuGetProcAddress_v2('cuLinkAddData', <void **>&__cuLinkAddData_v2, 6050, ptds_mode, NULL)
-
-        global __cuLinkAddFile_v2
-        _F_cuGetProcAddress_v2('cuLinkAddFile', <void **>&__cuLinkAddFile_v2, 6050, ptds_mode, NULL)
-
-        global __cuLinkComplete
-        _F_cuGetProcAddress_v2('cuLinkComplete', <void **>&__cuLinkComplete, 5050, ptds_mode, NULL)
-
-        global __cuLinkDestroy
-        _F_cuGetProcAddress_v2('cuLinkDestroy', <void **>&__cuLinkDestroy, 5050, ptds_mode, NULL)
-
-        global __cuModuleGetTexRef
-        _F_cuGetProcAddress_v2('cuModuleGetTexRef', <void **>&__cuModuleGetTexRef, 2000, ptds_mode, NULL)
-
-        global __cuModuleGetSurfRef
-        _F_cuGetProcAddress_v2('cuModuleGetSurfRef', <void **>&__cuModuleGetSurfRef, 3000, ptds_mode, NULL)
-
-        global __cuLibraryLoadData
-        _F_cuGetProcAddress_v2('cuLibraryLoadData', <void **>&__cuLibraryLoadData, 12000, ptds_mode, NULL)
-
-        global __cuLibraryLoadFromFile
-        _F_cuGetProcAddress_v2('cuLibraryLoadFromFile', <void **>&__cuLibraryLoadFromFile, 12000, ptds_mode, NULL)
-
-        global __cuLibraryUnload
-        _F_cuGetProcAddress_v2('cuLibraryUnload', <void **>&__cuLibraryUnload, 12000, ptds_mode, NULL)
-
-        global __cuLibraryGetKernel
-        _F_cuGetProcAddress_v2('cuLibraryGetKernel', <void **>&__cuLibraryGetKernel, 12000, ptds_mode, NULL)
-
-        global __cuLibraryGetKernelCount
-        _F_cuGetProcAddress_v2('cuLibraryGetKernelCount', <void **>&__cuLibraryGetKernelCount, 12040, ptds_mode, NULL)
-
-        global __cuLibraryEnumerateKernels
-        _F_cuGetProcAddress_v2('cuLibraryEnumerateKernels', <void **>&__cuLibraryEnumerateKernels, 12040, ptds_mode, NULL)
-
-        global __cuLibraryGetModule
-        _F_cuGetProcAddress_v2('cuLibraryGetModule', <void **>&__cuLibraryGetModule, 12000, ptds_mode, NULL)
-
-        global __cuKernelGetFunction
-        _F_cuGetProcAddress_v2('cuKernelGetFunction', <void **>&__cuKernelGetFunction, 12000, ptds_mode, NULL)
-
-        global __cuKernelGetLibrary
-        _F_cuGetProcAddress_v2('cuKernelGetLibrary', <void **>&__cuKernelGetLibrary, 12050, ptds_mode, NULL)
-
-        global __cuLibraryGetGlobal
-        _F_cuGetProcAddress_v2('cuLibraryGetGlobal', <void **>&__cuLibraryGetGlobal, 12000, ptds_mode, NULL)
-
-        global __cuLibraryGetManaged
-        _F_cuGetProcAddress_v2('cuLibraryGetManaged', <void **>&__cuLibraryGetManaged, 12000, ptds_mode, NULL)
-
-        global __cuLibraryGetUnifiedFunction
-        _F_cuGetProcAddress_v2('cuLibraryGetUnifiedFunction', <void **>&__cuLibraryGetUnifiedFunction, 12000, ptds_mode, NULL)
-
-        global __cuKernelGetAttribute
-        _F_cuGetProcAddress_v2('cuKernelGetAttribute', <void **>&__cuKernelGetAttribute, 12000, ptds_mode, NULL)
-
-        global __cuKernelSetAttribute
-        _F_cuGetProcAddress_v2('cuKernelSetAttribute', <void **>&__cuKernelSetAttribute, 12000, ptds_mode, NULL)
-
-        global __cuKernelSetCacheConfig
-        _F_cuGetProcAddress_v2('cuKernelSetCacheConfig', <void **>&__cuKernelSetCacheConfig, 12000, ptds_mode, NULL)
-
-        global __cuKernelGetName
-        _F_cuGetProcAddress_v2('cuKernelGetName', <void **>&__cuKernelGetName, 12030, ptds_mode, NULL)
-
-        global __cuKernelGetParamInfo
-        _F_cuGetProcAddress_v2('cuKernelGetParamInfo', <void **>&__cuKernelGetParamInfo, 12040, ptds_mode, NULL)
-
-        global __cuMemGetInfo_v2
-        _F_cuGetProcAddress_v2('cuMemGetInfo', <void **>&__cuMemGetInfo_v2, 3020, ptds_mode, NULL)
-
-        global __cuMemAlloc_v2
-        _F_cuGetProcAddress_v2('cuMemAlloc', <void **>&__cuMemAlloc_v2, 3020, ptds_mode, NULL)
-
-        global __cuMemAllocPitch_v2
-        _F_cuGetProcAddress_v2('cuMemAllocPitch', <void **>&__cuMemAllocPitch_v2, 3020, ptds_mode, NULL)
-
-        global __cuMemFree_v2
-        _F_cuGetProcAddress_v2('cuMemFree', <void **>&__cuMemFree_v2, 3020, ptds_mode, NULL)
-
-        global __cuMemGetAddressRange_v2
-        _F_cuGetProcAddress_v2('cuMemGetAddressRange', <void **>&__cuMemGetAddressRange_v2, 3020, ptds_mode, NULL)
-
-        global __cuMemAllocHost_v2
-        _F_cuGetProcAddress_v2('cuMemAllocHost', <void **>&__cuMemAllocHost_v2, 3020, ptds_mode, NULL)
-
-        global __cuMemFreeHost
-        _F_cuGetProcAddress_v2('cuMemFreeHost', <void **>&__cuMemFreeHost, 2000, ptds_mode, NULL)
-
-        global __cuMemHostAlloc
-        _F_cuGetProcAddress_v2('cuMemHostAlloc', <void **>&__cuMemHostAlloc, 2020, ptds_mode, NULL)
-
-        global __cuMemHostGetDevicePointer_v2
-        _F_cuGetProcAddress_v2('cuMemHostGetDevicePointer', <void **>&__cuMemHostGetDevicePointer_v2, 3020, ptds_mode, NULL)
-
-        global __cuMemHostGetFlags
-        _F_cuGetProcAddress_v2('cuMemHostGetFlags', <void **>&__cuMemHostGetFlags, 2030, ptds_mode, NULL)
-
-        global __cuMemAllocManaged
-        _F_cuGetProcAddress_v2('cuMemAllocManaged', <void **>&__cuMemAllocManaged, 6000, ptds_mode, NULL)
-
-        global __cuDeviceRegisterAsyncNotification
-        _F_cuGetProcAddress_v2('cuDeviceRegisterAsyncNotification', <void **>&__cuDeviceRegisterAsyncNotification, 12040, ptds_mode, NULL)
-
-        global __cuDeviceUnregisterAsyncNotification
-        _F_cuGetProcAddress_v2('cuDeviceUnregisterAsyncNotification', <void **>&__cuDeviceUnregisterAsyncNotification, 12040, ptds_mode, NULL)
-
-        global __cuDeviceGetByPCIBusId
-        _F_cuGetProcAddress_v2('cuDeviceGetByPCIBusId', <void **>&__cuDeviceGetByPCIBusId, 4010, ptds_mode, NULL)
-
-        global __cuDeviceGetPCIBusId
-        _F_cuGetProcAddress_v2('cuDeviceGetPCIBusId', <void **>&__cuDeviceGetPCIBusId, 4010, ptds_mode, NULL)
-
-        global __cuIpcGetEventHandle
-        _F_cuGetProcAddress_v2('cuIpcGetEventHandle', <void **>&__cuIpcGetEventHandle, 4010, ptds_mode, NULL)
-
-        global __cuIpcOpenEventHandle
-        _F_cuGetProcAddress_v2('cuIpcOpenEventHandle', <void **>&__cuIpcOpenEventHandle, 4010, ptds_mode, NULL)
-
-        global __cuIpcGetMemHandle
-        _F_cuGetProcAddress_v2('cuIpcGetMemHandle', <void **>&__cuIpcGetMemHandle, 4010, ptds_mode, NULL)
-
-        global __cuIpcOpenMemHandle_v2
-        _F_cuGetProcAddress_v2('cuIpcOpenMemHandle', <void **>&__cuIpcOpenMemHandle_v2, 11000, ptds_mode, NULL)
-
-        global __cuIpcCloseMemHandle
-        _F_cuGetProcAddress_v2('cuIpcCloseMemHandle', <void **>&__cuIpcCloseMemHandle, 4010, ptds_mode, NULL)
-
-        global __cuMemHostRegister_v2
-        _F_cuGetProcAddress_v2('cuMemHostRegister', <void **>&__cuMemHostRegister_v2, 6050, ptds_mode, NULL)
-
-        global __cuMemHostUnregister
-        _F_cuGetProcAddress_v2('cuMemHostUnregister', <void **>&__cuMemHostUnregister, 4000, ptds_mode, NULL)
-
-        global __cuMemcpy
-        _F_cuGetProcAddress_v2('cuMemcpy', <void **>&__cuMemcpy, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
-
-        global __cuMemcpyPeer
-        _F_cuGetProcAddress_v2('cuMemcpyPeer', <void **>&__cuMemcpyPeer, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
-
-        global __cuMemcpyHtoD_v2
-        _F_cuGetProcAddress_v2('cuMemcpyHtoD', <void **>&__cuMemcpyHtoD_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemcpyDtoH_v2
-        _F_cuGetProcAddress_v2('cuMemcpyDtoH', <void **>&__cuMemcpyDtoH_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemcpyDtoD_v2
-        _F_cuGetProcAddress_v2('cuMemcpyDtoD', <void **>&__cuMemcpyDtoD_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemcpyDtoA_v2
-        _F_cuGetProcAddress_v2('cuMemcpyDtoA', <void **>&__cuMemcpyDtoA_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemcpyAtoD_v2
-        _F_cuGetProcAddress_v2('cuMemcpyAtoD', <void **>&__cuMemcpyAtoD_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemcpyHtoA_v2
-        _F_cuGetProcAddress_v2('cuMemcpyHtoA', <void **>&__cuMemcpyHtoA_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemcpyAtoH_v2
-        _F_cuGetProcAddress_v2('cuMemcpyAtoH', <void **>&__cuMemcpyAtoH_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemcpyAtoA_v2
-        _F_cuGetProcAddress_v2('cuMemcpyAtoA', <void **>&__cuMemcpyAtoA_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemcpy2D_v2
-        _F_cuGetProcAddress_v2('cuMemcpy2D', <void **>&__cuMemcpy2D_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemcpy2DUnaligned_v2
-        _F_cuGetProcAddress_v2('cuMemcpy2DUnaligned', <void **>&__cuMemcpy2DUnaligned_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemcpy3D_v2
-        _F_cuGetProcAddress_v2('cuMemcpy3D', <void **>&__cuMemcpy3D_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemcpy3DPeer
-        _F_cuGetProcAddress_v2('cuMemcpy3DPeer', <void **>&__cuMemcpy3DPeer, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
-
-        global __cuMemcpyAsync
-        _F_cuGetProcAddress_v2('cuMemcpyAsync', <void **>&__cuMemcpyAsync, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
-
-        global __cuMemcpyPeerAsync
-        _F_cuGetProcAddress_v2('cuMemcpyPeerAsync', <void **>&__cuMemcpyPeerAsync, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
-
-        global __cuMemcpyHtoDAsync_v2
-        _F_cuGetProcAddress_v2('cuMemcpyHtoDAsync', <void **>&__cuMemcpyHtoDAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemcpyDtoHAsync_v2
-        _F_cuGetProcAddress_v2('cuMemcpyDtoHAsync', <void **>&__cuMemcpyDtoHAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemcpyDtoDAsync_v2
-        _F_cuGetProcAddress_v2('cuMemcpyDtoDAsync', <void **>&__cuMemcpyDtoDAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemcpyHtoAAsync_v2
-        _F_cuGetProcAddress_v2('cuMemcpyHtoAAsync', <void **>&__cuMemcpyHtoAAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemcpyAtoHAsync_v2
-        _F_cuGetProcAddress_v2('cuMemcpyAtoHAsync', <void **>&__cuMemcpyAtoHAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemcpy2DAsync_v2
-        _F_cuGetProcAddress_v2('cuMemcpy2DAsync', <void **>&__cuMemcpy2DAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemcpy3DAsync_v2
-        _F_cuGetProcAddress_v2('cuMemcpy3DAsync', <void **>&__cuMemcpy3DAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemcpy3DPeerAsync
-        _F_cuGetProcAddress_v2('cuMemcpy3DPeerAsync', <void **>&__cuMemcpy3DPeerAsync, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
-
-        global __cuMemsetD8_v2
-        _F_cuGetProcAddress_v2('cuMemsetD8', <void **>&__cuMemsetD8_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemsetD16_v2
-        _F_cuGetProcAddress_v2('cuMemsetD16', <void **>&__cuMemsetD16_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemsetD32_v2
-        _F_cuGetProcAddress_v2('cuMemsetD32', <void **>&__cuMemsetD32_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemsetD2D8_v2
-        _F_cuGetProcAddress_v2('cuMemsetD2D8', <void **>&__cuMemsetD2D8_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemsetD2D16_v2
-        _F_cuGetProcAddress_v2('cuMemsetD2D16', <void **>&__cuMemsetD2D16_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemsetD2D32_v2
-        _F_cuGetProcAddress_v2('cuMemsetD2D32', <void **>&__cuMemsetD2D32_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemsetD8Async
-        _F_cuGetProcAddress_v2('cuMemsetD8Async', <void **>&__cuMemsetD8Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemsetD16Async
-        _F_cuGetProcAddress_v2('cuMemsetD16Async', <void **>&__cuMemsetD16Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemsetD32Async
-        _F_cuGetProcAddress_v2('cuMemsetD32Async', <void **>&__cuMemsetD32Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemsetD2D8Async
-        _F_cuGetProcAddress_v2('cuMemsetD2D8Async', <void **>&__cuMemsetD2D8Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemsetD2D16Async
-        _F_cuGetProcAddress_v2('cuMemsetD2D16Async', <void **>&__cuMemsetD2D16Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuMemsetD2D32Async
-        _F_cuGetProcAddress_v2('cuMemsetD2D32Async', <void **>&__cuMemsetD2D32Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuArrayCreate_v2
-        _F_cuGetProcAddress_v2('cuArrayCreate', <void **>&__cuArrayCreate_v2, 3020, ptds_mode, NULL)
-
-        global __cuArrayGetDescriptor_v2
-        _F_cuGetProcAddress_v2('cuArrayGetDescriptor', <void **>&__cuArrayGetDescriptor_v2, 3020, ptds_mode, NULL)
-
-        global __cuArrayGetSparseProperties
-        _F_cuGetProcAddress_v2('cuArrayGetSparseProperties', <void **>&__cuArrayGetSparseProperties, 11010, ptds_mode, NULL)
-
-        global __cuMipmappedArrayGetSparseProperties
-        _F_cuGetProcAddress_v2('cuMipmappedArrayGetSparseProperties', <void **>&__cuMipmappedArrayGetSparseProperties, 11010, ptds_mode, NULL)
-
-        global __cuArrayGetMemoryRequirements
-        _F_cuGetProcAddress_v2('cuArrayGetMemoryRequirements', <void **>&__cuArrayGetMemoryRequirements, 11060, ptds_mode, NULL)
-
-        global __cuMipmappedArrayGetMemoryRequirements
-        _F_cuGetProcAddress_v2('cuMipmappedArrayGetMemoryRequirements', <void **>&__cuMipmappedArrayGetMemoryRequirements, 11060, ptds_mode, NULL)
-
-        global __cuArrayGetPlane
-        _F_cuGetProcAddress_v2('cuArrayGetPlane', <void **>&__cuArrayGetPlane, 11020, ptds_mode, NULL)
-
-        global __cuArrayDestroy
-        _F_cuGetProcAddress_v2('cuArrayDestroy', <void **>&__cuArrayDestroy, 2000, ptds_mode, NULL)
-
-        global __cuArray3DCreate_v2
-        _F_cuGetProcAddress_v2('cuArray3DCreate', <void **>&__cuArray3DCreate_v2, 3020, ptds_mode, NULL)
-
-        global __cuArray3DGetDescriptor_v2
-        _F_cuGetProcAddress_v2('cuArray3DGetDescriptor', <void **>&__cuArray3DGetDescriptor_v2, 3020, ptds_mode, NULL)
-
-        global __cuMipmappedArrayCreate
-        _F_cuGetProcAddress_v2('cuMipmappedArrayCreate', <void **>&__cuMipmappedArrayCreate, 5000, ptds_mode, NULL)
-
-        global __cuMipmappedArrayGetLevel
-        _F_cuGetProcAddress_v2('cuMipmappedArrayGetLevel', <void **>&__cuMipmappedArrayGetLevel, 5000, ptds_mode, NULL)
-
-        global __cuMipmappedArrayDestroy
-        _F_cuGetProcAddress_v2('cuMipmappedArrayDestroy', <void **>&__cuMipmappedArrayDestroy, 5000, ptds_mode, NULL)
-
-        global __cuMemGetHandleForAddressRange
-        _F_cuGetProcAddress_v2('cuMemGetHandleForAddressRange', <void **>&__cuMemGetHandleForAddressRange, 11070, ptds_mode, NULL)
-
-        global __cuMemBatchDecompressAsync
-        _F_cuGetProcAddress_v2('cuMemBatchDecompressAsync', <void **>&__cuMemBatchDecompressAsync, 12060, ptds_mode, NULL)
-
-        global __cuMemAddressReserve
-        _F_cuGetProcAddress_v2('cuMemAddressReserve', <void **>&__cuMemAddressReserve, 10020, ptds_mode, NULL)
-
-        global __cuMemAddressFree
-        _F_cuGetProcAddress_v2('cuMemAddressFree', <void **>&__cuMemAddressFree, 10020, ptds_mode, NULL)
-
-        global __cuMemCreate
-        _F_cuGetProcAddress_v2('cuMemCreate', <void **>&__cuMemCreate, 10020, ptds_mode, NULL)
-
-        global __cuMemRelease
-        _F_cuGetProcAddress_v2('cuMemRelease', <void **>&__cuMemRelease, 10020, ptds_mode, NULL)
-
-        global __cuMemMap
-        _F_cuGetProcAddress_v2('cuMemMap', <void **>&__cuMemMap, 10020, ptds_mode, NULL)
-
-        global __cuMemMapArrayAsync
-        _F_cuGetProcAddress_v2('cuMemMapArrayAsync', <void **>&__cuMemMapArrayAsync, 11010, ptds_mode, NULL)
-
-        global __cuMemUnmap
-        _F_cuGetProcAddress_v2('cuMemUnmap', <void **>&__cuMemUnmap, 10020, ptds_mode, NULL)
-
-        global __cuMemSetAccess
-        _F_cuGetProcAddress_v2('cuMemSetAccess', <void **>&__cuMemSetAccess, 10020, ptds_mode, NULL)
-
-        global __cuMemGetAccess
-        _F_cuGetProcAddress_v2('cuMemGetAccess', <void **>&__cuMemGetAccess, 10020, ptds_mode, NULL)
-
-        global __cuMemExportToShareableHandle
-        _F_cuGetProcAddress_v2('cuMemExportToShareableHandle', <void **>&__cuMemExportToShareableHandle, 10020, ptds_mode, NULL)
-
-        global __cuMemImportFromShareableHandle
-        _F_cuGetProcAddress_v2('cuMemImportFromShareableHandle', <void **>&__cuMemImportFromShareableHandle, 10020, ptds_mode, NULL)
-
-        global __cuMemGetAllocationGranularity
-        _F_cuGetProcAddress_v2('cuMemGetAllocationGranularity', <void **>&__cuMemGetAllocationGranularity, 10020, ptds_mode, NULL)
-
-        global __cuMemGetAllocationPropertiesFromHandle
-        _F_cuGetProcAddress_v2('cuMemGetAllocationPropertiesFromHandle', <void **>&__cuMemGetAllocationPropertiesFromHandle, 10020, ptds_mode, NULL)
-
-        global __cuMemRetainAllocationHandle
-        _F_cuGetProcAddress_v2('cuMemRetainAllocationHandle', <void **>&__cuMemRetainAllocationHandle, 11000, ptds_mode, NULL)
-
-        global __cuMemFreeAsync
-        _F_cuGetProcAddress_v2('cuMemFreeAsync', <void **>&__cuMemFreeAsync, 11020, ptds_mode, NULL)
-
-        global __cuMemAllocAsync
-        _F_cuGetProcAddress_v2('cuMemAllocAsync', <void **>&__cuMemAllocAsync, 11020, ptds_mode, NULL)
-
-        global __cuMemPoolTrimTo
-        _F_cuGetProcAddress_v2('cuMemPoolTrimTo', <void **>&__cuMemPoolTrimTo, 11020, ptds_mode, NULL)
-
-        global __cuMemPoolSetAttribute
-        _F_cuGetProcAddress_v2('cuMemPoolSetAttribute', <void **>&__cuMemPoolSetAttribute, 11020, ptds_mode, NULL)
-
-        global __cuMemPoolGetAttribute
-        _F_cuGetProcAddress_v2('cuMemPoolGetAttribute', <void **>&__cuMemPoolGetAttribute, 11020, ptds_mode, NULL)
-
-        global __cuMemPoolSetAccess
-        _F_cuGetProcAddress_v2('cuMemPoolSetAccess', <void **>&__cuMemPoolSetAccess, 11020, ptds_mode, NULL)
-
-        global __cuMemPoolGetAccess
-        _F_cuGetProcAddress_v2('cuMemPoolGetAccess', <void **>&__cuMemPoolGetAccess, 11020, ptds_mode, NULL)
-
-        global __cuMemPoolCreate
-        _F_cuGetProcAddress_v2('cuMemPoolCreate', <void **>&__cuMemPoolCreate, 11020, ptds_mode, NULL)
-
-        global __cuMemPoolDestroy
-        _F_cuGetProcAddress_v2('cuMemPoolDestroy', <void **>&__cuMemPoolDestroy, 11020, ptds_mode, NULL)
-
-        global __cuMemAllocFromPoolAsync
-        _F_cuGetProcAddress_v2('cuMemAllocFromPoolAsync', <void **>&__cuMemAllocFromPoolAsync, 11020, ptds_mode, NULL)
-
-        global __cuMemPoolExportToShareableHandle
-        _F_cuGetProcAddress_v2('cuMemPoolExportToShareableHandle', <void **>&__cuMemPoolExportToShareableHandle, 11020, ptds_mode, NULL)
-
-        global __cuMemPoolImportFromShareableHandle
-        _F_cuGetProcAddress_v2('cuMemPoolImportFromShareableHandle', <void **>&__cuMemPoolImportFromShareableHandle, 11020, ptds_mode, NULL)
-
-        global __cuMemPoolExportPointer
-        _F_cuGetProcAddress_v2('cuMemPoolExportPointer', <void **>&__cuMemPoolExportPointer, 11020, ptds_mode, NULL)
-
-        global __cuMemPoolImportPointer
-        _F_cuGetProcAddress_v2('cuMemPoolImportPointer', <void **>&__cuMemPoolImportPointer, 11020, ptds_mode, NULL)
-
-        global __cuMulticastCreate
-        _F_cuGetProcAddress_v2('cuMulticastCreate', <void **>&__cuMulticastCreate, 12010, ptds_mode, NULL)
-
-        global __cuMulticastAddDevice
-        _F_cuGetProcAddress_v2('cuMulticastAddDevice', <void **>&__cuMulticastAddDevice, 12010, ptds_mode, NULL)
-
-        global __cuMulticastBindMem
-        _F_cuGetProcAddress_v2('cuMulticastBindMem', <void **>&__cuMulticastBindMem, 12010, ptds_mode, NULL)
-
-        global __cuMulticastBindAddr
-        _F_cuGetProcAddress_v2('cuMulticastBindAddr', <void **>&__cuMulticastBindAddr, 12010, ptds_mode, NULL)
-
-        global __cuMulticastUnbind
-        _F_cuGetProcAddress_v2('cuMulticastUnbind', <void **>&__cuMulticastUnbind, 12010, ptds_mode, NULL)
-
-        global __cuMulticastGetGranularity
-        _F_cuGetProcAddress_v2('cuMulticastGetGranularity', <void **>&__cuMulticastGetGranularity, 12010, ptds_mode, NULL)
-
-        global __cuPointerGetAttribute
-        _F_cuGetProcAddress_v2('cuPointerGetAttribute', <void **>&__cuPointerGetAttribute, 4000, ptds_mode, NULL)
-
-        global __cuMemPrefetchAsync_v2
-        _F_cuGetProcAddress_v2('cuMemPrefetchAsync', <void **>&__cuMemPrefetchAsync_v2, 12020, ptds_mode, NULL)
-
-        global __cuMemAdvise_v2
-        _F_cuGetProcAddress_v2('cuMemAdvise', <void **>&__cuMemAdvise_v2, 12020, ptds_mode, NULL)
-
-        global __cuMemRangeGetAttribute
-        _F_cuGetProcAddress_v2('cuMemRangeGetAttribute', <void **>&__cuMemRangeGetAttribute, 8000, ptds_mode, NULL)
-
-        global __cuMemRangeGetAttributes
-        _F_cuGetProcAddress_v2('cuMemRangeGetAttributes', <void **>&__cuMemRangeGetAttributes, 8000, ptds_mode, NULL)
-
-        global __cuPointerSetAttribute
-        _F_cuGetProcAddress_v2('cuPointerSetAttribute', <void **>&__cuPointerSetAttribute, 6000, ptds_mode, NULL)
-
-        global __cuPointerGetAttributes
-        _F_cuGetProcAddress_v2('cuPointerGetAttributes', <void **>&__cuPointerGetAttributes, 7000, ptds_mode, NULL)
-
-        global __cuStreamCreate
-        _F_cuGetProcAddress_v2('cuStreamCreate', <void **>&__cuStreamCreate, 2000, ptds_mode, NULL)
-
-        global __cuStreamCreateWithPriority
-        _F_cuGetProcAddress_v2('cuStreamCreateWithPriority', <void **>&__cuStreamCreateWithPriority, 5050, ptds_mode, NULL)
-
-        global __cuStreamGetPriority
-        _F_cuGetProcAddress_v2('cuStreamGetPriority', <void **>&__cuStreamGetPriority, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 5050, ptds_mode, NULL)
-
-        global __cuStreamGetDevice
-        _F_cuGetProcAddress_v2('cuStreamGetDevice', <void **>&__cuStreamGetDevice, 12080, ptds_mode, NULL)
-
-        global __cuStreamGetFlags
-        _F_cuGetProcAddress_v2('cuStreamGetFlags', <void **>&__cuStreamGetFlags, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 5050, ptds_mode, NULL)
-
-        global __cuStreamGetId
-        _F_cuGetProcAddress_v2('cuStreamGetId', <void **>&__cuStreamGetId, 12000, ptds_mode, NULL)
-
-        global __cuStreamGetCtx
-        _F_cuGetProcAddress_v2('cuStreamGetCtx', <void **>&__cuStreamGetCtx, 9020, ptds_mode, NULL)
-
-        global __cuStreamGetCtx_v2
-        _F_cuGetProcAddress_v2('cuStreamGetCtx', <void **>&__cuStreamGetCtx_v2, 12050, ptds_mode, NULL)
-
-        global __cuStreamWaitEvent
-        _F_cuGetProcAddress_v2('cuStreamWaitEvent', <void **>&__cuStreamWaitEvent, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuStreamAddCallback
-        _F_cuGetProcAddress_v2('cuStreamAddCallback', <void **>&__cuStreamAddCallback, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 5000, ptds_mode, NULL)
-
-        global __cuStreamBeginCapture_v2
-        _F_cuGetProcAddress_v2('cuStreamBeginCapture', <void **>&__cuStreamBeginCapture_v2, 10010, ptds_mode, NULL)
-
-        global __cuStreamBeginCaptureToGraph
-        _F_cuGetProcAddress_v2('cuStreamBeginCaptureToGraph', <void **>&__cuStreamBeginCaptureToGraph, 12030, ptds_mode, NULL)
-
-        global __cuThreadExchangeStreamCaptureMode
-        _F_cuGetProcAddress_v2('cuThreadExchangeStreamCaptureMode', <void **>&__cuThreadExchangeStreamCaptureMode, 10010, ptds_mode, NULL)
-
-        global __cuStreamEndCapture
-        _F_cuGetProcAddress_v2('cuStreamEndCapture', <void **>&__cuStreamEndCapture, 10000, ptds_mode, NULL)
-
-        global __cuStreamIsCapturing
-        _F_cuGetProcAddress_v2('cuStreamIsCapturing', <void **>&__cuStreamIsCapturing, 10000, ptds_mode, NULL)
-
-        global __cuStreamGetCaptureInfo_v2
-        _F_cuGetProcAddress_v2('cuStreamGetCaptureInfo', <void **>&__cuStreamGetCaptureInfo_v2, 11030, ptds_mode, NULL)
-
-        global __cuStreamGetCaptureInfo_v3
-        _F_cuGetProcAddress_v2('cuStreamGetCaptureInfo', <void **>&__cuStreamGetCaptureInfo_v3, 12030, ptds_mode, NULL)
-
-        global __cuStreamUpdateCaptureDependencies_v2
-        _F_cuGetProcAddress_v2('cuStreamUpdateCaptureDependencies', <void **>&__cuStreamUpdateCaptureDependencies_v2, 12030, ptds_mode, NULL)
-
-        global __cuStreamAttachMemAsync
-        _F_cuGetProcAddress_v2('cuStreamAttachMemAsync', <void **>&__cuStreamAttachMemAsync, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 6000, ptds_mode, NULL)
-
-        global __cuStreamQuery
-        _F_cuGetProcAddress_v2('cuStreamQuery', <void **>&__cuStreamQuery, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 2000, ptds_mode, NULL)
-
-        global __cuStreamSynchronize
-        _F_cuGetProcAddress_v2('cuStreamSynchronize', <void **>&__cuStreamSynchronize, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 2000, ptds_mode, NULL)
-
-        global __cuStreamDestroy_v2
-        _F_cuGetProcAddress_v2('cuStreamDestroy', <void **>&__cuStreamDestroy_v2, 4000, ptds_mode, NULL)
-
-        global __cuStreamCopyAttributes
-        _F_cuGetProcAddress_v2('cuStreamCopyAttributes', <void **>&__cuStreamCopyAttributes, 11000, ptds_mode, NULL)
-
-        global __cuStreamGetAttribute
-        _F_cuGetProcAddress_v2('cuStreamGetAttribute', <void **>&__cuStreamGetAttribute, 11000, ptds_mode, NULL)
-
-        global __cuStreamSetAttribute
-        _F_cuGetProcAddress_v2('cuStreamSetAttribute', <void **>&__cuStreamSetAttribute, 11000, ptds_mode, NULL)
-
-        global __cuEventCreate
-        _F_cuGetProcAddress_v2('cuEventCreate', <void **>&__cuEventCreate, 2000, ptds_mode, NULL)
-
-        global __cuEventRecord
-        _F_cuGetProcAddress_v2('cuEventRecord', <void **>&__cuEventRecord, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 2000, ptds_mode, NULL)
-
-        global __cuEventRecordWithFlags
-        _F_cuGetProcAddress_v2('cuEventRecordWithFlags', <void **>&__cuEventRecordWithFlags, 11010, ptds_mode, NULL)
-
-        global __cuEventQuery
-        _F_cuGetProcAddress_v2('cuEventQuery', <void **>&__cuEventQuery, 2000, ptds_mode, NULL)
-
-        global __cuEventSynchronize
-        _F_cuGetProcAddress_v2('cuEventSynchronize', <void **>&__cuEventSynchronize, 2000, ptds_mode, NULL)
-
-        global __cuEventDestroy_v2
-        _F_cuGetProcAddress_v2('cuEventDestroy', <void **>&__cuEventDestroy_v2, 4000, ptds_mode, NULL)
-
-        global __cuEventElapsedTime_v2
-        _F_cuGetProcAddress_v2('cuEventElapsedTime', <void **>&__cuEventElapsedTime_v2, 12080, ptds_mode, NULL)
-
-        global __cuImportExternalMemory
-        _F_cuGetProcAddress_v2('cuImportExternalMemory', <void **>&__cuImportExternalMemory, 10000, ptds_mode, NULL)
-
-        global __cuExternalMemoryGetMappedBuffer
-        _F_cuGetProcAddress_v2('cuExternalMemoryGetMappedBuffer', <void **>&__cuExternalMemoryGetMappedBuffer, 10000, ptds_mode, NULL)
-
-        global __cuExternalMemoryGetMappedMipmappedArray
-        _F_cuGetProcAddress_v2('cuExternalMemoryGetMappedMipmappedArray', <void **>&__cuExternalMemoryGetMappedMipmappedArray, 10000, ptds_mode, NULL)
-
-        global __cuDestroyExternalMemory
-        _F_cuGetProcAddress_v2('cuDestroyExternalMemory', <void **>&__cuDestroyExternalMemory, 10000, ptds_mode, NULL)
-
-        global __cuImportExternalSemaphore
-        _F_cuGetProcAddress_v2('cuImportExternalSemaphore', <void **>&__cuImportExternalSemaphore, 10000, ptds_mode, NULL)
-
-        global __cuSignalExternalSemaphoresAsync
-        _F_cuGetProcAddress_v2('cuSignalExternalSemaphoresAsync', <void **>&__cuSignalExternalSemaphoresAsync, 10000, ptds_mode, NULL)
-
-        global __cuWaitExternalSemaphoresAsync
-        _F_cuGetProcAddress_v2('cuWaitExternalSemaphoresAsync', <void **>&__cuWaitExternalSemaphoresAsync, 10000, ptds_mode, NULL)
-
-        global __cuDestroyExternalSemaphore
-        _F_cuGetProcAddress_v2('cuDestroyExternalSemaphore', <void **>&__cuDestroyExternalSemaphore, 10000, ptds_mode, NULL)
-
-        global __cuStreamWaitValue32_v2
-        _F_cuGetProcAddress_v2('cuStreamWaitValue32', <void **>&__cuStreamWaitValue32_v2, 11070, ptds_mode, NULL)
-
-        global __cuStreamWaitValue64_v2
-        _F_cuGetProcAddress_v2('cuStreamWaitValue64', <void **>&__cuStreamWaitValue64_v2, 11070, ptds_mode, NULL)
-
-        global __cuStreamWriteValue32_v2
-        _F_cuGetProcAddress_v2('cuStreamWriteValue32', <void **>&__cuStreamWriteValue32_v2, 11070, ptds_mode, NULL)
-
-        global __cuStreamWriteValue64_v2
-        _F_cuGetProcAddress_v2('cuStreamWriteValue64', <void **>&__cuStreamWriteValue64_v2, 11070, ptds_mode, NULL)
-
-        global __cuStreamBatchMemOp_v2
-        _F_cuGetProcAddress_v2('cuStreamBatchMemOp', <void **>&__cuStreamBatchMemOp_v2, 11070, ptds_mode, NULL)
-
-        global __cuFuncGetAttribute
-        _F_cuGetProcAddress_v2('cuFuncGetAttribute', <void **>&__cuFuncGetAttribute, 2020, ptds_mode, NULL)
-
-        global __cuFuncSetAttribute
-        _F_cuGetProcAddress_v2('cuFuncSetAttribute', <void **>&__cuFuncSetAttribute, 9000, ptds_mode, NULL)
-
-        global __cuFuncSetCacheConfig
-        _F_cuGetProcAddress_v2('cuFuncSetCacheConfig', <void **>&__cuFuncSetCacheConfig, 3000, ptds_mode, NULL)
-
-        global __cuFuncGetModule
-        _F_cuGetProcAddress_v2('cuFuncGetModule', <void **>&__cuFuncGetModule, 11000, ptds_mode, NULL)
-
-        global __cuFuncGetName
-        _F_cuGetProcAddress_v2('cuFuncGetName', <void **>&__cuFuncGetName, 12030, ptds_mode, NULL)
-
-        global __cuFuncGetParamInfo
-        _F_cuGetProcAddress_v2('cuFuncGetParamInfo', <void **>&__cuFuncGetParamInfo, 12040, ptds_mode, NULL)
-
-        global __cuFuncIsLoaded
-        _F_cuGetProcAddress_v2('cuFuncIsLoaded', <void **>&__cuFuncIsLoaded, 12040, ptds_mode, NULL)
-
-        global __cuFuncLoad
-        _F_cuGetProcAddress_v2('cuFuncLoad', <void **>&__cuFuncLoad, 12040, ptds_mode, NULL)
-
-        global __cuLaunchKernel
-        _F_cuGetProcAddress_v2('cuLaunchKernel', <void **>&__cuLaunchKernel, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
-
-        global __cuLaunchKernelEx
-        _F_cuGetProcAddress_v2('cuLaunchKernelEx', <void **>&__cuLaunchKernelEx, 11060, ptds_mode, NULL)
-
-        global __cuLaunchCooperativeKernel
-        _F_cuGetProcAddress_v2('cuLaunchCooperativeKernel', <void **>&__cuLaunchCooperativeKernel, 9000, ptds_mode, NULL)
-
-        global __cuLaunchCooperativeKernelMultiDevice
-        _F_cuGetProcAddress_v2('cuLaunchCooperativeKernelMultiDevice', <void **>&__cuLaunchCooperativeKernelMultiDevice, 9000, ptds_mode, NULL)
-
-        global __cuLaunchHostFunc
-        _F_cuGetProcAddress_v2('cuLaunchHostFunc', <void **>&__cuLaunchHostFunc, 10000, ptds_mode, NULL)
-
-        global __cuFuncSetBlockShape
-        _F_cuGetProcAddress_v2('cuFuncSetBlockShape', <void **>&__cuFuncSetBlockShape, 2000, ptds_mode, NULL)
-
-        global __cuFuncSetSharedSize
-        _F_cuGetProcAddress_v2('cuFuncSetSharedSize', <void **>&__cuFuncSetSharedSize, 2000, ptds_mode, NULL)
-
-        global __cuParamSetSize
-        _F_cuGetProcAddress_v2('cuParamSetSize', <void **>&__cuParamSetSize, 2000, ptds_mode, NULL)
-
-        global __cuParamSeti
-        _F_cuGetProcAddress_v2('cuParamSeti', <void **>&__cuParamSeti, 2000, ptds_mode, NULL)
-
-        global __cuParamSetf
-        _F_cuGetProcAddress_v2('cuParamSetf', <void **>&__cuParamSetf, 2000, ptds_mode, NULL)
-
-        global __cuParamSetv
-        _F_cuGetProcAddress_v2('cuParamSetv', <void **>&__cuParamSetv, 2000, ptds_mode, NULL)
-
-        global __cuLaunch
-        _F_cuGetProcAddress_v2('cuLaunch', <void **>&__cuLaunch, 2000, ptds_mode, NULL)
-
-        global __cuLaunchGrid
-        _F_cuGetProcAddress_v2('cuLaunchGrid', <void **>&__cuLaunchGrid, 2000, ptds_mode, NULL)
-
-        global __cuLaunchGridAsync
-        _F_cuGetProcAddress_v2('cuLaunchGridAsync', <void **>&__cuLaunchGridAsync, 2000, ptds_mode, NULL)
-
-        global __cuParamSetTexRef
-        _F_cuGetProcAddress_v2('cuParamSetTexRef', <void **>&__cuParamSetTexRef, 2000, ptds_mode, NULL)
-
-        global __cuFuncSetSharedMemConfig
-        _F_cuGetProcAddress_v2('cuFuncSetSharedMemConfig', <void **>&__cuFuncSetSharedMemConfig, 4020, ptds_mode, NULL)
-
-        global __cuGraphCreate
-        _F_cuGetProcAddress_v2('cuGraphCreate', <void **>&__cuGraphCreate, 10000, ptds_mode, NULL)
-
-        global __cuGraphAddKernelNode_v2
-        _F_cuGetProcAddress_v2('cuGraphAddKernelNode', <void **>&__cuGraphAddKernelNode_v2, 12000, ptds_mode, NULL)
-
-        global __cuGraphKernelNodeGetParams_v2
-        _F_cuGetProcAddress_v2('cuGraphKernelNodeGetParams', <void **>&__cuGraphKernelNodeGetParams_v2, 12000, ptds_mode, NULL)
-
-        global __cuGraphKernelNodeSetParams_v2
-        _F_cuGetProcAddress_v2('cuGraphKernelNodeSetParams', <void **>&__cuGraphKernelNodeSetParams_v2, 12000, ptds_mode, NULL)
-
-        global __cuGraphAddMemcpyNode
-        _F_cuGetProcAddress_v2('cuGraphAddMemcpyNode', <void **>&__cuGraphAddMemcpyNode, 10000, ptds_mode, NULL)
-
-        global __cuGraphMemcpyNodeGetParams
-        _F_cuGetProcAddress_v2('cuGraphMemcpyNodeGetParams', <void **>&__cuGraphMemcpyNodeGetParams, 10000, ptds_mode, NULL)
-
-        global __cuGraphMemcpyNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphMemcpyNodeSetParams', <void **>&__cuGraphMemcpyNodeSetParams, 10000, ptds_mode, NULL)
-
-        global __cuGraphAddMemsetNode
-        _F_cuGetProcAddress_v2('cuGraphAddMemsetNode', <void **>&__cuGraphAddMemsetNode, 10000, ptds_mode, NULL)
-
-        global __cuGraphMemsetNodeGetParams
-        _F_cuGetProcAddress_v2('cuGraphMemsetNodeGetParams', <void **>&__cuGraphMemsetNodeGetParams, 10000, ptds_mode, NULL)
-
-        global __cuGraphMemsetNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphMemsetNodeSetParams', <void **>&__cuGraphMemsetNodeSetParams, 10000, ptds_mode, NULL)
-
-        global __cuGraphAddHostNode
-        _F_cuGetProcAddress_v2('cuGraphAddHostNode', <void **>&__cuGraphAddHostNode, 10000, ptds_mode, NULL)
-
-        global __cuGraphHostNodeGetParams
-        _F_cuGetProcAddress_v2('cuGraphHostNodeGetParams', <void **>&__cuGraphHostNodeGetParams, 10000, ptds_mode, NULL)
-
-        global __cuGraphHostNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphHostNodeSetParams', <void **>&__cuGraphHostNodeSetParams, 10000, ptds_mode, NULL)
-
-        global __cuGraphAddChildGraphNode
-        _F_cuGetProcAddress_v2('cuGraphAddChildGraphNode', <void **>&__cuGraphAddChildGraphNode, 10000, ptds_mode, NULL)
-
-        global __cuGraphChildGraphNodeGetGraph
-        _F_cuGetProcAddress_v2('cuGraphChildGraphNodeGetGraph', <void **>&__cuGraphChildGraphNodeGetGraph, 10000, ptds_mode, NULL)
-
-        global __cuGraphAddEmptyNode
-        _F_cuGetProcAddress_v2('cuGraphAddEmptyNode', <void **>&__cuGraphAddEmptyNode, 10000, ptds_mode, NULL)
-
-        global __cuGraphAddEventRecordNode
-        _F_cuGetProcAddress_v2('cuGraphAddEventRecordNode', <void **>&__cuGraphAddEventRecordNode, 11010, ptds_mode, NULL)
-
-        global __cuGraphEventRecordNodeGetEvent
-        _F_cuGetProcAddress_v2('cuGraphEventRecordNodeGetEvent', <void **>&__cuGraphEventRecordNodeGetEvent, 11010, ptds_mode, NULL)
-
-        global __cuGraphEventRecordNodeSetEvent
-        _F_cuGetProcAddress_v2('cuGraphEventRecordNodeSetEvent', <void **>&__cuGraphEventRecordNodeSetEvent, 11010, ptds_mode, NULL)
-
-        global __cuGraphAddEventWaitNode
-        _F_cuGetProcAddress_v2('cuGraphAddEventWaitNode', <void **>&__cuGraphAddEventWaitNode, 11010, ptds_mode, NULL)
-
-        global __cuGraphEventWaitNodeGetEvent
-        _F_cuGetProcAddress_v2('cuGraphEventWaitNodeGetEvent', <void **>&__cuGraphEventWaitNodeGetEvent, 11010, ptds_mode, NULL)
-
-        global __cuGraphEventWaitNodeSetEvent
-        _F_cuGetProcAddress_v2('cuGraphEventWaitNodeSetEvent', <void **>&__cuGraphEventWaitNodeSetEvent, 11010, ptds_mode, NULL)
-
-        global __cuGraphAddExternalSemaphoresSignalNode
-        _F_cuGetProcAddress_v2('cuGraphAddExternalSemaphoresSignalNode', <void **>&__cuGraphAddExternalSemaphoresSignalNode, 11020, ptds_mode, NULL)
-
-        global __cuGraphExternalSemaphoresSignalNodeGetParams
-        _F_cuGetProcAddress_v2('cuGraphExternalSemaphoresSignalNodeGetParams', <void **>&__cuGraphExternalSemaphoresSignalNodeGetParams, 11020, ptds_mode, NULL)
-
-        global __cuGraphExternalSemaphoresSignalNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphExternalSemaphoresSignalNodeSetParams', <void **>&__cuGraphExternalSemaphoresSignalNodeSetParams, 11020, ptds_mode, NULL)
-
-        global __cuGraphAddExternalSemaphoresWaitNode
-        _F_cuGetProcAddress_v2('cuGraphAddExternalSemaphoresWaitNode', <void **>&__cuGraphAddExternalSemaphoresWaitNode, 11020, ptds_mode, NULL)
-
-        global __cuGraphExternalSemaphoresWaitNodeGetParams
-        _F_cuGetProcAddress_v2('cuGraphExternalSemaphoresWaitNodeGetParams', <void **>&__cuGraphExternalSemaphoresWaitNodeGetParams, 11020, ptds_mode, NULL)
-
-        global __cuGraphExternalSemaphoresWaitNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphExternalSemaphoresWaitNodeSetParams', <void **>&__cuGraphExternalSemaphoresWaitNodeSetParams, 11020, ptds_mode, NULL)
-
-        global __cuGraphAddBatchMemOpNode
-        _F_cuGetProcAddress_v2('cuGraphAddBatchMemOpNode', <void **>&__cuGraphAddBatchMemOpNode, 11070, ptds_mode, NULL)
-
-        global __cuGraphBatchMemOpNodeGetParams
-        _F_cuGetProcAddress_v2('cuGraphBatchMemOpNodeGetParams', <void **>&__cuGraphBatchMemOpNodeGetParams, 11070, ptds_mode, NULL)
-
-        global __cuGraphBatchMemOpNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphBatchMemOpNodeSetParams', <void **>&__cuGraphBatchMemOpNodeSetParams, 11070, ptds_mode, NULL)
-
-        global __cuGraphExecBatchMemOpNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphExecBatchMemOpNodeSetParams', <void **>&__cuGraphExecBatchMemOpNodeSetParams, 11070, ptds_mode, NULL)
-
-        global __cuGraphAddMemAllocNode
-        _F_cuGetProcAddress_v2('cuGraphAddMemAllocNode', <void **>&__cuGraphAddMemAllocNode, 11040, ptds_mode, NULL)
-
-        global __cuGraphMemAllocNodeGetParams
-        _F_cuGetProcAddress_v2('cuGraphMemAllocNodeGetParams', <void **>&__cuGraphMemAllocNodeGetParams, 11040, ptds_mode, NULL)
-
-        global __cuGraphAddMemFreeNode
-        _F_cuGetProcAddress_v2('cuGraphAddMemFreeNode', <void **>&__cuGraphAddMemFreeNode, 11040, ptds_mode, NULL)
-
-        global __cuGraphMemFreeNodeGetParams
-        _F_cuGetProcAddress_v2('cuGraphMemFreeNodeGetParams', <void **>&__cuGraphMemFreeNodeGetParams, 11040, ptds_mode, NULL)
-
-        global __cuDeviceGraphMemTrim
-        _F_cuGetProcAddress_v2('cuDeviceGraphMemTrim', <void **>&__cuDeviceGraphMemTrim, 11040, ptds_mode, NULL)
-
-        global __cuDeviceGetGraphMemAttribute
-        _F_cuGetProcAddress_v2('cuDeviceGetGraphMemAttribute', <void **>&__cuDeviceGetGraphMemAttribute, 11040, ptds_mode, NULL)
-
-        global __cuDeviceSetGraphMemAttribute
-        _F_cuGetProcAddress_v2('cuDeviceSetGraphMemAttribute', <void **>&__cuDeviceSetGraphMemAttribute, 11040, ptds_mode, NULL)
-
-        global __cuGraphClone
-        _F_cuGetProcAddress_v2('cuGraphClone', <void **>&__cuGraphClone, 10000, ptds_mode, NULL)
-
-        global __cuGraphNodeFindInClone
-        _F_cuGetProcAddress_v2('cuGraphNodeFindInClone', <void **>&__cuGraphNodeFindInClone, 10000, ptds_mode, NULL)
-
-        global __cuGraphNodeGetType
-        _F_cuGetProcAddress_v2('cuGraphNodeGetType', <void **>&__cuGraphNodeGetType, 10000, ptds_mode, NULL)
-
-        global __cuGraphGetNodes
-        _F_cuGetProcAddress_v2('cuGraphGetNodes', <void **>&__cuGraphGetNodes, 10000, ptds_mode, NULL)
-
-        global __cuGraphGetRootNodes
-        _F_cuGetProcAddress_v2('cuGraphGetRootNodes', <void **>&__cuGraphGetRootNodes, 10000, ptds_mode, NULL)
-
-        global __cuGraphGetEdges_v2
-        _F_cuGetProcAddress_v2('cuGraphGetEdges', <void **>&__cuGraphGetEdges_v2, 12030, ptds_mode, NULL)
-
-        global __cuGraphNodeGetDependencies_v2
-        _F_cuGetProcAddress_v2('cuGraphNodeGetDependencies', <void **>&__cuGraphNodeGetDependencies_v2, 12030, ptds_mode, NULL)
-
-        global __cuGraphNodeGetDependentNodes_v2
-        _F_cuGetProcAddress_v2('cuGraphNodeGetDependentNodes', <void **>&__cuGraphNodeGetDependentNodes_v2, 12030, ptds_mode, NULL)
-
-        global __cuGraphAddDependencies_v2
-        _F_cuGetProcAddress_v2('cuGraphAddDependencies', <void **>&__cuGraphAddDependencies_v2, 12030, ptds_mode, NULL)
-
-        global __cuGraphRemoveDependencies_v2
-        _F_cuGetProcAddress_v2('cuGraphRemoveDependencies', <void **>&__cuGraphRemoveDependencies_v2, 12030, ptds_mode, NULL)
-
-        global __cuGraphDestroyNode
-        _F_cuGetProcAddress_v2('cuGraphDestroyNode', <void **>&__cuGraphDestroyNode, 10000, ptds_mode, NULL)
-
-        global __cuGraphInstantiateWithFlags
-        _F_cuGetProcAddress_v2('cuGraphInstantiateWithFlags', <void **>&__cuGraphInstantiateWithFlags, 11040, ptds_mode, NULL)
-
-        global __cuGraphInstantiateWithParams
-        _F_cuGetProcAddress_v2('cuGraphInstantiateWithParams', <void **>&__cuGraphInstantiateWithParams, 12000, ptds_mode, NULL)
-
-        global __cuGraphExecGetFlags
-        _F_cuGetProcAddress_v2('cuGraphExecGetFlags', <void **>&__cuGraphExecGetFlags, 12000, ptds_mode, NULL)
-
-        global __cuGraphExecKernelNodeSetParams_v2
-        _F_cuGetProcAddress_v2('cuGraphExecKernelNodeSetParams', <void **>&__cuGraphExecKernelNodeSetParams_v2, 12000, ptds_mode, NULL)
-
-        global __cuGraphExecMemcpyNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphExecMemcpyNodeSetParams', <void **>&__cuGraphExecMemcpyNodeSetParams, 10020, ptds_mode, NULL)
-
-        global __cuGraphExecMemsetNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphExecMemsetNodeSetParams', <void **>&__cuGraphExecMemsetNodeSetParams, 10020, ptds_mode, NULL)
-
-        global __cuGraphExecHostNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphExecHostNodeSetParams', <void **>&__cuGraphExecHostNodeSetParams, 10020, ptds_mode, NULL)
-
-        global __cuGraphExecChildGraphNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphExecChildGraphNodeSetParams', <void **>&__cuGraphExecChildGraphNodeSetParams, 11010, ptds_mode, NULL)
-
-        global __cuGraphExecEventRecordNodeSetEvent
-        _F_cuGetProcAddress_v2('cuGraphExecEventRecordNodeSetEvent', <void **>&__cuGraphExecEventRecordNodeSetEvent, 11010, ptds_mode, NULL)
-
-        global __cuGraphExecEventWaitNodeSetEvent
-        _F_cuGetProcAddress_v2('cuGraphExecEventWaitNodeSetEvent', <void **>&__cuGraphExecEventWaitNodeSetEvent, 11010, ptds_mode, NULL)
-
-        global __cuGraphExecExternalSemaphoresSignalNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphExecExternalSemaphoresSignalNodeSetParams', <void **>&__cuGraphExecExternalSemaphoresSignalNodeSetParams, 11020, ptds_mode, NULL)
-
-        global __cuGraphExecExternalSemaphoresWaitNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphExecExternalSemaphoresWaitNodeSetParams', <void **>&__cuGraphExecExternalSemaphoresWaitNodeSetParams, 11020, ptds_mode, NULL)
-
-        global __cuGraphNodeSetEnabled
-        _F_cuGetProcAddress_v2('cuGraphNodeSetEnabled', <void **>&__cuGraphNodeSetEnabled, 11060, ptds_mode, NULL)
-
-        global __cuGraphNodeGetEnabled
-        _F_cuGetProcAddress_v2('cuGraphNodeGetEnabled', <void **>&__cuGraphNodeGetEnabled, 11060, ptds_mode, NULL)
-
-        global __cuGraphUpload
-        _F_cuGetProcAddress_v2('cuGraphUpload', <void **>&__cuGraphUpload, 11010, ptds_mode, NULL)
-
-        global __cuGraphLaunch
-        _F_cuGetProcAddress_v2('cuGraphLaunch', <void **>&__cuGraphLaunch, 10000, ptds_mode, NULL)
-
-        global __cuGraphExecDestroy
-        _F_cuGetProcAddress_v2('cuGraphExecDestroy', <void **>&__cuGraphExecDestroy, 10000, ptds_mode, NULL)
-
-        global __cuGraphDestroy
-        _F_cuGetProcAddress_v2('cuGraphDestroy', <void **>&__cuGraphDestroy, 10000, ptds_mode, NULL)
-
-        global __cuGraphExecUpdate_v2
-        _F_cuGetProcAddress_v2('cuGraphExecUpdate', <void **>&__cuGraphExecUpdate_v2, 12000, ptds_mode, NULL)
-
-        global __cuGraphKernelNodeCopyAttributes
-        _F_cuGetProcAddress_v2('cuGraphKernelNodeCopyAttributes', <void **>&__cuGraphKernelNodeCopyAttributes, 11000, ptds_mode, NULL)
-
-        global __cuGraphKernelNodeGetAttribute
-        _F_cuGetProcAddress_v2('cuGraphKernelNodeGetAttribute', <void **>&__cuGraphKernelNodeGetAttribute, 11000, ptds_mode, NULL)
-
-        global __cuGraphKernelNodeSetAttribute
-        _F_cuGetProcAddress_v2('cuGraphKernelNodeSetAttribute', <void **>&__cuGraphKernelNodeSetAttribute, 11000, ptds_mode, NULL)
-
-        global __cuGraphDebugDotPrint
-        _F_cuGetProcAddress_v2('cuGraphDebugDotPrint', <void **>&__cuGraphDebugDotPrint, 11030, ptds_mode, NULL)
-
-        global __cuUserObjectCreate
-        _F_cuGetProcAddress_v2('cuUserObjectCreate', <void **>&__cuUserObjectCreate, 11030, ptds_mode, NULL)
-
-        global __cuUserObjectRetain
-        _F_cuGetProcAddress_v2('cuUserObjectRetain', <void **>&__cuUserObjectRetain, 11030, ptds_mode, NULL)
-
-        global __cuUserObjectRelease
-        _F_cuGetProcAddress_v2('cuUserObjectRelease', <void **>&__cuUserObjectRelease, 11030, ptds_mode, NULL)
-
-        global __cuGraphRetainUserObject
-        _F_cuGetProcAddress_v2('cuGraphRetainUserObject', <void **>&__cuGraphRetainUserObject, 11030, ptds_mode, NULL)
-
-        global __cuGraphReleaseUserObject
-        _F_cuGetProcAddress_v2('cuGraphReleaseUserObject', <void **>&__cuGraphReleaseUserObject, 11030, ptds_mode, NULL)
-
-        global __cuGraphAddNode_v2
-        _F_cuGetProcAddress_v2('cuGraphAddNode', <void **>&__cuGraphAddNode_v2, 12030, ptds_mode, NULL)
-
-        global __cuGraphNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphNodeSetParams', <void **>&__cuGraphNodeSetParams, 12020, ptds_mode, NULL)
-
-        global __cuGraphExecNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphExecNodeSetParams', <void **>&__cuGraphExecNodeSetParams, 12020, ptds_mode, NULL)
-
-        global __cuGraphConditionalHandleCreate
-        _F_cuGetProcAddress_v2('cuGraphConditionalHandleCreate', <void **>&__cuGraphConditionalHandleCreate, 12030, ptds_mode, NULL)
-
-        global __cuOccupancyMaxActiveBlocksPerMultiprocessor
-        _F_cuGetProcAddress_v2('cuOccupancyMaxActiveBlocksPerMultiprocessor', <void **>&__cuOccupancyMaxActiveBlocksPerMultiprocessor, 6050, ptds_mode, NULL)
-
-        global __cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags
-        _F_cuGetProcAddress_v2('cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags', <void **>&__cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags, 7000, ptds_mode, NULL)
-
-        global __cuOccupancyMaxPotentialBlockSize
-        _F_cuGetProcAddress_v2('cuOccupancyMaxPotentialBlockSize', <void **>&__cuOccupancyMaxPotentialBlockSize, 6050, ptds_mode, NULL)
-
-        global __cuOccupancyMaxPotentialBlockSizeWithFlags
-        _F_cuGetProcAddress_v2('cuOccupancyMaxPotentialBlockSizeWithFlags', <void **>&__cuOccupancyMaxPotentialBlockSizeWithFlags, 7000, ptds_mode, NULL)
-
-        global __cuOccupancyAvailableDynamicSMemPerBlock
-        _F_cuGetProcAddress_v2('cuOccupancyAvailableDynamicSMemPerBlock', <void **>&__cuOccupancyAvailableDynamicSMemPerBlock, 10020, ptds_mode, NULL)
-
-        global __cuOccupancyMaxPotentialClusterSize
-        _F_cuGetProcAddress_v2('cuOccupancyMaxPotentialClusterSize', <void **>&__cuOccupancyMaxPotentialClusterSize, 11070, ptds_mode, NULL)
-
-        global __cuOccupancyMaxActiveClusters
-        _F_cuGetProcAddress_v2('cuOccupancyMaxActiveClusters', <void **>&__cuOccupancyMaxActiveClusters, 11070, ptds_mode, NULL)
-
-        global __cuTexRefSetArray
-        _F_cuGetProcAddress_v2('cuTexRefSetArray', <void **>&__cuTexRefSetArray, 2000, ptds_mode, NULL)
-
-        global __cuTexRefSetMipmappedArray
-        _F_cuGetProcAddress_v2('cuTexRefSetMipmappedArray', <void **>&__cuTexRefSetMipmappedArray, 5000, ptds_mode, NULL)
-
-        global __cuTexRefSetAddress_v2
-        _F_cuGetProcAddress_v2('cuTexRefSetAddress', <void **>&__cuTexRefSetAddress_v2, 3020, ptds_mode, NULL)
-
-        global __cuTexRefSetAddress2D_v3
-        _F_cuGetProcAddress_v2('cuTexRefSetAddress2D', <void **>&__cuTexRefSetAddress2D_v3, 4010, ptds_mode, NULL)
-
-        global __cuTexRefSetFormat
-        _F_cuGetProcAddress_v2('cuTexRefSetFormat', <void **>&__cuTexRefSetFormat, 2000, ptds_mode, NULL)
-
-        global __cuTexRefSetAddressMode
-        _F_cuGetProcAddress_v2('cuTexRefSetAddressMode', <void **>&__cuTexRefSetAddressMode, 2000, ptds_mode, NULL)
-
-        global __cuTexRefSetFilterMode
-        _F_cuGetProcAddress_v2('cuTexRefSetFilterMode', <void **>&__cuTexRefSetFilterMode, 2000, ptds_mode, NULL)
-
-        global __cuTexRefSetMipmapFilterMode
-        _F_cuGetProcAddress_v2('cuTexRefSetMipmapFilterMode', <void **>&__cuTexRefSetMipmapFilterMode, 5000, ptds_mode, NULL)
-
-        global __cuTexRefSetMipmapLevelBias
-        _F_cuGetProcAddress_v2('cuTexRefSetMipmapLevelBias', <void **>&__cuTexRefSetMipmapLevelBias, 5000, ptds_mode, NULL)
-
-        global __cuTexRefSetMipmapLevelClamp
-        _F_cuGetProcAddress_v2('cuTexRefSetMipmapLevelClamp', <void **>&__cuTexRefSetMipmapLevelClamp, 5000, ptds_mode, NULL)
-
-        global __cuTexRefSetMaxAnisotropy
-        _F_cuGetProcAddress_v2('cuTexRefSetMaxAnisotropy', <void **>&__cuTexRefSetMaxAnisotropy, 5000, ptds_mode, NULL)
-
-        global __cuTexRefSetBorderColor
-        _F_cuGetProcAddress_v2('cuTexRefSetBorderColor', <void **>&__cuTexRefSetBorderColor, 8000, ptds_mode, NULL)
-
-        global __cuTexRefSetFlags
-        _F_cuGetProcAddress_v2('cuTexRefSetFlags', <void **>&__cuTexRefSetFlags, 2000, ptds_mode, NULL)
-
-        global __cuTexRefGetAddress_v2
-        _F_cuGetProcAddress_v2('cuTexRefGetAddress', <void **>&__cuTexRefGetAddress_v2, 3020, ptds_mode, NULL)
-
-        global __cuTexRefGetArray
-        _F_cuGetProcAddress_v2('cuTexRefGetArray', <void **>&__cuTexRefGetArray, 2000, ptds_mode, NULL)
-
-        global __cuTexRefGetMipmappedArray
-        _F_cuGetProcAddress_v2('cuTexRefGetMipmappedArray', <void **>&__cuTexRefGetMipmappedArray, 5000, ptds_mode, NULL)
-
-        global __cuTexRefGetAddressMode
-        _F_cuGetProcAddress_v2('cuTexRefGetAddressMode', <void **>&__cuTexRefGetAddressMode, 2000, ptds_mode, NULL)
-
-        global __cuTexRefGetFilterMode
-        _F_cuGetProcAddress_v2('cuTexRefGetFilterMode', <void **>&__cuTexRefGetFilterMode, 2000, ptds_mode, NULL)
-
-        global __cuTexRefGetFormat
-        _F_cuGetProcAddress_v2('cuTexRefGetFormat', <void **>&__cuTexRefGetFormat, 2000, ptds_mode, NULL)
-
-        global __cuTexRefGetMipmapFilterMode
-        _F_cuGetProcAddress_v2('cuTexRefGetMipmapFilterMode', <void **>&__cuTexRefGetMipmapFilterMode, 5000, ptds_mode, NULL)
-
-        global __cuTexRefGetMipmapLevelBias
-        _F_cuGetProcAddress_v2('cuTexRefGetMipmapLevelBias', <void **>&__cuTexRefGetMipmapLevelBias, 5000, ptds_mode, NULL)
-
-        global __cuTexRefGetMipmapLevelClamp
-        _F_cuGetProcAddress_v2('cuTexRefGetMipmapLevelClamp', <void **>&__cuTexRefGetMipmapLevelClamp, 5000, ptds_mode, NULL)
-
-        global __cuTexRefGetMaxAnisotropy
-        _F_cuGetProcAddress_v2('cuTexRefGetMaxAnisotropy', <void **>&__cuTexRefGetMaxAnisotropy, 5000, ptds_mode, NULL)
-
-        global __cuTexRefGetBorderColor
-        _F_cuGetProcAddress_v2('cuTexRefGetBorderColor', <void **>&__cuTexRefGetBorderColor, 8000, ptds_mode, NULL)
-
-        global __cuTexRefGetFlags
-        _F_cuGetProcAddress_v2('cuTexRefGetFlags', <void **>&__cuTexRefGetFlags, 2000, ptds_mode, NULL)
-
-        global __cuTexRefCreate
-        _F_cuGetProcAddress_v2('cuTexRefCreate', <void **>&__cuTexRefCreate, 2000, ptds_mode, NULL)
-
-        global __cuTexRefDestroy
-        _F_cuGetProcAddress_v2('cuTexRefDestroy', <void **>&__cuTexRefDestroy, 2000, ptds_mode, NULL)
-
-        global __cuSurfRefSetArray
-        _F_cuGetProcAddress_v2('cuSurfRefSetArray', <void **>&__cuSurfRefSetArray, 3000, ptds_mode, NULL)
-
-        global __cuSurfRefGetArray
-        _F_cuGetProcAddress_v2('cuSurfRefGetArray', <void **>&__cuSurfRefGetArray, 3000, ptds_mode, NULL)
-
-        global __cuTexObjectCreate
-        _F_cuGetProcAddress_v2('cuTexObjectCreate', <void **>&__cuTexObjectCreate, 5000, ptds_mode, NULL)
-
-        global __cuTexObjectDestroy
-        _F_cuGetProcAddress_v2('cuTexObjectDestroy', <void **>&__cuTexObjectDestroy, 5000, ptds_mode, NULL)
-
-        global __cuTexObjectGetResourceDesc
-        _F_cuGetProcAddress_v2('cuTexObjectGetResourceDesc', <void **>&__cuTexObjectGetResourceDesc, 5000, ptds_mode, NULL)
-
-        global __cuTexObjectGetTextureDesc
-        _F_cuGetProcAddress_v2('cuTexObjectGetTextureDesc', <void **>&__cuTexObjectGetTextureDesc, 5000, ptds_mode, NULL)
-
-        global __cuTexObjectGetResourceViewDesc
-        _F_cuGetProcAddress_v2('cuTexObjectGetResourceViewDesc', <void **>&__cuTexObjectGetResourceViewDesc, 5000, ptds_mode, NULL)
-
-        global __cuSurfObjectCreate
-        _F_cuGetProcAddress_v2('cuSurfObjectCreate', <void **>&__cuSurfObjectCreate, 5000, ptds_mode, NULL)
-
-        global __cuSurfObjectDestroy
-        _F_cuGetProcAddress_v2('cuSurfObjectDestroy', <void **>&__cuSurfObjectDestroy, 5000, ptds_mode, NULL)
-
-        global __cuSurfObjectGetResourceDesc
-        _F_cuGetProcAddress_v2('cuSurfObjectGetResourceDesc', <void **>&__cuSurfObjectGetResourceDesc, 5000, ptds_mode, NULL)
-
-        global __cuTensorMapEncodeTiled
-        _F_cuGetProcAddress_v2('cuTensorMapEncodeTiled', <void **>&__cuTensorMapEncodeTiled, 12000, ptds_mode, NULL)
-
-        global __cuTensorMapEncodeIm2col
-        _F_cuGetProcAddress_v2('cuTensorMapEncodeIm2col', <void **>&__cuTensorMapEncodeIm2col, 12000, ptds_mode, NULL)
-
-        global __cuTensorMapEncodeIm2colWide
-        _F_cuGetProcAddress_v2('cuTensorMapEncodeIm2colWide', <void **>&__cuTensorMapEncodeIm2colWide, 12080, ptds_mode, NULL)
-
-        global __cuTensorMapReplaceAddress
-        _F_cuGetProcAddress_v2('cuTensorMapReplaceAddress', <void **>&__cuTensorMapReplaceAddress, 12000, ptds_mode, NULL)
-
-        global __cuDeviceCanAccessPeer
-        _F_cuGetProcAddress_v2('cuDeviceCanAccessPeer', <void **>&__cuDeviceCanAccessPeer, 4000, ptds_mode, NULL)
-
-        global __cuCtxEnablePeerAccess
-        _F_cuGetProcAddress_v2('cuCtxEnablePeerAccess', <void **>&__cuCtxEnablePeerAccess, 4000, ptds_mode, NULL)
-
-        global __cuCtxDisablePeerAccess
-        _F_cuGetProcAddress_v2('cuCtxDisablePeerAccess', <void **>&__cuCtxDisablePeerAccess, 4000, ptds_mode, NULL)
-
-        global __cuDeviceGetP2PAttribute
-        _F_cuGetProcAddress_v2('cuDeviceGetP2PAttribute', <void **>&__cuDeviceGetP2PAttribute, 8000, ptds_mode, NULL)
-
-        global __cuGraphicsUnregisterResource
-        _F_cuGetProcAddress_v2('cuGraphicsUnregisterResource', <void **>&__cuGraphicsUnregisterResource, 3000, ptds_mode, NULL)
-
-        global __cuGraphicsSubResourceGetMappedArray
-        _F_cuGetProcAddress_v2('cuGraphicsSubResourceGetMappedArray', <void **>&__cuGraphicsSubResourceGetMappedArray, 3000, ptds_mode, NULL)
-
-        global __cuGraphicsResourceGetMappedMipmappedArray
-        _F_cuGetProcAddress_v2('cuGraphicsResourceGetMappedMipmappedArray', <void **>&__cuGraphicsResourceGetMappedMipmappedArray, 5000, ptds_mode, NULL)
-
-        global __cuGraphicsResourceGetMappedPointer_v2
-        _F_cuGetProcAddress_v2('cuGraphicsResourceGetMappedPointer', <void **>&__cuGraphicsResourceGetMappedPointer_v2, 3020, ptds_mode, NULL)
-
-        global __cuGraphicsResourceSetMapFlags_v2
-        _F_cuGetProcAddress_v2('cuGraphicsResourceSetMapFlags', <void **>&__cuGraphicsResourceSetMapFlags_v2, 6050, ptds_mode, NULL)
-
-        global __cuGraphicsMapResources
-        _F_cuGetProcAddress_v2('cuGraphicsMapResources', <void **>&__cuGraphicsMapResources, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3000, ptds_mode, NULL)
-
-        global __cuGraphicsUnmapResources
-        _F_cuGetProcAddress_v2('cuGraphicsUnmapResources', <void **>&__cuGraphicsUnmapResources, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3000, ptds_mode, NULL)
-
-        global __cuGetProcAddress_v2
-        _F_cuGetProcAddress_v2('cuGetProcAddress', <void **>&__cuGetProcAddress_v2, 12000, ptds_mode, NULL)
-
-        global __cuCoredumpGetAttribute
-        _F_cuGetProcAddress_v2('cuCoredumpGetAttribute', <void **>&__cuCoredumpGetAttribute, 12010, ptds_mode, NULL)
-
-        global __cuCoredumpGetAttributeGlobal
-        _F_cuGetProcAddress_v2('cuCoredumpGetAttributeGlobal', <void **>&__cuCoredumpGetAttributeGlobal, 12010, ptds_mode, NULL)
-
-        global __cuCoredumpSetAttribute
-        _F_cuGetProcAddress_v2('cuCoredumpSetAttribute', <void **>&__cuCoredumpSetAttribute, 12010, ptds_mode, NULL)
-
-        global __cuCoredumpSetAttributeGlobal
-        _F_cuGetProcAddress_v2('cuCoredumpSetAttributeGlobal', <void **>&__cuCoredumpSetAttributeGlobal, 12010, ptds_mode, NULL)
-
-        global __cuGetExportTable
-        _F_cuGetProcAddress_v2('cuGetExportTable', <void **>&__cuGetExportTable, 3000, ptds_mode, NULL)
-
-        global __cuGreenCtxCreate
-        _F_cuGetProcAddress_v2('cuGreenCtxCreate', <void **>&__cuGreenCtxCreate, 12040, ptds_mode, NULL)
-
-        global __cuGreenCtxDestroy
-        _F_cuGetProcAddress_v2('cuGreenCtxDestroy', <void **>&__cuGreenCtxDestroy, 12040, ptds_mode, NULL)
-
-        global __cuCtxFromGreenCtx
-        _F_cuGetProcAddress_v2('cuCtxFromGreenCtx', <void **>&__cuCtxFromGreenCtx, 12040, ptds_mode, NULL)
-
-        global __cuDeviceGetDevResource
-        _F_cuGetProcAddress_v2('cuDeviceGetDevResource', <void **>&__cuDeviceGetDevResource, 12040, ptds_mode, NULL)
-
-        global __cuCtxGetDevResource
-        _F_cuGetProcAddress_v2('cuCtxGetDevResource', <void **>&__cuCtxGetDevResource, 12040, ptds_mode, NULL)
-
-        global __cuGreenCtxGetDevResource
-        _F_cuGetProcAddress_v2('cuGreenCtxGetDevResource', <void **>&__cuGreenCtxGetDevResource, 12040, ptds_mode, NULL)
-
-        global __cuDevSmResourceSplitByCount
-        _F_cuGetProcAddress_v2('cuDevSmResourceSplitByCount', <void **>&__cuDevSmResourceSplitByCount, 12040, ptds_mode, NULL)
-
-        global __cuDevResourceGenerateDesc
-        _F_cuGetProcAddress_v2('cuDevResourceGenerateDesc', <void **>&__cuDevResourceGenerateDesc, 12040, ptds_mode, NULL)
-
-        global __cuGreenCtxRecordEvent
-        _F_cuGetProcAddress_v2('cuGreenCtxRecordEvent', <void **>&__cuGreenCtxRecordEvent, 12040, ptds_mode, NULL)
-
-        global __cuGreenCtxWaitEvent
-        _F_cuGetProcAddress_v2('cuGreenCtxWaitEvent', <void **>&__cuGreenCtxWaitEvent, 12040, ptds_mode, NULL)
-
-        global __cuStreamGetGreenCtx
-        _F_cuGetProcAddress_v2('cuStreamGetGreenCtx', <void **>&__cuStreamGetGreenCtx, 12040, ptds_mode, NULL)
-
-        global __cuGreenCtxStreamCreate
-        _F_cuGetProcAddress_v2('cuGreenCtxStreamCreate', <void **>&__cuGreenCtxStreamCreate, 12050, ptds_mode, NULL)
-
-        global __cuLogsRegisterCallback
-        _F_cuGetProcAddress_v2('cuLogsRegisterCallback', <void **>&__cuLogsRegisterCallback, 12080, ptds_mode, NULL)
-
-        global __cuLogsUnregisterCallback
-        _F_cuGetProcAddress_v2('cuLogsUnregisterCallback', <void **>&__cuLogsUnregisterCallback, 12080, ptds_mode, NULL)
-
-        global __cuLogsCurrent
-        _F_cuGetProcAddress_v2('cuLogsCurrent', <void **>&__cuLogsCurrent, 12080, ptds_mode, NULL)
-
-        global __cuLogsDumpToFile
-        _F_cuGetProcAddress_v2('cuLogsDumpToFile', <void **>&__cuLogsDumpToFile, 12080, ptds_mode, NULL)
-
-        global __cuLogsDumpToMemory
-        _F_cuGetProcAddress_v2('cuLogsDumpToMemory', <void **>&__cuLogsDumpToMemory, 12080, ptds_mode, NULL)
-
-        global __cuCheckpointProcessGetRestoreThreadId
-        _F_cuGetProcAddress_v2('cuCheckpointProcessGetRestoreThreadId', <void **>&__cuCheckpointProcessGetRestoreThreadId, 12080, ptds_mode, NULL)
-
-        global __cuCheckpointProcessGetState
-        _F_cuGetProcAddress_v2('cuCheckpointProcessGetState', <void **>&__cuCheckpointProcessGetState, 12080, ptds_mode, NULL)
-
-        global __cuCheckpointProcessLock
-        _F_cuGetProcAddress_v2('cuCheckpointProcessLock', <void **>&__cuCheckpointProcessLock, 12080, ptds_mode, NULL)
-
-        global __cuCheckpointProcessCheckpoint
-        _F_cuGetProcAddress_v2('cuCheckpointProcessCheckpoint', <void **>&__cuCheckpointProcessCheckpoint, 12080, ptds_mode, NULL)
-
-        global __cuCheckpointProcessRestore
-        _F_cuGetProcAddress_v2('cuCheckpointProcessRestore', <void **>&__cuCheckpointProcessRestore, 12080, ptds_mode, NULL)
-
-        global __cuCheckpointProcessUnlock
-        _F_cuGetProcAddress_v2('cuCheckpointProcessUnlock', <void **>&__cuCheckpointProcessUnlock, 12080, ptds_mode, NULL)
-
-        global __cuGraphicsEGLRegisterImage
-        _F_cuGetProcAddress_v2('cuGraphicsEGLRegisterImage', <void **>&__cuGraphicsEGLRegisterImage, 7000, ptds_mode, NULL)
-
-        global __cuEGLStreamConsumerConnect
-        _F_cuGetProcAddress_v2('cuEGLStreamConsumerConnect', <void **>&__cuEGLStreamConsumerConnect, 7000, ptds_mode, NULL)
-
-        global __cuEGLStreamConsumerConnectWithFlags
-        _F_cuGetProcAddress_v2('cuEGLStreamConsumerConnectWithFlags', <void **>&__cuEGLStreamConsumerConnectWithFlags, 8000, ptds_mode, NULL)
-
-        global __cuEGLStreamConsumerDisconnect
-        _F_cuGetProcAddress_v2('cuEGLStreamConsumerDisconnect', <void **>&__cuEGLStreamConsumerDisconnect, 7000, ptds_mode, NULL)
-
-        global __cuEGLStreamConsumerAcquireFrame
-        _F_cuGetProcAddress_v2('cuEGLStreamConsumerAcquireFrame', <void **>&__cuEGLStreamConsumerAcquireFrame, 7000, ptds_mode, NULL)
-
-        global __cuEGLStreamConsumerReleaseFrame
-        _F_cuGetProcAddress_v2('cuEGLStreamConsumerReleaseFrame', <void **>&__cuEGLStreamConsumerReleaseFrame, 7000, ptds_mode, NULL)
-
-        global __cuEGLStreamProducerConnect
-        _F_cuGetProcAddress_v2('cuEGLStreamProducerConnect', <void **>&__cuEGLStreamProducerConnect, 7000, ptds_mode, NULL)
-
-        global __cuEGLStreamProducerDisconnect
-        _F_cuGetProcAddress_v2('cuEGLStreamProducerDisconnect', <void **>&__cuEGLStreamProducerDisconnect, 7000, ptds_mode, NULL)
-
-        global __cuEGLStreamProducerPresentFrame
-        _F_cuGetProcAddress_v2('cuEGLStreamProducerPresentFrame', <void **>&__cuEGLStreamProducerPresentFrame, 7000, ptds_mode, NULL)
-
-        global __cuEGLStreamProducerReturnFrame
-        _F_cuGetProcAddress_v2('cuEGLStreamProducerReturnFrame', <void **>&__cuEGLStreamProducerReturnFrame, 7000, ptds_mode, NULL)
-
-        global __cuGraphicsResourceGetMappedEglFrame
-        _F_cuGetProcAddress_v2('cuGraphicsResourceGetMappedEglFrame', <void **>&__cuGraphicsResourceGetMappedEglFrame, 7000, ptds_mode, NULL)
-
-        global __cuEventCreateFromEGLSync
-        _F_cuGetProcAddress_v2('cuEventCreateFromEGLSync', <void **>&__cuEventCreateFromEGLSync, 9000, ptds_mode, NULL)
-
-        global __cuGraphicsGLRegisterBuffer
-        _F_cuGetProcAddress_v2('cuGraphicsGLRegisterBuffer', <void **>&__cuGraphicsGLRegisterBuffer, 3000, ptds_mode, NULL)
-
-        global __cuGraphicsGLRegisterImage
-        _F_cuGetProcAddress_v2('cuGraphicsGLRegisterImage', <void **>&__cuGraphicsGLRegisterImage, 3000, ptds_mode, NULL)
-
-        global __cuGLGetDevices_v2
-        _F_cuGetProcAddress_v2('cuGLGetDevices', <void **>&__cuGLGetDevices_v2, 6050, ptds_mode, NULL)
-
-        global __cuGLCtxCreate_v2
-        _F_cuGetProcAddress_v2('cuGLCtxCreate', <void **>&__cuGLCtxCreate_v2, 3020, ptds_mode, NULL)
-
-        global __cuGLInit
-        _F_cuGetProcAddress_v2('cuGLInit', <void **>&__cuGLInit, 2000, ptds_mode, NULL)
-
-        global __cuGLRegisterBufferObject
-        _F_cuGetProcAddress_v2('cuGLRegisterBufferObject', <void **>&__cuGLRegisterBufferObject, 2000, ptds_mode, NULL)
-
-        global __cuGLMapBufferObject_v2
-        _F_cuGetProcAddress_v2('cuGLMapBufferObject', <void **>&__cuGLMapBufferObject_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuGLUnmapBufferObject
-        _F_cuGetProcAddress_v2('cuGLUnmapBufferObject', <void **>&__cuGLUnmapBufferObject, 2000, ptds_mode, NULL)
-
-        global __cuGLUnregisterBufferObject
-        _F_cuGetProcAddress_v2('cuGLUnregisterBufferObject', <void **>&__cuGLUnregisterBufferObject, 2000, ptds_mode, NULL)
-
-        global __cuGLSetBufferObjectMapFlags
-        _F_cuGetProcAddress_v2('cuGLSetBufferObjectMapFlags', <void **>&__cuGLSetBufferObjectMapFlags, 2030, ptds_mode, NULL)
-
-        global __cuGLMapBufferObjectAsync_v2
-        _F_cuGetProcAddress_v2('cuGLMapBufferObjectAsync', <void **>&__cuGLMapBufferObjectAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
-
-        global __cuGLUnmapBufferObjectAsync
-        _F_cuGetProcAddress_v2('cuGLUnmapBufferObjectAsync', <void **>&__cuGLUnmapBufferObjectAsync, 2030, ptds_mode, NULL)
-
-        global __cuProfilerInitialize
-        _F_cuGetProcAddress_v2('cuProfilerInitialize', <void **>&__cuProfilerInitialize, 4000, ptds_mode, NULL)
-
-        global __cuProfilerStart
-        _F_cuGetProcAddress_v2('cuProfilerStart', <void **>&__cuProfilerStart, 4000, ptds_mode, NULL)
-
-        global __cuProfilerStop
-        _F_cuGetProcAddress_v2('cuProfilerStop', <void **>&__cuProfilerStop, 4000, ptds_mode, NULL)
-
-        global __cuVDPAUGetDevice
-        _F_cuGetProcAddress_v2('cuVDPAUGetDevice', <void **>&__cuVDPAUGetDevice, 3010, ptds_mode, NULL)
-
-        global __cuVDPAUCtxCreate_v2
-        _F_cuGetProcAddress_v2('cuVDPAUCtxCreate', <void **>&__cuVDPAUCtxCreate_v2, 3020, ptds_mode, NULL)
-
-        global __cuGraphicsVDPAURegisterVideoSurface
-        _F_cuGetProcAddress_v2('cuGraphicsVDPAURegisterVideoSurface', <void **>&__cuGraphicsVDPAURegisterVideoSurface, 3010, ptds_mode, NULL)
-
-        global __cuGraphicsVDPAURegisterOutputSurface
-        _F_cuGetProcAddress_v2('cuGraphicsVDPAURegisterOutputSurface', <void **>&__cuGraphicsVDPAURegisterOutputSurface, 3010, ptds_mode, NULL)
-
-        global __cuDeviceGetHostAtomicCapabilities
-        _F_cuGetProcAddress_v2('cuDeviceGetHostAtomicCapabilities', <void **>&__cuDeviceGetHostAtomicCapabilities, 13000, ptds_mode, NULL)
-
-        global __cuCtxGetDevice_v2
-        _F_cuGetProcAddress_v2('cuCtxGetDevice', <void **>&__cuCtxGetDevice_v2, 13000, ptds_mode, NULL)
-
-        global __cuCtxSynchronize_v2
-        _F_cuGetProcAddress_v2('cuCtxSynchronize', <void **>&__cuCtxSynchronize_v2, 13000, ptds_mode, NULL)
-
-        global __cuMemcpyBatchAsync_v2
-        _F_cuGetProcAddress_v2('cuMemcpyBatchAsync', <void **>&__cuMemcpyBatchAsync_v2, 13000, ptds_mode, NULL)
-
-        global __cuMemcpy3DBatchAsync_v2
-        _F_cuGetProcAddress_v2('cuMemcpy3DBatchAsync', <void **>&__cuMemcpy3DBatchAsync_v2, 13000, ptds_mode, NULL)
-
-        global __cuMemGetDefaultMemPool
-        _F_cuGetProcAddress_v2('cuMemGetDefaultMemPool', <void **>&__cuMemGetDefaultMemPool, 13000, ptds_mode, NULL)
-
-        global __cuMemGetMemPool
-        _F_cuGetProcAddress_v2('cuMemGetMemPool', <void **>&__cuMemGetMemPool, 13000, ptds_mode, NULL)
-
-        global __cuMemSetMemPool
-        _F_cuGetProcAddress_v2('cuMemSetMemPool', <void **>&__cuMemSetMemPool, 13000, ptds_mode, NULL)
-
-        global __cuMemPrefetchBatchAsync
-        _F_cuGetProcAddress_v2('cuMemPrefetchBatchAsync', <void **>&__cuMemPrefetchBatchAsync, 13000, ptds_mode, NULL)
-
-        global __cuMemDiscardBatchAsync
-        _F_cuGetProcAddress_v2('cuMemDiscardBatchAsync', <void **>&__cuMemDiscardBatchAsync, 13000, ptds_mode, NULL)
-
-        global __cuMemDiscardAndPrefetchBatchAsync
-        _F_cuGetProcAddress_v2('cuMemDiscardAndPrefetchBatchAsync', <void **>&__cuMemDiscardAndPrefetchBatchAsync, 13000, ptds_mode, NULL)
-
-        global __cuDeviceGetP2PAtomicCapabilities
-        _F_cuGetProcAddress_v2('cuDeviceGetP2PAtomicCapabilities', <void **>&__cuDeviceGetP2PAtomicCapabilities, 13000, ptds_mode, NULL)
-
-        global __cuGreenCtxGetId
-        _F_cuGetProcAddress_v2('cuGreenCtxGetId', <void **>&__cuGreenCtxGetId, 13000, ptds_mode, NULL)
-
-        global __cuMulticastBindMem_v2
-        _F_cuGetProcAddress_v2('cuMulticastBindMem', <void **>&__cuMulticastBindMem_v2, 13010, ptds_mode, NULL)
-
-        global __cuMulticastBindAddr_v2
-        _F_cuGetProcAddress_v2('cuMulticastBindAddr', <void **>&__cuMulticastBindAddr_v2, 13010, ptds_mode, NULL)
-
-        global __cuGraphNodeGetContainingGraph
-        _F_cuGetProcAddress_v2('cuGraphNodeGetContainingGraph', <void **>&__cuGraphNodeGetContainingGraph, 13010, ptds_mode, NULL)
-
-        global __cuGraphNodeGetLocalId
-        _F_cuGetProcAddress_v2('cuGraphNodeGetLocalId', <void **>&__cuGraphNodeGetLocalId, 13010, ptds_mode, NULL)
-
-        global __cuGraphNodeGetToolsId
-        _F_cuGetProcAddress_v2('cuGraphNodeGetToolsId', <void **>&__cuGraphNodeGetToolsId, 13010, ptds_mode, NULL)
-
-        global __cuGraphGetId
-        _F_cuGetProcAddress_v2('cuGraphGetId', <void **>&__cuGraphGetId, 13010, ptds_mode, NULL)
-
-        global __cuGraphExecGetId
-        _F_cuGetProcAddress_v2('cuGraphExecGetId', <void **>&__cuGraphExecGetId, 13010, ptds_mode, NULL)
-
-        global __cuDevSmResourceSplit
-        _F_cuGetProcAddress_v2('cuDevSmResourceSplit', <void **>&__cuDevSmResourceSplit, 13010, ptds_mode, NULL)
-
-        global __cuStreamGetDevResource
-        _F_cuGetProcAddress_v2('cuStreamGetDevResource', <void **>&__cuStreamGetDevResource, 13010, ptds_mode, NULL)
-
-        global __cuKernelGetParamCount
-        _F_cuGetProcAddress_v2('cuKernelGetParamCount', <void **>&__cuKernelGetParamCount, 13020, ptds_mode, NULL)
-
-        global __cuMemcpyWithAttributesAsync
-        _F_cuGetProcAddress_v2('cuMemcpyWithAttributesAsync', <void **>&__cuMemcpyWithAttributesAsync, 13020, ptds_mode, NULL)
-
-        global __cuMemcpy3DWithAttributesAsync
-        _F_cuGetProcAddress_v2('cuMemcpy3DWithAttributesAsync', <void **>&__cuMemcpy3DWithAttributesAsync, 13020, ptds_mode, NULL)
-
-        global __cuStreamBeginCaptureToCig
-        _F_cuGetProcAddress_v2('cuStreamBeginCaptureToCig', <void **>&__cuStreamBeginCaptureToCig, 13020, ptds_mode, NULL)
-
-        global __cuStreamEndCaptureToCig
-        _F_cuGetProcAddress_v2('cuStreamEndCaptureToCig', <void **>&__cuStreamEndCaptureToCig, 13020, ptds_mode, NULL)
-
-        global __cuFuncGetParamCount
-        _F_cuGetProcAddress_v2('cuFuncGetParamCount', <void **>&__cuFuncGetParamCount, 13020, ptds_mode, NULL)
-
-        global __cuLaunchHostFunc_v2
-        _F_cuGetProcAddress_v2('cuLaunchHostFunc', <void **>&__cuLaunchHostFunc_v2, 13020, ptds_mode, NULL)
-
-        global __cuGraphNodeGetParams
-        _F_cuGetProcAddress_v2('cuGraphNodeGetParams', <void **>&__cuGraphNodeGetParams, 13020, ptds_mode, NULL)
-
-        global __cuCoredumpRegisterStartCallback
-        _F_cuGetProcAddress_v2('cuCoredumpRegisterStartCallback', <void **>&__cuCoredumpRegisterStartCallback, 13020, ptds_mode, NULL)
-
-        global __cuCoredumpRegisterCompleteCallback
-        _F_cuGetProcAddress_v2('cuCoredumpRegisterCompleteCallback', <void **>&__cuCoredumpRegisterCompleteCallback, 13020, ptds_mode, NULL)
-
-        global __cuCoredumpDeregisterStartCallback
-        _F_cuGetProcAddress_v2('cuCoredumpDeregisterStartCallback', <void **>&__cuCoredumpDeregisterStartCallback, 13020, ptds_mode, NULL)
-
-        global __cuCoredumpDeregisterCompleteCallback
-        _F_cuGetProcAddress_v2('cuCoredumpDeregisterCompleteCallback', <void **>&__cuCoredumpDeregisterCompleteCallback, 13020, ptds_mode, NULL)
-
-        global __cuLogicalEndpointIdReserve
-        _F_cuGetProcAddress_v2('cuLogicalEndpointIdReserve', <void **>&__cuLogicalEndpointIdReserve, 13030, ptds_mode, NULL)
-
-        global __cuLogicalEndpointIdRelease
-        _F_cuGetProcAddress_v2('cuLogicalEndpointIdRelease', <void **>&__cuLogicalEndpointIdRelease, 13030, ptds_mode, NULL)
-
-        global __cuLogicalEndpointCreate
-        _F_cuGetProcAddress_v2('cuLogicalEndpointCreate', <void **>&__cuLogicalEndpointCreate, 13030, ptds_mode, NULL)
-
-        global __cuLogicalEndpointAddDevice
-        _F_cuGetProcAddress_v2('cuLogicalEndpointAddDevice', <void **>&__cuLogicalEndpointAddDevice, 13030, ptds_mode, NULL)
-
-        global __cuLogicalEndpointDestroy
-        _F_cuGetProcAddress_v2('cuLogicalEndpointDestroy', <void **>&__cuLogicalEndpointDestroy, 13030, ptds_mode, NULL)
-
-        global __cuLogicalEndpointBindAddr
-        _F_cuGetProcAddress_v2('cuLogicalEndpointBindAddr', <void **>&__cuLogicalEndpointBindAddr, 13030, ptds_mode, NULL)
-
-        global __cuLogicalEndpointBindMem
-        _F_cuGetProcAddress_v2('cuLogicalEndpointBindMem', <void **>&__cuLogicalEndpointBindMem, 13030, ptds_mode, NULL)
-
-        global __cuLogicalEndpointUnbind
-        _F_cuGetProcAddress_v2('cuLogicalEndpointUnbind', <void **>&__cuLogicalEndpointUnbind, 13030, ptds_mode, NULL)
-
-        global __cuLogicalEndpointExport
-        _F_cuGetProcAddress_v2('cuLogicalEndpointExport', <void **>&__cuLogicalEndpointExport, 13030, ptds_mode, NULL)
-
-        global __cuLogicalEndpointImport
-        _F_cuGetProcAddress_v2('cuLogicalEndpointImport', <void **>&__cuLogicalEndpointImport, 13030, ptds_mode, NULL)
-
-        global __cuLogicalEndpointGetLimits
-        _F_cuGetProcAddress_v2('cuLogicalEndpointGetLimits', <void **>&__cuLogicalEndpointGetLimits, 13030, ptds_mode, NULL)
-
-        global __cuLogicalEndpointQuery
-        _F_cuGetProcAddress_v2('cuLogicalEndpointQuery', <void **>&__cuLogicalEndpointQuery, 13030, ptds_mode, NULL)
-
-        global __cuStreamBeginRecaptureToGraph
-        _F_cuGetProcAddress_v2('cuStreamBeginRecaptureToGraph', <void **>&__cuStreamBeginRecaptureToGraph, 13030, ptds_mode, NULL)
-
-        __py_driver_init = True
-        return 0
-
-
-cdef inline int _check_or_init_driver() except -1 nogil:
-    if __py_driver_init:
-        return 0
-
-    return _init_driver()
-
-cdef dict func_ptrs = None
-
-
-cpdef dict _inspect_function_pointers():
-    global func_ptrs
-    if func_ptrs is not None:
-        return func_ptrs
-
-    _check_or_init_driver()
-    cdef dict data = {}
-
-    global __cuGetErrorString
-    data["__cuGetErrorString"] = <intptr_t>__cuGetErrorString
-
-    global __cuGetErrorName
-    data["__cuGetErrorName"] = <intptr_t>__cuGetErrorName
-
-    global __cuInit
-    data["__cuInit"] = <intptr_t>__cuInit
-
-    global __cuDriverGetVersion
-    data["__cuDriverGetVersion"] = <intptr_t>__cuDriverGetVersion
-
-    global __cuDeviceGet
-    data["__cuDeviceGet"] = <intptr_t>__cuDeviceGet
-
-    global __cuDeviceGetCount
-    data["__cuDeviceGetCount"] = <intptr_t>__cuDeviceGetCount
-
-    global __cuDeviceGetName
-    data["__cuDeviceGetName"] = <intptr_t>__cuDeviceGetName
-
-    global __cuDeviceGetUuid_v2
-    data["__cuDeviceGetUuid_v2"] = <intptr_t>__cuDeviceGetUuid_v2
-
-    global __cuDeviceGetLuid
-    data["__cuDeviceGetLuid"] = <intptr_t>__cuDeviceGetLuid
-
-    global __cuDeviceTotalMem_v2
-    data["__cuDeviceTotalMem_v2"] = <intptr_t>__cuDeviceTotalMem_v2
-
-    global __cuDeviceGetTexture1DLinearMaxWidth
-    data["__cuDeviceGetTexture1DLinearMaxWidth"] = <intptr_t>__cuDeviceGetTexture1DLinearMaxWidth
-
-    global __cuDeviceGetAttribute
-    data["__cuDeviceGetAttribute"] = <intptr_t>__cuDeviceGetAttribute
-
-    global __cuDeviceGetNvSciSyncAttributes
-    data["__cuDeviceGetNvSciSyncAttributes"] = <intptr_t>__cuDeviceGetNvSciSyncAttributes
-
-    global __cuDeviceSetMemPool
-    data["__cuDeviceSetMemPool"] = <intptr_t>__cuDeviceSetMemPool
-
-    global __cuDeviceGetMemPool
-    data["__cuDeviceGetMemPool"] = <intptr_t>__cuDeviceGetMemPool
-
-    global __cuDeviceGetDefaultMemPool
-    data["__cuDeviceGetDefaultMemPool"] = <intptr_t>__cuDeviceGetDefaultMemPool
-
-    global __cuDeviceGetExecAffinitySupport
-    data["__cuDeviceGetExecAffinitySupport"] = <intptr_t>__cuDeviceGetExecAffinitySupport
-
-    global __cuFlushGPUDirectRDMAWrites
-    data["__cuFlushGPUDirectRDMAWrites"] = <intptr_t>__cuFlushGPUDirectRDMAWrites
-
-    global __cuDeviceGetProperties
-    data["__cuDeviceGetProperties"] = <intptr_t>__cuDeviceGetProperties
-
-    global __cuDeviceComputeCapability
-    data["__cuDeviceComputeCapability"] = <intptr_t>__cuDeviceComputeCapability
-
-    global __cuDevicePrimaryCtxRetain
-    data["__cuDevicePrimaryCtxRetain"] = <intptr_t>__cuDevicePrimaryCtxRetain
-
-    global __cuDevicePrimaryCtxRelease_v2
-    data["__cuDevicePrimaryCtxRelease_v2"] = <intptr_t>__cuDevicePrimaryCtxRelease_v2
-
-    global __cuDevicePrimaryCtxSetFlags_v2
-    data["__cuDevicePrimaryCtxSetFlags_v2"] = <intptr_t>__cuDevicePrimaryCtxSetFlags_v2
-
-    global __cuDevicePrimaryCtxGetState
-    data["__cuDevicePrimaryCtxGetState"] = <intptr_t>__cuDevicePrimaryCtxGetState
-
-    global __cuDevicePrimaryCtxReset_v2
-    data["__cuDevicePrimaryCtxReset_v2"] = <intptr_t>__cuDevicePrimaryCtxReset_v2
-
-    global __cuCtxCreate_v2
-    data["__cuCtxCreate_v2"] = <intptr_t>__cuCtxCreate_v2
-
-    global __cuCtxCreate_v3
-    data["__cuCtxCreate_v3"] = <intptr_t>__cuCtxCreate_v3
-
-    global __cuCtxCreate_v4
-    data["__cuCtxCreate_v4"] = <intptr_t>__cuCtxCreate_v4
-
-    global __cuCtxDestroy_v2
-    data["__cuCtxDestroy_v2"] = <intptr_t>__cuCtxDestroy_v2
-
-    global __cuCtxPushCurrent_v2
-    data["__cuCtxPushCurrent_v2"] = <intptr_t>__cuCtxPushCurrent_v2
-
-    global __cuCtxPopCurrent_v2
-    data["__cuCtxPopCurrent_v2"] = <intptr_t>__cuCtxPopCurrent_v2
-
-    global __cuCtxSetCurrent
-    data["__cuCtxSetCurrent"] = <intptr_t>__cuCtxSetCurrent
-
-    global __cuCtxGetCurrent
-    data["__cuCtxGetCurrent"] = <intptr_t>__cuCtxGetCurrent
-
-    global __cuCtxGetDevice
-    data["__cuCtxGetDevice"] = <intptr_t>__cuCtxGetDevice
-
-    global __cuCtxGetFlags
-    data["__cuCtxGetFlags"] = <intptr_t>__cuCtxGetFlags
-
-    global __cuCtxSetFlags
-    data["__cuCtxSetFlags"] = <intptr_t>__cuCtxSetFlags
-
-    global __cuCtxGetId
-    data["__cuCtxGetId"] = <intptr_t>__cuCtxGetId
-
-    global __cuCtxSynchronize
-    data["__cuCtxSynchronize"] = <intptr_t>__cuCtxSynchronize
-
-    global __cuCtxSetLimit
-    data["__cuCtxSetLimit"] = <intptr_t>__cuCtxSetLimit
-
-    global __cuCtxGetLimit
-    data["__cuCtxGetLimit"] = <intptr_t>__cuCtxGetLimit
-
-    global __cuCtxGetCacheConfig
-    data["__cuCtxGetCacheConfig"] = <intptr_t>__cuCtxGetCacheConfig
-
-    global __cuCtxSetCacheConfig
-    data["__cuCtxSetCacheConfig"] = <intptr_t>__cuCtxSetCacheConfig
-
-    global __cuCtxGetApiVersion
-    data["__cuCtxGetApiVersion"] = <intptr_t>__cuCtxGetApiVersion
-
-    global __cuCtxGetStreamPriorityRange
-    data["__cuCtxGetStreamPriorityRange"] = <intptr_t>__cuCtxGetStreamPriorityRange
-
-    global __cuCtxResetPersistingL2Cache
-    data["__cuCtxResetPersistingL2Cache"] = <intptr_t>__cuCtxResetPersistingL2Cache
-
-    global __cuCtxGetExecAffinity
-    data["__cuCtxGetExecAffinity"] = <intptr_t>__cuCtxGetExecAffinity
-
-    global __cuCtxRecordEvent
-    data["__cuCtxRecordEvent"] = <intptr_t>__cuCtxRecordEvent
-
-    global __cuCtxWaitEvent
-    data["__cuCtxWaitEvent"] = <intptr_t>__cuCtxWaitEvent
-
-    global __cuCtxAttach
-    data["__cuCtxAttach"] = <intptr_t>__cuCtxAttach
-
-    global __cuCtxDetach
-    data["__cuCtxDetach"] = <intptr_t>__cuCtxDetach
-
-    global __cuCtxGetSharedMemConfig
-    data["__cuCtxGetSharedMemConfig"] = <intptr_t>__cuCtxGetSharedMemConfig
-
-    global __cuCtxSetSharedMemConfig
-    data["__cuCtxSetSharedMemConfig"] = <intptr_t>__cuCtxSetSharedMemConfig
-
-    global __cuModuleLoad
-    data["__cuModuleLoad"] = <intptr_t>__cuModuleLoad
-
-    global __cuModuleLoadData
-    data["__cuModuleLoadData"] = <intptr_t>__cuModuleLoadData
-
-    global __cuModuleLoadDataEx
-    data["__cuModuleLoadDataEx"] = <intptr_t>__cuModuleLoadDataEx
-
-    global __cuModuleLoadFatBinary
-    data["__cuModuleLoadFatBinary"] = <intptr_t>__cuModuleLoadFatBinary
-
-    global __cuModuleUnload
-    data["__cuModuleUnload"] = <intptr_t>__cuModuleUnload
-
-    global __cuModuleGetLoadingMode
-    data["__cuModuleGetLoadingMode"] = <intptr_t>__cuModuleGetLoadingMode
-
-    global __cuModuleGetFunction
-    data["__cuModuleGetFunction"] = <intptr_t>__cuModuleGetFunction
-
-    global __cuModuleGetFunctionCount
-    data["__cuModuleGetFunctionCount"] = <intptr_t>__cuModuleGetFunctionCount
-
-    global __cuModuleEnumerateFunctions
-    data["__cuModuleEnumerateFunctions"] = <intptr_t>__cuModuleEnumerateFunctions
-
-    global __cuModuleGetGlobal_v2
-    data["__cuModuleGetGlobal_v2"] = <intptr_t>__cuModuleGetGlobal_v2
-
-    global __cuLinkCreate_v2
-    data["__cuLinkCreate_v2"] = <intptr_t>__cuLinkCreate_v2
-
-    global __cuLinkAddData_v2
-    data["__cuLinkAddData_v2"] = <intptr_t>__cuLinkAddData_v2
-
-    global __cuLinkAddFile_v2
-    data["__cuLinkAddFile_v2"] = <intptr_t>__cuLinkAddFile_v2
-
-    global __cuLinkComplete
-    data["__cuLinkComplete"] = <intptr_t>__cuLinkComplete
-
-    global __cuLinkDestroy
-    data["__cuLinkDestroy"] = <intptr_t>__cuLinkDestroy
-
-    global __cuModuleGetTexRef
-    data["__cuModuleGetTexRef"] = <intptr_t>__cuModuleGetTexRef
-
-    global __cuModuleGetSurfRef
-    data["__cuModuleGetSurfRef"] = <intptr_t>__cuModuleGetSurfRef
-
-    global __cuLibraryLoadData
-    data["__cuLibraryLoadData"] = <intptr_t>__cuLibraryLoadData
-
-    global __cuLibraryLoadFromFile
-    data["__cuLibraryLoadFromFile"] = <intptr_t>__cuLibraryLoadFromFile
-
-    global __cuLibraryUnload
-    data["__cuLibraryUnload"] = <intptr_t>__cuLibraryUnload
-
-    global __cuLibraryGetKernel
-    data["__cuLibraryGetKernel"] = <intptr_t>__cuLibraryGetKernel
-
-    global __cuLibraryGetKernelCount
-    data["__cuLibraryGetKernelCount"] = <intptr_t>__cuLibraryGetKernelCount
-
-    global __cuLibraryEnumerateKernels
-    data["__cuLibraryEnumerateKernels"] = <intptr_t>__cuLibraryEnumerateKernels
-
-    global __cuLibraryGetModule
-    data["__cuLibraryGetModule"] = <intptr_t>__cuLibraryGetModule
-
-    global __cuKernelGetFunction
-    data["__cuKernelGetFunction"] = <intptr_t>__cuKernelGetFunction
-
-    global __cuKernelGetLibrary
-    data["__cuKernelGetLibrary"] = <intptr_t>__cuKernelGetLibrary
-
-    global __cuLibraryGetGlobal
-    data["__cuLibraryGetGlobal"] = <intptr_t>__cuLibraryGetGlobal
-
-    global __cuLibraryGetManaged
-    data["__cuLibraryGetManaged"] = <intptr_t>__cuLibraryGetManaged
-
-    global __cuLibraryGetUnifiedFunction
-    data["__cuLibraryGetUnifiedFunction"] = <intptr_t>__cuLibraryGetUnifiedFunction
-
-    global __cuKernelGetAttribute
-    data["__cuKernelGetAttribute"] = <intptr_t>__cuKernelGetAttribute
-
-    global __cuKernelSetAttribute
-    data["__cuKernelSetAttribute"] = <intptr_t>__cuKernelSetAttribute
-
-    global __cuKernelSetCacheConfig
-    data["__cuKernelSetCacheConfig"] = <intptr_t>__cuKernelSetCacheConfig
-
-    global __cuKernelGetName
-    data["__cuKernelGetName"] = <intptr_t>__cuKernelGetName
-
-    global __cuKernelGetParamInfo
-    data["__cuKernelGetParamInfo"] = <intptr_t>__cuKernelGetParamInfo
-
-    global __cuMemGetInfo_v2
-    data["__cuMemGetInfo_v2"] = <intptr_t>__cuMemGetInfo_v2
-
-    global __cuMemAlloc_v2
-    data["__cuMemAlloc_v2"] = <intptr_t>__cuMemAlloc_v2
-
-    global __cuMemAllocPitch_v2
-    data["__cuMemAllocPitch_v2"] = <intptr_t>__cuMemAllocPitch_v2
-
-    global __cuMemFree_v2
-    data["__cuMemFree_v2"] = <intptr_t>__cuMemFree_v2
-
-    global __cuMemGetAddressRange_v2
-    data["__cuMemGetAddressRange_v2"] = <intptr_t>__cuMemGetAddressRange_v2
-
-    global __cuMemAllocHost_v2
-    data["__cuMemAllocHost_v2"] = <intptr_t>__cuMemAllocHost_v2
-
-    global __cuMemFreeHost
-    data["__cuMemFreeHost"] = <intptr_t>__cuMemFreeHost
-
-    global __cuMemHostAlloc
-    data["__cuMemHostAlloc"] = <intptr_t>__cuMemHostAlloc
-
-    global __cuMemHostGetDevicePointer_v2
-    data["__cuMemHostGetDevicePointer_v2"] = <intptr_t>__cuMemHostGetDevicePointer_v2
-
-    global __cuMemHostGetFlags
-    data["__cuMemHostGetFlags"] = <intptr_t>__cuMemHostGetFlags
-
-    global __cuMemAllocManaged
-    data["__cuMemAllocManaged"] = <intptr_t>__cuMemAllocManaged
-
-    global __cuDeviceRegisterAsyncNotification
-    data["__cuDeviceRegisterAsyncNotification"] = <intptr_t>__cuDeviceRegisterAsyncNotification
-
-    global __cuDeviceUnregisterAsyncNotification
-    data["__cuDeviceUnregisterAsyncNotification"] = <intptr_t>__cuDeviceUnregisterAsyncNotification
-
-    global __cuDeviceGetByPCIBusId
-    data["__cuDeviceGetByPCIBusId"] = <intptr_t>__cuDeviceGetByPCIBusId
-
-    global __cuDeviceGetPCIBusId
-    data["__cuDeviceGetPCIBusId"] = <intptr_t>__cuDeviceGetPCIBusId
-
-    global __cuIpcGetEventHandle
-    data["__cuIpcGetEventHandle"] = <intptr_t>__cuIpcGetEventHandle
-
-    global __cuIpcOpenEventHandle
-    data["__cuIpcOpenEventHandle"] = <intptr_t>__cuIpcOpenEventHandle
-
-    global __cuIpcGetMemHandle
-    data["__cuIpcGetMemHandle"] = <intptr_t>__cuIpcGetMemHandle
-
-    global __cuIpcOpenMemHandle_v2
-    data["__cuIpcOpenMemHandle_v2"] = <intptr_t>__cuIpcOpenMemHandle_v2
-
-    global __cuIpcCloseMemHandle
-    data["__cuIpcCloseMemHandle"] = <intptr_t>__cuIpcCloseMemHandle
-
-    global __cuMemHostRegister_v2
-    data["__cuMemHostRegister_v2"] = <intptr_t>__cuMemHostRegister_v2
-
-    global __cuMemHostUnregister
-    data["__cuMemHostUnregister"] = <intptr_t>__cuMemHostUnregister
-
-    global __cuMemcpy
-    data["__cuMemcpy"] = <intptr_t>__cuMemcpy
-
-    global __cuMemcpyPeer
-    data["__cuMemcpyPeer"] = <intptr_t>__cuMemcpyPeer
-
-    global __cuMemcpyHtoD_v2
-    data["__cuMemcpyHtoD_v2"] = <intptr_t>__cuMemcpyHtoD_v2
-
-    global __cuMemcpyDtoH_v2
-    data["__cuMemcpyDtoH_v2"] = <intptr_t>__cuMemcpyDtoH_v2
-
-    global __cuMemcpyDtoD_v2
-    data["__cuMemcpyDtoD_v2"] = <intptr_t>__cuMemcpyDtoD_v2
-
-    global __cuMemcpyDtoA_v2
-    data["__cuMemcpyDtoA_v2"] = <intptr_t>__cuMemcpyDtoA_v2
-
-    global __cuMemcpyAtoD_v2
-    data["__cuMemcpyAtoD_v2"] = <intptr_t>__cuMemcpyAtoD_v2
-
-    global __cuMemcpyHtoA_v2
-    data["__cuMemcpyHtoA_v2"] = <intptr_t>__cuMemcpyHtoA_v2
-
-    global __cuMemcpyAtoH_v2
-    data["__cuMemcpyAtoH_v2"] = <intptr_t>__cuMemcpyAtoH_v2
-
-    global __cuMemcpyAtoA_v2
-    data["__cuMemcpyAtoA_v2"] = <intptr_t>__cuMemcpyAtoA_v2
-
-    global __cuMemcpy2D_v2
-    data["__cuMemcpy2D_v2"] = <intptr_t>__cuMemcpy2D_v2
-
-    global __cuMemcpy2DUnaligned_v2
-    data["__cuMemcpy2DUnaligned_v2"] = <intptr_t>__cuMemcpy2DUnaligned_v2
-
-    global __cuMemcpy3D_v2
-    data["__cuMemcpy3D_v2"] = <intptr_t>__cuMemcpy3D_v2
-
-    global __cuMemcpy3DPeer
-    data["__cuMemcpy3DPeer"] = <intptr_t>__cuMemcpy3DPeer
-
-    global __cuMemcpyAsync
-    data["__cuMemcpyAsync"] = <intptr_t>__cuMemcpyAsync
-
-    global __cuMemcpyPeerAsync
-    data["__cuMemcpyPeerAsync"] = <intptr_t>__cuMemcpyPeerAsync
-
-    global __cuMemcpyHtoDAsync_v2
-    data["__cuMemcpyHtoDAsync_v2"] = <intptr_t>__cuMemcpyHtoDAsync_v2
-
-    global __cuMemcpyDtoHAsync_v2
-    data["__cuMemcpyDtoHAsync_v2"] = <intptr_t>__cuMemcpyDtoHAsync_v2
-
-    global __cuMemcpyDtoDAsync_v2
-    data["__cuMemcpyDtoDAsync_v2"] = <intptr_t>__cuMemcpyDtoDAsync_v2
-
-    global __cuMemcpyHtoAAsync_v2
-    data["__cuMemcpyHtoAAsync_v2"] = <intptr_t>__cuMemcpyHtoAAsync_v2
-
-    global __cuMemcpyAtoHAsync_v2
-    data["__cuMemcpyAtoHAsync_v2"] = <intptr_t>__cuMemcpyAtoHAsync_v2
-
-    global __cuMemcpy2DAsync_v2
-    data["__cuMemcpy2DAsync_v2"] = <intptr_t>__cuMemcpy2DAsync_v2
-
-    global __cuMemcpy3DAsync_v2
-    data["__cuMemcpy3DAsync_v2"] = <intptr_t>__cuMemcpy3DAsync_v2
-
-    global __cuMemcpy3DPeerAsync
-    data["__cuMemcpy3DPeerAsync"] = <intptr_t>__cuMemcpy3DPeerAsync
-
-    global __cuMemsetD8_v2
-    data["__cuMemsetD8_v2"] = <intptr_t>__cuMemsetD8_v2
-
-    global __cuMemsetD16_v2
-    data["__cuMemsetD16_v2"] = <intptr_t>__cuMemsetD16_v2
-
-    global __cuMemsetD32_v2
-    data["__cuMemsetD32_v2"] = <intptr_t>__cuMemsetD32_v2
-
-    global __cuMemsetD2D8_v2
-    data["__cuMemsetD2D8_v2"] = <intptr_t>__cuMemsetD2D8_v2
-
-    global __cuMemsetD2D16_v2
-    data["__cuMemsetD2D16_v2"] = <intptr_t>__cuMemsetD2D16_v2
-
-    global __cuMemsetD2D32_v2
-    data["__cuMemsetD2D32_v2"] = <intptr_t>__cuMemsetD2D32_v2
-
-    global __cuMemsetD8Async
-    data["__cuMemsetD8Async"] = <intptr_t>__cuMemsetD8Async
-
-    global __cuMemsetD16Async
-    data["__cuMemsetD16Async"] = <intptr_t>__cuMemsetD16Async
-
-    global __cuMemsetD32Async
-    data["__cuMemsetD32Async"] = <intptr_t>__cuMemsetD32Async
-
-    global __cuMemsetD2D8Async
-    data["__cuMemsetD2D8Async"] = <intptr_t>__cuMemsetD2D8Async
-
-    global __cuMemsetD2D16Async
-    data["__cuMemsetD2D16Async"] = <intptr_t>__cuMemsetD2D16Async
-
-    global __cuMemsetD2D32Async
-    data["__cuMemsetD2D32Async"] = <intptr_t>__cuMemsetD2D32Async
-
-    global __cuArrayCreate_v2
-    data["__cuArrayCreate_v2"] = <intptr_t>__cuArrayCreate_v2
-
-    global __cuArrayGetDescriptor_v2
-    data["__cuArrayGetDescriptor_v2"] = <intptr_t>__cuArrayGetDescriptor_v2
-
-    global __cuArrayGetSparseProperties
-    data["__cuArrayGetSparseProperties"] = <intptr_t>__cuArrayGetSparseProperties
-
-    global __cuMipmappedArrayGetSparseProperties
-    data["__cuMipmappedArrayGetSparseProperties"] = <intptr_t>__cuMipmappedArrayGetSparseProperties
-
-    global __cuArrayGetMemoryRequirements
-    data["__cuArrayGetMemoryRequirements"] = <intptr_t>__cuArrayGetMemoryRequirements
-
-    global __cuMipmappedArrayGetMemoryRequirements
-    data["__cuMipmappedArrayGetMemoryRequirements"] = <intptr_t>__cuMipmappedArrayGetMemoryRequirements
-
-    global __cuArrayGetPlane
-    data["__cuArrayGetPlane"] = <intptr_t>__cuArrayGetPlane
-
-    global __cuArrayDestroy
-    data["__cuArrayDestroy"] = <intptr_t>__cuArrayDestroy
-
-    global __cuArray3DCreate_v2
-    data["__cuArray3DCreate_v2"] = <intptr_t>__cuArray3DCreate_v2
-
-    global __cuArray3DGetDescriptor_v2
-    data["__cuArray3DGetDescriptor_v2"] = <intptr_t>__cuArray3DGetDescriptor_v2
-
-    global __cuMipmappedArrayCreate
-    data["__cuMipmappedArrayCreate"] = <intptr_t>__cuMipmappedArrayCreate
-
-    global __cuMipmappedArrayGetLevel
-    data["__cuMipmappedArrayGetLevel"] = <intptr_t>__cuMipmappedArrayGetLevel
-
-    global __cuMipmappedArrayDestroy
-    data["__cuMipmappedArrayDestroy"] = <intptr_t>__cuMipmappedArrayDestroy
-
-    global __cuMemGetHandleForAddressRange
-    data["__cuMemGetHandleForAddressRange"] = <intptr_t>__cuMemGetHandleForAddressRange
-
-    global __cuMemBatchDecompressAsync
-    data["__cuMemBatchDecompressAsync"] = <intptr_t>__cuMemBatchDecompressAsync
-
-    global __cuMemAddressReserve
-    data["__cuMemAddressReserve"] = <intptr_t>__cuMemAddressReserve
-
-    global __cuMemAddressFree
-    data["__cuMemAddressFree"] = <intptr_t>__cuMemAddressFree
-
-    global __cuMemCreate
-    data["__cuMemCreate"] = <intptr_t>__cuMemCreate
-
-    global __cuMemRelease
-    data["__cuMemRelease"] = <intptr_t>__cuMemRelease
-
-    global __cuMemMap
-    data["__cuMemMap"] = <intptr_t>__cuMemMap
-
-    global __cuMemMapArrayAsync
-    data["__cuMemMapArrayAsync"] = <intptr_t>__cuMemMapArrayAsync
-
-    global __cuMemUnmap
-    data["__cuMemUnmap"] = <intptr_t>__cuMemUnmap
-
-    global __cuMemSetAccess
-    data["__cuMemSetAccess"] = <intptr_t>__cuMemSetAccess
-
-    global __cuMemGetAccess
-    data["__cuMemGetAccess"] = <intptr_t>__cuMemGetAccess
-
-    global __cuMemExportToShareableHandle
-    data["__cuMemExportToShareableHandle"] = <intptr_t>__cuMemExportToShareableHandle
-
-    global __cuMemImportFromShareableHandle
-    data["__cuMemImportFromShareableHandle"] = <intptr_t>__cuMemImportFromShareableHandle
-
-    global __cuMemGetAllocationGranularity
-    data["__cuMemGetAllocationGranularity"] = <intptr_t>__cuMemGetAllocationGranularity
-
-    global __cuMemGetAllocationPropertiesFromHandle
-    data["__cuMemGetAllocationPropertiesFromHandle"] = <intptr_t>__cuMemGetAllocationPropertiesFromHandle
-
-    global __cuMemRetainAllocationHandle
-    data["__cuMemRetainAllocationHandle"] = <intptr_t>__cuMemRetainAllocationHandle
-
-    global __cuMemFreeAsync
-    data["__cuMemFreeAsync"] = <intptr_t>__cuMemFreeAsync
-
-    global __cuMemAllocAsync
-    data["__cuMemAllocAsync"] = <intptr_t>__cuMemAllocAsync
-
-    global __cuMemPoolTrimTo
-    data["__cuMemPoolTrimTo"] = <intptr_t>__cuMemPoolTrimTo
-
-    global __cuMemPoolSetAttribute
-    data["__cuMemPoolSetAttribute"] = <intptr_t>__cuMemPoolSetAttribute
-
-    global __cuMemPoolGetAttribute
-    data["__cuMemPoolGetAttribute"] = <intptr_t>__cuMemPoolGetAttribute
-
-    global __cuMemPoolSetAccess
-    data["__cuMemPoolSetAccess"] = <intptr_t>__cuMemPoolSetAccess
-
-    global __cuMemPoolGetAccess
-    data["__cuMemPoolGetAccess"] = <intptr_t>__cuMemPoolGetAccess
-
-    global __cuMemPoolCreate
-    data["__cuMemPoolCreate"] = <intptr_t>__cuMemPoolCreate
-
-    global __cuMemPoolDestroy
-    data["__cuMemPoolDestroy"] = <intptr_t>__cuMemPoolDestroy
-
-    global __cuMemAllocFromPoolAsync
-    data["__cuMemAllocFromPoolAsync"] = <intptr_t>__cuMemAllocFromPoolAsync
-
-    global __cuMemPoolExportToShareableHandle
-    data["__cuMemPoolExportToShareableHandle"] = <intptr_t>__cuMemPoolExportToShareableHandle
-
-    global __cuMemPoolImportFromShareableHandle
-    data["__cuMemPoolImportFromShareableHandle"] = <intptr_t>__cuMemPoolImportFromShareableHandle
-
-    global __cuMemPoolExportPointer
-    data["__cuMemPoolExportPointer"] = <intptr_t>__cuMemPoolExportPointer
-
-    global __cuMemPoolImportPointer
-    data["__cuMemPoolImportPointer"] = <intptr_t>__cuMemPoolImportPointer
-
-    global __cuMulticastCreate
-    data["__cuMulticastCreate"] = <intptr_t>__cuMulticastCreate
-
-    global __cuMulticastAddDevice
-    data["__cuMulticastAddDevice"] = <intptr_t>__cuMulticastAddDevice
-
-    global __cuMulticastBindMem
-    data["__cuMulticastBindMem"] = <intptr_t>__cuMulticastBindMem
-
-    global __cuMulticastBindAddr
-    data["__cuMulticastBindAddr"] = <intptr_t>__cuMulticastBindAddr
-
-    global __cuMulticastUnbind
-    data["__cuMulticastUnbind"] = <intptr_t>__cuMulticastUnbind
-
-    global __cuMulticastGetGranularity
-    data["__cuMulticastGetGranularity"] = <intptr_t>__cuMulticastGetGranularity
-
-    global __cuPointerGetAttribute
-    data["__cuPointerGetAttribute"] = <intptr_t>__cuPointerGetAttribute
-
-    global __cuMemPrefetchAsync_v2
-    data["__cuMemPrefetchAsync_v2"] = <intptr_t>__cuMemPrefetchAsync_v2
-
-    global __cuMemAdvise_v2
-    data["__cuMemAdvise_v2"] = <intptr_t>__cuMemAdvise_v2
-
-    global __cuMemRangeGetAttribute
-    data["__cuMemRangeGetAttribute"] = <intptr_t>__cuMemRangeGetAttribute
-
-    global __cuMemRangeGetAttributes
-    data["__cuMemRangeGetAttributes"] = <intptr_t>__cuMemRangeGetAttributes
-
-    global __cuPointerSetAttribute
-    data["__cuPointerSetAttribute"] = <intptr_t>__cuPointerSetAttribute
-
-    global __cuPointerGetAttributes
-    data["__cuPointerGetAttributes"] = <intptr_t>__cuPointerGetAttributes
-
-    global __cuStreamCreate
-    data["__cuStreamCreate"] = <intptr_t>__cuStreamCreate
-
-    global __cuStreamCreateWithPriority
-    data["__cuStreamCreateWithPriority"] = <intptr_t>__cuStreamCreateWithPriority
-
-    global __cuStreamGetPriority
-    data["__cuStreamGetPriority"] = <intptr_t>__cuStreamGetPriority
-
-    global __cuStreamGetDevice
-    data["__cuStreamGetDevice"] = <intptr_t>__cuStreamGetDevice
-
-    global __cuStreamGetFlags
-    data["__cuStreamGetFlags"] = <intptr_t>__cuStreamGetFlags
-
-    global __cuStreamGetId
-    data["__cuStreamGetId"] = <intptr_t>__cuStreamGetId
-
-    global __cuStreamGetCtx
-    data["__cuStreamGetCtx"] = <intptr_t>__cuStreamGetCtx
-
-    global __cuStreamGetCtx_v2
-    data["__cuStreamGetCtx_v2"] = <intptr_t>__cuStreamGetCtx_v2
-
-    global __cuStreamWaitEvent
-    data["__cuStreamWaitEvent"] = <intptr_t>__cuStreamWaitEvent
-
-    global __cuStreamAddCallback
-    data["__cuStreamAddCallback"] = <intptr_t>__cuStreamAddCallback
-
-    global __cuStreamBeginCapture_v2
-    data["__cuStreamBeginCapture_v2"] = <intptr_t>__cuStreamBeginCapture_v2
-
-    global __cuStreamBeginCaptureToGraph
-    data["__cuStreamBeginCaptureToGraph"] = <intptr_t>__cuStreamBeginCaptureToGraph
-
-    global __cuThreadExchangeStreamCaptureMode
-    data["__cuThreadExchangeStreamCaptureMode"] = <intptr_t>__cuThreadExchangeStreamCaptureMode
-
-    global __cuStreamEndCapture
-    data["__cuStreamEndCapture"] = <intptr_t>__cuStreamEndCapture
-
-    global __cuStreamIsCapturing
-    data["__cuStreamIsCapturing"] = <intptr_t>__cuStreamIsCapturing
-
-    global __cuStreamGetCaptureInfo_v2
-    data["__cuStreamGetCaptureInfo_v2"] = <intptr_t>__cuStreamGetCaptureInfo_v2
-
-    global __cuStreamGetCaptureInfo_v3
-    data["__cuStreamGetCaptureInfo_v3"] = <intptr_t>__cuStreamGetCaptureInfo_v3
-
-    global __cuStreamUpdateCaptureDependencies_v2
-    data["__cuStreamUpdateCaptureDependencies_v2"] = <intptr_t>__cuStreamUpdateCaptureDependencies_v2
-
-    global __cuStreamAttachMemAsync
-    data["__cuStreamAttachMemAsync"] = <intptr_t>__cuStreamAttachMemAsync
-
-    global __cuStreamQuery
-    data["__cuStreamQuery"] = <intptr_t>__cuStreamQuery
-
-    global __cuStreamSynchronize
-    data["__cuStreamSynchronize"] = <intptr_t>__cuStreamSynchronize
-
-    global __cuStreamDestroy_v2
-    data["__cuStreamDestroy_v2"] = <intptr_t>__cuStreamDestroy_v2
-
-    global __cuStreamCopyAttributes
-    data["__cuStreamCopyAttributes"] = <intptr_t>__cuStreamCopyAttributes
-
-    global __cuStreamGetAttribute
-    data["__cuStreamGetAttribute"] = <intptr_t>__cuStreamGetAttribute
-
-    global __cuStreamSetAttribute
-    data["__cuStreamSetAttribute"] = <intptr_t>__cuStreamSetAttribute
-
-    global __cuEventCreate
-    data["__cuEventCreate"] = <intptr_t>__cuEventCreate
-
-    global __cuEventRecord
-    data["__cuEventRecord"] = <intptr_t>__cuEventRecord
-
-    global __cuEventRecordWithFlags
-    data["__cuEventRecordWithFlags"] = <intptr_t>__cuEventRecordWithFlags
-
-    global __cuEventQuery
-    data["__cuEventQuery"] = <intptr_t>__cuEventQuery
-
-    global __cuEventSynchronize
-    data["__cuEventSynchronize"] = <intptr_t>__cuEventSynchronize
-
-    global __cuEventDestroy_v2
-    data["__cuEventDestroy_v2"] = <intptr_t>__cuEventDestroy_v2
-
-    global __cuEventElapsedTime_v2
-    data["__cuEventElapsedTime_v2"] = <intptr_t>__cuEventElapsedTime_v2
-
-    global __cuImportExternalMemory
-    data["__cuImportExternalMemory"] = <intptr_t>__cuImportExternalMemory
-
-    global __cuExternalMemoryGetMappedBuffer
-    data["__cuExternalMemoryGetMappedBuffer"] = <intptr_t>__cuExternalMemoryGetMappedBuffer
-
-    global __cuExternalMemoryGetMappedMipmappedArray
-    data["__cuExternalMemoryGetMappedMipmappedArray"] = <intptr_t>__cuExternalMemoryGetMappedMipmappedArray
-
-    global __cuDestroyExternalMemory
-    data["__cuDestroyExternalMemory"] = <intptr_t>__cuDestroyExternalMemory
-
-    global __cuImportExternalSemaphore
-    data["__cuImportExternalSemaphore"] = <intptr_t>__cuImportExternalSemaphore
-
-    global __cuSignalExternalSemaphoresAsync
-    data["__cuSignalExternalSemaphoresAsync"] = <intptr_t>__cuSignalExternalSemaphoresAsync
-
-    global __cuWaitExternalSemaphoresAsync
-    data["__cuWaitExternalSemaphoresAsync"] = <intptr_t>__cuWaitExternalSemaphoresAsync
-
-    global __cuDestroyExternalSemaphore
-    data["__cuDestroyExternalSemaphore"] = <intptr_t>__cuDestroyExternalSemaphore
-
-    global __cuStreamWaitValue32_v2
-    data["__cuStreamWaitValue32_v2"] = <intptr_t>__cuStreamWaitValue32_v2
-
-    global __cuStreamWaitValue64_v2
-    data["__cuStreamWaitValue64_v2"] = <intptr_t>__cuStreamWaitValue64_v2
-
-    global __cuStreamWriteValue32_v2
-    data["__cuStreamWriteValue32_v2"] = <intptr_t>__cuStreamWriteValue32_v2
-
-    global __cuStreamWriteValue64_v2
-    data["__cuStreamWriteValue64_v2"] = <intptr_t>__cuStreamWriteValue64_v2
-
-    global __cuStreamBatchMemOp_v2
-    data["__cuStreamBatchMemOp_v2"] = <intptr_t>__cuStreamBatchMemOp_v2
-
-    global __cuFuncGetAttribute
-    data["__cuFuncGetAttribute"] = <intptr_t>__cuFuncGetAttribute
-
-    global __cuFuncSetAttribute
-    data["__cuFuncSetAttribute"] = <intptr_t>__cuFuncSetAttribute
-
-    global __cuFuncSetCacheConfig
-    data["__cuFuncSetCacheConfig"] = <intptr_t>__cuFuncSetCacheConfig
-
-    global __cuFuncGetModule
-    data["__cuFuncGetModule"] = <intptr_t>__cuFuncGetModule
-
-    global __cuFuncGetName
-    data["__cuFuncGetName"] = <intptr_t>__cuFuncGetName
-
-    global __cuFuncGetParamInfo
-    data["__cuFuncGetParamInfo"] = <intptr_t>__cuFuncGetParamInfo
-
-    global __cuFuncIsLoaded
-    data["__cuFuncIsLoaded"] = <intptr_t>__cuFuncIsLoaded
-
-    global __cuFuncLoad
-    data["__cuFuncLoad"] = <intptr_t>__cuFuncLoad
-
-    global __cuLaunchKernel
-    data["__cuLaunchKernel"] = <intptr_t>__cuLaunchKernel
-
-    global __cuLaunchKernelEx
-    data["__cuLaunchKernelEx"] = <intptr_t>__cuLaunchKernelEx
-
-    global __cuLaunchCooperativeKernel
-    data["__cuLaunchCooperativeKernel"] = <intptr_t>__cuLaunchCooperativeKernel
-
-    global __cuLaunchCooperativeKernelMultiDevice
-    data["__cuLaunchCooperativeKernelMultiDevice"] = <intptr_t>__cuLaunchCooperativeKernelMultiDevice
-
-    global __cuLaunchHostFunc
-    data["__cuLaunchHostFunc"] = <intptr_t>__cuLaunchHostFunc
-
-    global __cuFuncSetBlockShape
-    data["__cuFuncSetBlockShape"] = <intptr_t>__cuFuncSetBlockShape
-
-    global __cuFuncSetSharedSize
-    data["__cuFuncSetSharedSize"] = <intptr_t>__cuFuncSetSharedSize
-
-    global __cuParamSetSize
-    data["__cuParamSetSize"] = <intptr_t>__cuParamSetSize
-
-    global __cuParamSeti
-    data["__cuParamSeti"] = <intptr_t>__cuParamSeti
-
-    global __cuParamSetf
-    data["__cuParamSetf"] = <intptr_t>__cuParamSetf
-
-    global __cuParamSetv
-    data["__cuParamSetv"] = <intptr_t>__cuParamSetv
-
-    global __cuLaunch
-    data["__cuLaunch"] = <intptr_t>__cuLaunch
-
-    global __cuLaunchGrid
-    data["__cuLaunchGrid"] = <intptr_t>__cuLaunchGrid
-
-    global __cuLaunchGridAsync
-    data["__cuLaunchGridAsync"] = <intptr_t>__cuLaunchGridAsync
-
-    global __cuParamSetTexRef
-    data["__cuParamSetTexRef"] = <intptr_t>__cuParamSetTexRef
-
-    global __cuFuncSetSharedMemConfig
-    data["__cuFuncSetSharedMemConfig"] = <intptr_t>__cuFuncSetSharedMemConfig
-
-    global __cuGraphCreate
-    data["__cuGraphCreate"] = <intptr_t>__cuGraphCreate
-
-    global __cuGraphAddKernelNode_v2
-    data["__cuGraphAddKernelNode_v2"] = <intptr_t>__cuGraphAddKernelNode_v2
-
-    global __cuGraphKernelNodeGetParams_v2
-    data["__cuGraphKernelNodeGetParams_v2"] = <intptr_t>__cuGraphKernelNodeGetParams_v2
-
-    global __cuGraphKernelNodeSetParams_v2
-    data["__cuGraphKernelNodeSetParams_v2"] = <intptr_t>__cuGraphKernelNodeSetParams_v2
-
-    global __cuGraphAddMemcpyNode
-    data["__cuGraphAddMemcpyNode"] = <intptr_t>__cuGraphAddMemcpyNode
-
-    global __cuGraphMemcpyNodeGetParams
-    data["__cuGraphMemcpyNodeGetParams"] = <intptr_t>__cuGraphMemcpyNodeGetParams
-
-    global __cuGraphMemcpyNodeSetParams
-    data["__cuGraphMemcpyNodeSetParams"] = <intptr_t>__cuGraphMemcpyNodeSetParams
-
-    global __cuGraphAddMemsetNode
-    data["__cuGraphAddMemsetNode"] = <intptr_t>__cuGraphAddMemsetNode
-
-    global __cuGraphMemsetNodeGetParams
-    data["__cuGraphMemsetNodeGetParams"] = <intptr_t>__cuGraphMemsetNodeGetParams
-
-    global __cuGraphMemsetNodeSetParams
-    data["__cuGraphMemsetNodeSetParams"] = <intptr_t>__cuGraphMemsetNodeSetParams
-
-    global __cuGraphAddHostNode
-    data["__cuGraphAddHostNode"] = <intptr_t>__cuGraphAddHostNode
-
-    global __cuGraphHostNodeGetParams
-    data["__cuGraphHostNodeGetParams"] = <intptr_t>__cuGraphHostNodeGetParams
-
-    global __cuGraphHostNodeSetParams
-    data["__cuGraphHostNodeSetParams"] = <intptr_t>__cuGraphHostNodeSetParams
-
-    global __cuGraphAddChildGraphNode
-    data["__cuGraphAddChildGraphNode"] = <intptr_t>__cuGraphAddChildGraphNode
-
-    global __cuGraphChildGraphNodeGetGraph
-    data["__cuGraphChildGraphNodeGetGraph"] = <intptr_t>__cuGraphChildGraphNodeGetGraph
-
-    global __cuGraphAddEmptyNode
-    data["__cuGraphAddEmptyNode"] = <intptr_t>__cuGraphAddEmptyNode
-
-    global __cuGraphAddEventRecordNode
-    data["__cuGraphAddEventRecordNode"] = <intptr_t>__cuGraphAddEventRecordNode
-
-    global __cuGraphEventRecordNodeGetEvent
-    data["__cuGraphEventRecordNodeGetEvent"] = <intptr_t>__cuGraphEventRecordNodeGetEvent
-
-    global __cuGraphEventRecordNodeSetEvent
-    data["__cuGraphEventRecordNodeSetEvent"] = <intptr_t>__cuGraphEventRecordNodeSetEvent
-
-    global __cuGraphAddEventWaitNode
-    data["__cuGraphAddEventWaitNode"] = <intptr_t>__cuGraphAddEventWaitNode
-
-    global __cuGraphEventWaitNodeGetEvent
-    data["__cuGraphEventWaitNodeGetEvent"] = <intptr_t>__cuGraphEventWaitNodeGetEvent
-
-    global __cuGraphEventWaitNodeSetEvent
-    data["__cuGraphEventWaitNodeSetEvent"] = <intptr_t>__cuGraphEventWaitNodeSetEvent
-
-    global __cuGraphAddExternalSemaphoresSignalNode
-    data["__cuGraphAddExternalSemaphoresSignalNode"] = <intptr_t>__cuGraphAddExternalSemaphoresSignalNode
-
-    global __cuGraphExternalSemaphoresSignalNodeGetParams
-    data["__cuGraphExternalSemaphoresSignalNodeGetParams"] = <intptr_t>__cuGraphExternalSemaphoresSignalNodeGetParams
-
-    global __cuGraphExternalSemaphoresSignalNodeSetParams
-    data["__cuGraphExternalSemaphoresSignalNodeSetParams"] = <intptr_t>__cuGraphExternalSemaphoresSignalNodeSetParams
-
-    global __cuGraphAddExternalSemaphoresWaitNode
-    data["__cuGraphAddExternalSemaphoresWaitNode"] = <intptr_t>__cuGraphAddExternalSemaphoresWaitNode
-
-    global __cuGraphExternalSemaphoresWaitNodeGetParams
-    data["__cuGraphExternalSemaphoresWaitNodeGetParams"] = <intptr_t>__cuGraphExternalSemaphoresWaitNodeGetParams
-
-    global __cuGraphExternalSemaphoresWaitNodeSetParams
-    data["__cuGraphExternalSemaphoresWaitNodeSetParams"] = <intptr_t>__cuGraphExternalSemaphoresWaitNodeSetParams
-
-    global __cuGraphAddBatchMemOpNode
-    data["__cuGraphAddBatchMemOpNode"] = <intptr_t>__cuGraphAddBatchMemOpNode
-
-    global __cuGraphBatchMemOpNodeGetParams
-    data["__cuGraphBatchMemOpNodeGetParams"] = <intptr_t>__cuGraphBatchMemOpNodeGetParams
-
-    global __cuGraphBatchMemOpNodeSetParams
-    data["__cuGraphBatchMemOpNodeSetParams"] = <intptr_t>__cuGraphBatchMemOpNodeSetParams
-
-    global __cuGraphExecBatchMemOpNodeSetParams
-    data["__cuGraphExecBatchMemOpNodeSetParams"] = <intptr_t>__cuGraphExecBatchMemOpNodeSetParams
-
-    global __cuGraphAddMemAllocNode
-    data["__cuGraphAddMemAllocNode"] = <intptr_t>__cuGraphAddMemAllocNode
-
-    global __cuGraphMemAllocNodeGetParams
-    data["__cuGraphMemAllocNodeGetParams"] = <intptr_t>__cuGraphMemAllocNodeGetParams
-
-    global __cuGraphAddMemFreeNode
-    data["__cuGraphAddMemFreeNode"] = <intptr_t>__cuGraphAddMemFreeNode
-
-    global __cuGraphMemFreeNodeGetParams
-    data["__cuGraphMemFreeNodeGetParams"] = <intptr_t>__cuGraphMemFreeNodeGetParams
-
-    global __cuDeviceGraphMemTrim
-    data["__cuDeviceGraphMemTrim"] = <intptr_t>__cuDeviceGraphMemTrim
-
-    global __cuDeviceGetGraphMemAttribute
-    data["__cuDeviceGetGraphMemAttribute"] = <intptr_t>__cuDeviceGetGraphMemAttribute
-
-    global __cuDeviceSetGraphMemAttribute
-    data["__cuDeviceSetGraphMemAttribute"] = <intptr_t>__cuDeviceSetGraphMemAttribute
-
-    global __cuGraphClone
-    data["__cuGraphClone"] = <intptr_t>__cuGraphClone
-
-    global __cuGraphNodeFindInClone
-    data["__cuGraphNodeFindInClone"] = <intptr_t>__cuGraphNodeFindInClone
-
-    global __cuGraphNodeGetType
-    data["__cuGraphNodeGetType"] = <intptr_t>__cuGraphNodeGetType
-
-    global __cuGraphGetNodes
-    data["__cuGraphGetNodes"] = <intptr_t>__cuGraphGetNodes
-
-    global __cuGraphGetRootNodes
-    data["__cuGraphGetRootNodes"] = <intptr_t>__cuGraphGetRootNodes
-
-    global __cuGraphGetEdges_v2
-    data["__cuGraphGetEdges_v2"] = <intptr_t>__cuGraphGetEdges_v2
-
-    global __cuGraphNodeGetDependencies_v2
-    data["__cuGraphNodeGetDependencies_v2"] = <intptr_t>__cuGraphNodeGetDependencies_v2
-
-    global __cuGraphNodeGetDependentNodes_v2
-    data["__cuGraphNodeGetDependentNodes_v2"] = <intptr_t>__cuGraphNodeGetDependentNodes_v2
-
-    global __cuGraphAddDependencies_v2
-    data["__cuGraphAddDependencies_v2"] = <intptr_t>__cuGraphAddDependencies_v2
-
-    global __cuGraphRemoveDependencies_v2
-    data["__cuGraphRemoveDependencies_v2"] = <intptr_t>__cuGraphRemoveDependencies_v2
-
-    global __cuGraphDestroyNode
-    data["__cuGraphDestroyNode"] = <intptr_t>__cuGraphDestroyNode
-
-    global __cuGraphInstantiateWithFlags
-    data["__cuGraphInstantiateWithFlags"] = <intptr_t>__cuGraphInstantiateWithFlags
-
-    global __cuGraphInstantiateWithParams
-    data["__cuGraphInstantiateWithParams"] = <intptr_t>__cuGraphInstantiateWithParams
-
-    global __cuGraphExecGetFlags
-    data["__cuGraphExecGetFlags"] = <intptr_t>__cuGraphExecGetFlags
-
-    global __cuGraphExecKernelNodeSetParams_v2
-    data["__cuGraphExecKernelNodeSetParams_v2"] = <intptr_t>__cuGraphExecKernelNodeSetParams_v2
-
-    global __cuGraphExecMemcpyNodeSetParams
-    data["__cuGraphExecMemcpyNodeSetParams"] = <intptr_t>__cuGraphExecMemcpyNodeSetParams
-
-    global __cuGraphExecMemsetNodeSetParams
-    data["__cuGraphExecMemsetNodeSetParams"] = <intptr_t>__cuGraphExecMemsetNodeSetParams
-
-    global __cuGraphExecHostNodeSetParams
-    data["__cuGraphExecHostNodeSetParams"] = <intptr_t>__cuGraphExecHostNodeSetParams
-
-    global __cuGraphExecChildGraphNodeSetParams
-    data["__cuGraphExecChildGraphNodeSetParams"] = <intptr_t>__cuGraphExecChildGraphNodeSetParams
-
-    global __cuGraphExecEventRecordNodeSetEvent
-    data["__cuGraphExecEventRecordNodeSetEvent"] = <intptr_t>__cuGraphExecEventRecordNodeSetEvent
-
-    global __cuGraphExecEventWaitNodeSetEvent
-    data["__cuGraphExecEventWaitNodeSetEvent"] = <intptr_t>__cuGraphExecEventWaitNodeSetEvent
-
-    global __cuGraphExecExternalSemaphoresSignalNodeSetParams
-    data["__cuGraphExecExternalSemaphoresSignalNodeSetParams"] = <intptr_t>__cuGraphExecExternalSemaphoresSignalNodeSetParams
-
-    global __cuGraphExecExternalSemaphoresWaitNodeSetParams
-    data["__cuGraphExecExternalSemaphoresWaitNodeSetParams"] = <intptr_t>__cuGraphExecExternalSemaphoresWaitNodeSetParams
-
-    global __cuGraphNodeSetEnabled
-    data["__cuGraphNodeSetEnabled"] = <intptr_t>__cuGraphNodeSetEnabled
-
-    global __cuGraphNodeGetEnabled
-    data["__cuGraphNodeGetEnabled"] = <intptr_t>__cuGraphNodeGetEnabled
-
-    global __cuGraphUpload
-    data["__cuGraphUpload"] = <intptr_t>__cuGraphUpload
-
-    global __cuGraphLaunch
-    data["__cuGraphLaunch"] = <intptr_t>__cuGraphLaunch
-
-    global __cuGraphExecDestroy
-    data["__cuGraphExecDestroy"] = <intptr_t>__cuGraphExecDestroy
-
-    global __cuGraphDestroy
-    data["__cuGraphDestroy"] = <intptr_t>__cuGraphDestroy
-
-    global __cuGraphExecUpdate_v2
-    data["__cuGraphExecUpdate_v2"] = <intptr_t>__cuGraphExecUpdate_v2
-
-    global __cuGraphKernelNodeCopyAttributes
-    data["__cuGraphKernelNodeCopyAttributes"] = <intptr_t>__cuGraphKernelNodeCopyAttributes
-
-    global __cuGraphKernelNodeGetAttribute
-    data["__cuGraphKernelNodeGetAttribute"] = <intptr_t>__cuGraphKernelNodeGetAttribute
-
-    global __cuGraphKernelNodeSetAttribute
-    data["__cuGraphKernelNodeSetAttribute"] = <intptr_t>__cuGraphKernelNodeSetAttribute
-
-    global __cuGraphDebugDotPrint
-    data["__cuGraphDebugDotPrint"] = <intptr_t>__cuGraphDebugDotPrint
-
-    global __cuUserObjectCreate
-    data["__cuUserObjectCreate"] = <intptr_t>__cuUserObjectCreate
-
-    global __cuUserObjectRetain
-    data["__cuUserObjectRetain"] = <intptr_t>__cuUserObjectRetain
-
-    global __cuUserObjectRelease
-    data["__cuUserObjectRelease"] = <intptr_t>__cuUserObjectRelease
-
-    global __cuGraphRetainUserObject
-    data["__cuGraphRetainUserObject"] = <intptr_t>__cuGraphRetainUserObject
-
-    global __cuGraphReleaseUserObject
-    data["__cuGraphReleaseUserObject"] = <intptr_t>__cuGraphReleaseUserObject
-
-    global __cuGraphAddNode_v2
-    data["__cuGraphAddNode_v2"] = <intptr_t>__cuGraphAddNode_v2
-
-    global __cuGraphNodeSetParams
-    data["__cuGraphNodeSetParams"] = <intptr_t>__cuGraphNodeSetParams
-
-    global __cuGraphExecNodeSetParams
-    data["__cuGraphExecNodeSetParams"] = <intptr_t>__cuGraphExecNodeSetParams
-
-    global __cuGraphConditionalHandleCreate
-    data["__cuGraphConditionalHandleCreate"] = <intptr_t>__cuGraphConditionalHandleCreate
-
-    global __cuOccupancyMaxActiveBlocksPerMultiprocessor
-    data["__cuOccupancyMaxActiveBlocksPerMultiprocessor"] = <intptr_t>__cuOccupancyMaxActiveBlocksPerMultiprocessor
-
-    global __cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags
-    data["__cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags"] = <intptr_t>__cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags
-
-    global __cuOccupancyMaxPotentialBlockSize
-    data["__cuOccupancyMaxPotentialBlockSize"] = <intptr_t>__cuOccupancyMaxPotentialBlockSize
-
-    global __cuOccupancyMaxPotentialBlockSizeWithFlags
-    data["__cuOccupancyMaxPotentialBlockSizeWithFlags"] = <intptr_t>__cuOccupancyMaxPotentialBlockSizeWithFlags
-
-    global __cuOccupancyAvailableDynamicSMemPerBlock
-    data["__cuOccupancyAvailableDynamicSMemPerBlock"] = <intptr_t>__cuOccupancyAvailableDynamicSMemPerBlock
-
-    global __cuOccupancyMaxPotentialClusterSize
-    data["__cuOccupancyMaxPotentialClusterSize"] = <intptr_t>__cuOccupancyMaxPotentialClusterSize
-
-    global __cuOccupancyMaxActiveClusters
-    data["__cuOccupancyMaxActiveClusters"] = <intptr_t>__cuOccupancyMaxActiveClusters
-
-    global __cuTexRefSetArray
-    data["__cuTexRefSetArray"] = <intptr_t>__cuTexRefSetArray
-
-    global __cuTexRefSetMipmappedArray
-    data["__cuTexRefSetMipmappedArray"] = <intptr_t>__cuTexRefSetMipmappedArray
-
-    global __cuTexRefSetAddress_v2
-    data["__cuTexRefSetAddress_v2"] = <intptr_t>__cuTexRefSetAddress_v2
-
-    global __cuTexRefSetAddress2D_v3
-    data["__cuTexRefSetAddress2D_v3"] = <intptr_t>__cuTexRefSetAddress2D_v3
-
-    global __cuTexRefSetFormat
-    data["__cuTexRefSetFormat"] = <intptr_t>__cuTexRefSetFormat
-
-    global __cuTexRefSetAddressMode
-    data["__cuTexRefSetAddressMode"] = <intptr_t>__cuTexRefSetAddressMode
-
-    global __cuTexRefSetFilterMode
-    data["__cuTexRefSetFilterMode"] = <intptr_t>__cuTexRefSetFilterMode
-
-    global __cuTexRefSetMipmapFilterMode
-    data["__cuTexRefSetMipmapFilterMode"] = <intptr_t>__cuTexRefSetMipmapFilterMode
-
-    global __cuTexRefSetMipmapLevelBias
-    data["__cuTexRefSetMipmapLevelBias"] = <intptr_t>__cuTexRefSetMipmapLevelBias
-
-    global __cuTexRefSetMipmapLevelClamp
-    data["__cuTexRefSetMipmapLevelClamp"] = <intptr_t>__cuTexRefSetMipmapLevelClamp
-
-    global __cuTexRefSetMaxAnisotropy
-    data["__cuTexRefSetMaxAnisotropy"] = <intptr_t>__cuTexRefSetMaxAnisotropy
-
-    global __cuTexRefSetBorderColor
-    data["__cuTexRefSetBorderColor"] = <intptr_t>__cuTexRefSetBorderColor
-
-    global __cuTexRefSetFlags
-    data["__cuTexRefSetFlags"] = <intptr_t>__cuTexRefSetFlags
-
-    global __cuTexRefGetAddress_v2
-    data["__cuTexRefGetAddress_v2"] = <intptr_t>__cuTexRefGetAddress_v2
-
-    global __cuTexRefGetArray
-    data["__cuTexRefGetArray"] = <intptr_t>__cuTexRefGetArray
-
-    global __cuTexRefGetMipmappedArray
-    data["__cuTexRefGetMipmappedArray"] = <intptr_t>__cuTexRefGetMipmappedArray
-
-    global __cuTexRefGetAddressMode
-    data["__cuTexRefGetAddressMode"] = <intptr_t>__cuTexRefGetAddressMode
-
-    global __cuTexRefGetFilterMode
-    data["__cuTexRefGetFilterMode"] = <intptr_t>__cuTexRefGetFilterMode
-
-    global __cuTexRefGetFormat
-    data["__cuTexRefGetFormat"] = <intptr_t>__cuTexRefGetFormat
-
-    global __cuTexRefGetMipmapFilterMode
-    data["__cuTexRefGetMipmapFilterMode"] = <intptr_t>__cuTexRefGetMipmapFilterMode
-
-    global __cuTexRefGetMipmapLevelBias
-    data["__cuTexRefGetMipmapLevelBias"] = <intptr_t>__cuTexRefGetMipmapLevelBias
-
-    global __cuTexRefGetMipmapLevelClamp
-    data["__cuTexRefGetMipmapLevelClamp"] = <intptr_t>__cuTexRefGetMipmapLevelClamp
-
-    global __cuTexRefGetMaxAnisotropy
-    data["__cuTexRefGetMaxAnisotropy"] = <intptr_t>__cuTexRefGetMaxAnisotropy
-
-    global __cuTexRefGetBorderColor
-    data["__cuTexRefGetBorderColor"] = <intptr_t>__cuTexRefGetBorderColor
-
-    global __cuTexRefGetFlags
-    data["__cuTexRefGetFlags"] = <intptr_t>__cuTexRefGetFlags
-
-    global __cuTexRefCreate
-    data["__cuTexRefCreate"] = <intptr_t>__cuTexRefCreate
-
-    global __cuTexRefDestroy
-    data["__cuTexRefDestroy"] = <intptr_t>__cuTexRefDestroy
-
-    global __cuSurfRefSetArray
-    data["__cuSurfRefSetArray"] = <intptr_t>__cuSurfRefSetArray
-
-    global __cuSurfRefGetArray
-    data["__cuSurfRefGetArray"] = <intptr_t>__cuSurfRefGetArray
-
-    global __cuTexObjectCreate
-    data["__cuTexObjectCreate"] = <intptr_t>__cuTexObjectCreate
-
-    global __cuTexObjectDestroy
-    data["__cuTexObjectDestroy"] = <intptr_t>__cuTexObjectDestroy
-
-    global __cuTexObjectGetResourceDesc
-    data["__cuTexObjectGetResourceDesc"] = <intptr_t>__cuTexObjectGetResourceDesc
-
-    global __cuTexObjectGetTextureDesc
-    data["__cuTexObjectGetTextureDesc"] = <intptr_t>__cuTexObjectGetTextureDesc
-
-    global __cuTexObjectGetResourceViewDesc
-    data["__cuTexObjectGetResourceViewDesc"] = <intptr_t>__cuTexObjectGetResourceViewDesc
-
-    global __cuSurfObjectCreate
-    data["__cuSurfObjectCreate"] = <intptr_t>__cuSurfObjectCreate
-
-    global __cuSurfObjectDestroy
-    data["__cuSurfObjectDestroy"] = <intptr_t>__cuSurfObjectDestroy
-
-    global __cuSurfObjectGetResourceDesc
-    data["__cuSurfObjectGetResourceDesc"] = <intptr_t>__cuSurfObjectGetResourceDesc
-
-    global __cuTensorMapEncodeTiled
-    data["__cuTensorMapEncodeTiled"] = <intptr_t>__cuTensorMapEncodeTiled
-
-    global __cuTensorMapEncodeIm2col
-    data["__cuTensorMapEncodeIm2col"] = <intptr_t>__cuTensorMapEncodeIm2col
-
-    global __cuTensorMapEncodeIm2colWide
-    data["__cuTensorMapEncodeIm2colWide"] = <intptr_t>__cuTensorMapEncodeIm2colWide
-
-    global __cuTensorMapReplaceAddress
-    data["__cuTensorMapReplaceAddress"] = <intptr_t>__cuTensorMapReplaceAddress
-
-    global __cuDeviceCanAccessPeer
-    data["__cuDeviceCanAccessPeer"] = <intptr_t>__cuDeviceCanAccessPeer
-
-    global __cuCtxEnablePeerAccess
-    data["__cuCtxEnablePeerAccess"] = <intptr_t>__cuCtxEnablePeerAccess
-
-    global __cuCtxDisablePeerAccess
-    data["__cuCtxDisablePeerAccess"] = <intptr_t>__cuCtxDisablePeerAccess
-
-    global __cuDeviceGetP2PAttribute
-    data["__cuDeviceGetP2PAttribute"] = <intptr_t>__cuDeviceGetP2PAttribute
-
-    global __cuGraphicsUnregisterResource
-    data["__cuGraphicsUnregisterResource"] = <intptr_t>__cuGraphicsUnregisterResource
-
-    global __cuGraphicsSubResourceGetMappedArray
-    data["__cuGraphicsSubResourceGetMappedArray"] = <intptr_t>__cuGraphicsSubResourceGetMappedArray
-
-    global __cuGraphicsResourceGetMappedMipmappedArray
-    data["__cuGraphicsResourceGetMappedMipmappedArray"] = <intptr_t>__cuGraphicsResourceGetMappedMipmappedArray
-
-    global __cuGraphicsResourceGetMappedPointer_v2
-    data["__cuGraphicsResourceGetMappedPointer_v2"] = <intptr_t>__cuGraphicsResourceGetMappedPointer_v2
-
-    global __cuGraphicsResourceSetMapFlags_v2
-    data["__cuGraphicsResourceSetMapFlags_v2"] = <intptr_t>__cuGraphicsResourceSetMapFlags_v2
-
-    global __cuGraphicsMapResources
-    data["__cuGraphicsMapResources"] = <intptr_t>__cuGraphicsMapResources
-
-    global __cuGraphicsUnmapResources
-    data["__cuGraphicsUnmapResources"] = <intptr_t>__cuGraphicsUnmapResources
-
-    global __cuGetProcAddress_v2
-    data["__cuGetProcAddress_v2"] = <intptr_t>__cuGetProcAddress_v2
-
-    global __cuCoredumpGetAttribute
-    data["__cuCoredumpGetAttribute"] = <intptr_t>__cuCoredumpGetAttribute
-
-    global __cuCoredumpGetAttributeGlobal
-    data["__cuCoredumpGetAttributeGlobal"] = <intptr_t>__cuCoredumpGetAttributeGlobal
-
-    global __cuCoredumpSetAttribute
-    data["__cuCoredumpSetAttribute"] = <intptr_t>__cuCoredumpSetAttribute
-
-    global __cuCoredumpSetAttributeGlobal
-    data["__cuCoredumpSetAttributeGlobal"] = <intptr_t>__cuCoredumpSetAttributeGlobal
-
-    global __cuGetExportTable
-    data["__cuGetExportTable"] = <intptr_t>__cuGetExportTable
-
-    global __cuGreenCtxCreate
-    data["__cuGreenCtxCreate"] = <intptr_t>__cuGreenCtxCreate
-
-    global __cuGreenCtxDestroy
-    data["__cuGreenCtxDestroy"] = <intptr_t>__cuGreenCtxDestroy
-
-    global __cuCtxFromGreenCtx
-    data["__cuCtxFromGreenCtx"] = <intptr_t>__cuCtxFromGreenCtx
-
-    global __cuDeviceGetDevResource
-    data["__cuDeviceGetDevResource"] = <intptr_t>__cuDeviceGetDevResource
-
-    global __cuCtxGetDevResource
-    data["__cuCtxGetDevResource"] = <intptr_t>__cuCtxGetDevResource
-
-    global __cuGreenCtxGetDevResource
-    data["__cuGreenCtxGetDevResource"] = <intptr_t>__cuGreenCtxGetDevResource
-
-    global __cuDevSmResourceSplitByCount
-    data["__cuDevSmResourceSplitByCount"] = <intptr_t>__cuDevSmResourceSplitByCount
-
-    global __cuDevResourceGenerateDesc
-    data["__cuDevResourceGenerateDesc"] = <intptr_t>__cuDevResourceGenerateDesc
-
-    global __cuGreenCtxRecordEvent
-    data["__cuGreenCtxRecordEvent"] = <intptr_t>__cuGreenCtxRecordEvent
-
-    global __cuGreenCtxWaitEvent
-    data["__cuGreenCtxWaitEvent"] = <intptr_t>__cuGreenCtxWaitEvent
-
-    global __cuStreamGetGreenCtx
-    data["__cuStreamGetGreenCtx"] = <intptr_t>__cuStreamGetGreenCtx
-
-    global __cuGreenCtxStreamCreate
-    data["__cuGreenCtxStreamCreate"] = <intptr_t>__cuGreenCtxStreamCreate
-
-    global __cuLogsRegisterCallback
-    data["__cuLogsRegisterCallback"] = <intptr_t>__cuLogsRegisterCallback
-
-    global __cuLogsUnregisterCallback
-    data["__cuLogsUnregisterCallback"] = <intptr_t>__cuLogsUnregisterCallback
-
-    global __cuLogsCurrent
-    data["__cuLogsCurrent"] = <intptr_t>__cuLogsCurrent
-
-    global __cuLogsDumpToFile
-    data["__cuLogsDumpToFile"] = <intptr_t>__cuLogsDumpToFile
-
-    global __cuLogsDumpToMemory
-    data["__cuLogsDumpToMemory"] = <intptr_t>__cuLogsDumpToMemory
-
-    global __cuCheckpointProcessGetRestoreThreadId
-    data["__cuCheckpointProcessGetRestoreThreadId"] = <intptr_t>__cuCheckpointProcessGetRestoreThreadId
-
-    global __cuCheckpointProcessGetState
-    data["__cuCheckpointProcessGetState"] = <intptr_t>__cuCheckpointProcessGetState
-
-    global __cuCheckpointProcessLock
-    data["__cuCheckpointProcessLock"] = <intptr_t>__cuCheckpointProcessLock
-
-    global __cuCheckpointProcessCheckpoint
-    data["__cuCheckpointProcessCheckpoint"] = <intptr_t>__cuCheckpointProcessCheckpoint
-
-    global __cuCheckpointProcessRestore
-    data["__cuCheckpointProcessRestore"] = <intptr_t>__cuCheckpointProcessRestore
-
-    global __cuCheckpointProcessUnlock
-    data["__cuCheckpointProcessUnlock"] = <intptr_t>__cuCheckpointProcessUnlock
-
-    global __cuGraphicsEGLRegisterImage
-    data["__cuGraphicsEGLRegisterImage"] = <intptr_t>__cuGraphicsEGLRegisterImage
-
-    global __cuEGLStreamConsumerConnect
-    data["__cuEGLStreamConsumerConnect"] = <intptr_t>__cuEGLStreamConsumerConnect
-
-    global __cuEGLStreamConsumerConnectWithFlags
-    data["__cuEGLStreamConsumerConnectWithFlags"] = <intptr_t>__cuEGLStreamConsumerConnectWithFlags
-
-    global __cuEGLStreamConsumerDisconnect
-    data["__cuEGLStreamConsumerDisconnect"] = <intptr_t>__cuEGLStreamConsumerDisconnect
-
-    global __cuEGLStreamConsumerAcquireFrame
-    data["__cuEGLStreamConsumerAcquireFrame"] = <intptr_t>__cuEGLStreamConsumerAcquireFrame
-
-    global __cuEGLStreamConsumerReleaseFrame
-    data["__cuEGLStreamConsumerReleaseFrame"] = <intptr_t>__cuEGLStreamConsumerReleaseFrame
-
-    global __cuEGLStreamProducerConnect
-    data["__cuEGLStreamProducerConnect"] = <intptr_t>__cuEGLStreamProducerConnect
-
-    global __cuEGLStreamProducerDisconnect
-    data["__cuEGLStreamProducerDisconnect"] = <intptr_t>__cuEGLStreamProducerDisconnect
-
-    global __cuEGLStreamProducerPresentFrame
-    data["__cuEGLStreamProducerPresentFrame"] = <intptr_t>__cuEGLStreamProducerPresentFrame
-
-    global __cuEGLStreamProducerReturnFrame
-    data["__cuEGLStreamProducerReturnFrame"] = <intptr_t>__cuEGLStreamProducerReturnFrame
-
-    global __cuGraphicsResourceGetMappedEglFrame
-    data["__cuGraphicsResourceGetMappedEglFrame"] = <intptr_t>__cuGraphicsResourceGetMappedEglFrame
-
-    global __cuEventCreateFromEGLSync
-    data["__cuEventCreateFromEGLSync"] = <intptr_t>__cuEventCreateFromEGLSync
-
-    global __cuGraphicsGLRegisterBuffer
-    data["__cuGraphicsGLRegisterBuffer"] = <intptr_t>__cuGraphicsGLRegisterBuffer
-
-    global __cuGraphicsGLRegisterImage
-    data["__cuGraphicsGLRegisterImage"] = <intptr_t>__cuGraphicsGLRegisterImage
-
-    global __cuGLGetDevices_v2
-    data["__cuGLGetDevices_v2"] = <intptr_t>__cuGLGetDevices_v2
-
-    global __cuGLCtxCreate_v2
-    data["__cuGLCtxCreate_v2"] = <intptr_t>__cuGLCtxCreate_v2
-
-    global __cuGLInit
-    data["__cuGLInit"] = <intptr_t>__cuGLInit
-
-    global __cuGLRegisterBufferObject
-    data["__cuGLRegisterBufferObject"] = <intptr_t>__cuGLRegisterBufferObject
-
-    global __cuGLMapBufferObject_v2
-    data["__cuGLMapBufferObject_v2"] = <intptr_t>__cuGLMapBufferObject_v2
-
-    global __cuGLUnmapBufferObject
-    data["__cuGLUnmapBufferObject"] = <intptr_t>__cuGLUnmapBufferObject
-
-    global __cuGLUnregisterBufferObject
-    data["__cuGLUnregisterBufferObject"] = <intptr_t>__cuGLUnregisterBufferObject
-
-    global __cuGLSetBufferObjectMapFlags
-    data["__cuGLSetBufferObjectMapFlags"] = <intptr_t>__cuGLSetBufferObjectMapFlags
-
-    global __cuGLMapBufferObjectAsync_v2
-    data["__cuGLMapBufferObjectAsync_v2"] = <intptr_t>__cuGLMapBufferObjectAsync_v2
-
-    global __cuGLUnmapBufferObjectAsync
-    data["__cuGLUnmapBufferObjectAsync"] = <intptr_t>__cuGLUnmapBufferObjectAsync
-
-    global __cuProfilerInitialize
-    data["__cuProfilerInitialize"] = <intptr_t>__cuProfilerInitialize
-
-    global __cuProfilerStart
-    data["__cuProfilerStart"] = <intptr_t>__cuProfilerStart
-
-    global __cuProfilerStop
-    data["__cuProfilerStop"] = <intptr_t>__cuProfilerStop
-
-    global __cuVDPAUGetDevice
-    data["__cuVDPAUGetDevice"] = <intptr_t>__cuVDPAUGetDevice
-
-    global __cuVDPAUCtxCreate_v2
-    data["__cuVDPAUCtxCreate_v2"] = <intptr_t>__cuVDPAUCtxCreate_v2
-
-    global __cuGraphicsVDPAURegisterVideoSurface
-    data["__cuGraphicsVDPAURegisterVideoSurface"] = <intptr_t>__cuGraphicsVDPAURegisterVideoSurface
-
-    global __cuGraphicsVDPAURegisterOutputSurface
-    data["__cuGraphicsVDPAURegisterOutputSurface"] = <intptr_t>__cuGraphicsVDPAURegisterOutputSurface
-
-    global __cuDeviceGetHostAtomicCapabilities
-    data["__cuDeviceGetHostAtomicCapabilities"] = <intptr_t>__cuDeviceGetHostAtomicCapabilities
-
-    global __cuCtxGetDevice_v2
-    data["__cuCtxGetDevice_v2"] = <intptr_t>__cuCtxGetDevice_v2
-
-    global __cuCtxSynchronize_v2
-    data["__cuCtxSynchronize_v2"] = <intptr_t>__cuCtxSynchronize_v2
-
-    global __cuMemcpyBatchAsync_v2
-    data["__cuMemcpyBatchAsync_v2"] = <intptr_t>__cuMemcpyBatchAsync_v2
-
-    global __cuMemcpy3DBatchAsync_v2
-    data["__cuMemcpy3DBatchAsync_v2"] = <intptr_t>__cuMemcpy3DBatchAsync_v2
-
-    global __cuMemGetDefaultMemPool
-    data["__cuMemGetDefaultMemPool"] = <intptr_t>__cuMemGetDefaultMemPool
-
-    global __cuMemGetMemPool
-    data["__cuMemGetMemPool"] = <intptr_t>__cuMemGetMemPool
-
-    global __cuMemSetMemPool
-    data["__cuMemSetMemPool"] = <intptr_t>__cuMemSetMemPool
-
-    global __cuMemPrefetchBatchAsync
-    data["__cuMemPrefetchBatchAsync"] = <intptr_t>__cuMemPrefetchBatchAsync
-
-    global __cuMemDiscardBatchAsync
-    data["__cuMemDiscardBatchAsync"] = <intptr_t>__cuMemDiscardBatchAsync
-
-    global __cuMemDiscardAndPrefetchBatchAsync
-    data["__cuMemDiscardAndPrefetchBatchAsync"] = <intptr_t>__cuMemDiscardAndPrefetchBatchAsync
-
-    global __cuDeviceGetP2PAtomicCapabilities
-    data["__cuDeviceGetP2PAtomicCapabilities"] = <intptr_t>__cuDeviceGetP2PAtomicCapabilities
-
-    global __cuGreenCtxGetId
-    data["__cuGreenCtxGetId"] = <intptr_t>__cuGreenCtxGetId
-
-    global __cuMulticastBindMem_v2
-    data["__cuMulticastBindMem_v2"] = <intptr_t>__cuMulticastBindMem_v2
-
-    global __cuMulticastBindAddr_v2
-    data["__cuMulticastBindAddr_v2"] = <intptr_t>__cuMulticastBindAddr_v2
-
-    global __cuGraphNodeGetContainingGraph
-    data["__cuGraphNodeGetContainingGraph"] = <intptr_t>__cuGraphNodeGetContainingGraph
-
-    global __cuGraphNodeGetLocalId
-    data["__cuGraphNodeGetLocalId"] = <intptr_t>__cuGraphNodeGetLocalId
-
-    global __cuGraphNodeGetToolsId
-    data["__cuGraphNodeGetToolsId"] = <intptr_t>__cuGraphNodeGetToolsId
-
-    global __cuGraphGetId
-    data["__cuGraphGetId"] = <intptr_t>__cuGraphGetId
-
-    global __cuGraphExecGetId
-    data["__cuGraphExecGetId"] = <intptr_t>__cuGraphExecGetId
-
-    global __cuDevSmResourceSplit
-    data["__cuDevSmResourceSplit"] = <intptr_t>__cuDevSmResourceSplit
-
-    global __cuStreamGetDevResource
-    data["__cuStreamGetDevResource"] = <intptr_t>__cuStreamGetDevResource
-
-    global __cuKernelGetParamCount
-    data["__cuKernelGetParamCount"] = <intptr_t>__cuKernelGetParamCount
-
-    global __cuMemcpyWithAttributesAsync
-    data["__cuMemcpyWithAttributesAsync"] = <intptr_t>__cuMemcpyWithAttributesAsync
-
-    global __cuMemcpy3DWithAttributesAsync
-    data["__cuMemcpy3DWithAttributesAsync"] = <intptr_t>__cuMemcpy3DWithAttributesAsync
-
-    global __cuStreamBeginCaptureToCig
-    data["__cuStreamBeginCaptureToCig"] = <intptr_t>__cuStreamBeginCaptureToCig
-
-    global __cuStreamEndCaptureToCig
-    data["__cuStreamEndCaptureToCig"] = <intptr_t>__cuStreamEndCaptureToCig
-
-    global __cuFuncGetParamCount
-    data["__cuFuncGetParamCount"] = <intptr_t>__cuFuncGetParamCount
-
-    global __cuLaunchHostFunc_v2
-    data["__cuLaunchHostFunc_v2"] = <intptr_t>__cuLaunchHostFunc_v2
-
-    global __cuGraphNodeGetParams
-    data["__cuGraphNodeGetParams"] = <intptr_t>__cuGraphNodeGetParams
-
-    global __cuCoredumpRegisterStartCallback
-    data["__cuCoredumpRegisterStartCallback"] = <intptr_t>__cuCoredumpRegisterStartCallback
-
-    global __cuCoredumpRegisterCompleteCallback
-    data["__cuCoredumpRegisterCompleteCallback"] = <intptr_t>__cuCoredumpRegisterCompleteCallback
-
-    global __cuCoredumpDeregisterStartCallback
-    data["__cuCoredumpDeregisterStartCallback"] = <intptr_t>__cuCoredumpDeregisterStartCallback
-
-    global __cuCoredumpDeregisterCompleteCallback
-    data["__cuCoredumpDeregisterCompleteCallback"] = <intptr_t>__cuCoredumpDeregisterCompleteCallback
-
-    global __cuLogicalEndpointIdReserve
-    data["__cuLogicalEndpointIdReserve"] = <intptr_t>__cuLogicalEndpointIdReserve
-
-    global __cuLogicalEndpointIdRelease
-    data["__cuLogicalEndpointIdRelease"] = <intptr_t>__cuLogicalEndpointIdRelease
-
-    global __cuLogicalEndpointCreate
-    data["__cuLogicalEndpointCreate"] = <intptr_t>__cuLogicalEndpointCreate
-
-    global __cuLogicalEndpointAddDevice
-    data["__cuLogicalEndpointAddDevice"] = <intptr_t>__cuLogicalEndpointAddDevice
-
-    global __cuLogicalEndpointDestroy
-    data["__cuLogicalEndpointDestroy"] = <intptr_t>__cuLogicalEndpointDestroy
-
-    global __cuLogicalEndpointBindAddr
-    data["__cuLogicalEndpointBindAddr"] = <intptr_t>__cuLogicalEndpointBindAddr
-
-    global __cuLogicalEndpointBindMem
-    data["__cuLogicalEndpointBindMem"] = <intptr_t>__cuLogicalEndpointBindMem
-
-    global __cuLogicalEndpointUnbind
-    data["__cuLogicalEndpointUnbind"] = <intptr_t>__cuLogicalEndpointUnbind
-
-    global __cuLogicalEndpointExport
-    data["__cuLogicalEndpointExport"] = <intptr_t>__cuLogicalEndpointExport
-
-    global __cuLogicalEndpointImport
-    data["__cuLogicalEndpointImport"] = <intptr_t>__cuLogicalEndpointImport
-
-    global __cuLogicalEndpointGetLimits
-    data["__cuLogicalEndpointGetLimits"] = <intptr_t>__cuLogicalEndpointGetLimits
-
-    global __cuLogicalEndpointQuery
-    data["__cuLogicalEndpointQuery"] = <intptr_t>__cuLogicalEndpointQuery
-
-    global __cuStreamBeginRecaptureToGraph
-    data["__cuStreamBeginRecaptureToGraph"] = <intptr_t>__cuStreamBeginRecaptureToGraph
-
-    func_ptrs = data
-    return data
-
-
-cpdef _inspect_function_pointer(str name):
-    global func_ptrs
-    if func_ptrs is None:
-        func_ptrs = _inspect_function_pointers()
-    return func_ptrs[name]
 
 
 ###############################################################################

--- a/cuda_bindings/cuda/bindings/_internal/driver_windows.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/driver_windows.pyx
@@ -3,81 +3,38 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.9.0 to 13.3.0. Do not modify it directly.
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=501497a3d88840c62eda1dfb0b72fe7494ff20a208230b1f45ad2f0c11bf47a5
 
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=51232c67845ad8bb70e4d63f8f48ed1246b27d371b929f229fa09c27b23235c8
-from libc.stdint cimport intptr_t
 
-import os
-import threading
-from .utils import FunctionNotFoundError, NotSupportedError
+# <<<< PREAMBLE CONTENT >>>>
 
-from cuda.pathfinder import load_nvidia_dynamic_lib
-
-from libc.stddef cimport wchar_t
-from libc.stdint cimport uintptr_t
-from cpython cimport PyUnicode_AsWideCharString, PyMem_Free
-
-# You must 'from .utils import NotSupportedError' before using this template
-
-cdef extern from "windows.h" nogil:
+cdef extern from "<windows.h>":
     ctypedef void* HMODULE
-    ctypedef void* HANDLE
-    ctypedef void* FARPROC
-    ctypedef unsigned long DWORD
-    ctypedef const wchar_t *LPCWSTR
-    ctypedef const char *LPCSTR
+    void* _cyb_GetProcAddress "GetProcAddress"(HMODULE, const char*) nogil
 
-    cdef DWORD LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800
-    cdef DWORD LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000
-    cdef DWORD LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR = 0x00000100
+from libc.stdint cimport intptr_t as _cyb_intptr_t
 
-    HMODULE _LoadLibraryExW "LoadLibraryExW"(
-        LPCWSTR lpLibFileName,
-        HANDLE hFile,
-        DWORD dwFlags
-    )
+from os import getenv as _cyb_getenv
+import threading as _cyb_threading
 
-    FARPROC _GetProcAddress "GetProcAddress"(HMODULE hModule, LPCSTR lpProcName)
+ctypedef int (*_cyb_cuGetProcAddress_v2_T)(const char *, void **, int, cuuint64_t, CUdriverProcAddressQueryResult *)except?CUDA_ERROR_NOT_FOUND nogil
 
-cdef inline uintptr_t LoadLibraryExW(str path, HANDLE hFile, DWORD dwFlags):
-    cdef uintptr_t result
-    cdef wchar_t* wpath = PyUnicode_AsWideCharString(path, NULL)
-    with nogil:
-        result = <uintptr_t>_LoadLibraryExW(
-            wpath,
-            hFile,
-            dwFlags
-        )
-    PyMem_Free(wpath)
-    return result
+cdef bint _cyb___py_driver_init = False
+cdef dict _cyb_func_ptrs = None
+cdef object _cyb_symbol_lock = _cyb_threading.Lock()
 
-cdef inline void *GetProcAddress(uintptr_t hModule, const char* lpProcName) nogil:
-    return _GetProcAddress(<HMODULE>hModule, lpProcName)
+# <<<< END OF PREAMBLE CONTENT >>>>
 
-cdef int get_cuda_version():
-    cdef int err, driver_ver = 0
+from libc.stdint cimport uintptr_t
 
-    # Load driver to check version
-    handle = LoadLibraryExW("nvcuda.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32)
-    if handle == 0:
-        raise NotSupportedError('CUDA driver is not found')
-    cuDriverGetVersion = GetProcAddress(handle, 'cuDriverGetVersion')
-    if cuDriverGetVersion == NULL:
-        raise RuntimeError('Did not find cuDriverGetVersion symbol in nvcuda.dll')
-    err = (<int (*)(int*) noexcept nogil>cuDriverGetVersion)(&driver_ver)
-    if err != 0:
-        raise RuntimeError(f'cuDriverGetVersion returned error code {err}')
-
-    return driver_ver
-
+from .utils import FunctionNotFoundError, NotSupportedError
+from cuda.pathfinder import load_nvidia_dynamic_lib
 
 
 ###############################################################################
 # Wrapper init
 ###############################################################################
 
-cdef object __symbol_lock = threading.Lock()
-cdef bint __py_driver_init = False
 
 cdef void* __cuGetErrorString = NULL
 cdef void* __cuGetErrorName = NULL
@@ -597,3177 +554,3161 @@ cdef void* __cuLogicalEndpointGetLimits = NULL
 cdef void* __cuLogicalEndpointQuery = NULL
 cdef void* __cuStreamBeginRecaptureToGraph = NULL
 
-
-cdef uintptr_t load_library() except* with gil:
-    cdef uintptr_t handle = load_nvidia_dynamic_lib("cuda")._handle_uint
-    return handle
-
-
-ctypedef CUresult (*__cuGetProcAddress_v2_T)(const char*, void**, int, cuuint64_t, CUdriverProcAddressQueryResult*) except?CUDA_ERROR_NOT_FOUND nogil
-cdef __cuGetProcAddress_v2_T _F_cuGetProcAddress_v2 = NULL
-
-
 cdef int _init_driver() except -1 nogil:
-    global __py_driver_init
-
+    global _cyb___py_driver_init
     cdef uintptr_t handle = 0
     cdef int ptds_mode
+    cdef _cyb_cuGetProcAddress_v2_T cuGetProcAddress_v2
+    with gil, _cyb_symbol_lock:
+        if _cyb___py_driver_init: return 0
 
-    with gil, __symbol_lock:
-        # Recheck the flag after obtaining the locks
-        if __py_driver_init:
-            return 0
-
-        # Load library
         handle = load_library()
         if handle == 0:
             raise RuntimeError('Failed to open cuda')
-
         # Get latest __cuGetProcAddress_v2
-        global __cuGetProcAddress_v2
-        __cuGetProcAddress_v2 = GetProcAddress(handle, 'cuGetProcAddress_v2')
-        if __cuGetProcAddress_v2 == NULL:
-            raise RuntimeError("Failed to get __cuGetProcAddress_v2")
-        _F_cuGetProcAddress_v2 = <__cuGetProcAddress_v2_T>__cuGetProcAddress_v2
-
-        if bool(int(os.getenv('CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM', default=0))):
+        cuGetProcAddress_v2 = <_cyb_cuGetProcAddress_v2_T>_cyb_GetProcAddress(
+            <HMODULE>handle, 'cuGetProcAddress_v2'
+        )
+        if cuGetProcAddress_v2 == NULL:
+            raise RuntimeError("Failed to get cuGetProcAddress_v2")
+        if bool(int(_cyb_getenv('CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM', default=0))):
             ptds_mode = CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM
         else:
             ptds_mode = CU_GET_PROC_ADDRESS_DEFAULT
-
-        # Load function
         global __cuGetErrorString
-        _F_cuGetProcAddress_v2('cuGetErrorString', <void **>&__cuGetErrorString, 6000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGetErrorString', <void **>&__cuGetErrorString, 6000, ptds_mode, NULL)
 
         global __cuGetErrorName
-        _F_cuGetProcAddress_v2('cuGetErrorName', <void **>&__cuGetErrorName, 6000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGetErrorName', <void **>&__cuGetErrorName, 6000, ptds_mode, NULL)
 
         global __cuInit
-        _F_cuGetProcAddress_v2('cuInit', <void **>&__cuInit, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuInit', <void **>&__cuInit, 2000, ptds_mode, NULL)
 
         global __cuDriverGetVersion
-        _F_cuGetProcAddress_v2('cuDriverGetVersion', <void **>&__cuDriverGetVersion, 2020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDriverGetVersion', <void **>&__cuDriverGetVersion, 2020, ptds_mode, NULL)
 
         global __cuDeviceGet
-        _F_cuGetProcAddress_v2('cuDeviceGet', <void **>&__cuDeviceGet, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceGet', <void **>&__cuDeviceGet, 2000, ptds_mode, NULL)
 
         global __cuDeviceGetCount
-        _F_cuGetProcAddress_v2('cuDeviceGetCount', <void **>&__cuDeviceGetCount, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceGetCount', <void **>&__cuDeviceGetCount, 2000, ptds_mode, NULL)
 
         global __cuDeviceGetName
-        _F_cuGetProcAddress_v2('cuDeviceGetName', <void **>&__cuDeviceGetName, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceGetName', <void **>&__cuDeviceGetName, 2000, ptds_mode, NULL)
 
         global __cuDeviceGetUuid_v2
-        _F_cuGetProcAddress_v2('cuDeviceGetUuid', <void **>&__cuDeviceGetUuid_v2, 11040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceGetUuid', <void **>&__cuDeviceGetUuid_v2, 11040, ptds_mode, NULL)
 
         global __cuDeviceGetLuid
-        _F_cuGetProcAddress_v2('cuDeviceGetLuid', <void **>&__cuDeviceGetLuid, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceGetLuid', <void **>&__cuDeviceGetLuid, 10000, ptds_mode, NULL)
 
         global __cuDeviceTotalMem_v2
-        _F_cuGetProcAddress_v2('cuDeviceTotalMem', <void **>&__cuDeviceTotalMem_v2, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceTotalMem', <void **>&__cuDeviceTotalMem_v2, 3020, ptds_mode, NULL)
 
         global __cuDeviceGetTexture1DLinearMaxWidth
-        _F_cuGetProcAddress_v2('cuDeviceGetTexture1DLinearMaxWidth', <void **>&__cuDeviceGetTexture1DLinearMaxWidth, 11010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceGetTexture1DLinearMaxWidth', <void **>&__cuDeviceGetTexture1DLinearMaxWidth, 11010, ptds_mode, NULL)
 
         global __cuDeviceGetAttribute
-        _F_cuGetProcAddress_v2('cuDeviceGetAttribute', <void **>&__cuDeviceGetAttribute, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceGetAttribute', <void **>&__cuDeviceGetAttribute, 2000, ptds_mode, NULL)
 
         global __cuDeviceGetNvSciSyncAttributes
-        _F_cuGetProcAddress_v2('cuDeviceGetNvSciSyncAttributes', <void **>&__cuDeviceGetNvSciSyncAttributes, 10020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceGetNvSciSyncAttributes', <void **>&__cuDeviceGetNvSciSyncAttributes, 10020, ptds_mode, NULL)
 
         global __cuDeviceSetMemPool
-        _F_cuGetProcAddress_v2('cuDeviceSetMemPool', <void **>&__cuDeviceSetMemPool, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceSetMemPool', <void **>&__cuDeviceSetMemPool, 11020, ptds_mode, NULL)
 
         global __cuDeviceGetMemPool
-        _F_cuGetProcAddress_v2('cuDeviceGetMemPool', <void **>&__cuDeviceGetMemPool, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceGetMemPool', <void **>&__cuDeviceGetMemPool, 11020, ptds_mode, NULL)
 
         global __cuDeviceGetDefaultMemPool
-        _F_cuGetProcAddress_v2('cuDeviceGetDefaultMemPool', <void **>&__cuDeviceGetDefaultMemPool, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceGetDefaultMemPool', <void **>&__cuDeviceGetDefaultMemPool, 11020, ptds_mode, NULL)
 
         global __cuDeviceGetExecAffinitySupport
-        _F_cuGetProcAddress_v2('cuDeviceGetExecAffinitySupport', <void **>&__cuDeviceGetExecAffinitySupport, 11040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceGetExecAffinitySupport', <void **>&__cuDeviceGetExecAffinitySupport, 11040, ptds_mode, NULL)
 
         global __cuFlushGPUDirectRDMAWrites
-        _F_cuGetProcAddress_v2('cuFlushGPUDirectRDMAWrites', <void **>&__cuFlushGPUDirectRDMAWrites, 11030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuFlushGPUDirectRDMAWrites', <void **>&__cuFlushGPUDirectRDMAWrites, 11030, ptds_mode, NULL)
 
         global __cuDeviceGetProperties
-        _F_cuGetProcAddress_v2('cuDeviceGetProperties', <void **>&__cuDeviceGetProperties, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceGetProperties', <void **>&__cuDeviceGetProperties, 2000, ptds_mode, NULL)
 
         global __cuDeviceComputeCapability
-        _F_cuGetProcAddress_v2('cuDeviceComputeCapability', <void **>&__cuDeviceComputeCapability, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceComputeCapability', <void **>&__cuDeviceComputeCapability, 2000, ptds_mode, NULL)
 
         global __cuDevicePrimaryCtxRetain
-        _F_cuGetProcAddress_v2('cuDevicePrimaryCtxRetain', <void **>&__cuDevicePrimaryCtxRetain, 7000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDevicePrimaryCtxRetain', <void **>&__cuDevicePrimaryCtxRetain, 7000, ptds_mode, NULL)
 
         global __cuDevicePrimaryCtxRelease_v2
-        _F_cuGetProcAddress_v2('cuDevicePrimaryCtxRelease', <void **>&__cuDevicePrimaryCtxRelease_v2, 11000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDevicePrimaryCtxRelease', <void **>&__cuDevicePrimaryCtxRelease_v2, 11000, ptds_mode, NULL)
 
         global __cuDevicePrimaryCtxSetFlags_v2
-        _F_cuGetProcAddress_v2('cuDevicePrimaryCtxSetFlags', <void **>&__cuDevicePrimaryCtxSetFlags_v2, 11000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDevicePrimaryCtxSetFlags', <void **>&__cuDevicePrimaryCtxSetFlags_v2, 11000, ptds_mode, NULL)
 
         global __cuDevicePrimaryCtxGetState
-        _F_cuGetProcAddress_v2('cuDevicePrimaryCtxGetState', <void **>&__cuDevicePrimaryCtxGetState, 7000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDevicePrimaryCtxGetState', <void **>&__cuDevicePrimaryCtxGetState, 7000, ptds_mode, NULL)
 
         global __cuDevicePrimaryCtxReset_v2
-        _F_cuGetProcAddress_v2('cuDevicePrimaryCtxReset', <void **>&__cuDevicePrimaryCtxReset_v2, 11000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDevicePrimaryCtxReset', <void **>&__cuDevicePrimaryCtxReset_v2, 11000, ptds_mode, NULL)
 
         global __cuCtxCreate_v2
-        _F_cuGetProcAddress_v2('cuCtxCreate', <void **>&__cuCtxCreate_v2, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxCreate', <void **>&__cuCtxCreate_v2, 3020, ptds_mode, NULL)
 
         global __cuCtxCreate_v3
-        _F_cuGetProcAddress_v2('cuCtxCreate', <void **>&__cuCtxCreate_v3, 11040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxCreate', <void **>&__cuCtxCreate_v3, 11040, ptds_mode, NULL)
 
         global __cuCtxCreate_v4
-        _F_cuGetProcAddress_v2('cuCtxCreate', <void **>&__cuCtxCreate_v4, 12050, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxCreate', <void **>&__cuCtxCreate_v4, 12050, ptds_mode, NULL)
 
         global __cuCtxDestroy_v2
-        _F_cuGetProcAddress_v2('cuCtxDestroy', <void **>&__cuCtxDestroy_v2, 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxDestroy', <void **>&__cuCtxDestroy_v2, 4000, ptds_mode, NULL)
 
         global __cuCtxPushCurrent_v2
-        _F_cuGetProcAddress_v2('cuCtxPushCurrent', <void **>&__cuCtxPushCurrent_v2, 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxPushCurrent', <void **>&__cuCtxPushCurrent_v2, 4000, ptds_mode, NULL)
 
         global __cuCtxPopCurrent_v2
-        _F_cuGetProcAddress_v2('cuCtxPopCurrent', <void **>&__cuCtxPopCurrent_v2, 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxPopCurrent', <void **>&__cuCtxPopCurrent_v2, 4000, ptds_mode, NULL)
 
         global __cuCtxSetCurrent
-        _F_cuGetProcAddress_v2('cuCtxSetCurrent', <void **>&__cuCtxSetCurrent, 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxSetCurrent', <void **>&__cuCtxSetCurrent, 4000, ptds_mode, NULL)
 
         global __cuCtxGetCurrent
-        _F_cuGetProcAddress_v2('cuCtxGetCurrent', <void **>&__cuCtxGetCurrent, 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxGetCurrent', <void **>&__cuCtxGetCurrent, 4000, ptds_mode, NULL)
 
         global __cuCtxGetDevice
-        _F_cuGetProcAddress_v2('cuCtxGetDevice', <void **>&__cuCtxGetDevice, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxGetDevice', <void **>&__cuCtxGetDevice, 2000, ptds_mode, NULL)
 
         global __cuCtxGetFlags
-        _F_cuGetProcAddress_v2('cuCtxGetFlags', <void **>&__cuCtxGetFlags, 7000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxGetFlags', <void **>&__cuCtxGetFlags, 7000, ptds_mode, NULL)
 
         global __cuCtxSetFlags
-        _F_cuGetProcAddress_v2('cuCtxSetFlags', <void **>&__cuCtxSetFlags, 12010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxSetFlags', <void **>&__cuCtxSetFlags, 12010, ptds_mode, NULL)
 
         global __cuCtxGetId
-        _F_cuGetProcAddress_v2('cuCtxGetId', <void **>&__cuCtxGetId, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxGetId', <void **>&__cuCtxGetId, 12000, ptds_mode, NULL)
 
         global __cuCtxSynchronize
-        _F_cuGetProcAddress_v2('cuCtxSynchronize', <void **>&__cuCtxSynchronize, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxSynchronize', <void **>&__cuCtxSynchronize, 2000, ptds_mode, NULL)
 
         global __cuCtxSetLimit
-        _F_cuGetProcAddress_v2('cuCtxSetLimit', <void **>&__cuCtxSetLimit, 3010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxSetLimit', <void **>&__cuCtxSetLimit, 3010, ptds_mode, NULL)
 
         global __cuCtxGetLimit
-        _F_cuGetProcAddress_v2('cuCtxGetLimit', <void **>&__cuCtxGetLimit, 3010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxGetLimit', <void **>&__cuCtxGetLimit, 3010, ptds_mode, NULL)
 
         global __cuCtxGetCacheConfig
-        _F_cuGetProcAddress_v2('cuCtxGetCacheConfig', <void **>&__cuCtxGetCacheConfig, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxGetCacheConfig', <void **>&__cuCtxGetCacheConfig, 3020, ptds_mode, NULL)
 
         global __cuCtxSetCacheConfig
-        _F_cuGetProcAddress_v2('cuCtxSetCacheConfig', <void **>&__cuCtxSetCacheConfig, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxSetCacheConfig', <void **>&__cuCtxSetCacheConfig, 3020, ptds_mode, NULL)
 
         global __cuCtxGetApiVersion
-        _F_cuGetProcAddress_v2('cuCtxGetApiVersion', <void **>&__cuCtxGetApiVersion, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxGetApiVersion', <void **>&__cuCtxGetApiVersion, 3020, ptds_mode, NULL)
 
         global __cuCtxGetStreamPriorityRange
-        _F_cuGetProcAddress_v2('cuCtxGetStreamPriorityRange', <void **>&__cuCtxGetStreamPriorityRange, 5050, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxGetStreamPriorityRange', <void **>&__cuCtxGetStreamPriorityRange, 5050, ptds_mode, NULL)
 
         global __cuCtxResetPersistingL2Cache
-        _F_cuGetProcAddress_v2('cuCtxResetPersistingL2Cache', <void **>&__cuCtxResetPersistingL2Cache, 11000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxResetPersistingL2Cache', <void **>&__cuCtxResetPersistingL2Cache, 11000, ptds_mode, NULL)
 
         global __cuCtxGetExecAffinity
-        _F_cuGetProcAddress_v2('cuCtxGetExecAffinity', <void **>&__cuCtxGetExecAffinity, 11040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxGetExecAffinity', <void **>&__cuCtxGetExecAffinity, 11040, ptds_mode, NULL)
 
         global __cuCtxRecordEvent
-        _F_cuGetProcAddress_v2('cuCtxRecordEvent', <void **>&__cuCtxRecordEvent, 12050, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxRecordEvent', <void **>&__cuCtxRecordEvent, 12050, ptds_mode, NULL)
 
         global __cuCtxWaitEvent
-        _F_cuGetProcAddress_v2('cuCtxWaitEvent', <void **>&__cuCtxWaitEvent, 12050, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxWaitEvent', <void **>&__cuCtxWaitEvent, 12050, ptds_mode, NULL)
 
         global __cuCtxAttach
-        _F_cuGetProcAddress_v2('cuCtxAttach', <void **>&__cuCtxAttach, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxAttach', <void **>&__cuCtxAttach, 2000, ptds_mode, NULL)
 
         global __cuCtxDetach
-        _F_cuGetProcAddress_v2('cuCtxDetach', <void **>&__cuCtxDetach, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxDetach', <void **>&__cuCtxDetach, 2000, ptds_mode, NULL)
 
         global __cuCtxGetSharedMemConfig
-        _F_cuGetProcAddress_v2('cuCtxGetSharedMemConfig', <void **>&__cuCtxGetSharedMemConfig, 4020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxGetSharedMemConfig', <void **>&__cuCtxGetSharedMemConfig, 4020, ptds_mode, NULL)
 
         global __cuCtxSetSharedMemConfig
-        _F_cuGetProcAddress_v2('cuCtxSetSharedMemConfig', <void **>&__cuCtxSetSharedMemConfig, 4020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxSetSharedMemConfig', <void **>&__cuCtxSetSharedMemConfig, 4020, ptds_mode, NULL)
 
         global __cuModuleLoad
-        _F_cuGetProcAddress_v2('cuModuleLoad', <void **>&__cuModuleLoad, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuModuleLoad', <void **>&__cuModuleLoad, 2000, ptds_mode, NULL)
 
         global __cuModuleLoadData
-        _F_cuGetProcAddress_v2('cuModuleLoadData', <void **>&__cuModuleLoadData, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuModuleLoadData', <void **>&__cuModuleLoadData, 2000, ptds_mode, NULL)
 
         global __cuModuleLoadDataEx
-        _F_cuGetProcAddress_v2('cuModuleLoadDataEx', <void **>&__cuModuleLoadDataEx, 2010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuModuleLoadDataEx', <void **>&__cuModuleLoadDataEx, 2010, ptds_mode, NULL)
 
         global __cuModuleLoadFatBinary
-        _F_cuGetProcAddress_v2('cuModuleLoadFatBinary', <void **>&__cuModuleLoadFatBinary, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuModuleLoadFatBinary', <void **>&__cuModuleLoadFatBinary, 2000, ptds_mode, NULL)
 
         global __cuModuleUnload
-        _F_cuGetProcAddress_v2('cuModuleUnload', <void **>&__cuModuleUnload, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuModuleUnload', <void **>&__cuModuleUnload, 2000, ptds_mode, NULL)
 
         global __cuModuleGetLoadingMode
-        _F_cuGetProcAddress_v2('cuModuleGetLoadingMode', <void **>&__cuModuleGetLoadingMode, 11070, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuModuleGetLoadingMode', <void **>&__cuModuleGetLoadingMode, 11070, ptds_mode, NULL)
 
         global __cuModuleGetFunction
-        _F_cuGetProcAddress_v2('cuModuleGetFunction', <void **>&__cuModuleGetFunction, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuModuleGetFunction', <void **>&__cuModuleGetFunction, 2000, ptds_mode, NULL)
 
         global __cuModuleGetFunctionCount
-        _F_cuGetProcAddress_v2('cuModuleGetFunctionCount', <void **>&__cuModuleGetFunctionCount, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuModuleGetFunctionCount', <void **>&__cuModuleGetFunctionCount, 12040, ptds_mode, NULL)
 
         global __cuModuleEnumerateFunctions
-        _F_cuGetProcAddress_v2('cuModuleEnumerateFunctions', <void **>&__cuModuleEnumerateFunctions, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuModuleEnumerateFunctions', <void **>&__cuModuleEnumerateFunctions, 12040, ptds_mode, NULL)
 
         global __cuModuleGetGlobal_v2
-        _F_cuGetProcAddress_v2('cuModuleGetGlobal', <void **>&__cuModuleGetGlobal_v2, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuModuleGetGlobal', <void **>&__cuModuleGetGlobal_v2, 3020, ptds_mode, NULL)
 
         global __cuLinkCreate_v2
-        _F_cuGetProcAddress_v2('cuLinkCreate', <void **>&__cuLinkCreate_v2, 6050, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLinkCreate', <void **>&__cuLinkCreate_v2, 6050, ptds_mode, NULL)
 
         global __cuLinkAddData_v2
-        _F_cuGetProcAddress_v2('cuLinkAddData', <void **>&__cuLinkAddData_v2, 6050, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLinkAddData', <void **>&__cuLinkAddData_v2, 6050, ptds_mode, NULL)
 
         global __cuLinkAddFile_v2
-        _F_cuGetProcAddress_v2('cuLinkAddFile', <void **>&__cuLinkAddFile_v2, 6050, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLinkAddFile', <void **>&__cuLinkAddFile_v2, 6050, ptds_mode, NULL)
 
         global __cuLinkComplete
-        _F_cuGetProcAddress_v2('cuLinkComplete', <void **>&__cuLinkComplete, 5050, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLinkComplete', <void **>&__cuLinkComplete, 5050, ptds_mode, NULL)
 
         global __cuLinkDestroy
-        _F_cuGetProcAddress_v2('cuLinkDestroy', <void **>&__cuLinkDestroy, 5050, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLinkDestroy', <void **>&__cuLinkDestroy, 5050, ptds_mode, NULL)
 
         global __cuModuleGetTexRef
-        _F_cuGetProcAddress_v2('cuModuleGetTexRef', <void **>&__cuModuleGetTexRef, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuModuleGetTexRef', <void **>&__cuModuleGetTexRef, 2000, ptds_mode, NULL)
 
         global __cuModuleGetSurfRef
-        _F_cuGetProcAddress_v2('cuModuleGetSurfRef', <void **>&__cuModuleGetSurfRef, 3000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuModuleGetSurfRef', <void **>&__cuModuleGetSurfRef, 3000, ptds_mode, NULL)
 
         global __cuLibraryLoadData
-        _F_cuGetProcAddress_v2('cuLibraryLoadData', <void **>&__cuLibraryLoadData, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLibraryLoadData', <void **>&__cuLibraryLoadData, 12000, ptds_mode, NULL)
 
         global __cuLibraryLoadFromFile
-        _F_cuGetProcAddress_v2('cuLibraryLoadFromFile', <void **>&__cuLibraryLoadFromFile, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLibraryLoadFromFile', <void **>&__cuLibraryLoadFromFile, 12000, ptds_mode, NULL)
 
         global __cuLibraryUnload
-        _F_cuGetProcAddress_v2('cuLibraryUnload', <void **>&__cuLibraryUnload, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLibraryUnload', <void **>&__cuLibraryUnload, 12000, ptds_mode, NULL)
 
         global __cuLibraryGetKernel
-        _F_cuGetProcAddress_v2('cuLibraryGetKernel', <void **>&__cuLibraryGetKernel, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLibraryGetKernel', <void **>&__cuLibraryGetKernel, 12000, ptds_mode, NULL)
 
         global __cuLibraryGetKernelCount
-        _F_cuGetProcAddress_v2('cuLibraryGetKernelCount', <void **>&__cuLibraryGetKernelCount, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLibraryGetKernelCount', <void **>&__cuLibraryGetKernelCount, 12040, ptds_mode, NULL)
 
         global __cuLibraryEnumerateKernels
-        _F_cuGetProcAddress_v2('cuLibraryEnumerateKernels', <void **>&__cuLibraryEnumerateKernels, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLibraryEnumerateKernels', <void **>&__cuLibraryEnumerateKernels, 12040, ptds_mode, NULL)
 
         global __cuLibraryGetModule
-        _F_cuGetProcAddress_v2('cuLibraryGetModule', <void **>&__cuLibraryGetModule, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLibraryGetModule', <void **>&__cuLibraryGetModule, 12000, ptds_mode, NULL)
 
         global __cuKernelGetFunction
-        _F_cuGetProcAddress_v2('cuKernelGetFunction', <void **>&__cuKernelGetFunction, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuKernelGetFunction', <void **>&__cuKernelGetFunction, 12000, ptds_mode, NULL)
 
         global __cuKernelGetLibrary
-        _F_cuGetProcAddress_v2('cuKernelGetLibrary', <void **>&__cuKernelGetLibrary, 12050, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuKernelGetLibrary', <void **>&__cuKernelGetLibrary, 12050, ptds_mode, NULL)
 
         global __cuLibraryGetGlobal
-        _F_cuGetProcAddress_v2('cuLibraryGetGlobal', <void **>&__cuLibraryGetGlobal, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLibraryGetGlobal', <void **>&__cuLibraryGetGlobal, 12000, ptds_mode, NULL)
 
         global __cuLibraryGetManaged
-        _F_cuGetProcAddress_v2('cuLibraryGetManaged', <void **>&__cuLibraryGetManaged, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLibraryGetManaged', <void **>&__cuLibraryGetManaged, 12000, ptds_mode, NULL)
 
         global __cuLibraryGetUnifiedFunction
-        _F_cuGetProcAddress_v2('cuLibraryGetUnifiedFunction', <void **>&__cuLibraryGetUnifiedFunction, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLibraryGetUnifiedFunction', <void **>&__cuLibraryGetUnifiedFunction, 12000, ptds_mode, NULL)
 
         global __cuKernelGetAttribute
-        _F_cuGetProcAddress_v2('cuKernelGetAttribute', <void **>&__cuKernelGetAttribute, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuKernelGetAttribute', <void **>&__cuKernelGetAttribute, 12000, ptds_mode, NULL)
 
         global __cuKernelSetAttribute
-        _F_cuGetProcAddress_v2('cuKernelSetAttribute', <void **>&__cuKernelSetAttribute, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuKernelSetAttribute', <void **>&__cuKernelSetAttribute, 12000, ptds_mode, NULL)
 
         global __cuKernelSetCacheConfig
-        _F_cuGetProcAddress_v2('cuKernelSetCacheConfig', <void **>&__cuKernelSetCacheConfig, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuKernelSetCacheConfig', <void **>&__cuKernelSetCacheConfig, 12000, ptds_mode, NULL)
 
         global __cuKernelGetName
-        _F_cuGetProcAddress_v2('cuKernelGetName', <void **>&__cuKernelGetName, 12030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuKernelGetName', <void **>&__cuKernelGetName, 12030, ptds_mode, NULL)
 
         global __cuKernelGetParamInfo
-        _F_cuGetProcAddress_v2('cuKernelGetParamInfo', <void **>&__cuKernelGetParamInfo, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuKernelGetParamInfo', <void **>&__cuKernelGetParamInfo, 12040, ptds_mode, NULL)
 
         global __cuMemGetInfo_v2
-        _F_cuGetProcAddress_v2('cuMemGetInfo', <void **>&__cuMemGetInfo_v2, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemGetInfo', <void **>&__cuMemGetInfo_v2, 3020, ptds_mode, NULL)
 
         global __cuMemAlloc_v2
-        _F_cuGetProcAddress_v2('cuMemAlloc', <void **>&__cuMemAlloc_v2, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemAlloc', <void **>&__cuMemAlloc_v2, 3020, ptds_mode, NULL)
 
         global __cuMemAllocPitch_v2
-        _F_cuGetProcAddress_v2('cuMemAllocPitch', <void **>&__cuMemAllocPitch_v2, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemAllocPitch', <void **>&__cuMemAllocPitch_v2, 3020, ptds_mode, NULL)
 
         global __cuMemFree_v2
-        _F_cuGetProcAddress_v2('cuMemFree', <void **>&__cuMemFree_v2, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemFree', <void **>&__cuMemFree_v2, 3020, ptds_mode, NULL)
 
         global __cuMemGetAddressRange_v2
-        _F_cuGetProcAddress_v2('cuMemGetAddressRange', <void **>&__cuMemGetAddressRange_v2, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemGetAddressRange', <void **>&__cuMemGetAddressRange_v2, 3020, ptds_mode, NULL)
 
         global __cuMemAllocHost_v2
-        _F_cuGetProcAddress_v2('cuMemAllocHost', <void **>&__cuMemAllocHost_v2, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemAllocHost', <void **>&__cuMemAllocHost_v2, 3020, ptds_mode, NULL)
 
         global __cuMemFreeHost
-        _F_cuGetProcAddress_v2('cuMemFreeHost', <void **>&__cuMemFreeHost, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemFreeHost', <void **>&__cuMemFreeHost, 2000, ptds_mode, NULL)
 
         global __cuMemHostAlloc
-        _F_cuGetProcAddress_v2('cuMemHostAlloc', <void **>&__cuMemHostAlloc, 2020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemHostAlloc', <void **>&__cuMemHostAlloc, 2020, ptds_mode, NULL)
 
         global __cuMemHostGetDevicePointer_v2
-        _F_cuGetProcAddress_v2('cuMemHostGetDevicePointer', <void **>&__cuMemHostGetDevicePointer_v2, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemHostGetDevicePointer', <void **>&__cuMemHostGetDevicePointer_v2, 3020, ptds_mode, NULL)
 
         global __cuMemHostGetFlags
-        _F_cuGetProcAddress_v2('cuMemHostGetFlags', <void **>&__cuMemHostGetFlags, 2030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemHostGetFlags', <void **>&__cuMemHostGetFlags, 2030, ptds_mode, NULL)
 
         global __cuMemAllocManaged
-        _F_cuGetProcAddress_v2('cuMemAllocManaged', <void **>&__cuMemAllocManaged, 6000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemAllocManaged', <void **>&__cuMemAllocManaged, 6000, ptds_mode, NULL)
 
         global __cuDeviceRegisterAsyncNotification
-        _F_cuGetProcAddress_v2('cuDeviceRegisterAsyncNotification', <void **>&__cuDeviceRegisterAsyncNotification, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceRegisterAsyncNotification', <void **>&__cuDeviceRegisterAsyncNotification, 12040, ptds_mode, NULL)
 
         global __cuDeviceUnregisterAsyncNotification
-        _F_cuGetProcAddress_v2('cuDeviceUnregisterAsyncNotification', <void **>&__cuDeviceUnregisterAsyncNotification, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceUnregisterAsyncNotification', <void **>&__cuDeviceUnregisterAsyncNotification, 12040, ptds_mode, NULL)
 
         global __cuDeviceGetByPCIBusId
-        _F_cuGetProcAddress_v2('cuDeviceGetByPCIBusId', <void **>&__cuDeviceGetByPCIBusId, 4010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceGetByPCIBusId', <void **>&__cuDeviceGetByPCIBusId, 4010, ptds_mode, NULL)
 
         global __cuDeviceGetPCIBusId
-        _F_cuGetProcAddress_v2('cuDeviceGetPCIBusId', <void **>&__cuDeviceGetPCIBusId, 4010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceGetPCIBusId', <void **>&__cuDeviceGetPCIBusId, 4010, ptds_mode, NULL)
 
         global __cuIpcGetEventHandle
-        _F_cuGetProcAddress_v2('cuIpcGetEventHandle', <void **>&__cuIpcGetEventHandle, 4010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuIpcGetEventHandle', <void **>&__cuIpcGetEventHandle, 4010, ptds_mode, NULL)
 
         global __cuIpcOpenEventHandle
-        _F_cuGetProcAddress_v2('cuIpcOpenEventHandle', <void **>&__cuIpcOpenEventHandle, 4010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuIpcOpenEventHandle', <void **>&__cuIpcOpenEventHandle, 4010, ptds_mode, NULL)
 
         global __cuIpcGetMemHandle
-        _F_cuGetProcAddress_v2('cuIpcGetMemHandle', <void **>&__cuIpcGetMemHandle, 4010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuIpcGetMemHandle', <void **>&__cuIpcGetMemHandle, 4010, ptds_mode, NULL)
 
         global __cuIpcOpenMemHandle_v2
-        _F_cuGetProcAddress_v2('cuIpcOpenMemHandle', <void **>&__cuIpcOpenMemHandle_v2, 11000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuIpcOpenMemHandle', <void **>&__cuIpcOpenMemHandle_v2, 11000, ptds_mode, NULL)
 
         global __cuIpcCloseMemHandle
-        _F_cuGetProcAddress_v2('cuIpcCloseMemHandle', <void **>&__cuIpcCloseMemHandle, 4010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuIpcCloseMemHandle', <void **>&__cuIpcCloseMemHandle, 4010, ptds_mode, NULL)
 
         global __cuMemHostRegister_v2
-        _F_cuGetProcAddress_v2('cuMemHostRegister', <void **>&__cuMemHostRegister_v2, 6050, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemHostRegister', <void **>&__cuMemHostRegister_v2, 6050, ptds_mode, NULL)
 
         global __cuMemHostUnregister
-        _F_cuGetProcAddress_v2('cuMemHostUnregister', <void **>&__cuMemHostUnregister, 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemHostUnregister', <void **>&__cuMemHostUnregister, 4000, ptds_mode, NULL)
 
         global __cuMemcpy
-        _F_cuGetProcAddress_v2('cuMemcpy', <void **>&__cuMemcpy, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpy', <void **>&__cuMemcpy, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
 
         global __cuMemcpyPeer
-        _F_cuGetProcAddress_v2('cuMemcpyPeer', <void **>&__cuMemcpyPeer, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpyPeer', <void **>&__cuMemcpyPeer, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
 
         global __cuMemcpyHtoD_v2
-        _F_cuGetProcAddress_v2('cuMemcpyHtoD', <void **>&__cuMemcpyHtoD_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpyHtoD', <void **>&__cuMemcpyHtoD_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemcpyDtoH_v2
-        _F_cuGetProcAddress_v2('cuMemcpyDtoH', <void **>&__cuMemcpyDtoH_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpyDtoH', <void **>&__cuMemcpyDtoH_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemcpyDtoD_v2
-        _F_cuGetProcAddress_v2('cuMemcpyDtoD', <void **>&__cuMemcpyDtoD_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpyDtoD', <void **>&__cuMemcpyDtoD_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemcpyDtoA_v2
-        _F_cuGetProcAddress_v2('cuMemcpyDtoA', <void **>&__cuMemcpyDtoA_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpyDtoA', <void **>&__cuMemcpyDtoA_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemcpyAtoD_v2
-        _F_cuGetProcAddress_v2('cuMemcpyAtoD', <void **>&__cuMemcpyAtoD_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpyAtoD', <void **>&__cuMemcpyAtoD_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemcpyHtoA_v2
-        _F_cuGetProcAddress_v2('cuMemcpyHtoA', <void **>&__cuMemcpyHtoA_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpyHtoA', <void **>&__cuMemcpyHtoA_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemcpyAtoH_v2
-        _F_cuGetProcAddress_v2('cuMemcpyAtoH', <void **>&__cuMemcpyAtoH_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpyAtoH', <void **>&__cuMemcpyAtoH_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemcpyAtoA_v2
-        _F_cuGetProcAddress_v2('cuMemcpyAtoA', <void **>&__cuMemcpyAtoA_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpyAtoA', <void **>&__cuMemcpyAtoA_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemcpy2D_v2
-        _F_cuGetProcAddress_v2('cuMemcpy2D', <void **>&__cuMemcpy2D_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpy2D', <void **>&__cuMemcpy2D_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemcpy2DUnaligned_v2
-        _F_cuGetProcAddress_v2('cuMemcpy2DUnaligned', <void **>&__cuMemcpy2DUnaligned_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpy2DUnaligned', <void **>&__cuMemcpy2DUnaligned_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemcpy3D_v2
-        _F_cuGetProcAddress_v2('cuMemcpy3D', <void **>&__cuMemcpy3D_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpy3D', <void **>&__cuMemcpy3D_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemcpy3DPeer
-        _F_cuGetProcAddress_v2('cuMemcpy3DPeer', <void **>&__cuMemcpy3DPeer, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpy3DPeer', <void **>&__cuMemcpy3DPeer, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
 
         global __cuMemcpyAsync
-        _F_cuGetProcAddress_v2('cuMemcpyAsync', <void **>&__cuMemcpyAsync, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpyAsync', <void **>&__cuMemcpyAsync, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
 
         global __cuMemcpyPeerAsync
-        _F_cuGetProcAddress_v2('cuMemcpyPeerAsync', <void **>&__cuMemcpyPeerAsync, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpyPeerAsync', <void **>&__cuMemcpyPeerAsync, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
 
         global __cuMemcpyHtoDAsync_v2
-        _F_cuGetProcAddress_v2('cuMemcpyHtoDAsync', <void **>&__cuMemcpyHtoDAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpyHtoDAsync', <void **>&__cuMemcpyHtoDAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemcpyDtoHAsync_v2
-        _F_cuGetProcAddress_v2('cuMemcpyDtoHAsync', <void **>&__cuMemcpyDtoHAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpyDtoHAsync', <void **>&__cuMemcpyDtoHAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemcpyDtoDAsync_v2
-        _F_cuGetProcAddress_v2('cuMemcpyDtoDAsync', <void **>&__cuMemcpyDtoDAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpyDtoDAsync', <void **>&__cuMemcpyDtoDAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemcpyHtoAAsync_v2
-        _F_cuGetProcAddress_v2('cuMemcpyHtoAAsync', <void **>&__cuMemcpyHtoAAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpyHtoAAsync', <void **>&__cuMemcpyHtoAAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemcpyAtoHAsync_v2
-        _F_cuGetProcAddress_v2('cuMemcpyAtoHAsync', <void **>&__cuMemcpyAtoHAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpyAtoHAsync', <void **>&__cuMemcpyAtoHAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemcpy2DAsync_v2
-        _F_cuGetProcAddress_v2('cuMemcpy2DAsync', <void **>&__cuMemcpy2DAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpy2DAsync', <void **>&__cuMemcpy2DAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemcpy3DAsync_v2
-        _F_cuGetProcAddress_v2('cuMemcpy3DAsync', <void **>&__cuMemcpy3DAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpy3DAsync', <void **>&__cuMemcpy3DAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemcpy3DPeerAsync
-        _F_cuGetProcAddress_v2('cuMemcpy3DPeerAsync', <void **>&__cuMemcpy3DPeerAsync, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpy3DPeerAsync', <void **>&__cuMemcpy3DPeerAsync, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
 
         global __cuMemsetD8_v2
-        _F_cuGetProcAddress_v2('cuMemsetD8', <void **>&__cuMemsetD8_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemsetD8', <void **>&__cuMemsetD8_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemsetD16_v2
-        _F_cuGetProcAddress_v2('cuMemsetD16', <void **>&__cuMemsetD16_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemsetD16', <void **>&__cuMemsetD16_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemsetD32_v2
-        _F_cuGetProcAddress_v2('cuMemsetD32', <void **>&__cuMemsetD32_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemsetD32', <void **>&__cuMemsetD32_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemsetD2D8_v2
-        _F_cuGetProcAddress_v2('cuMemsetD2D8', <void **>&__cuMemsetD2D8_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemsetD2D8', <void **>&__cuMemsetD2D8_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemsetD2D16_v2
-        _F_cuGetProcAddress_v2('cuMemsetD2D16', <void **>&__cuMemsetD2D16_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemsetD2D16', <void **>&__cuMemsetD2D16_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemsetD2D32_v2
-        _F_cuGetProcAddress_v2('cuMemsetD2D32', <void **>&__cuMemsetD2D32_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemsetD2D32', <void **>&__cuMemsetD2D32_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemsetD8Async
-        _F_cuGetProcAddress_v2('cuMemsetD8Async', <void **>&__cuMemsetD8Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemsetD8Async', <void **>&__cuMemsetD8Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemsetD16Async
-        _F_cuGetProcAddress_v2('cuMemsetD16Async', <void **>&__cuMemsetD16Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemsetD16Async', <void **>&__cuMemsetD16Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemsetD32Async
-        _F_cuGetProcAddress_v2('cuMemsetD32Async', <void **>&__cuMemsetD32Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemsetD32Async', <void **>&__cuMemsetD32Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemsetD2D8Async
-        _F_cuGetProcAddress_v2('cuMemsetD2D8Async', <void **>&__cuMemsetD2D8Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemsetD2D8Async', <void **>&__cuMemsetD2D8Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemsetD2D16Async
-        _F_cuGetProcAddress_v2('cuMemsetD2D16Async', <void **>&__cuMemsetD2D16Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemsetD2D16Async', <void **>&__cuMemsetD2D16Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuMemsetD2D32Async
-        _F_cuGetProcAddress_v2('cuMemsetD2D32Async', <void **>&__cuMemsetD2D32Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemsetD2D32Async', <void **>&__cuMemsetD2D32Async, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuArrayCreate_v2
-        _F_cuGetProcAddress_v2('cuArrayCreate', <void **>&__cuArrayCreate_v2, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuArrayCreate', <void **>&__cuArrayCreate_v2, 3020, ptds_mode, NULL)
 
         global __cuArrayGetDescriptor_v2
-        _F_cuGetProcAddress_v2('cuArrayGetDescriptor', <void **>&__cuArrayGetDescriptor_v2, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuArrayGetDescriptor', <void **>&__cuArrayGetDescriptor_v2, 3020, ptds_mode, NULL)
 
         global __cuArrayGetSparseProperties
-        _F_cuGetProcAddress_v2('cuArrayGetSparseProperties', <void **>&__cuArrayGetSparseProperties, 11010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuArrayGetSparseProperties', <void **>&__cuArrayGetSparseProperties, 11010, ptds_mode, NULL)
 
         global __cuMipmappedArrayGetSparseProperties
-        _F_cuGetProcAddress_v2('cuMipmappedArrayGetSparseProperties', <void **>&__cuMipmappedArrayGetSparseProperties, 11010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMipmappedArrayGetSparseProperties', <void **>&__cuMipmappedArrayGetSparseProperties, 11010, ptds_mode, NULL)
 
         global __cuArrayGetMemoryRequirements
-        _F_cuGetProcAddress_v2('cuArrayGetMemoryRequirements', <void **>&__cuArrayGetMemoryRequirements, 11060, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuArrayGetMemoryRequirements', <void **>&__cuArrayGetMemoryRequirements, 11060, ptds_mode, NULL)
 
         global __cuMipmappedArrayGetMemoryRequirements
-        _F_cuGetProcAddress_v2('cuMipmappedArrayGetMemoryRequirements', <void **>&__cuMipmappedArrayGetMemoryRequirements, 11060, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMipmappedArrayGetMemoryRequirements', <void **>&__cuMipmappedArrayGetMemoryRequirements, 11060, ptds_mode, NULL)
 
         global __cuArrayGetPlane
-        _F_cuGetProcAddress_v2('cuArrayGetPlane', <void **>&__cuArrayGetPlane, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuArrayGetPlane', <void **>&__cuArrayGetPlane, 11020, ptds_mode, NULL)
 
         global __cuArrayDestroy
-        _F_cuGetProcAddress_v2('cuArrayDestroy', <void **>&__cuArrayDestroy, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuArrayDestroy', <void **>&__cuArrayDestroy, 2000, ptds_mode, NULL)
 
         global __cuArray3DCreate_v2
-        _F_cuGetProcAddress_v2('cuArray3DCreate', <void **>&__cuArray3DCreate_v2, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuArray3DCreate', <void **>&__cuArray3DCreate_v2, 3020, ptds_mode, NULL)
 
         global __cuArray3DGetDescriptor_v2
-        _F_cuGetProcAddress_v2('cuArray3DGetDescriptor', <void **>&__cuArray3DGetDescriptor_v2, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuArray3DGetDescriptor', <void **>&__cuArray3DGetDescriptor_v2, 3020, ptds_mode, NULL)
 
         global __cuMipmappedArrayCreate
-        _F_cuGetProcAddress_v2('cuMipmappedArrayCreate', <void **>&__cuMipmappedArrayCreate, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMipmappedArrayCreate', <void **>&__cuMipmappedArrayCreate, 5000, ptds_mode, NULL)
 
         global __cuMipmappedArrayGetLevel
-        _F_cuGetProcAddress_v2('cuMipmappedArrayGetLevel', <void **>&__cuMipmappedArrayGetLevel, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMipmappedArrayGetLevel', <void **>&__cuMipmappedArrayGetLevel, 5000, ptds_mode, NULL)
 
         global __cuMipmappedArrayDestroy
-        _F_cuGetProcAddress_v2('cuMipmappedArrayDestroy', <void **>&__cuMipmappedArrayDestroy, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMipmappedArrayDestroy', <void **>&__cuMipmappedArrayDestroy, 5000, ptds_mode, NULL)
 
         global __cuMemGetHandleForAddressRange
-        _F_cuGetProcAddress_v2('cuMemGetHandleForAddressRange', <void **>&__cuMemGetHandleForAddressRange, 11070, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemGetHandleForAddressRange', <void **>&__cuMemGetHandleForAddressRange, 11070, ptds_mode, NULL)
 
         global __cuMemBatchDecompressAsync
-        _F_cuGetProcAddress_v2('cuMemBatchDecompressAsync', <void **>&__cuMemBatchDecompressAsync, 12060, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemBatchDecompressAsync', <void **>&__cuMemBatchDecompressAsync, 12060, ptds_mode, NULL)
 
         global __cuMemAddressReserve
-        _F_cuGetProcAddress_v2('cuMemAddressReserve', <void **>&__cuMemAddressReserve, 10020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemAddressReserve', <void **>&__cuMemAddressReserve, 10020, ptds_mode, NULL)
 
         global __cuMemAddressFree
-        _F_cuGetProcAddress_v2('cuMemAddressFree', <void **>&__cuMemAddressFree, 10020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemAddressFree', <void **>&__cuMemAddressFree, 10020, ptds_mode, NULL)
 
         global __cuMemCreate
-        _F_cuGetProcAddress_v2('cuMemCreate', <void **>&__cuMemCreate, 10020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemCreate', <void **>&__cuMemCreate, 10020, ptds_mode, NULL)
 
         global __cuMemRelease
-        _F_cuGetProcAddress_v2('cuMemRelease', <void **>&__cuMemRelease, 10020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemRelease', <void **>&__cuMemRelease, 10020, ptds_mode, NULL)
 
         global __cuMemMap
-        _F_cuGetProcAddress_v2('cuMemMap', <void **>&__cuMemMap, 10020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemMap', <void **>&__cuMemMap, 10020, ptds_mode, NULL)
 
         global __cuMemMapArrayAsync
-        _F_cuGetProcAddress_v2('cuMemMapArrayAsync', <void **>&__cuMemMapArrayAsync, 11010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemMapArrayAsync', <void **>&__cuMemMapArrayAsync, 11010, ptds_mode, NULL)
 
         global __cuMemUnmap
-        _F_cuGetProcAddress_v2('cuMemUnmap', <void **>&__cuMemUnmap, 10020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemUnmap', <void **>&__cuMemUnmap, 10020, ptds_mode, NULL)
 
         global __cuMemSetAccess
-        _F_cuGetProcAddress_v2('cuMemSetAccess', <void **>&__cuMemSetAccess, 10020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemSetAccess', <void **>&__cuMemSetAccess, 10020, ptds_mode, NULL)
 
         global __cuMemGetAccess
-        _F_cuGetProcAddress_v2('cuMemGetAccess', <void **>&__cuMemGetAccess, 10020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemGetAccess', <void **>&__cuMemGetAccess, 10020, ptds_mode, NULL)
 
         global __cuMemExportToShareableHandle
-        _F_cuGetProcAddress_v2('cuMemExportToShareableHandle', <void **>&__cuMemExportToShareableHandle, 10020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemExportToShareableHandle', <void **>&__cuMemExportToShareableHandle, 10020, ptds_mode, NULL)
 
         global __cuMemImportFromShareableHandle
-        _F_cuGetProcAddress_v2('cuMemImportFromShareableHandle', <void **>&__cuMemImportFromShareableHandle, 10020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemImportFromShareableHandle', <void **>&__cuMemImportFromShareableHandle, 10020, ptds_mode, NULL)
 
         global __cuMemGetAllocationGranularity
-        _F_cuGetProcAddress_v2('cuMemGetAllocationGranularity', <void **>&__cuMemGetAllocationGranularity, 10020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemGetAllocationGranularity', <void **>&__cuMemGetAllocationGranularity, 10020, ptds_mode, NULL)
 
         global __cuMemGetAllocationPropertiesFromHandle
-        _F_cuGetProcAddress_v2('cuMemGetAllocationPropertiesFromHandle', <void **>&__cuMemGetAllocationPropertiesFromHandle, 10020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemGetAllocationPropertiesFromHandle', <void **>&__cuMemGetAllocationPropertiesFromHandle, 10020, ptds_mode, NULL)
 
         global __cuMemRetainAllocationHandle
-        _F_cuGetProcAddress_v2('cuMemRetainAllocationHandle', <void **>&__cuMemRetainAllocationHandle, 11000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemRetainAllocationHandle', <void **>&__cuMemRetainAllocationHandle, 11000, ptds_mode, NULL)
 
         global __cuMemFreeAsync
-        _F_cuGetProcAddress_v2('cuMemFreeAsync', <void **>&__cuMemFreeAsync, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemFreeAsync', <void **>&__cuMemFreeAsync, 11020, ptds_mode, NULL)
 
         global __cuMemAllocAsync
-        _F_cuGetProcAddress_v2('cuMemAllocAsync', <void **>&__cuMemAllocAsync, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemAllocAsync', <void **>&__cuMemAllocAsync, 11020, ptds_mode, NULL)
 
         global __cuMemPoolTrimTo
-        _F_cuGetProcAddress_v2('cuMemPoolTrimTo', <void **>&__cuMemPoolTrimTo, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemPoolTrimTo', <void **>&__cuMemPoolTrimTo, 11020, ptds_mode, NULL)
 
         global __cuMemPoolSetAttribute
-        _F_cuGetProcAddress_v2('cuMemPoolSetAttribute', <void **>&__cuMemPoolSetAttribute, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemPoolSetAttribute', <void **>&__cuMemPoolSetAttribute, 11020, ptds_mode, NULL)
 
         global __cuMemPoolGetAttribute
-        _F_cuGetProcAddress_v2('cuMemPoolGetAttribute', <void **>&__cuMemPoolGetAttribute, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemPoolGetAttribute', <void **>&__cuMemPoolGetAttribute, 11020, ptds_mode, NULL)
 
         global __cuMemPoolSetAccess
-        _F_cuGetProcAddress_v2('cuMemPoolSetAccess', <void **>&__cuMemPoolSetAccess, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemPoolSetAccess', <void **>&__cuMemPoolSetAccess, 11020, ptds_mode, NULL)
 
         global __cuMemPoolGetAccess
-        _F_cuGetProcAddress_v2('cuMemPoolGetAccess', <void **>&__cuMemPoolGetAccess, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemPoolGetAccess', <void **>&__cuMemPoolGetAccess, 11020, ptds_mode, NULL)
 
         global __cuMemPoolCreate
-        _F_cuGetProcAddress_v2('cuMemPoolCreate', <void **>&__cuMemPoolCreate, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemPoolCreate', <void **>&__cuMemPoolCreate, 11020, ptds_mode, NULL)
 
         global __cuMemPoolDestroy
-        _F_cuGetProcAddress_v2('cuMemPoolDestroy', <void **>&__cuMemPoolDestroy, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemPoolDestroy', <void **>&__cuMemPoolDestroy, 11020, ptds_mode, NULL)
 
         global __cuMemAllocFromPoolAsync
-        _F_cuGetProcAddress_v2('cuMemAllocFromPoolAsync', <void **>&__cuMemAllocFromPoolAsync, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemAllocFromPoolAsync', <void **>&__cuMemAllocFromPoolAsync, 11020, ptds_mode, NULL)
 
         global __cuMemPoolExportToShareableHandle
-        _F_cuGetProcAddress_v2('cuMemPoolExportToShareableHandle', <void **>&__cuMemPoolExportToShareableHandle, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemPoolExportToShareableHandle', <void **>&__cuMemPoolExportToShareableHandle, 11020, ptds_mode, NULL)
 
         global __cuMemPoolImportFromShareableHandle
-        _F_cuGetProcAddress_v2('cuMemPoolImportFromShareableHandle', <void **>&__cuMemPoolImportFromShareableHandle, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemPoolImportFromShareableHandle', <void **>&__cuMemPoolImportFromShareableHandle, 11020, ptds_mode, NULL)
 
         global __cuMemPoolExportPointer
-        _F_cuGetProcAddress_v2('cuMemPoolExportPointer', <void **>&__cuMemPoolExportPointer, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemPoolExportPointer', <void **>&__cuMemPoolExportPointer, 11020, ptds_mode, NULL)
 
         global __cuMemPoolImportPointer
-        _F_cuGetProcAddress_v2('cuMemPoolImportPointer', <void **>&__cuMemPoolImportPointer, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemPoolImportPointer', <void **>&__cuMemPoolImportPointer, 11020, ptds_mode, NULL)
 
         global __cuMulticastCreate
-        _F_cuGetProcAddress_v2('cuMulticastCreate', <void **>&__cuMulticastCreate, 12010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMulticastCreate', <void **>&__cuMulticastCreate, 12010, ptds_mode, NULL)
 
         global __cuMulticastAddDevice
-        _F_cuGetProcAddress_v2('cuMulticastAddDevice', <void **>&__cuMulticastAddDevice, 12010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMulticastAddDevice', <void **>&__cuMulticastAddDevice, 12010, ptds_mode, NULL)
 
         global __cuMulticastBindMem
-        _F_cuGetProcAddress_v2('cuMulticastBindMem', <void **>&__cuMulticastBindMem, 12010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMulticastBindMem', <void **>&__cuMulticastBindMem, 12010, ptds_mode, NULL)
 
         global __cuMulticastBindAddr
-        _F_cuGetProcAddress_v2('cuMulticastBindAddr', <void **>&__cuMulticastBindAddr, 12010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMulticastBindAddr', <void **>&__cuMulticastBindAddr, 12010, ptds_mode, NULL)
 
         global __cuMulticastUnbind
-        _F_cuGetProcAddress_v2('cuMulticastUnbind', <void **>&__cuMulticastUnbind, 12010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMulticastUnbind', <void **>&__cuMulticastUnbind, 12010, ptds_mode, NULL)
 
         global __cuMulticastGetGranularity
-        _F_cuGetProcAddress_v2('cuMulticastGetGranularity', <void **>&__cuMulticastGetGranularity, 12010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMulticastGetGranularity', <void **>&__cuMulticastGetGranularity, 12010, ptds_mode, NULL)
 
         global __cuPointerGetAttribute
-        _F_cuGetProcAddress_v2('cuPointerGetAttribute', <void **>&__cuPointerGetAttribute, 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuPointerGetAttribute', <void **>&__cuPointerGetAttribute, 4000, ptds_mode, NULL)
 
         global __cuMemPrefetchAsync_v2
-        _F_cuGetProcAddress_v2('cuMemPrefetchAsync', <void **>&__cuMemPrefetchAsync_v2, 12020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemPrefetchAsync', <void **>&__cuMemPrefetchAsync_v2, 12020, ptds_mode, NULL)
 
         global __cuMemAdvise_v2
-        _F_cuGetProcAddress_v2('cuMemAdvise', <void **>&__cuMemAdvise_v2, 12020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemAdvise', <void **>&__cuMemAdvise_v2, 12020, ptds_mode, NULL)
 
         global __cuMemRangeGetAttribute
-        _F_cuGetProcAddress_v2('cuMemRangeGetAttribute', <void **>&__cuMemRangeGetAttribute, 8000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemRangeGetAttribute', <void **>&__cuMemRangeGetAttribute, 8000, ptds_mode, NULL)
 
         global __cuMemRangeGetAttributes
-        _F_cuGetProcAddress_v2('cuMemRangeGetAttributes', <void **>&__cuMemRangeGetAttributes, 8000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemRangeGetAttributes', <void **>&__cuMemRangeGetAttributes, 8000, ptds_mode, NULL)
 
         global __cuPointerSetAttribute
-        _F_cuGetProcAddress_v2('cuPointerSetAttribute', <void **>&__cuPointerSetAttribute, 6000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuPointerSetAttribute', <void **>&__cuPointerSetAttribute, 6000, ptds_mode, NULL)
 
         global __cuPointerGetAttributes
-        _F_cuGetProcAddress_v2('cuPointerGetAttributes', <void **>&__cuPointerGetAttributes, 7000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuPointerGetAttributes', <void **>&__cuPointerGetAttributes, 7000, ptds_mode, NULL)
 
         global __cuStreamCreate
-        _F_cuGetProcAddress_v2('cuStreamCreate', <void **>&__cuStreamCreate, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamCreate', <void **>&__cuStreamCreate, 2000, ptds_mode, NULL)
 
         global __cuStreamCreateWithPriority
-        _F_cuGetProcAddress_v2('cuStreamCreateWithPriority', <void **>&__cuStreamCreateWithPriority, 5050, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamCreateWithPriority', <void **>&__cuStreamCreateWithPriority, 5050, ptds_mode, NULL)
 
         global __cuStreamGetPriority
-        _F_cuGetProcAddress_v2('cuStreamGetPriority', <void **>&__cuStreamGetPriority, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 5050, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamGetPriority', <void **>&__cuStreamGetPriority, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 5050, ptds_mode, NULL)
 
         global __cuStreamGetDevice
-        _F_cuGetProcAddress_v2('cuStreamGetDevice', <void **>&__cuStreamGetDevice, 12080, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamGetDevice', <void **>&__cuStreamGetDevice, 12080, ptds_mode, NULL)
 
         global __cuStreamGetFlags
-        _F_cuGetProcAddress_v2('cuStreamGetFlags', <void **>&__cuStreamGetFlags, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 5050, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamGetFlags', <void **>&__cuStreamGetFlags, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 5050, ptds_mode, NULL)
 
         global __cuStreamGetId
-        _F_cuGetProcAddress_v2('cuStreamGetId', <void **>&__cuStreamGetId, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamGetId', <void **>&__cuStreamGetId, 12000, ptds_mode, NULL)
 
         global __cuStreamGetCtx
-        _F_cuGetProcAddress_v2('cuStreamGetCtx', <void **>&__cuStreamGetCtx, 9020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamGetCtx', <void **>&__cuStreamGetCtx, 9020, ptds_mode, NULL)
 
         global __cuStreamGetCtx_v2
-        _F_cuGetProcAddress_v2('cuStreamGetCtx', <void **>&__cuStreamGetCtx_v2, 12050, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamGetCtx', <void **>&__cuStreamGetCtx_v2, 12050, ptds_mode, NULL)
 
         global __cuStreamWaitEvent
-        _F_cuGetProcAddress_v2('cuStreamWaitEvent', <void **>&__cuStreamWaitEvent, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamWaitEvent', <void **>&__cuStreamWaitEvent, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuStreamAddCallback
-        _F_cuGetProcAddress_v2('cuStreamAddCallback', <void **>&__cuStreamAddCallback, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamAddCallback', <void **>&__cuStreamAddCallback, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 5000, ptds_mode, NULL)
 
         global __cuStreamBeginCapture_v2
-        _F_cuGetProcAddress_v2('cuStreamBeginCapture', <void **>&__cuStreamBeginCapture_v2, 10010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamBeginCapture', <void **>&__cuStreamBeginCapture_v2, 10010, ptds_mode, NULL)
 
         global __cuStreamBeginCaptureToGraph
-        _F_cuGetProcAddress_v2('cuStreamBeginCaptureToGraph', <void **>&__cuStreamBeginCaptureToGraph, 12030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamBeginCaptureToGraph', <void **>&__cuStreamBeginCaptureToGraph, 12030, ptds_mode, NULL)
 
         global __cuThreadExchangeStreamCaptureMode
-        _F_cuGetProcAddress_v2('cuThreadExchangeStreamCaptureMode', <void **>&__cuThreadExchangeStreamCaptureMode, 10010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuThreadExchangeStreamCaptureMode', <void **>&__cuThreadExchangeStreamCaptureMode, 10010, ptds_mode, NULL)
 
         global __cuStreamEndCapture
-        _F_cuGetProcAddress_v2('cuStreamEndCapture', <void **>&__cuStreamEndCapture, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamEndCapture', <void **>&__cuStreamEndCapture, 10000, ptds_mode, NULL)
 
         global __cuStreamIsCapturing
-        _F_cuGetProcAddress_v2('cuStreamIsCapturing', <void **>&__cuStreamIsCapturing, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamIsCapturing', <void **>&__cuStreamIsCapturing, 10000, ptds_mode, NULL)
 
         global __cuStreamGetCaptureInfo_v2
-        _F_cuGetProcAddress_v2('cuStreamGetCaptureInfo', <void **>&__cuStreamGetCaptureInfo_v2, 11030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamGetCaptureInfo', <void **>&__cuStreamGetCaptureInfo_v2, 11030, ptds_mode, NULL)
 
         global __cuStreamGetCaptureInfo_v3
-        _F_cuGetProcAddress_v2('cuStreamGetCaptureInfo', <void **>&__cuStreamGetCaptureInfo_v3, 12030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamGetCaptureInfo', <void **>&__cuStreamGetCaptureInfo_v3, 12030, ptds_mode, NULL)
 
         global __cuStreamUpdateCaptureDependencies_v2
-        _F_cuGetProcAddress_v2('cuStreamUpdateCaptureDependencies', <void **>&__cuStreamUpdateCaptureDependencies_v2, 12030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamUpdateCaptureDependencies', <void **>&__cuStreamUpdateCaptureDependencies_v2, 12030, ptds_mode, NULL)
 
         global __cuStreamAttachMemAsync
-        _F_cuGetProcAddress_v2('cuStreamAttachMemAsync', <void **>&__cuStreamAttachMemAsync, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 6000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamAttachMemAsync', <void **>&__cuStreamAttachMemAsync, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 6000, ptds_mode, NULL)
 
         global __cuStreamQuery
-        _F_cuGetProcAddress_v2('cuStreamQuery', <void **>&__cuStreamQuery, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamQuery', <void **>&__cuStreamQuery, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 2000, ptds_mode, NULL)
 
         global __cuStreamSynchronize
-        _F_cuGetProcAddress_v2('cuStreamSynchronize', <void **>&__cuStreamSynchronize, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamSynchronize', <void **>&__cuStreamSynchronize, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 2000, ptds_mode, NULL)
 
         global __cuStreamDestroy_v2
-        _F_cuGetProcAddress_v2('cuStreamDestroy', <void **>&__cuStreamDestroy_v2, 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamDestroy', <void **>&__cuStreamDestroy_v2, 4000, ptds_mode, NULL)
 
         global __cuStreamCopyAttributes
-        _F_cuGetProcAddress_v2('cuStreamCopyAttributes', <void **>&__cuStreamCopyAttributes, 11000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamCopyAttributes', <void **>&__cuStreamCopyAttributes, 11000, ptds_mode, NULL)
 
         global __cuStreamGetAttribute
-        _F_cuGetProcAddress_v2('cuStreamGetAttribute', <void **>&__cuStreamGetAttribute, 11000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamGetAttribute', <void **>&__cuStreamGetAttribute, 11000, ptds_mode, NULL)
 
         global __cuStreamSetAttribute
-        _F_cuGetProcAddress_v2('cuStreamSetAttribute', <void **>&__cuStreamSetAttribute, 11000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamSetAttribute', <void **>&__cuStreamSetAttribute, 11000, ptds_mode, NULL)
 
         global __cuEventCreate
-        _F_cuGetProcAddress_v2('cuEventCreate', <void **>&__cuEventCreate, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuEventCreate', <void **>&__cuEventCreate, 2000, ptds_mode, NULL)
 
         global __cuEventRecord
-        _F_cuGetProcAddress_v2('cuEventRecord', <void **>&__cuEventRecord, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuEventRecord', <void **>&__cuEventRecord, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 2000, ptds_mode, NULL)
 
         global __cuEventRecordWithFlags
-        _F_cuGetProcAddress_v2('cuEventRecordWithFlags', <void **>&__cuEventRecordWithFlags, 11010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuEventRecordWithFlags', <void **>&__cuEventRecordWithFlags, 11010, ptds_mode, NULL)
 
         global __cuEventQuery
-        _F_cuGetProcAddress_v2('cuEventQuery', <void **>&__cuEventQuery, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuEventQuery', <void **>&__cuEventQuery, 2000, ptds_mode, NULL)
 
         global __cuEventSynchronize
-        _F_cuGetProcAddress_v2('cuEventSynchronize', <void **>&__cuEventSynchronize, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuEventSynchronize', <void **>&__cuEventSynchronize, 2000, ptds_mode, NULL)
 
         global __cuEventDestroy_v2
-        _F_cuGetProcAddress_v2('cuEventDestroy', <void **>&__cuEventDestroy_v2, 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuEventDestroy', <void **>&__cuEventDestroy_v2, 4000, ptds_mode, NULL)
 
         global __cuEventElapsedTime_v2
-        _F_cuGetProcAddress_v2('cuEventElapsedTime', <void **>&__cuEventElapsedTime_v2, 12080, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuEventElapsedTime', <void **>&__cuEventElapsedTime_v2, 12080, ptds_mode, NULL)
 
         global __cuImportExternalMemory
-        _F_cuGetProcAddress_v2('cuImportExternalMemory', <void **>&__cuImportExternalMemory, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuImportExternalMemory', <void **>&__cuImportExternalMemory, 10000, ptds_mode, NULL)
 
         global __cuExternalMemoryGetMappedBuffer
-        _F_cuGetProcAddress_v2('cuExternalMemoryGetMappedBuffer', <void **>&__cuExternalMemoryGetMappedBuffer, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuExternalMemoryGetMappedBuffer', <void **>&__cuExternalMemoryGetMappedBuffer, 10000, ptds_mode, NULL)
 
         global __cuExternalMemoryGetMappedMipmappedArray
-        _F_cuGetProcAddress_v2('cuExternalMemoryGetMappedMipmappedArray', <void **>&__cuExternalMemoryGetMappedMipmappedArray, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuExternalMemoryGetMappedMipmappedArray', <void **>&__cuExternalMemoryGetMappedMipmappedArray, 10000, ptds_mode, NULL)
 
         global __cuDestroyExternalMemory
-        _F_cuGetProcAddress_v2('cuDestroyExternalMemory', <void **>&__cuDestroyExternalMemory, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDestroyExternalMemory', <void **>&__cuDestroyExternalMemory, 10000, ptds_mode, NULL)
 
         global __cuImportExternalSemaphore
-        _F_cuGetProcAddress_v2('cuImportExternalSemaphore', <void **>&__cuImportExternalSemaphore, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuImportExternalSemaphore', <void **>&__cuImportExternalSemaphore, 10000, ptds_mode, NULL)
 
         global __cuSignalExternalSemaphoresAsync
-        _F_cuGetProcAddress_v2('cuSignalExternalSemaphoresAsync', <void **>&__cuSignalExternalSemaphoresAsync, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuSignalExternalSemaphoresAsync', <void **>&__cuSignalExternalSemaphoresAsync, 10000, ptds_mode, NULL)
 
         global __cuWaitExternalSemaphoresAsync
-        _F_cuGetProcAddress_v2('cuWaitExternalSemaphoresAsync', <void **>&__cuWaitExternalSemaphoresAsync, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuWaitExternalSemaphoresAsync', <void **>&__cuWaitExternalSemaphoresAsync, 10000, ptds_mode, NULL)
 
         global __cuDestroyExternalSemaphore
-        _F_cuGetProcAddress_v2('cuDestroyExternalSemaphore', <void **>&__cuDestroyExternalSemaphore, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDestroyExternalSemaphore', <void **>&__cuDestroyExternalSemaphore, 10000, ptds_mode, NULL)
 
         global __cuStreamWaitValue32_v2
-        _F_cuGetProcAddress_v2('cuStreamWaitValue32', <void **>&__cuStreamWaitValue32_v2, 11070, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamWaitValue32', <void **>&__cuStreamWaitValue32_v2, 11070, ptds_mode, NULL)
 
         global __cuStreamWaitValue64_v2
-        _F_cuGetProcAddress_v2('cuStreamWaitValue64', <void **>&__cuStreamWaitValue64_v2, 11070, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamWaitValue64', <void **>&__cuStreamWaitValue64_v2, 11070, ptds_mode, NULL)
 
         global __cuStreamWriteValue32_v2
-        _F_cuGetProcAddress_v2('cuStreamWriteValue32', <void **>&__cuStreamWriteValue32_v2, 11070, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamWriteValue32', <void **>&__cuStreamWriteValue32_v2, 11070, ptds_mode, NULL)
 
         global __cuStreamWriteValue64_v2
-        _F_cuGetProcAddress_v2('cuStreamWriteValue64', <void **>&__cuStreamWriteValue64_v2, 11070, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamWriteValue64', <void **>&__cuStreamWriteValue64_v2, 11070, ptds_mode, NULL)
 
         global __cuStreamBatchMemOp_v2
-        _F_cuGetProcAddress_v2('cuStreamBatchMemOp', <void **>&__cuStreamBatchMemOp_v2, 11070, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamBatchMemOp', <void **>&__cuStreamBatchMemOp_v2, 11070, ptds_mode, NULL)
 
         global __cuFuncGetAttribute
-        _F_cuGetProcAddress_v2('cuFuncGetAttribute', <void **>&__cuFuncGetAttribute, 2020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuFuncGetAttribute', <void **>&__cuFuncGetAttribute, 2020, ptds_mode, NULL)
 
         global __cuFuncSetAttribute
-        _F_cuGetProcAddress_v2('cuFuncSetAttribute', <void **>&__cuFuncSetAttribute, 9000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuFuncSetAttribute', <void **>&__cuFuncSetAttribute, 9000, ptds_mode, NULL)
 
         global __cuFuncSetCacheConfig
-        _F_cuGetProcAddress_v2('cuFuncSetCacheConfig', <void **>&__cuFuncSetCacheConfig, 3000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuFuncSetCacheConfig', <void **>&__cuFuncSetCacheConfig, 3000, ptds_mode, NULL)
 
         global __cuFuncGetModule
-        _F_cuGetProcAddress_v2('cuFuncGetModule', <void **>&__cuFuncGetModule, 11000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuFuncGetModule', <void **>&__cuFuncGetModule, 11000, ptds_mode, NULL)
 
         global __cuFuncGetName
-        _F_cuGetProcAddress_v2('cuFuncGetName', <void **>&__cuFuncGetName, 12030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuFuncGetName', <void **>&__cuFuncGetName, 12030, ptds_mode, NULL)
 
         global __cuFuncGetParamInfo
-        _F_cuGetProcAddress_v2('cuFuncGetParamInfo', <void **>&__cuFuncGetParamInfo, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuFuncGetParamInfo', <void **>&__cuFuncGetParamInfo, 12040, ptds_mode, NULL)
 
         global __cuFuncIsLoaded
-        _F_cuGetProcAddress_v2('cuFuncIsLoaded', <void **>&__cuFuncIsLoaded, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuFuncIsLoaded', <void **>&__cuFuncIsLoaded, 12040, ptds_mode, NULL)
 
         global __cuFuncLoad
-        _F_cuGetProcAddress_v2('cuFuncLoad', <void **>&__cuFuncLoad, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuFuncLoad', <void **>&__cuFuncLoad, 12040, ptds_mode, NULL)
 
         global __cuLaunchKernel
-        _F_cuGetProcAddress_v2('cuLaunchKernel', <void **>&__cuLaunchKernel, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLaunchKernel', <void **>&__cuLaunchKernel, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 4000, ptds_mode, NULL)
 
         global __cuLaunchKernelEx
-        _F_cuGetProcAddress_v2('cuLaunchKernelEx', <void **>&__cuLaunchKernelEx, 11060, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLaunchKernelEx', <void **>&__cuLaunchKernelEx, 11060, ptds_mode, NULL)
 
         global __cuLaunchCooperativeKernel
-        _F_cuGetProcAddress_v2('cuLaunchCooperativeKernel', <void **>&__cuLaunchCooperativeKernel, 9000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLaunchCooperativeKernel', <void **>&__cuLaunchCooperativeKernel, 9000, ptds_mode, NULL)
 
         global __cuLaunchCooperativeKernelMultiDevice
-        _F_cuGetProcAddress_v2('cuLaunchCooperativeKernelMultiDevice', <void **>&__cuLaunchCooperativeKernelMultiDevice, 9000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLaunchCooperativeKernelMultiDevice', <void **>&__cuLaunchCooperativeKernelMultiDevice, 9000, ptds_mode, NULL)
 
         global __cuLaunchHostFunc
-        _F_cuGetProcAddress_v2('cuLaunchHostFunc', <void **>&__cuLaunchHostFunc, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLaunchHostFunc', <void **>&__cuLaunchHostFunc, 10000, ptds_mode, NULL)
 
         global __cuFuncSetBlockShape
-        _F_cuGetProcAddress_v2('cuFuncSetBlockShape', <void **>&__cuFuncSetBlockShape, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuFuncSetBlockShape', <void **>&__cuFuncSetBlockShape, 2000, ptds_mode, NULL)
 
         global __cuFuncSetSharedSize
-        _F_cuGetProcAddress_v2('cuFuncSetSharedSize', <void **>&__cuFuncSetSharedSize, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuFuncSetSharedSize', <void **>&__cuFuncSetSharedSize, 2000, ptds_mode, NULL)
 
         global __cuParamSetSize
-        _F_cuGetProcAddress_v2('cuParamSetSize', <void **>&__cuParamSetSize, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuParamSetSize', <void **>&__cuParamSetSize, 2000, ptds_mode, NULL)
 
         global __cuParamSeti
-        _F_cuGetProcAddress_v2('cuParamSeti', <void **>&__cuParamSeti, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuParamSeti', <void **>&__cuParamSeti, 2000, ptds_mode, NULL)
 
         global __cuParamSetf
-        _F_cuGetProcAddress_v2('cuParamSetf', <void **>&__cuParamSetf, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuParamSetf', <void **>&__cuParamSetf, 2000, ptds_mode, NULL)
 
         global __cuParamSetv
-        _F_cuGetProcAddress_v2('cuParamSetv', <void **>&__cuParamSetv, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuParamSetv', <void **>&__cuParamSetv, 2000, ptds_mode, NULL)
 
         global __cuLaunch
-        _F_cuGetProcAddress_v2('cuLaunch', <void **>&__cuLaunch, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLaunch', <void **>&__cuLaunch, 2000, ptds_mode, NULL)
 
         global __cuLaunchGrid
-        _F_cuGetProcAddress_v2('cuLaunchGrid', <void **>&__cuLaunchGrid, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLaunchGrid', <void **>&__cuLaunchGrid, 2000, ptds_mode, NULL)
 
         global __cuLaunchGridAsync
-        _F_cuGetProcAddress_v2('cuLaunchGridAsync', <void **>&__cuLaunchGridAsync, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLaunchGridAsync', <void **>&__cuLaunchGridAsync, 2000, ptds_mode, NULL)
 
         global __cuParamSetTexRef
-        _F_cuGetProcAddress_v2('cuParamSetTexRef', <void **>&__cuParamSetTexRef, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuParamSetTexRef', <void **>&__cuParamSetTexRef, 2000, ptds_mode, NULL)
 
         global __cuFuncSetSharedMemConfig
-        _F_cuGetProcAddress_v2('cuFuncSetSharedMemConfig', <void **>&__cuFuncSetSharedMemConfig, 4020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuFuncSetSharedMemConfig', <void **>&__cuFuncSetSharedMemConfig, 4020, ptds_mode, NULL)
 
         global __cuGraphCreate
-        _F_cuGetProcAddress_v2('cuGraphCreate', <void **>&__cuGraphCreate, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphCreate', <void **>&__cuGraphCreate, 10000, ptds_mode, NULL)
 
         global __cuGraphAddKernelNode_v2
-        _F_cuGetProcAddress_v2('cuGraphAddKernelNode', <void **>&__cuGraphAddKernelNode_v2, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphAddKernelNode', <void **>&__cuGraphAddKernelNode_v2, 12000, ptds_mode, NULL)
 
         global __cuGraphKernelNodeGetParams_v2
-        _F_cuGetProcAddress_v2('cuGraphKernelNodeGetParams', <void **>&__cuGraphKernelNodeGetParams_v2, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphKernelNodeGetParams', <void **>&__cuGraphKernelNodeGetParams_v2, 12000, ptds_mode, NULL)
 
         global __cuGraphKernelNodeSetParams_v2
-        _F_cuGetProcAddress_v2('cuGraphKernelNodeSetParams', <void **>&__cuGraphKernelNodeSetParams_v2, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphKernelNodeSetParams', <void **>&__cuGraphKernelNodeSetParams_v2, 12000, ptds_mode, NULL)
 
         global __cuGraphAddMemcpyNode
-        _F_cuGetProcAddress_v2('cuGraphAddMemcpyNode', <void **>&__cuGraphAddMemcpyNode, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphAddMemcpyNode', <void **>&__cuGraphAddMemcpyNode, 10000, ptds_mode, NULL)
 
         global __cuGraphMemcpyNodeGetParams
-        _F_cuGetProcAddress_v2('cuGraphMemcpyNodeGetParams', <void **>&__cuGraphMemcpyNodeGetParams, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphMemcpyNodeGetParams', <void **>&__cuGraphMemcpyNodeGetParams, 10000, ptds_mode, NULL)
 
         global __cuGraphMemcpyNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphMemcpyNodeSetParams', <void **>&__cuGraphMemcpyNodeSetParams, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphMemcpyNodeSetParams', <void **>&__cuGraphMemcpyNodeSetParams, 10000, ptds_mode, NULL)
 
         global __cuGraphAddMemsetNode
-        _F_cuGetProcAddress_v2('cuGraphAddMemsetNode', <void **>&__cuGraphAddMemsetNode, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphAddMemsetNode', <void **>&__cuGraphAddMemsetNode, 10000, ptds_mode, NULL)
 
         global __cuGraphMemsetNodeGetParams
-        _F_cuGetProcAddress_v2('cuGraphMemsetNodeGetParams', <void **>&__cuGraphMemsetNodeGetParams, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphMemsetNodeGetParams', <void **>&__cuGraphMemsetNodeGetParams, 10000, ptds_mode, NULL)
 
         global __cuGraphMemsetNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphMemsetNodeSetParams', <void **>&__cuGraphMemsetNodeSetParams, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphMemsetNodeSetParams', <void **>&__cuGraphMemsetNodeSetParams, 10000, ptds_mode, NULL)
 
         global __cuGraphAddHostNode
-        _F_cuGetProcAddress_v2('cuGraphAddHostNode', <void **>&__cuGraphAddHostNode, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphAddHostNode', <void **>&__cuGraphAddHostNode, 10000, ptds_mode, NULL)
 
         global __cuGraphHostNodeGetParams
-        _F_cuGetProcAddress_v2('cuGraphHostNodeGetParams', <void **>&__cuGraphHostNodeGetParams, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphHostNodeGetParams', <void **>&__cuGraphHostNodeGetParams, 10000, ptds_mode, NULL)
 
         global __cuGraphHostNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphHostNodeSetParams', <void **>&__cuGraphHostNodeSetParams, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphHostNodeSetParams', <void **>&__cuGraphHostNodeSetParams, 10000, ptds_mode, NULL)
 
         global __cuGraphAddChildGraphNode
-        _F_cuGetProcAddress_v2('cuGraphAddChildGraphNode', <void **>&__cuGraphAddChildGraphNode, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphAddChildGraphNode', <void **>&__cuGraphAddChildGraphNode, 10000, ptds_mode, NULL)
 
         global __cuGraphChildGraphNodeGetGraph
-        _F_cuGetProcAddress_v2('cuGraphChildGraphNodeGetGraph', <void **>&__cuGraphChildGraphNodeGetGraph, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphChildGraphNodeGetGraph', <void **>&__cuGraphChildGraphNodeGetGraph, 10000, ptds_mode, NULL)
 
         global __cuGraphAddEmptyNode
-        _F_cuGetProcAddress_v2('cuGraphAddEmptyNode', <void **>&__cuGraphAddEmptyNode, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphAddEmptyNode', <void **>&__cuGraphAddEmptyNode, 10000, ptds_mode, NULL)
 
         global __cuGraphAddEventRecordNode
-        _F_cuGetProcAddress_v2('cuGraphAddEventRecordNode', <void **>&__cuGraphAddEventRecordNode, 11010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphAddEventRecordNode', <void **>&__cuGraphAddEventRecordNode, 11010, ptds_mode, NULL)
 
         global __cuGraphEventRecordNodeGetEvent
-        _F_cuGetProcAddress_v2('cuGraphEventRecordNodeGetEvent', <void **>&__cuGraphEventRecordNodeGetEvent, 11010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphEventRecordNodeGetEvent', <void **>&__cuGraphEventRecordNodeGetEvent, 11010, ptds_mode, NULL)
 
         global __cuGraphEventRecordNodeSetEvent
-        _F_cuGetProcAddress_v2('cuGraphEventRecordNodeSetEvent', <void **>&__cuGraphEventRecordNodeSetEvent, 11010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphEventRecordNodeSetEvent', <void **>&__cuGraphEventRecordNodeSetEvent, 11010, ptds_mode, NULL)
 
         global __cuGraphAddEventWaitNode
-        _F_cuGetProcAddress_v2('cuGraphAddEventWaitNode', <void **>&__cuGraphAddEventWaitNode, 11010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphAddEventWaitNode', <void **>&__cuGraphAddEventWaitNode, 11010, ptds_mode, NULL)
 
         global __cuGraphEventWaitNodeGetEvent
-        _F_cuGetProcAddress_v2('cuGraphEventWaitNodeGetEvent', <void **>&__cuGraphEventWaitNodeGetEvent, 11010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphEventWaitNodeGetEvent', <void **>&__cuGraphEventWaitNodeGetEvent, 11010, ptds_mode, NULL)
 
         global __cuGraphEventWaitNodeSetEvent
-        _F_cuGetProcAddress_v2('cuGraphEventWaitNodeSetEvent', <void **>&__cuGraphEventWaitNodeSetEvent, 11010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphEventWaitNodeSetEvent', <void **>&__cuGraphEventWaitNodeSetEvent, 11010, ptds_mode, NULL)
 
         global __cuGraphAddExternalSemaphoresSignalNode
-        _F_cuGetProcAddress_v2('cuGraphAddExternalSemaphoresSignalNode', <void **>&__cuGraphAddExternalSemaphoresSignalNode, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphAddExternalSemaphoresSignalNode', <void **>&__cuGraphAddExternalSemaphoresSignalNode, 11020, ptds_mode, NULL)
 
         global __cuGraphExternalSemaphoresSignalNodeGetParams
-        _F_cuGetProcAddress_v2('cuGraphExternalSemaphoresSignalNodeGetParams', <void **>&__cuGraphExternalSemaphoresSignalNodeGetParams, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphExternalSemaphoresSignalNodeGetParams', <void **>&__cuGraphExternalSemaphoresSignalNodeGetParams, 11020, ptds_mode, NULL)
 
         global __cuGraphExternalSemaphoresSignalNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphExternalSemaphoresSignalNodeSetParams', <void **>&__cuGraphExternalSemaphoresSignalNodeSetParams, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphExternalSemaphoresSignalNodeSetParams', <void **>&__cuGraphExternalSemaphoresSignalNodeSetParams, 11020, ptds_mode, NULL)
 
         global __cuGraphAddExternalSemaphoresWaitNode
-        _F_cuGetProcAddress_v2('cuGraphAddExternalSemaphoresWaitNode', <void **>&__cuGraphAddExternalSemaphoresWaitNode, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphAddExternalSemaphoresWaitNode', <void **>&__cuGraphAddExternalSemaphoresWaitNode, 11020, ptds_mode, NULL)
 
         global __cuGraphExternalSemaphoresWaitNodeGetParams
-        _F_cuGetProcAddress_v2('cuGraphExternalSemaphoresWaitNodeGetParams', <void **>&__cuGraphExternalSemaphoresWaitNodeGetParams, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphExternalSemaphoresWaitNodeGetParams', <void **>&__cuGraphExternalSemaphoresWaitNodeGetParams, 11020, ptds_mode, NULL)
 
         global __cuGraphExternalSemaphoresWaitNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphExternalSemaphoresWaitNodeSetParams', <void **>&__cuGraphExternalSemaphoresWaitNodeSetParams, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphExternalSemaphoresWaitNodeSetParams', <void **>&__cuGraphExternalSemaphoresWaitNodeSetParams, 11020, ptds_mode, NULL)
 
         global __cuGraphAddBatchMemOpNode
-        _F_cuGetProcAddress_v2('cuGraphAddBatchMemOpNode', <void **>&__cuGraphAddBatchMemOpNode, 11070, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphAddBatchMemOpNode', <void **>&__cuGraphAddBatchMemOpNode, 11070, ptds_mode, NULL)
 
         global __cuGraphBatchMemOpNodeGetParams
-        _F_cuGetProcAddress_v2('cuGraphBatchMemOpNodeGetParams', <void **>&__cuGraphBatchMemOpNodeGetParams, 11070, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphBatchMemOpNodeGetParams', <void **>&__cuGraphBatchMemOpNodeGetParams, 11070, ptds_mode, NULL)
 
         global __cuGraphBatchMemOpNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphBatchMemOpNodeSetParams', <void **>&__cuGraphBatchMemOpNodeSetParams, 11070, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphBatchMemOpNodeSetParams', <void **>&__cuGraphBatchMemOpNodeSetParams, 11070, ptds_mode, NULL)
 
         global __cuGraphExecBatchMemOpNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphExecBatchMemOpNodeSetParams', <void **>&__cuGraphExecBatchMemOpNodeSetParams, 11070, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphExecBatchMemOpNodeSetParams', <void **>&__cuGraphExecBatchMemOpNodeSetParams, 11070, ptds_mode, NULL)
 
         global __cuGraphAddMemAllocNode
-        _F_cuGetProcAddress_v2('cuGraphAddMemAllocNode', <void **>&__cuGraphAddMemAllocNode, 11040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphAddMemAllocNode', <void **>&__cuGraphAddMemAllocNode, 11040, ptds_mode, NULL)
 
         global __cuGraphMemAllocNodeGetParams
-        _F_cuGetProcAddress_v2('cuGraphMemAllocNodeGetParams', <void **>&__cuGraphMemAllocNodeGetParams, 11040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphMemAllocNodeGetParams', <void **>&__cuGraphMemAllocNodeGetParams, 11040, ptds_mode, NULL)
 
         global __cuGraphAddMemFreeNode
-        _F_cuGetProcAddress_v2('cuGraphAddMemFreeNode', <void **>&__cuGraphAddMemFreeNode, 11040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphAddMemFreeNode', <void **>&__cuGraphAddMemFreeNode, 11040, ptds_mode, NULL)
 
         global __cuGraphMemFreeNodeGetParams
-        _F_cuGetProcAddress_v2('cuGraphMemFreeNodeGetParams', <void **>&__cuGraphMemFreeNodeGetParams, 11040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphMemFreeNodeGetParams', <void **>&__cuGraphMemFreeNodeGetParams, 11040, ptds_mode, NULL)
 
         global __cuDeviceGraphMemTrim
-        _F_cuGetProcAddress_v2('cuDeviceGraphMemTrim', <void **>&__cuDeviceGraphMemTrim, 11040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceGraphMemTrim', <void **>&__cuDeviceGraphMemTrim, 11040, ptds_mode, NULL)
 
         global __cuDeviceGetGraphMemAttribute
-        _F_cuGetProcAddress_v2('cuDeviceGetGraphMemAttribute', <void **>&__cuDeviceGetGraphMemAttribute, 11040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceGetGraphMemAttribute', <void **>&__cuDeviceGetGraphMemAttribute, 11040, ptds_mode, NULL)
 
         global __cuDeviceSetGraphMemAttribute
-        _F_cuGetProcAddress_v2('cuDeviceSetGraphMemAttribute', <void **>&__cuDeviceSetGraphMemAttribute, 11040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceSetGraphMemAttribute', <void **>&__cuDeviceSetGraphMemAttribute, 11040, ptds_mode, NULL)
 
         global __cuGraphClone
-        _F_cuGetProcAddress_v2('cuGraphClone', <void **>&__cuGraphClone, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphClone', <void **>&__cuGraphClone, 10000, ptds_mode, NULL)
 
         global __cuGraphNodeFindInClone
-        _F_cuGetProcAddress_v2('cuGraphNodeFindInClone', <void **>&__cuGraphNodeFindInClone, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphNodeFindInClone', <void **>&__cuGraphNodeFindInClone, 10000, ptds_mode, NULL)
 
         global __cuGraphNodeGetType
-        _F_cuGetProcAddress_v2('cuGraphNodeGetType', <void **>&__cuGraphNodeGetType, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphNodeGetType', <void **>&__cuGraphNodeGetType, 10000, ptds_mode, NULL)
 
         global __cuGraphGetNodes
-        _F_cuGetProcAddress_v2('cuGraphGetNodes', <void **>&__cuGraphGetNodes, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphGetNodes', <void **>&__cuGraphGetNodes, 10000, ptds_mode, NULL)
 
         global __cuGraphGetRootNodes
-        _F_cuGetProcAddress_v2('cuGraphGetRootNodes', <void **>&__cuGraphGetRootNodes, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphGetRootNodes', <void **>&__cuGraphGetRootNodes, 10000, ptds_mode, NULL)
 
         global __cuGraphGetEdges_v2
-        _F_cuGetProcAddress_v2('cuGraphGetEdges', <void **>&__cuGraphGetEdges_v2, 12030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphGetEdges', <void **>&__cuGraphGetEdges_v2, 12030, ptds_mode, NULL)
 
         global __cuGraphNodeGetDependencies_v2
-        _F_cuGetProcAddress_v2('cuGraphNodeGetDependencies', <void **>&__cuGraphNodeGetDependencies_v2, 12030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphNodeGetDependencies', <void **>&__cuGraphNodeGetDependencies_v2, 12030, ptds_mode, NULL)
 
         global __cuGraphNodeGetDependentNodes_v2
-        _F_cuGetProcAddress_v2('cuGraphNodeGetDependentNodes', <void **>&__cuGraphNodeGetDependentNodes_v2, 12030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphNodeGetDependentNodes', <void **>&__cuGraphNodeGetDependentNodes_v2, 12030, ptds_mode, NULL)
 
         global __cuGraphAddDependencies_v2
-        _F_cuGetProcAddress_v2('cuGraphAddDependencies', <void **>&__cuGraphAddDependencies_v2, 12030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphAddDependencies', <void **>&__cuGraphAddDependencies_v2, 12030, ptds_mode, NULL)
 
         global __cuGraphRemoveDependencies_v2
-        _F_cuGetProcAddress_v2('cuGraphRemoveDependencies', <void **>&__cuGraphRemoveDependencies_v2, 12030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphRemoveDependencies', <void **>&__cuGraphRemoveDependencies_v2, 12030, ptds_mode, NULL)
 
         global __cuGraphDestroyNode
-        _F_cuGetProcAddress_v2('cuGraphDestroyNode', <void **>&__cuGraphDestroyNode, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphDestroyNode', <void **>&__cuGraphDestroyNode, 10000, ptds_mode, NULL)
 
         global __cuGraphInstantiateWithFlags
-        _F_cuGetProcAddress_v2('cuGraphInstantiateWithFlags', <void **>&__cuGraphInstantiateWithFlags, 11040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphInstantiateWithFlags', <void **>&__cuGraphInstantiateWithFlags, 11040, ptds_mode, NULL)
 
         global __cuGraphInstantiateWithParams
-        _F_cuGetProcAddress_v2('cuGraphInstantiateWithParams', <void **>&__cuGraphInstantiateWithParams, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphInstantiateWithParams', <void **>&__cuGraphInstantiateWithParams, 12000, ptds_mode, NULL)
 
         global __cuGraphExecGetFlags
-        _F_cuGetProcAddress_v2('cuGraphExecGetFlags', <void **>&__cuGraphExecGetFlags, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphExecGetFlags', <void **>&__cuGraphExecGetFlags, 12000, ptds_mode, NULL)
 
         global __cuGraphExecKernelNodeSetParams_v2
-        _F_cuGetProcAddress_v2('cuGraphExecKernelNodeSetParams', <void **>&__cuGraphExecKernelNodeSetParams_v2, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphExecKernelNodeSetParams', <void **>&__cuGraphExecKernelNodeSetParams_v2, 12000, ptds_mode, NULL)
 
         global __cuGraphExecMemcpyNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphExecMemcpyNodeSetParams', <void **>&__cuGraphExecMemcpyNodeSetParams, 10020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphExecMemcpyNodeSetParams', <void **>&__cuGraphExecMemcpyNodeSetParams, 10020, ptds_mode, NULL)
 
         global __cuGraphExecMemsetNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphExecMemsetNodeSetParams', <void **>&__cuGraphExecMemsetNodeSetParams, 10020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphExecMemsetNodeSetParams', <void **>&__cuGraphExecMemsetNodeSetParams, 10020, ptds_mode, NULL)
 
         global __cuGraphExecHostNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphExecHostNodeSetParams', <void **>&__cuGraphExecHostNodeSetParams, 10020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphExecHostNodeSetParams', <void **>&__cuGraphExecHostNodeSetParams, 10020, ptds_mode, NULL)
 
         global __cuGraphExecChildGraphNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphExecChildGraphNodeSetParams', <void **>&__cuGraphExecChildGraphNodeSetParams, 11010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphExecChildGraphNodeSetParams', <void **>&__cuGraphExecChildGraphNodeSetParams, 11010, ptds_mode, NULL)
 
         global __cuGraphExecEventRecordNodeSetEvent
-        _F_cuGetProcAddress_v2('cuGraphExecEventRecordNodeSetEvent', <void **>&__cuGraphExecEventRecordNodeSetEvent, 11010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphExecEventRecordNodeSetEvent', <void **>&__cuGraphExecEventRecordNodeSetEvent, 11010, ptds_mode, NULL)
 
         global __cuGraphExecEventWaitNodeSetEvent
-        _F_cuGetProcAddress_v2('cuGraphExecEventWaitNodeSetEvent', <void **>&__cuGraphExecEventWaitNodeSetEvent, 11010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphExecEventWaitNodeSetEvent', <void **>&__cuGraphExecEventWaitNodeSetEvent, 11010, ptds_mode, NULL)
 
         global __cuGraphExecExternalSemaphoresSignalNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphExecExternalSemaphoresSignalNodeSetParams', <void **>&__cuGraphExecExternalSemaphoresSignalNodeSetParams, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphExecExternalSemaphoresSignalNodeSetParams', <void **>&__cuGraphExecExternalSemaphoresSignalNodeSetParams, 11020, ptds_mode, NULL)
 
         global __cuGraphExecExternalSemaphoresWaitNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphExecExternalSemaphoresWaitNodeSetParams', <void **>&__cuGraphExecExternalSemaphoresWaitNodeSetParams, 11020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphExecExternalSemaphoresWaitNodeSetParams', <void **>&__cuGraphExecExternalSemaphoresWaitNodeSetParams, 11020, ptds_mode, NULL)
 
         global __cuGraphNodeSetEnabled
-        _F_cuGetProcAddress_v2('cuGraphNodeSetEnabled', <void **>&__cuGraphNodeSetEnabled, 11060, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphNodeSetEnabled', <void **>&__cuGraphNodeSetEnabled, 11060, ptds_mode, NULL)
 
         global __cuGraphNodeGetEnabled
-        _F_cuGetProcAddress_v2('cuGraphNodeGetEnabled', <void **>&__cuGraphNodeGetEnabled, 11060, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphNodeGetEnabled', <void **>&__cuGraphNodeGetEnabled, 11060, ptds_mode, NULL)
 
         global __cuGraphUpload
-        _F_cuGetProcAddress_v2('cuGraphUpload', <void **>&__cuGraphUpload, 11010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphUpload', <void **>&__cuGraphUpload, 11010, ptds_mode, NULL)
 
         global __cuGraphLaunch
-        _F_cuGetProcAddress_v2('cuGraphLaunch', <void **>&__cuGraphLaunch, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphLaunch', <void **>&__cuGraphLaunch, 10000, ptds_mode, NULL)
 
         global __cuGraphExecDestroy
-        _F_cuGetProcAddress_v2('cuGraphExecDestroy', <void **>&__cuGraphExecDestroy, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphExecDestroy', <void **>&__cuGraphExecDestroy, 10000, ptds_mode, NULL)
 
         global __cuGraphDestroy
-        _F_cuGetProcAddress_v2('cuGraphDestroy', <void **>&__cuGraphDestroy, 10000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphDestroy', <void **>&__cuGraphDestroy, 10000, ptds_mode, NULL)
 
         global __cuGraphExecUpdate_v2
-        _F_cuGetProcAddress_v2('cuGraphExecUpdate', <void **>&__cuGraphExecUpdate_v2, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphExecUpdate', <void **>&__cuGraphExecUpdate_v2, 12000, ptds_mode, NULL)
 
         global __cuGraphKernelNodeCopyAttributes
-        _F_cuGetProcAddress_v2('cuGraphKernelNodeCopyAttributes', <void **>&__cuGraphKernelNodeCopyAttributes, 11000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphKernelNodeCopyAttributes', <void **>&__cuGraphKernelNodeCopyAttributes, 11000, ptds_mode, NULL)
 
         global __cuGraphKernelNodeGetAttribute
-        _F_cuGetProcAddress_v2('cuGraphKernelNodeGetAttribute', <void **>&__cuGraphKernelNodeGetAttribute, 11000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphKernelNodeGetAttribute', <void **>&__cuGraphKernelNodeGetAttribute, 11000, ptds_mode, NULL)
 
         global __cuGraphKernelNodeSetAttribute
-        _F_cuGetProcAddress_v2('cuGraphKernelNodeSetAttribute', <void **>&__cuGraphKernelNodeSetAttribute, 11000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphKernelNodeSetAttribute', <void **>&__cuGraphKernelNodeSetAttribute, 11000, ptds_mode, NULL)
 
         global __cuGraphDebugDotPrint
-        _F_cuGetProcAddress_v2('cuGraphDebugDotPrint', <void **>&__cuGraphDebugDotPrint, 11030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphDebugDotPrint', <void **>&__cuGraphDebugDotPrint, 11030, ptds_mode, NULL)
 
         global __cuUserObjectCreate
-        _F_cuGetProcAddress_v2('cuUserObjectCreate', <void **>&__cuUserObjectCreate, 11030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuUserObjectCreate', <void **>&__cuUserObjectCreate, 11030, ptds_mode, NULL)
 
         global __cuUserObjectRetain
-        _F_cuGetProcAddress_v2('cuUserObjectRetain', <void **>&__cuUserObjectRetain, 11030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuUserObjectRetain', <void **>&__cuUserObjectRetain, 11030, ptds_mode, NULL)
 
         global __cuUserObjectRelease
-        _F_cuGetProcAddress_v2('cuUserObjectRelease', <void **>&__cuUserObjectRelease, 11030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuUserObjectRelease', <void **>&__cuUserObjectRelease, 11030, ptds_mode, NULL)
 
         global __cuGraphRetainUserObject
-        _F_cuGetProcAddress_v2('cuGraphRetainUserObject', <void **>&__cuGraphRetainUserObject, 11030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphRetainUserObject', <void **>&__cuGraphRetainUserObject, 11030, ptds_mode, NULL)
 
         global __cuGraphReleaseUserObject
-        _F_cuGetProcAddress_v2('cuGraphReleaseUserObject', <void **>&__cuGraphReleaseUserObject, 11030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphReleaseUserObject', <void **>&__cuGraphReleaseUserObject, 11030, ptds_mode, NULL)
 
         global __cuGraphAddNode_v2
-        _F_cuGetProcAddress_v2('cuGraphAddNode', <void **>&__cuGraphAddNode_v2, 12030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphAddNode', <void **>&__cuGraphAddNode_v2, 12030, ptds_mode, NULL)
 
         global __cuGraphNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphNodeSetParams', <void **>&__cuGraphNodeSetParams, 12020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphNodeSetParams', <void **>&__cuGraphNodeSetParams, 12020, ptds_mode, NULL)
 
         global __cuGraphExecNodeSetParams
-        _F_cuGetProcAddress_v2('cuGraphExecNodeSetParams', <void **>&__cuGraphExecNodeSetParams, 12020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphExecNodeSetParams', <void **>&__cuGraphExecNodeSetParams, 12020, ptds_mode, NULL)
 
         global __cuGraphConditionalHandleCreate
-        _F_cuGetProcAddress_v2('cuGraphConditionalHandleCreate', <void **>&__cuGraphConditionalHandleCreate, 12030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphConditionalHandleCreate', <void **>&__cuGraphConditionalHandleCreate, 12030, ptds_mode, NULL)
 
         global __cuOccupancyMaxActiveBlocksPerMultiprocessor
-        _F_cuGetProcAddress_v2('cuOccupancyMaxActiveBlocksPerMultiprocessor', <void **>&__cuOccupancyMaxActiveBlocksPerMultiprocessor, 6050, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuOccupancyMaxActiveBlocksPerMultiprocessor', <void **>&__cuOccupancyMaxActiveBlocksPerMultiprocessor, 6050, ptds_mode, NULL)
 
         global __cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags
-        _F_cuGetProcAddress_v2('cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags', <void **>&__cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags, 7000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags', <void **>&__cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags, 7000, ptds_mode, NULL)
 
         global __cuOccupancyMaxPotentialBlockSize
-        _F_cuGetProcAddress_v2('cuOccupancyMaxPotentialBlockSize', <void **>&__cuOccupancyMaxPotentialBlockSize, 6050, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuOccupancyMaxPotentialBlockSize', <void **>&__cuOccupancyMaxPotentialBlockSize, 6050, ptds_mode, NULL)
 
         global __cuOccupancyMaxPotentialBlockSizeWithFlags
-        _F_cuGetProcAddress_v2('cuOccupancyMaxPotentialBlockSizeWithFlags', <void **>&__cuOccupancyMaxPotentialBlockSizeWithFlags, 7000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuOccupancyMaxPotentialBlockSizeWithFlags', <void **>&__cuOccupancyMaxPotentialBlockSizeWithFlags, 7000, ptds_mode, NULL)
 
         global __cuOccupancyAvailableDynamicSMemPerBlock
-        _F_cuGetProcAddress_v2('cuOccupancyAvailableDynamicSMemPerBlock', <void **>&__cuOccupancyAvailableDynamicSMemPerBlock, 10020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuOccupancyAvailableDynamicSMemPerBlock', <void **>&__cuOccupancyAvailableDynamicSMemPerBlock, 10020, ptds_mode, NULL)
 
         global __cuOccupancyMaxPotentialClusterSize
-        _F_cuGetProcAddress_v2('cuOccupancyMaxPotentialClusterSize', <void **>&__cuOccupancyMaxPotentialClusterSize, 11070, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuOccupancyMaxPotentialClusterSize', <void **>&__cuOccupancyMaxPotentialClusterSize, 11070, ptds_mode, NULL)
 
         global __cuOccupancyMaxActiveClusters
-        _F_cuGetProcAddress_v2('cuOccupancyMaxActiveClusters', <void **>&__cuOccupancyMaxActiveClusters, 11070, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuOccupancyMaxActiveClusters', <void **>&__cuOccupancyMaxActiveClusters, 11070, ptds_mode, NULL)
 
         global __cuTexRefSetArray
-        _F_cuGetProcAddress_v2('cuTexRefSetArray', <void **>&__cuTexRefSetArray, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefSetArray', <void **>&__cuTexRefSetArray, 2000, ptds_mode, NULL)
 
         global __cuTexRefSetMipmappedArray
-        _F_cuGetProcAddress_v2('cuTexRefSetMipmappedArray', <void **>&__cuTexRefSetMipmappedArray, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefSetMipmappedArray', <void **>&__cuTexRefSetMipmappedArray, 5000, ptds_mode, NULL)
 
         global __cuTexRefSetAddress_v2
-        _F_cuGetProcAddress_v2('cuTexRefSetAddress', <void **>&__cuTexRefSetAddress_v2, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefSetAddress', <void **>&__cuTexRefSetAddress_v2, 3020, ptds_mode, NULL)
 
         global __cuTexRefSetAddress2D_v3
-        _F_cuGetProcAddress_v2('cuTexRefSetAddress2D', <void **>&__cuTexRefSetAddress2D_v3, 4010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefSetAddress2D', <void **>&__cuTexRefSetAddress2D_v3, 4010, ptds_mode, NULL)
 
         global __cuTexRefSetFormat
-        _F_cuGetProcAddress_v2('cuTexRefSetFormat', <void **>&__cuTexRefSetFormat, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefSetFormat', <void **>&__cuTexRefSetFormat, 2000, ptds_mode, NULL)
 
         global __cuTexRefSetAddressMode
-        _F_cuGetProcAddress_v2('cuTexRefSetAddressMode', <void **>&__cuTexRefSetAddressMode, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefSetAddressMode', <void **>&__cuTexRefSetAddressMode, 2000, ptds_mode, NULL)
 
         global __cuTexRefSetFilterMode
-        _F_cuGetProcAddress_v2('cuTexRefSetFilterMode', <void **>&__cuTexRefSetFilterMode, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefSetFilterMode', <void **>&__cuTexRefSetFilterMode, 2000, ptds_mode, NULL)
 
         global __cuTexRefSetMipmapFilterMode
-        _F_cuGetProcAddress_v2('cuTexRefSetMipmapFilterMode', <void **>&__cuTexRefSetMipmapFilterMode, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefSetMipmapFilterMode', <void **>&__cuTexRefSetMipmapFilterMode, 5000, ptds_mode, NULL)
 
         global __cuTexRefSetMipmapLevelBias
-        _F_cuGetProcAddress_v2('cuTexRefSetMipmapLevelBias', <void **>&__cuTexRefSetMipmapLevelBias, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefSetMipmapLevelBias', <void **>&__cuTexRefSetMipmapLevelBias, 5000, ptds_mode, NULL)
 
         global __cuTexRefSetMipmapLevelClamp
-        _F_cuGetProcAddress_v2('cuTexRefSetMipmapLevelClamp', <void **>&__cuTexRefSetMipmapLevelClamp, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefSetMipmapLevelClamp', <void **>&__cuTexRefSetMipmapLevelClamp, 5000, ptds_mode, NULL)
 
         global __cuTexRefSetMaxAnisotropy
-        _F_cuGetProcAddress_v2('cuTexRefSetMaxAnisotropy', <void **>&__cuTexRefSetMaxAnisotropy, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefSetMaxAnisotropy', <void **>&__cuTexRefSetMaxAnisotropy, 5000, ptds_mode, NULL)
 
         global __cuTexRefSetBorderColor
-        _F_cuGetProcAddress_v2('cuTexRefSetBorderColor', <void **>&__cuTexRefSetBorderColor, 8000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefSetBorderColor', <void **>&__cuTexRefSetBorderColor, 8000, ptds_mode, NULL)
 
         global __cuTexRefSetFlags
-        _F_cuGetProcAddress_v2('cuTexRefSetFlags', <void **>&__cuTexRefSetFlags, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefSetFlags', <void **>&__cuTexRefSetFlags, 2000, ptds_mode, NULL)
 
         global __cuTexRefGetAddress_v2
-        _F_cuGetProcAddress_v2('cuTexRefGetAddress', <void **>&__cuTexRefGetAddress_v2, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefGetAddress', <void **>&__cuTexRefGetAddress_v2, 3020, ptds_mode, NULL)
 
         global __cuTexRefGetArray
-        _F_cuGetProcAddress_v2('cuTexRefGetArray', <void **>&__cuTexRefGetArray, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefGetArray', <void **>&__cuTexRefGetArray, 2000, ptds_mode, NULL)
 
         global __cuTexRefGetMipmappedArray
-        _F_cuGetProcAddress_v2('cuTexRefGetMipmappedArray', <void **>&__cuTexRefGetMipmappedArray, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefGetMipmappedArray', <void **>&__cuTexRefGetMipmappedArray, 5000, ptds_mode, NULL)
 
         global __cuTexRefGetAddressMode
-        _F_cuGetProcAddress_v2('cuTexRefGetAddressMode', <void **>&__cuTexRefGetAddressMode, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefGetAddressMode', <void **>&__cuTexRefGetAddressMode, 2000, ptds_mode, NULL)
 
         global __cuTexRefGetFilterMode
-        _F_cuGetProcAddress_v2('cuTexRefGetFilterMode', <void **>&__cuTexRefGetFilterMode, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefGetFilterMode', <void **>&__cuTexRefGetFilterMode, 2000, ptds_mode, NULL)
 
         global __cuTexRefGetFormat
-        _F_cuGetProcAddress_v2('cuTexRefGetFormat', <void **>&__cuTexRefGetFormat, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefGetFormat', <void **>&__cuTexRefGetFormat, 2000, ptds_mode, NULL)
 
         global __cuTexRefGetMipmapFilterMode
-        _F_cuGetProcAddress_v2('cuTexRefGetMipmapFilterMode', <void **>&__cuTexRefGetMipmapFilterMode, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefGetMipmapFilterMode', <void **>&__cuTexRefGetMipmapFilterMode, 5000, ptds_mode, NULL)
 
         global __cuTexRefGetMipmapLevelBias
-        _F_cuGetProcAddress_v2('cuTexRefGetMipmapLevelBias', <void **>&__cuTexRefGetMipmapLevelBias, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefGetMipmapLevelBias', <void **>&__cuTexRefGetMipmapLevelBias, 5000, ptds_mode, NULL)
 
         global __cuTexRefGetMipmapLevelClamp
-        _F_cuGetProcAddress_v2('cuTexRefGetMipmapLevelClamp', <void **>&__cuTexRefGetMipmapLevelClamp, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefGetMipmapLevelClamp', <void **>&__cuTexRefGetMipmapLevelClamp, 5000, ptds_mode, NULL)
 
         global __cuTexRefGetMaxAnisotropy
-        _F_cuGetProcAddress_v2('cuTexRefGetMaxAnisotropy', <void **>&__cuTexRefGetMaxAnisotropy, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefGetMaxAnisotropy', <void **>&__cuTexRefGetMaxAnisotropy, 5000, ptds_mode, NULL)
 
         global __cuTexRefGetBorderColor
-        _F_cuGetProcAddress_v2('cuTexRefGetBorderColor', <void **>&__cuTexRefGetBorderColor, 8000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefGetBorderColor', <void **>&__cuTexRefGetBorderColor, 8000, ptds_mode, NULL)
 
         global __cuTexRefGetFlags
-        _F_cuGetProcAddress_v2('cuTexRefGetFlags', <void **>&__cuTexRefGetFlags, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefGetFlags', <void **>&__cuTexRefGetFlags, 2000, ptds_mode, NULL)
 
         global __cuTexRefCreate
-        _F_cuGetProcAddress_v2('cuTexRefCreate', <void **>&__cuTexRefCreate, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefCreate', <void **>&__cuTexRefCreate, 2000, ptds_mode, NULL)
 
         global __cuTexRefDestroy
-        _F_cuGetProcAddress_v2('cuTexRefDestroy', <void **>&__cuTexRefDestroy, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexRefDestroy', <void **>&__cuTexRefDestroy, 2000, ptds_mode, NULL)
 
         global __cuSurfRefSetArray
-        _F_cuGetProcAddress_v2('cuSurfRefSetArray', <void **>&__cuSurfRefSetArray, 3000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuSurfRefSetArray', <void **>&__cuSurfRefSetArray, 3000, ptds_mode, NULL)
 
         global __cuSurfRefGetArray
-        _F_cuGetProcAddress_v2('cuSurfRefGetArray', <void **>&__cuSurfRefGetArray, 3000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuSurfRefGetArray', <void **>&__cuSurfRefGetArray, 3000, ptds_mode, NULL)
 
         global __cuTexObjectCreate
-        _F_cuGetProcAddress_v2('cuTexObjectCreate', <void **>&__cuTexObjectCreate, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexObjectCreate', <void **>&__cuTexObjectCreate, 5000, ptds_mode, NULL)
 
         global __cuTexObjectDestroy
-        _F_cuGetProcAddress_v2('cuTexObjectDestroy', <void **>&__cuTexObjectDestroy, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexObjectDestroy', <void **>&__cuTexObjectDestroy, 5000, ptds_mode, NULL)
 
         global __cuTexObjectGetResourceDesc
-        _F_cuGetProcAddress_v2('cuTexObjectGetResourceDesc', <void **>&__cuTexObjectGetResourceDesc, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexObjectGetResourceDesc', <void **>&__cuTexObjectGetResourceDesc, 5000, ptds_mode, NULL)
 
         global __cuTexObjectGetTextureDesc
-        _F_cuGetProcAddress_v2('cuTexObjectGetTextureDesc', <void **>&__cuTexObjectGetTextureDesc, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexObjectGetTextureDesc', <void **>&__cuTexObjectGetTextureDesc, 5000, ptds_mode, NULL)
 
         global __cuTexObjectGetResourceViewDesc
-        _F_cuGetProcAddress_v2('cuTexObjectGetResourceViewDesc', <void **>&__cuTexObjectGetResourceViewDesc, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTexObjectGetResourceViewDesc', <void **>&__cuTexObjectGetResourceViewDesc, 5000, ptds_mode, NULL)
 
         global __cuSurfObjectCreate
-        _F_cuGetProcAddress_v2('cuSurfObjectCreate', <void **>&__cuSurfObjectCreate, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuSurfObjectCreate', <void **>&__cuSurfObjectCreate, 5000, ptds_mode, NULL)
 
         global __cuSurfObjectDestroy
-        _F_cuGetProcAddress_v2('cuSurfObjectDestroy', <void **>&__cuSurfObjectDestroy, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuSurfObjectDestroy', <void **>&__cuSurfObjectDestroy, 5000, ptds_mode, NULL)
 
         global __cuSurfObjectGetResourceDesc
-        _F_cuGetProcAddress_v2('cuSurfObjectGetResourceDesc', <void **>&__cuSurfObjectGetResourceDesc, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuSurfObjectGetResourceDesc', <void **>&__cuSurfObjectGetResourceDesc, 5000, ptds_mode, NULL)
 
         global __cuTensorMapEncodeTiled
-        _F_cuGetProcAddress_v2('cuTensorMapEncodeTiled', <void **>&__cuTensorMapEncodeTiled, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTensorMapEncodeTiled', <void **>&__cuTensorMapEncodeTiled, 12000, ptds_mode, NULL)
 
         global __cuTensorMapEncodeIm2col
-        _F_cuGetProcAddress_v2('cuTensorMapEncodeIm2col', <void **>&__cuTensorMapEncodeIm2col, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTensorMapEncodeIm2col', <void **>&__cuTensorMapEncodeIm2col, 12000, ptds_mode, NULL)
 
         global __cuTensorMapEncodeIm2colWide
-        _F_cuGetProcAddress_v2('cuTensorMapEncodeIm2colWide', <void **>&__cuTensorMapEncodeIm2colWide, 12080, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTensorMapEncodeIm2colWide', <void **>&__cuTensorMapEncodeIm2colWide, 12080, ptds_mode, NULL)
 
         global __cuTensorMapReplaceAddress
-        _F_cuGetProcAddress_v2('cuTensorMapReplaceAddress', <void **>&__cuTensorMapReplaceAddress, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuTensorMapReplaceAddress', <void **>&__cuTensorMapReplaceAddress, 12000, ptds_mode, NULL)
 
         global __cuDeviceCanAccessPeer
-        _F_cuGetProcAddress_v2('cuDeviceCanAccessPeer', <void **>&__cuDeviceCanAccessPeer, 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceCanAccessPeer', <void **>&__cuDeviceCanAccessPeer, 4000, ptds_mode, NULL)
 
         global __cuCtxEnablePeerAccess
-        _F_cuGetProcAddress_v2('cuCtxEnablePeerAccess', <void **>&__cuCtxEnablePeerAccess, 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxEnablePeerAccess', <void **>&__cuCtxEnablePeerAccess, 4000, ptds_mode, NULL)
 
         global __cuCtxDisablePeerAccess
-        _F_cuGetProcAddress_v2('cuCtxDisablePeerAccess', <void **>&__cuCtxDisablePeerAccess, 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxDisablePeerAccess', <void **>&__cuCtxDisablePeerAccess, 4000, ptds_mode, NULL)
 
         global __cuDeviceGetP2PAttribute
-        _F_cuGetProcAddress_v2('cuDeviceGetP2PAttribute', <void **>&__cuDeviceGetP2PAttribute, 8000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceGetP2PAttribute', <void **>&__cuDeviceGetP2PAttribute, 8000, ptds_mode, NULL)
 
         global __cuGraphicsUnregisterResource
-        _F_cuGetProcAddress_v2('cuGraphicsUnregisterResource', <void **>&__cuGraphicsUnregisterResource, 3000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphicsUnregisterResource', <void **>&__cuGraphicsUnregisterResource, 3000, ptds_mode, NULL)
 
         global __cuGraphicsSubResourceGetMappedArray
-        _F_cuGetProcAddress_v2('cuGraphicsSubResourceGetMappedArray', <void **>&__cuGraphicsSubResourceGetMappedArray, 3000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphicsSubResourceGetMappedArray', <void **>&__cuGraphicsSubResourceGetMappedArray, 3000, ptds_mode, NULL)
 
         global __cuGraphicsResourceGetMappedMipmappedArray
-        _F_cuGetProcAddress_v2('cuGraphicsResourceGetMappedMipmappedArray', <void **>&__cuGraphicsResourceGetMappedMipmappedArray, 5000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphicsResourceGetMappedMipmappedArray', <void **>&__cuGraphicsResourceGetMappedMipmappedArray, 5000, ptds_mode, NULL)
 
         global __cuGraphicsResourceGetMappedPointer_v2
-        _F_cuGetProcAddress_v2('cuGraphicsResourceGetMappedPointer', <void **>&__cuGraphicsResourceGetMappedPointer_v2, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphicsResourceGetMappedPointer', <void **>&__cuGraphicsResourceGetMappedPointer_v2, 3020, ptds_mode, NULL)
 
         global __cuGraphicsResourceSetMapFlags_v2
-        _F_cuGetProcAddress_v2('cuGraphicsResourceSetMapFlags', <void **>&__cuGraphicsResourceSetMapFlags_v2, 6050, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphicsResourceSetMapFlags', <void **>&__cuGraphicsResourceSetMapFlags_v2, 6050, ptds_mode, NULL)
 
         global __cuGraphicsMapResources
-        _F_cuGetProcAddress_v2('cuGraphicsMapResources', <void **>&__cuGraphicsMapResources, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphicsMapResources', <void **>&__cuGraphicsMapResources, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3000, ptds_mode, NULL)
 
         global __cuGraphicsUnmapResources
-        _F_cuGetProcAddress_v2('cuGraphicsUnmapResources', <void **>&__cuGraphicsUnmapResources, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphicsUnmapResources', <void **>&__cuGraphicsUnmapResources, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3000, ptds_mode, NULL)
 
         global __cuGetProcAddress_v2
-        _F_cuGetProcAddress_v2('cuGetProcAddress', <void **>&__cuGetProcAddress_v2, 12000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGetProcAddress', <void **>&__cuGetProcAddress_v2, 12000, ptds_mode, NULL)
 
         global __cuCoredumpGetAttribute
-        _F_cuGetProcAddress_v2('cuCoredumpGetAttribute', <void **>&__cuCoredumpGetAttribute, 12010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCoredumpGetAttribute', <void **>&__cuCoredumpGetAttribute, 12010, ptds_mode, NULL)
 
         global __cuCoredumpGetAttributeGlobal
-        _F_cuGetProcAddress_v2('cuCoredumpGetAttributeGlobal', <void **>&__cuCoredumpGetAttributeGlobal, 12010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCoredumpGetAttributeGlobal', <void **>&__cuCoredumpGetAttributeGlobal, 12010, ptds_mode, NULL)
 
         global __cuCoredumpSetAttribute
-        _F_cuGetProcAddress_v2('cuCoredumpSetAttribute', <void **>&__cuCoredumpSetAttribute, 12010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCoredumpSetAttribute', <void **>&__cuCoredumpSetAttribute, 12010, ptds_mode, NULL)
 
         global __cuCoredumpSetAttributeGlobal
-        _F_cuGetProcAddress_v2('cuCoredumpSetAttributeGlobal', <void **>&__cuCoredumpSetAttributeGlobal, 12010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCoredumpSetAttributeGlobal', <void **>&__cuCoredumpSetAttributeGlobal, 12010, ptds_mode, NULL)
 
         global __cuGetExportTable
-        _F_cuGetProcAddress_v2('cuGetExportTable', <void **>&__cuGetExportTable, 3000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGetExportTable', <void **>&__cuGetExportTable, 3000, ptds_mode, NULL)
 
         global __cuGreenCtxCreate
-        _F_cuGetProcAddress_v2('cuGreenCtxCreate', <void **>&__cuGreenCtxCreate, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGreenCtxCreate', <void **>&__cuGreenCtxCreate, 12040, ptds_mode, NULL)
 
         global __cuGreenCtxDestroy
-        _F_cuGetProcAddress_v2('cuGreenCtxDestroy', <void **>&__cuGreenCtxDestroy, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGreenCtxDestroy', <void **>&__cuGreenCtxDestroy, 12040, ptds_mode, NULL)
 
         global __cuCtxFromGreenCtx
-        _F_cuGetProcAddress_v2('cuCtxFromGreenCtx', <void **>&__cuCtxFromGreenCtx, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxFromGreenCtx', <void **>&__cuCtxFromGreenCtx, 12040, ptds_mode, NULL)
 
         global __cuDeviceGetDevResource
-        _F_cuGetProcAddress_v2('cuDeviceGetDevResource', <void **>&__cuDeviceGetDevResource, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceGetDevResource', <void **>&__cuDeviceGetDevResource, 12040, ptds_mode, NULL)
 
         global __cuCtxGetDevResource
-        _F_cuGetProcAddress_v2('cuCtxGetDevResource', <void **>&__cuCtxGetDevResource, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxGetDevResource', <void **>&__cuCtxGetDevResource, 12040, ptds_mode, NULL)
 
         global __cuGreenCtxGetDevResource
-        _F_cuGetProcAddress_v2('cuGreenCtxGetDevResource', <void **>&__cuGreenCtxGetDevResource, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGreenCtxGetDevResource', <void **>&__cuGreenCtxGetDevResource, 12040, ptds_mode, NULL)
 
         global __cuDevSmResourceSplitByCount
-        _F_cuGetProcAddress_v2('cuDevSmResourceSplitByCount', <void **>&__cuDevSmResourceSplitByCount, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDevSmResourceSplitByCount', <void **>&__cuDevSmResourceSplitByCount, 12040, ptds_mode, NULL)
 
         global __cuDevResourceGenerateDesc
-        _F_cuGetProcAddress_v2('cuDevResourceGenerateDesc', <void **>&__cuDevResourceGenerateDesc, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDevResourceGenerateDesc', <void **>&__cuDevResourceGenerateDesc, 12040, ptds_mode, NULL)
 
         global __cuGreenCtxRecordEvent
-        _F_cuGetProcAddress_v2('cuGreenCtxRecordEvent', <void **>&__cuGreenCtxRecordEvent, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGreenCtxRecordEvent', <void **>&__cuGreenCtxRecordEvent, 12040, ptds_mode, NULL)
 
         global __cuGreenCtxWaitEvent
-        _F_cuGetProcAddress_v2('cuGreenCtxWaitEvent', <void **>&__cuGreenCtxWaitEvent, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGreenCtxWaitEvent', <void **>&__cuGreenCtxWaitEvent, 12040, ptds_mode, NULL)
 
         global __cuStreamGetGreenCtx
-        _F_cuGetProcAddress_v2('cuStreamGetGreenCtx', <void **>&__cuStreamGetGreenCtx, 12040, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamGetGreenCtx', <void **>&__cuStreamGetGreenCtx, 12040, ptds_mode, NULL)
 
         global __cuGreenCtxStreamCreate
-        _F_cuGetProcAddress_v2('cuGreenCtxStreamCreate', <void **>&__cuGreenCtxStreamCreate, 12050, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGreenCtxStreamCreate', <void **>&__cuGreenCtxStreamCreate, 12050, ptds_mode, NULL)
 
         global __cuLogsRegisterCallback
-        _F_cuGetProcAddress_v2('cuLogsRegisterCallback', <void **>&__cuLogsRegisterCallback, 12080, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLogsRegisterCallback', <void **>&__cuLogsRegisterCallback, 12080, ptds_mode, NULL)
 
         global __cuLogsUnregisterCallback
-        _F_cuGetProcAddress_v2('cuLogsUnregisterCallback', <void **>&__cuLogsUnregisterCallback, 12080, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLogsUnregisterCallback', <void **>&__cuLogsUnregisterCallback, 12080, ptds_mode, NULL)
 
         global __cuLogsCurrent
-        _F_cuGetProcAddress_v2('cuLogsCurrent', <void **>&__cuLogsCurrent, 12080, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLogsCurrent', <void **>&__cuLogsCurrent, 12080, ptds_mode, NULL)
 
         global __cuLogsDumpToFile
-        _F_cuGetProcAddress_v2('cuLogsDumpToFile', <void **>&__cuLogsDumpToFile, 12080, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLogsDumpToFile', <void **>&__cuLogsDumpToFile, 12080, ptds_mode, NULL)
 
         global __cuLogsDumpToMemory
-        _F_cuGetProcAddress_v2('cuLogsDumpToMemory', <void **>&__cuLogsDumpToMemory, 12080, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLogsDumpToMemory', <void **>&__cuLogsDumpToMemory, 12080, ptds_mode, NULL)
 
         global __cuCheckpointProcessGetRestoreThreadId
-        _F_cuGetProcAddress_v2('cuCheckpointProcessGetRestoreThreadId', <void **>&__cuCheckpointProcessGetRestoreThreadId, 12080, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCheckpointProcessGetRestoreThreadId', <void **>&__cuCheckpointProcessGetRestoreThreadId, 12080, ptds_mode, NULL)
 
         global __cuCheckpointProcessGetState
-        _F_cuGetProcAddress_v2('cuCheckpointProcessGetState', <void **>&__cuCheckpointProcessGetState, 12080, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCheckpointProcessGetState', <void **>&__cuCheckpointProcessGetState, 12080, ptds_mode, NULL)
 
         global __cuCheckpointProcessLock
-        _F_cuGetProcAddress_v2('cuCheckpointProcessLock', <void **>&__cuCheckpointProcessLock, 12080, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCheckpointProcessLock', <void **>&__cuCheckpointProcessLock, 12080, ptds_mode, NULL)
 
         global __cuCheckpointProcessCheckpoint
-        _F_cuGetProcAddress_v2('cuCheckpointProcessCheckpoint', <void **>&__cuCheckpointProcessCheckpoint, 12080, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCheckpointProcessCheckpoint', <void **>&__cuCheckpointProcessCheckpoint, 12080, ptds_mode, NULL)
 
         global __cuCheckpointProcessRestore
-        _F_cuGetProcAddress_v2('cuCheckpointProcessRestore', <void **>&__cuCheckpointProcessRestore, 12080, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCheckpointProcessRestore', <void **>&__cuCheckpointProcessRestore, 12080, ptds_mode, NULL)
 
         global __cuCheckpointProcessUnlock
-        _F_cuGetProcAddress_v2('cuCheckpointProcessUnlock', <void **>&__cuCheckpointProcessUnlock, 12080, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCheckpointProcessUnlock', <void **>&__cuCheckpointProcessUnlock, 12080, ptds_mode, NULL)
 
         global __cuGraphicsEGLRegisterImage
-        _F_cuGetProcAddress_v2('cuGraphicsEGLRegisterImage', <void **>&__cuGraphicsEGLRegisterImage, 7000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphicsEGLRegisterImage', <void **>&__cuGraphicsEGLRegisterImage, 7000, ptds_mode, NULL)
 
         global __cuEGLStreamConsumerConnect
-        _F_cuGetProcAddress_v2('cuEGLStreamConsumerConnect', <void **>&__cuEGLStreamConsumerConnect, 7000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuEGLStreamConsumerConnect', <void **>&__cuEGLStreamConsumerConnect, 7000, ptds_mode, NULL)
 
         global __cuEGLStreamConsumerConnectWithFlags
-        _F_cuGetProcAddress_v2('cuEGLStreamConsumerConnectWithFlags', <void **>&__cuEGLStreamConsumerConnectWithFlags, 8000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuEGLStreamConsumerConnectWithFlags', <void **>&__cuEGLStreamConsumerConnectWithFlags, 8000, ptds_mode, NULL)
 
         global __cuEGLStreamConsumerDisconnect
-        _F_cuGetProcAddress_v2('cuEGLStreamConsumerDisconnect', <void **>&__cuEGLStreamConsumerDisconnect, 7000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuEGLStreamConsumerDisconnect', <void **>&__cuEGLStreamConsumerDisconnect, 7000, ptds_mode, NULL)
 
         global __cuEGLStreamConsumerAcquireFrame
-        _F_cuGetProcAddress_v2('cuEGLStreamConsumerAcquireFrame', <void **>&__cuEGLStreamConsumerAcquireFrame, 7000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuEGLStreamConsumerAcquireFrame', <void **>&__cuEGLStreamConsumerAcquireFrame, 7000, ptds_mode, NULL)
 
         global __cuEGLStreamConsumerReleaseFrame
-        _F_cuGetProcAddress_v2('cuEGLStreamConsumerReleaseFrame', <void **>&__cuEGLStreamConsumerReleaseFrame, 7000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuEGLStreamConsumerReleaseFrame', <void **>&__cuEGLStreamConsumerReleaseFrame, 7000, ptds_mode, NULL)
 
         global __cuEGLStreamProducerConnect
-        _F_cuGetProcAddress_v2('cuEGLStreamProducerConnect', <void **>&__cuEGLStreamProducerConnect, 7000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuEGLStreamProducerConnect', <void **>&__cuEGLStreamProducerConnect, 7000, ptds_mode, NULL)
 
         global __cuEGLStreamProducerDisconnect
-        _F_cuGetProcAddress_v2('cuEGLStreamProducerDisconnect', <void **>&__cuEGLStreamProducerDisconnect, 7000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuEGLStreamProducerDisconnect', <void **>&__cuEGLStreamProducerDisconnect, 7000, ptds_mode, NULL)
 
         global __cuEGLStreamProducerPresentFrame
-        _F_cuGetProcAddress_v2('cuEGLStreamProducerPresentFrame', <void **>&__cuEGLStreamProducerPresentFrame, 7000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuEGLStreamProducerPresentFrame', <void **>&__cuEGLStreamProducerPresentFrame, 7000, ptds_mode, NULL)
 
         global __cuEGLStreamProducerReturnFrame
-        _F_cuGetProcAddress_v2('cuEGLStreamProducerReturnFrame', <void **>&__cuEGLStreamProducerReturnFrame, 7000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuEGLStreamProducerReturnFrame', <void **>&__cuEGLStreamProducerReturnFrame, 7000, ptds_mode, NULL)
 
         global __cuGraphicsResourceGetMappedEglFrame
-        _F_cuGetProcAddress_v2('cuGraphicsResourceGetMappedEglFrame', <void **>&__cuGraphicsResourceGetMappedEglFrame, 7000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphicsResourceGetMappedEglFrame', <void **>&__cuGraphicsResourceGetMappedEglFrame, 7000, ptds_mode, NULL)
 
         global __cuEventCreateFromEGLSync
-        _F_cuGetProcAddress_v2('cuEventCreateFromEGLSync', <void **>&__cuEventCreateFromEGLSync, 9000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuEventCreateFromEGLSync', <void **>&__cuEventCreateFromEGLSync, 9000, ptds_mode, NULL)
 
         global __cuGraphicsGLRegisterBuffer
-        _F_cuGetProcAddress_v2('cuGraphicsGLRegisterBuffer', <void **>&__cuGraphicsGLRegisterBuffer, 3000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphicsGLRegisterBuffer', <void **>&__cuGraphicsGLRegisterBuffer, 3000, ptds_mode, NULL)
 
         global __cuGraphicsGLRegisterImage
-        _F_cuGetProcAddress_v2('cuGraphicsGLRegisterImage', <void **>&__cuGraphicsGLRegisterImage, 3000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphicsGLRegisterImage', <void **>&__cuGraphicsGLRegisterImage, 3000, ptds_mode, NULL)
 
         global __cuGLGetDevices_v2
-        _F_cuGetProcAddress_v2('cuGLGetDevices', <void **>&__cuGLGetDevices_v2, 6050, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGLGetDevices', <void **>&__cuGLGetDevices_v2, 6050, ptds_mode, NULL)
 
         global __cuGLCtxCreate_v2
-        _F_cuGetProcAddress_v2('cuGLCtxCreate', <void **>&__cuGLCtxCreate_v2, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGLCtxCreate', <void **>&__cuGLCtxCreate_v2, 3020, ptds_mode, NULL)
 
         global __cuGLInit
-        _F_cuGetProcAddress_v2('cuGLInit', <void **>&__cuGLInit, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGLInit', <void **>&__cuGLInit, 2000, ptds_mode, NULL)
 
         global __cuGLRegisterBufferObject
-        _F_cuGetProcAddress_v2('cuGLRegisterBufferObject', <void **>&__cuGLRegisterBufferObject, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGLRegisterBufferObject', <void **>&__cuGLRegisterBufferObject, 2000, ptds_mode, NULL)
 
         global __cuGLMapBufferObject_v2
-        _F_cuGetProcAddress_v2('cuGLMapBufferObject', <void **>&__cuGLMapBufferObject_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGLMapBufferObject', <void **>&__cuGLMapBufferObject_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuGLUnmapBufferObject
-        _F_cuGetProcAddress_v2('cuGLUnmapBufferObject', <void **>&__cuGLUnmapBufferObject, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGLUnmapBufferObject', <void **>&__cuGLUnmapBufferObject, 2000, ptds_mode, NULL)
 
         global __cuGLUnregisterBufferObject
-        _F_cuGetProcAddress_v2('cuGLUnregisterBufferObject', <void **>&__cuGLUnregisterBufferObject, 2000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGLUnregisterBufferObject', <void **>&__cuGLUnregisterBufferObject, 2000, ptds_mode, NULL)
 
         global __cuGLSetBufferObjectMapFlags
-        _F_cuGetProcAddress_v2('cuGLSetBufferObjectMapFlags', <void **>&__cuGLSetBufferObjectMapFlags, 2030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGLSetBufferObjectMapFlags', <void **>&__cuGLSetBufferObjectMapFlags, 2030, ptds_mode, NULL)
 
         global __cuGLMapBufferObjectAsync_v2
-        _F_cuGetProcAddress_v2('cuGLMapBufferObjectAsync', <void **>&__cuGLMapBufferObjectAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGLMapBufferObjectAsync', <void **>&__cuGLMapBufferObjectAsync_v2, 7000 if ptds_mode == CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM else 3020, ptds_mode, NULL)
 
         global __cuGLUnmapBufferObjectAsync
-        _F_cuGetProcAddress_v2('cuGLUnmapBufferObjectAsync', <void **>&__cuGLUnmapBufferObjectAsync, 2030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGLUnmapBufferObjectAsync', <void **>&__cuGLUnmapBufferObjectAsync, 2030, ptds_mode, NULL)
 
         global __cuProfilerInitialize
-        _F_cuGetProcAddress_v2('cuProfilerInitialize', <void **>&__cuProfilerInitialize, 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuProfilerInitialize', <void **>&__cuProfilerInitialize, 4000, ptds_mode, NULL)
 
         global __cuProfilerStart
-        _F_cuGetProcAddress_v2('cuProfilerStart', <void **>&__cuProfilerStart, 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuProfilerStart', <void **>&__cuProfilerStart, 4000, ptds_mode, NULL)
 
         global __cuProfilerStop
-        _F_cuGetProcAddress_v2('cuProfilerStop', <void **>&__cuProfilerStop, 4000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuProfilerStop', <void **>&__cuProfilerStop, 4000, ptds_mode, NULL)
 
         global __cuVDPAUGetDevice
-        _F_cuGetProcAddress_v2('cuVDPAUGetDevice', <void **>&__cuVDPAUGetDevice, 3010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuVDPAUGetDevice', <void **>&__cuVDPAUGetDevice, 3010, ptds_mode, NULL)
 
         global __cuVDPAUCtxCreate_v2
-        _F_cuGetProcAddress_v2('cuVDPAUCtxCreate', <void **>&__cuVDPAUCtxCreate_v2, 3020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuVDPAUCtxCreate', <void **>&__cuVDPAUCtxCreate_v2, 3020, ptds_mode, NULL)
 
         global __cuGraphicsVDPAURegisterVideoSurface
-        _F_cuGetProcAddress_v2('cuGraphicsVDPAURegisterVideoSurface', <void **>&__cuGraphicsVDPAURegisterVideoSurface, 3010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphicsVDPAURegisterVideoSurface', <void **>&__cuGraphicsVDPAURegisterVideoSurface, 3010, ptds_mode, NULL)
 
         global __cuGraphicsVDPAURegisterOutputSurface
-        _F_cuGetProcAddress_v2('cuGraphicsVDPAURegisterOutputSurface', <void **>&__cuGraphicsVDPAURegisterOutputSurface, 3010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphicsVDPAURegisterOutputSurface', <void **>&__cuGraphicsVDPAURegisterOutputSurface, 3010, ptds_mode, NULL)
 
         global __cuDeviceGetHostAtomicCapabilities
-        _F_cuGetProcAddress_v2('cuDeviceGetHostAtomicCapabilities', <void **>&__cuDeviceGetHostAtomicCapabilities, 13000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceGetHostAtomicCapabilities', <void **>&__cuDeviceGetHostAtomicCapabilities, 13000, ptds_mode, NULL)
 
         global __cuCtxGetDevice_v2
-        _F_cuGetProcAddress_v2('cuCtxGetDevice', <void **>&__cuCtxGetDevice_v2, 13000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxGetDevice', <void **>&__cuCtxGetDevice_v2, 13000, ptds_mode, NULL)
 
         global __cuCtxSynchronize_v2
-        _F_cuGetProcAddress_v2('cuCtxSynchronize', <void **>&__cuCtxSynchronize_v2, 13000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCtxSynchronize', <void **>&__cuCtxSynchronize_v2, 13000, ptds_mode, NULL)
 
         global __cuMemcpyBatchAsync_v2
-        _F_cuGetProcAddress_v2('cuMemcpyBatchAsync', <void **>&__cuMemcpyBatchAsync_v2, 13000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpyBatchAsync', <void **>&__cuMemcpyBatchAsync_v2, 13000, ptds_mode, NULL)
 
         global __cuMemcpy3DBatchAsync_v2
-        _F_cuGetProcAddress_v2('cuMemcpy3DBatchAsync', <void **>&__cuMemcpy3DBatchAsync_v2, 13000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpy3DBatchAsync', <void **>&__cuMemcpy3DBatchAsync_v2, 13000, ptds_mode, NULL)
 
         global __cuMemGetDefaultMemPool
-        _F_cuGetProcAddress_v2('cuMemGetDefaultMemPool', <void **>&__cuMemGetDefaultMemPool, 13000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemGetDefaultMemPool', <void **>&__cuMemGetDefaultMemPool, 13000, ptds_mode, NULL)
 
         global __cuMemGetMemPool
-        _F_cuGetProcAddress_v2('cuMemGetMemPool', <void **>&__cuMemGetMemPool, 13000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemGetMemPool', <void **>&__cuMemGetMemPool, 13000, ptds_mode, NULL)
 
         global __cuMemSetMemPool
-        _F_cuGetProcAddress_v2('cuMemSetMemPool', <void **>&__cuMemSetMemPool, 13000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemSetMemPool', <void **>&__cuMemSetMemPool, 13000, ptds_mode, NULL)
 
         global __cuMemPrefetchBatchAsync
-        _F_cuGetProcAddress_v2('cuMemPrefetchBatchAsync', <void **>&__cuMemPrefetchBatchAsync, 13000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemPrefetchBatchAsync', <void **>&__cuMemPrefetchBatchAsync, 13000, ptds_mode, NULL)
 
         global __cuMemDiscardBatchAsync
-        _F_cuGetProcAddress_v2('cuMemDiscardBatchAsync', <void **>&__cuMemDiscardBatchAsync, 13000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemDiscardBatchAsync', <void **>&__cuMemDiscardBatchAsync, 13000, ptds_mode, NULL)
 
         global __cuMemDiscardAndPrefetchBatchAsync
-        _F_cuGetProcAddress_v2('cuMemDiscardAndPrefetchBatchAsync', <void **>&__cuMemDiscardAndPrefetchBatchAsync, 13000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemDiscardAndPrefetchBatchAsync', <void **>&__cuMemDiscardAndPrefetchBatchAsync, 13000, ptds_mode, NULL)
 
         global __cuDeviceGetP2PAtomicCapabilities
-        _F_cuGetProcAddress_v2('cuDeviceGetP2PAtomicCapabilities', <void **>&__cuDeviceGetP2PAtomicCapabilities, 13000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDeviceGetP2PAtomicCapabilities', <void **>&__cuDeviceGetP2PAtomicCapabilities, 13000, ptds_mode, NULL)
 
         global __cuGreenCtxGetId
-        _F_cuGetProcAddress_v2('cuGreenCtxGetId', <void **>&__cuGreenCtxGetId, 13000, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGreenCtxGetId', <void **>&__cuGreenCtxGetId, 13000, ptds_mode, NULL)
 
         global __cuMulticastBindMem_v2
-        _F_cuGetProcAddress_v2('cuMulticastBindMem', <void **>&__cuMulticastBindMem_v2, 13010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMulticastBindMem', <void **>&__cuMulticastBindMem_v2, 13010, ptds_mode, NULL)
 
         global __cuMulticastBindAddr_v2
-        _F_cuGetProcAddress_v2('cuMulticastBindAddr', <void **>&__cuMulticastBindAddr_v2, 13010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMulticastBindAddr', <void **>&__cuMulticastBindAddr_v2, 13010, ptds_mode, NULL)
 
         global __cuGraphNodeGetContainingGraph
-        _F_cuGetProcAddress_v2('cuGraphNodeGetContainingGraph', <void **>&__cuGraphNodeGetContainingGraph, 13010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphNodeGetContainingGraph', <void **>&__cuGraphNodeGetContainingGraph, 13010, ptds_mode, NULL)
 
         global __cuGraphNodeGetLocalId
-        _F_cuGetProcAddress_v2('cuGraphNodeGetLocalId', <void **>&__cuGraphNodeGetLocalId, 13010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphNodeGetLocalId', <void **>&__cuGraphNodeGetLocalId, 13010, ptds_mode, NULL)
 
         global __cuGraphNodeGetToolsId
-        _F_cuGetProcAddress_v2('cuGraphNodeGetToolsId', <void **>&__cuGraphNodeGetToolsId, 13010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphNodeGetToolsId', <void **>&__cuGraphNodeGetToolsId, 13010, ptds_mode, NULL)
 
         global __cuGraphGetId
-        _F_cuGetProcAddress_v2('cuGraphGetId', <void **>&__cuGraphGetId, 13010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphGetId', <void **>&__cuGraphGetId, 13010, ptds_mode, NULL)
 
         global __cuGraphExecGetId
-        _F_cuGetProcAddress_v2('cuGraphExecGetId', <void **>&__cuGraphExecGetId, 13010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphExecGetId', <void **>&__cuGraphExecGetId, 13010, ptds_mode, NULL)
 
         global __cuDevSmResourceSplit
-        _F_cuGetProcAddress_v2('cuDevSmResourceSplit', <void **>&__cuDevSmResourceSplit, 13010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuDevSmResourceSplit', <void **>&__cuDevSmResourceSplit, 13010, ptds_mode, NULL)
 
         global __cuStreamGetDevResource
-        _F_cuGetProcAddress_v2('cuStreamGetDevResource', <void **>&__cuStreamGetDevResource, 13010, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamGetDevResource', <void **>&__cuStreamGetDevResource, 13010, ptds_mode, NULL)
 
         global __cuKernelGetParamCount
-        _F_cuGetProcAddress_v2('cuKernelGetParamCount', <void **>&__cuKernelGetParamCount, 13020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuKernelGetParamCount', <void **>&__cuKernelGetParamCount, 13020, ptds_mode, NULL)
 
         global __cuMemcpyWithAttributesAsync
-        _F_cuGetProcAddress_v2('cuMemcpyWithAttributesAsync', <void **>&__cuMemcpyWithAttributesAsync, 13020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpyWithAttributesAsync', <void **>&__cuMemcpyWithAttributesAsync, 13020, ptds_mode, NULL)
 
         global __cuMemcpy3DWithAttributesAsync
-        _F_cuGetProcAddress_v2('cuMemcpy3DWithAttributesAsync', <void **>&__cuMemcpy3DWithAttributesAsync, 13020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuMemcpy3DWithAttributesAsync', <void **>&__cuMemcpy3DWithAttributesAsync, 13020, ptds_mode, NULL)
 
         global __cuStreamBeginCaptureToCig
-        _F_cuGetProcAddress_v2('cuStreamBeginCaptureToCig', <void **>&__cuStreamBeginCaptureToCig, 13020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamBeginCaptureToCig', <void **>&__cuStreamBeginCaptureToCig, 13020, ptds_mode, NULL)
 
         global __cuStreamEndCaptureToCig
-        _F_cuGetProcAddress_v2('cuStreamEndCaptureToCig', <void **>&__cuStreamEndCaptureToCig, 13020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamEndCaptureToCig', <void **>&__cuStreamEndCaptureToCig, 13020, ptds_mode, NULL)
 
         global __cuFuncGetParamCount
-        _F_cuGetProcAddress_v2('cuFuncGetParamCount', <void **>&__cuFuncGetParamCount, 13020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuFuncGetParamCount', <void **>&__cuFuncGetParamCount, 13020, ptds_mode, NULL)
 
         global __cuLaunchHostFunc_v2
-        _F_cuGetProcAddress_v2('cuLaunchHostFunc', <void **>&__cuLaunchHostFunc_v2, 13020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLaunchHostFunc', <void **>&__cuLaunchHostFunc_v2, 13020, ptds_mode, NULL)
 
         global __cuGraphNodeGetParams
-        _F_cuGetProcAddress_v2('cuGraphNodeGetParams', <void **>&__cuGraphNodeGetParams, 13020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuGraphNodeGetParams', <void **>&__cuGraphNodeGetParams, 13020, ptds_mode, NULL)
 
         global __cuCoredumpRegisterStartCallback
-        _F_cuGetProcAddress_v2('cuCoredumpRegisterStartCallback', <void **>&__cuCoredumpRegisterStartCallback, 13020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCoredumpRegisterStartCallback', <void **>&__cuCoredumpRegisterStartCallback, 13020, ptds_mode, NULL)
 
         global __cuCoredumpRegisterCompleteCallback
-        _F_cuGetProcAddress_v2('cuCoredumpRegisterCompleteCallback', <void **>&__cuCoredumpRegisterCompleteCallback, 13020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCoredumpRegisterCompleteCallback', <void **>&__cuCoredumpRegisterCompleteCallback, 13020, ptds_mode, NULL)
 
         global __cuCoredumpDeregisterStartCallback
-        _F_cuGetProcAddress_v2('cuCoredumpDeregisterStartCallback', <void **>&__cuCoredumpDeregisterStartCallback, 13020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCoredumpDeregisterStartCallback', <void **>&__cuCoredumpDeregisterStartCallback, 13020, ptds_mode, NULL)
 
         global __cuCoredumpDeregisterCompleteCallback
-        _F_cuGetProcAddress_v2('cuCoredumpDeregisterCompleteCallback', <void **>&__cuCoredumpDeregisterCompleteCallback, 13020, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuCoredumpDeregisterCompleteCallback', <void **>&__cuCoredumpDeregisterCompleteCallback, 13020, ptds_mode, NULL)
 
         global __cuLogicalEndpointIdReserve
-        _F_cuGetProcAddress_v2('cuLogicalEndpointIdReserve', <void **>&__cuLogicalEndpointIdReserve, 13030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLogicalEndpointIdReserve', <void **>&__cuLogicalEndpointIdReserve, 13030, ptds_mode, NULL)
 
         global __cuLogicalEndpointIdRelease
-        _F_cuGetProcAddress_v2('cuLogicalEndpointIdRelease', <void **>&__cuLogicalEndpointIdRelease, 13030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLogicalEndpointIdRelease', <void **>&__cuLogicalEndpointIdRelease, 13030, ptds_mode, NULL)
 
         global __cuLogicalEndpointCreate
-        _F_cuGetProcAddress_v2('cuLogicalEndpointCreate', <void **>&__cuLogicalEndpointCreate, 13030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLogicalEndpointCreate', <void **>&__cuLogicalEndpointCreate, 13030, ptds_mode, NULL)
 
         global __cuLogicalEndpointAddDevice
-        _F_cuGetProcAddress_v2('cuLogicalEndpointAddDevice', <void **>&__cuLogicalEndpointAddDevice, 13030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLogicalEndpointAddDevice', <void **>&__cuLogicalEndpointAddDevice, 13030, ptds_mode, NULL)
 
         global __cuLogicalEndpointDestroy
-        _F_cuGetProcAddress_v2('cuLogicalEndpointDestroy', <void **>&__cuLogicalEndpointDestroy, 13030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLogicalEndpointDestroy', <void **>&__cuLogicalEndpointDestroy, 13030, ptds_mode, NULL)
 
         global __cuLogicalEndpointBindAddr
-        _F_cuGetProcAddress_v2('cuLogicalEndpointBindAddr', <void **>&__cuLogicalEndpointBindAddr, 13030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLogicalEndpointBindAddr', <void **>&__cuLogicalEndpointBindAddr, 13030, ptds_mode, NULL)
 
         global __cuLogicalEndpointBindMem
-        _F_cuGetProcAddress_v2('cuLogicalEndpointBindMem', <void **>&__cuLogicalEndpointBindMem, 13030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLogicalEndpointBindMem', <void **>&__cuLogicalEndpointBindMem, 13030, ptds_mode, NULL)
 
         global __cuLogicalEndpointUnbind
-        _F_cuGetProcAddress_v2('cuLogicalEndpointUnbind', <void **>&__cuLogicalEndpointUnbind, 13030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLogicalEndpointUnbind', <void **>&__cuLogicalEndpointUnbind, 13030, ptds_mode, NULL)
 
         global __cuLogicalEndpointExport
-        _F_cuGetProcAddress_v2('cuLogicalEndpointExport', <void **>&__cuLogicalEndpointExport, 13030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLogicalEndpointExport', <void **>&__cuLogicalEndpointExport, 13030, ptds_mode, NULL)
 
         global __cuLogicalEndpointImport
-        _F_cuGetProcAddress_v2('cuLogicalEndpointImport', <void **>&__cuLogicalEndpointImport, 13030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLogicalEndpointImport', <void **>&__cuLogicalEndpointImport, 13030, ptds_mode, NULL)
 
         global __cuLogicalEndpointGetLimits
-        _F_cuGetProcAddress_v2('cuLogicalEndpointGetLimits', <void **>&__cuLogicalEndpointGetLimits, 13030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLogicalEndpointGetLimits', <void **>&__cuLogicalEndpointGetLimits, 13030, ptds_mode, NULL)
 
         global __cuLogicalEndpointQuery
-        _F_cuGetProcAddress_v2('cuLogicalEndpointQuery', <void **>&__cuLogicalEndpointQuery, 13030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuLogicalEndpointQuery', <void **>&__cuLogicalEndpointQuery, 13030, ptds_mode, NULL)
 
         global __cuStreamBeginRecaptureToGraph
-        _F_cuGetProcAddress_v2('cuStreamBeginRecaptureToGraph', <void **>&__cuStreamBeginRecaptureToGraph, 13030, ptds_mode, NULL)
+        cuGetProcAddress_v2('cuStreamBeginRecaptureToGraph', <void **>&__cuStreamBeginRecaptureToGraph, 13030, ptds_mode, NULL)
 
-        __py_driver_init = True
+        _cyb___py_driver_init = True
         return 0
 
-
 cdef inline int _check_or_init_driver() except -1 nogil:
-    if __py_driver_init:
+    if _cyb___py_driver_init:
         return 0
 
     return _init_driver()
 
-cdef dict func_ptrs = None
-
 
 cpdef dict _inspect_function_pointers():
-    global func_ptrs
-    if func_ptrs is not None:
-        return func_ptrs
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is not None:
+        return _cyb_func_ptrs
 
     _check_or_init_driver()
     cdef dict data = {}
-
     global __cuGetErrorString
-    data["__cuGetErrorString"] = <intptr_t>__cuGetErrorString
+    data["__cuGetErrorString"] = <_cyb_intptr_t>__cuGetErrorString
 
     global __cuGetErrorName
-    data["__cuGetErrorName"] = <intptr_t>__cuGetErrorName
+    data["__cuGetErrorName"] = <_cyb_intptr_t>__cuGetErrorName
 
     global __cuInit
-    data["__cuInit"] = <intptr_t>__cuInit
+    data["__cuInit"] = <_cyb_intptr_t>__cuInit
 
     global __cuDriverGetVersion
-    data["__cuDriverGetVersion"] = <intptr_t>__cuDriverGetVersion
+    data["__cuDriverGetVersion"] = <_cyb_intptr_t>__cuDriverGetVersion
 
     global __cuDeviceGet
-    data["__cuDeviceGet"] = <intptr_t>__cuDeviceGet
+    data["__cuDeviceGet"] = <_cyb_intptr_t>__cuDeviceGet
 
     global __cuDeviceGetCount
-    data["__cuDeviceGetCount"] = <intptr_t>__cuDeviceGetCount
+    data["__cuDeviceGetCount"] = <_cyb_intptr_t>__cuDeviceGetCount
 
     global __cuDeviceGetName
-    data["__cuDeviceGetName"] = <intptr_t>__cuDeviceGetName
+    data["__cuDeviceGetName"] = <_cyb_intptr_t>__cuDeviceGetName
 
     global __cuDeviceGetUuid_v2
-    data["__cuDeviceGetUuid_v2"] = <intptr_t>__cuDeviceGetUuid_v2
+    data["__cuDeviceGetUuid_v2"] = <_cyb_intptr_t>__cuDeviceGetUuid_v2
 
     global __cuDeviceGetLuid
-    data["__cuDeviceGetLuid"] = <intptr_t>__cuDeviceGetLuid
+    data["__cuDeviceGetLuid"] = <_cyb_intptr_t>__cuDeviceGetLuid
 
     global __cuDeviceTotalMem_v2
-    data["__cuDeviceTotalMem_v2"] = <intptr_t>__cuDeviceTotalMem_v2
+    data["__cuDeviceTotalMem_v2"] = <_cyb_intptr_t>__cuDeviceTotalMem_v2
 
     global __cuDeviceGetTexture1DLinearMaxWidth
-    data["__cuDeviceGetTexture1DLinearMaxWidth"] = <intptr_t>__cuDeviceGetTexture1DLinearMaxWidth
+    data["__cuDeviceGetTexture1DLinearMaxWidth"] = <_cyb_intptr_t>__cuDeviceGetTexture1DLinearMaxWidth
 
     global __cuDeviceGetAttribute
-    data["__cuDeviceGetAttribute"] = <intptr_t>__cuDeviceGetAttribute
+    data["__cuDeviceGetAttribute"] = <_cyb_intptr_t>__cuDeviceGetAttribute
 
     global __cuDeviceGetNvSciSyncAttributes
-    data["__cuDeviceGetNvSciSyncAttributes"] = <intptr_t>__cuDeviceGetNvSciSyncAttributes
+    data["__cuDeviceGetNvSciSyncAttributes"] = <_cyb_intptr_t>__cuDeviceGetNvSciSyncAttributes
 
     global __cuDeviceSetMemPool
-    data["__cuDeviceSetMemPool"] = <intptr_t>__cuDeviceSetMemPool
+    data["__cuDeviceSetMemPool"] = <_cyb_intptr_t>__cuDeviceSetMemPool
 
     global __cuDeviceGetMemPool
-    data["__cuDeviceGetMemPool"] = <intptr_t>__cuDeviceGetMemPool
+    data["__cuDeviceGetMemPool"] = <_cyb_intptr_t>__cuDeviceGetMemPool
 
     global __cuDeviceGetDefaultMemPool
-    data["__cuDeviceGetDefaultMemPool"] = <intptr_t>__cuDeviceGetDefaultMemPool
+    data["__cuDeviceGetDefaultMemPool"] = <_cyb_intptr_t>__cuDeviceGetDefaultMemPool
 
     global __cuDeviceGetExecAffinitySupport
-    data["__cuDeviceGetExecAffinitySupport"] = <intptr_t>__cuDeviceGetExecAffinitySupport
+    data["__cuDeviceGetExecAffinitySupport"] = <_cyb_intptr_t>__cuDeviceGetExecAffinitySupport
 
     global __cuFlushGPUDirectRDMAWrites
-    data["__cuFlushGPUDirectRDMAWrites"] = <intptr_t>__cuFlushGPUDirectRDMAWrites
+    data["__cuFlushGPUDirectRDMAWrites"] = <_cyb_intptr_t>__cuFlushGPUDirectRDMAWrites
 
     global __cuDeviceGetProperties
-    data["__cuDeviceGetProperties"] = <intptr_t>__cuDeviceGetProperties
+    data["__cuDeviceGetProperties"] = <_cyb_intptr_t>__cuDeviceGetProperties
 
     global __cuDeviceComputeCapability
-    data["__cuDeviceComputeCapability"] = <intptr_t>__cuDeviceComputeCapability
+    data["__cuDeviceComputeCapability"] = <_cyb_intptr_t>__cuDeviceComputeCapability
 
     global __cuDevicePrimaryCtxRetain
-    data["__cuDevicePrimaryCtxRetain"] = <intptr_t>__cuDevicePrimaryCtxRetain
+    data["__cuDevicePrimaryCtxRetain"] = <_cyb_intptr_t>__cuDevicePrimaryCtxRetain
 
     global __cuDevicePrimaryCtxRelease_v2
-    data["__cuDevicePrimaryCtxRelease_v2"] = <intptr_t>__cuDevicePrimaryCtxRelease_v2
+    data["__cuDevicePrimaryCtxRelease_v2"] = <_cyb_intptr_t>__cuDevicePrimaryCtxRelease_v2
 
     global __cuDevicePrimaryCtxSetFlags_v2
-    data["__cuDevicePrimaryCtxSetFlags_v2"] = <intptr_t>__cuDevicePrimaryCtxSetFlags_v2
+    data["__cuDevicePrimaryCtxSetFlags_v2"] = <_cyb_intptr_t>__cuDevicePrimaryCtxSetFlags_v2
 
     global __cuDevicePrimaryCtxGetState
-    data["__cuDevicePrimaryCtxGetState"] = <intptr_t>__cuDevicePrimaryCtxGetState
+    data["__cuDevicePrimaryCtxGetState"] = <_cyb_intptr_t>__cuDevicePrimaryCtxGetState
 
     global __cuDevicePrimaryCtxReset_v2
-    data["__cuDevicePrimaryCtxReset_v2"] = <intptr_t>__cuDevicePrimaryCtxReset_v2
+    data["__cuDevicePrimaryCtxReset_v2"] = <_cyb_intptr_t>__cuDevicePrimaryCtxReset_v2
 
     global __cuCtxCreate_v2
-    data["__cuCtxCreate_v2"] = <intptr_t>__cuCtxCreate_v2
+    data["__cuCtxCreate_v2"] = <_cyb_intptr_t>__cuCtxCreate_v2
 
     global __cuCtxCreate_v3
-    data["__cuCtxCreate_v3"] = <intptr_t>__cuCtxCreate_v3
+    data["__cuCtxCreate_v3"] = <_cyb_intptr_t>__cuCtxCreate_v3
 
     global __cuCtxCreate_v4
-    data["__cuCtxCreate_v4"] = <intptr_t>__cuCtxCreate_v4
+    data["__cuCtxCreate_v4"] = <_cyb_intptr_t>__cuCtxCreate_v4
 
     global __cuCtxDestroy_v2
-    data["__cuCtxDestroy_v2"] = <intptr_t>__cuCtxDestroy_v2
+    data["__cuCtxDestroy_v2"] = <_cyb_intptr_t>__cuCtxDestroy_v2
 
     global __cuCtxPushCurrent_v2
-    data["__cuCtxPushCurrent_v2"] = <intptr_t>__cuCtxPushCurrent_v2
+    data["__cuCtxPushCurrent_v2"] = <_cyb_intptr_t>__cuCtxPushCurrent_v2
 
     global __cuCtxPopCurrent_v2
-    data["__cuCtxPopCurrent_v2"] = <intptr_t>__cuCtxPopCurrent_v2
+    data["__cuCtxPopCurrent_v2"] = <_cyb_intptr_t>__cuCtxPopCurrent_v2
 
     global __cuCtxSetCurrent
-    data["__cuCtxSetCurrent"] = <intptr_t>__cuCtxSetCurrent
+    data["__cuCtxSetCurrent"] = <_cyb_intptr_t>__cuCtxSetCurrent
 
     global __cuCtxGetCurrent
-    data["__cuCtxGetCurrent"] = <intptr_t>__cuCtxGetCurrent
+    data["__cuCtxGetCurrent"] = <_cyb_intptr_t>__cuCtxGetCurrent
 
     global __cuCtxGetDevice
-    data["__cuCtxGetDevice"] = <intptr_t>__cuCtxGetDevice
+    data["__cuCtxGetDevice"] = <_cyb_intptr_t>__cuCtxGetDevice
 
     global __cuCtxGetFlags
-    data["__cuCtxGetFlags"] = <intptr_t>__cuCtxGetFlags
+    data["__cuCtxGetFlags"] = <_cyb_intptr_t>__cuCtxGetFlags
 
     global __cuCtxSetFlags
-    data["__cuCtxSetFlags"] = <intptr_t>__cuCtxSetFlags
+    data["__cuCtxSetFlags"] = <_cyb_intptr_t>__cuCtxSetFlags
 
     global __cuCtxGetId
-    data["__cuCtxGetId"] = <intptr_t>__cuCtxGetId
+    data["__cuCtxGetId"] = <_cyb_intptr_t>__cuCtxGetId
 
     global __cuCtxSynchronize
-    data["__cuCtxSynchronize"] = <intptr_t>__cuCtxSynchronize
+    data["__cuCtxSynchronize"] = <_cyb_intptr_t>__cuCtxSynchronize
 
     global __cuCtxSetLimit
-    data["__cuCtxSetLimit"] = <intptr_t>__cuCtxSetLimit
+    data["__cuCtxSetLimit"] = <_cyb_intptr_t>__cuCtxSetLimit
 
     global __cuCtxGetLimit
-    data["__cuCtxGetLimit"] = <intptr_t>__cuCtxGetLimit
+    data["__cuCtxGetLimit"] = <_cyb_intptr_t>__cuCtxGetLimit
 
     global __cuCtxGetCacheConfig
-    data["__cuCtxGetCacheConfig"] = <intptr_t>__cuCtxGetCacheConfig
+    data["__cuCtxGetCacheConfig"] = <_cyb_intptr_t>__cuCtxGetCacheConfig
 
     global __cuCtxSetCacheConfig
-    data["__cuCtxSetCacheConfig"] = <intptr_t>__cuCtxSetCacheConfig
+    data["__cuCtxSetCacheConfig"] = <_cyb_intptr_t>__cuCtxSetCacheConfig
 
     global __cuCtxGetApiVersion
-    data["__cuCtxGetApiVersion"] = <intptr_t>__cuCtxGetApiVersion
+    data["__cuCtxGetApiVersion"] = <_cyb_intptr_t>__cuCtxGetApiVersion
 
     global __cuCtxGetStreamPriorityRange
-    data["__cuCtxGetStreamPriorityRange"] = <intptr_t>__cuCtxGetStreamPriorityRange
+    data["__cuCtxGetStreamPriorityRange"] = <_cyb_intptr_t>__cuCtxGetStreamPriorityRange
 
     global __cuCtxResetPersistingL2Cache
-    data["__cuCtxResetPersistingL2Cache"] = <intptr_t>__cuCtxResetPersistingL2Cache
+    data["__cuCtxResetPersistingL2Cache"] = <_cyb_intptr_t>__cuCtxResetPersistingL2Cache
 
     global __cuCtxGetExecAffinity
-    data["__cuCtxGetExecAffinity"] = <intptr_t>__cuCtxGetExecAffinity
+    data["__cuCtxGetExecAffinity"] = <_cyb_intptr_t>__cuCtxGetExecAffinity
 
     global __cuCtxRecordEvent
-    data["__cuCtxRecordEvent"] = <intptr_t>__cuCtxRecordEvent
+    data["__cuCtxRecordEvent"] = <_cyb_intptr_t>__cuCtxRecordEvent
 
     global __cuCtxWaitEvent
-    data["__cuCtxWaitEvent"] = <intptr_t>__cuCtxWaitEvent
+    data["__cuCtxWaitEvent"] = <_cyb_intptr_t>__cuCtxWaitEvent
 
     global __cuCtxAttach
-    data["__cuCtxAttach"] = <intptr_t>__cuCtxAttach
+    data["__cuCtxAttach"] = <_cyb_intptr_t>__cuCtxAttach
 
     global __cuCtxDetach
-    data["__cuCtxDetach"] = <intptr_t>__cuCtxDetach
+    data["__cuCtxDetach"] = <_cyb_intptr_t>__cuCtxDetach
 
     global __cuCtxGetSharedMemConfig
-    data["__cuCtxGetSharedMemConfig"] = <intptr_t>__cuCtxGetSharedMemConfig
+    data["__cuCtxGetSharedMemConfig"] = <_cyb_intptr_t>__cuCtxGetSharedMemConfig
 
     global __cuCtxSetSharedMemConfig
-    data["__cuCtxSetSharedMemConfig"] = <intptr_t>__cuCtxSetSharedMemConfig
+    data["__cuCtxSetSharedMemConfig"] = <_cyb_intptr_t>__cuCtxSetSharedMemConfig
 
     global __cuModuleLoad
-    data["__cuModuleLoad"] = <intptr_t>__cuModuleLoad
+    data["__cuModuleLoad"] = <_cyb_intptr_t>__cuModuleLoad
 
     global __cuModuleLoadData
-    data["__cuModuleLoadData"] = <intptr_t>__cuModuleLoadData
+    data["__cuModuleLoadData"] = <_cyb_intptr_t>__cuModuleLoadData
 
     global __cuModuleLoadDataEx
-    data["__cuModuleLoadDataEx"] = <intptr_t>__cuModuleLoadDataEx
+    data["__cuModuleLoadDataEx"] = <_cyb_intptr_t>__cuModuleLoadDataEx
 
     global __cuModuleLoadFatBinary
-    data["__cuModuleLoadFatBinary"] = <intptr_t>__cuModuleLoadFatBinary
+    data["__cuModuleLoadFatBinary"] = <_cyb_intptr_t>__cuModuleLoadFatBinary
 
     global __cuModuleUnload
-    data["__cuModuleUnload"] = <intptr_t>__cuModuleUnload
+    data["__cuModuleUnload"] = <_cyb_intptr_t>__cuModuleUnload
 
     global __cuModuleGetLoadingMode
-    data["__cuModuleGetLoadingMode"] = <intptr_t>__cuModuleGetLoadingMode
+    data["__cuModuleGetLoadingMode"] = <_cyb_intptr_t>__cuModuleGetLoadingMode
 
     global __cuModuleGetFunction
-    data["__cuModuleGetFunction"] = <intptr_t>__cuModuleGetFunction
+    data["__cuModuleGetFunction"] = <_cyb_intptr_t>__cuModuleGetFunction
 
     global __cuModuleGetFunctionCount
-    data["__cuModuleGetFunctionCount"] = <intptr_t>__cuModuleGetFunctionCount
+    data["__cuModuleGetFunctionCount"] = <_cyb_intptr_t>__cuModuleGetFunctionCount
 
     global __cuModuleEnumerateFunctions
-    data["__cuModuleEnumerateFunctions"] = <intptr_t>__cuModuleEnumerateFunctions
+    data["__cuModuleEnumerateFunctions"] = <_cyb_intptr_t>__cuModuleEnumerateFunctions
 
     global __cuModuleGetGlobal_v2
-    data["__cuModuleGetGlobal_v2"] = <intptr_t>__cuModuleGetGlobal_v2
+    data["__cuModuleGetGlobal_v2"] = <_cyb_intptr_t>__cuModuleGetGlobal_v2
 
     global __cuLinkCreate_v2
-    data["__cuLinkCreate_v2"] = <intptr_t>__cuLinkCreate_v2
+    data["__cuLinkCreate_v2"] = <_cyb_intptr_t>__cuLinkCreate_v2
 
     global __cuLinkAddData_v2
-    data["__cuLinkAddData_v2"] = <intptr_t>__cuLinkAddData_v2
+    data["__cuLinkAddData_v2"] = <_cyb_intptr_t>__cuLinkAddData_v2
 
     global __cuLinkAddFile_v2
-    data["__cuLinkAddFile_v2"] = <intptr_t>__cuLinkAddFile_v2
+    data["__cuLinkAddFile_v2"] = <_cyb_intptr_t>__cuLinkAddFile_v2
 
     global __cuLinkComplete
-    data["__cuLinkComplete"] = <intptr_t>__cuLinkComplete
+    data["__cuLinkComplete"] = <_cyb_intptr_t>__cuLinkComplete
 
     global __cuLinkDestroy
-    data["__cuLinkDestroy"] = <intptr_t>__cuLinkDestroy
+    data["__cuLinkDestroy"] = <_cyb_intptr_t>__cuLinkDestroy
 
     global __cuModuleGetTexRef
-    data["__cuModuleGetTexRef"] = <intptr_t>__cuModuleGetTexRef
+    data["__cuModuleGetTexRef"] = <_cyb_intptr_t>__cuModuleGetTexRef
 
     global __cuModuleGetSurfRef
-    data["__cuModuleGetSurfRef"] = <intptr_t>__cuModuleGetSurfRef
+    data["__cuModuleGetSurfRef"] = <_cyb_intptr_t>__cuModuleGetSurfRef
 
     global __cuLibraryLoadData
-    data["__cuLibraryLoadData"] = <intptr_t>__cuLibraryLoadData
+    data["__cuLibraryLoadData"] = <_cyb_intptr_t>__cuLibraryLoadData
 
     global __cuLibraryLoadFromFile
-    data["__cuLibraryLoadFromFile"] = <intptr_t>__cuLibraryLoadFromFile
+    data["__cuLibraryLoadFromFile"] = <_cyb_intptr_t>__cuLibraryLoadFromFile
 
     global __cuLibraryUnload
-    data["__cuLibraryUnload"] = <intptr_t>__cuLibraryUnload
+    data["__cuLibraryUnload"] = <_cyb_intptr_t>__cuLibraryUnload
 
     global __cuLibraryGetKernel
-    data["__cuLibraryGetKernel"] = <intptr_t>__cuLibraryGetKernel
+    data["__cuLibraryGetKernel"] = <_cyb_intptr_t>__cuLibraryGetKernel
 
     global __cuLibraryGetKernelCount
-    data["__cuLibraryGetKernelCount"] = <intptr_t>__cuLibraryGetKernelCount
+    data["__cuLibraryGetKernelCount"] = <_cyb_intptr_t>__cuLibraryGetKernelCount
 
     global __cuLibraryEnumerateKernels
-    data["__cuLibraryEnumerateKernels"] = <intptr_t>__cuLibraryEnumerateKernels
+    data["__cuLibraryEnumerateKernels"] = <_cyb_intptr_t>__cuLibraryEnumerateKernels
 
     global __cuLibraryGetModule
-    data["__cuLibraryGetModule"] = <intptr_t>__cuLibraryGetModule
+    data["__cuLibraryGetModule"] = <_cyb_intptr_t>__cuLibraryGetModule
 
     global __cuKernelGetFunction
-    data["__cuKernelGetFunction"] = <intptr_t>__cuKernelGetFunction
+    data["__cuKernelGetFunction"] = <_cyb_intptr_t>__cuKernelGetFunction
 
     global __cuKernelGetLibrary
-    data["__cuKernelGetLibrary"] = <intptr_t>__cuKernelGetLibrary
+    data["__cuKernelGetLibrary"] = <_cyb_intptr_t>__cuKernelGetLibrary
 
     global __cuLibraryGetGlobal
-    data["__cuLibraryGetGlobal"] = <intptr_t>__cuLibraryGetGlobal
+    data["__cuLibraryGetGlobal"] = <_cyb_intptr_t>__cuLibraryGetGlobal
 
     global __cuLibraryGetManaged
-    data["__cuLibraryGetManaged"] = <intptr_t>__cuLibraryGetManaged
+    data["__cuLibraryGetManaged"] = <_cyb_intptr_t>__cuLibraryGetManaged
 
     global __cuLibraryGetUnifiedFunction
-    data["__cuLibraryGetUnifiedFunction"] = <intptr_t>__cuLibraryGetUnifiedFunction
+    data["__cuLibraryGetUnifiedFunction"] = <_cyb_intptr_t>__cuLibraryGetUnifiedFunction
 
     global __cuKernelGetAttribute
-    data["__cuKernelGetAttribute"] = <intptr_t>__cuKernelGetAttribute
+    data["__cuKernelGetAttribute"] = <_cyb_intptr_t>__cuKernelGetAttribute
 
     global __cuKernelSetAttribute
-    data["__cuKernelSetAttribute"] = <intptr_t>__cuKernelSetAttribute
+    data["__cuKernelSetAttribute"] = <_cyb_intptr_t>__cuKernelSetAttribute
 
     global __cuKernelSetCacheConfig
-    data["__cuKernelSetCacheConfig"] = <intptr_t>__cuKernelSetCacheConfig
+    data["__cuKernelSetCacheConfig"] = <_cyb_intptr_t>__cuKernelSetCacheConfig
 
     global __cuKernelGetName
-    data["__cuKernelGetName"] = <intptr_t>__cuKernelGetName
+    data["__cuKernelGetName"] = <_cyb_intptr_t>__cuKernelGetName
 
     global __cuKernelGetParamInfo
-    data["__cuKernelGetParamInfo"] = <intptr_t>__cuKernelGetParamInfo
+    data["__cuKernelGetParamInfo"] = <_cyb_intptr_t>__cuKernelGetParamInfo
 
     global __cuMemGetInfo_v2
-    data["__cuMemGetInfo_v2"] = <intptr_t>__cuMemGetInfo_v2
+    data["__cuMemGetInfo_v2"] = <_cyb_intptr_t>__cuMemGetInfo_v2
 
     global __cuMemAlloc_v2
-    data["__cuMemAlloc_v2"] = <intptr_t>__cuMemAlloc_v2
+    data["__cuMemAlloc_v2"] = <_cyb_intptr_t>__cuMemAlloc_v2
 
     global __cuMemAllocPitch_v2
-    data["__cuMemAllocPitch_v2"] = <intptr_t>__cuMemAllocPitch_v2
+    data["__cuMemAllocPitch_v2"] = <_cyb_intptr_t>__cuMemAllocPitch_v2
 
     global __cuMemFree_v2
-    data["__cuMemFree_v2"] = <intptr_t>__cuMemFree_v2
+    data["__cuMemFree_v2"] = <_cyb_intptr_t>__cuMemFree_v2
 
     global __cuMemGetAddressRange_v2
-    data["__cuMemGetAddressRange_v2"] = <intptr_t>__cuMemGetAddressRange_v2
+    data["__cuMemGetAddressRange_v2"] = <_cyb_intptr_t>__cuMemGetAddressRange_v2
 
     global __cuMemAllocHost_v2
-    data["__cuMemAllocHost_v2"] = <intptr_t>__cuMemAllocHost_v2
+    data["__cuMemAllocHost_v2"] = <_cyb_intptr_t>__cuMemAllocHost_v2
 
     global __cuMemFreeHost
-    data["__cuMemFreeHost"] = <intptr_t>__cuMemFreeHost
+    data["__cuMemFreeHost"] = <_cyb_intptr_t>__cuMemFreeHost
 
     global __cuMemHostAlloc
-    data["__cuMemHostAlloc"] = <intptr_t>__cuMemHostAlloc
+    data["__cuMemHostAlloc"] = <_cyb_intptr_t>__cuMemHostAlloc
 
     global __cuMemHostGetDevicePointer_v2
-    data["__cuMemHostGetDevicePointer_v2"] = <intptr_t>__cuMemHostGetDevicePointer_v2
+    data["__cuMemHostGetDevicePointer_v2"] = <_cyb_intptr_t>__cuMemHostGetDevicePointer_v2
 
     global __cuMemHostGetFlags
-    data["__cuMemHostGetFlags"] = <intptr_t>__cuMemHostGetFlags
+    data["__cuMemHostGetFlags"] = <_cyb_intptr_t>__cuMemHostGetFlags
 
     global __cuMemAllocManaged
-    data["__cuMemAllocManaged"] = <intptr_t>__cuMemAllocManaged
+    data["__cuMemAllocManaged"] = <_cyb_intptr_t>__cuMemAllocManaged
 
     global __cuDeviceRegisterAsyncNotification
-    data["__cuDeviceRegisterAsyncNotification"] = <intptr_t>__cuDeviceRegisterAsyncNotification
+    data["__cuDeviceRegisterAsyncNotification"] = <_cyb_intptr_t>__cuDeviceRegisterAsyncNotification
 
     global __cuDeviceUnregisterAsyncNotification
-    data["__cuDeviceUnregisterAsyncNotification"] = <intptr_t>__cuDeviceUnregisterAsyncNotification
+    data["__cuDeviceUnregisterAsyncNotification"] = <_cyb_intptr_t>__cuDeviceUnregisterAsyncNotification
 
     global __cuDeviceGetByPCIBusId
-    data["__cuDeviceGetByPCIBusId"] = <intptr_t>__cuDeviceGetByPCIBusId
+    data["__cuDeviceGetByPCIBusId"] = <_cyb_intptr_t>__cuDeviceGetByPCIBusId
 
     global __cuDeviceGetPCIBusId
-    data["__cuDeviceGetPCIBusId"] = <intptr_t>__cuDeviceGetPCIBusId
+    data["__cuDeviceGetPCIBusId"] = <_cyb_intptr_t>__cuDeviceGetPCIBusId
 
     global __cuIpcGetEventHandle
-    data["__cuIpcGetEventHandle"] = <intptr_t>__cuIpcGetEventHandle
+    data["__cuIpcGetEventHandle"] = <_cyb_intptr_t>__cuIpcGetEventHandle
 
     global __cuIpcOpenEventHandle
-    data["__cuIpcOpenEventHandle"] = <intptr_t>__cuIpcOpenEventHandle
+    data["__cuIpcOpenEventHandle"] = <_cyb_intptr_t>__cuIpcOpenEventHandle
 
     global __cuIpcGetMemHandle
-    data["__cuIpcGetMemHandle"] = <intptr_t>__cuIpcGetMemHandle
+    data["__cuIpcGetMemHandle"] = <_cyb_intptr_t>__cuIpcGetMemHandle
 
     global __cuIpcOpenMemHandle_v2
-    data["__cuIpcOpenMemHandle_v2"] = <intptr_t>__cuIpcOpenMemHandle_v2
+    data["__cuIpcOpenMemHandle_v2"] = <_cyb_intptr_t>__cuIpcOpenMemHandle_v2
 
     global __cuIpcCloseMemHandle
-    data["__cuIpcCloseMemHandle"] = <intptr_t>__cuIpcCloseMemHandle
+    data["__cuIpcCloseMemHandle"] = <_cyb_intptr_t>__cuIpcCloseMemHandle
 
     global __cuMemHostRegister_v2
-    data["__cuMemHostRegister_v2"] = <intptr_t>__cuMemHostRegister_v2
+    data["__cuMemHostRegister_v2"] = <_cyb_intptr_t>__cuMemHostRegister_v2
 
     global __cuMemHostUnregister
-    data["__cuMemHostUnregister"] = <intptr_t>__cuMemHostUnregister
+    data["__cuMemHostUnregister"] = <_cyb_intptr_t>__cuMemHostUnregister
 
     global __cuMemcpy
-    data["__cuMemcpy"] = <intptr_t>__cuMemcpy
+    data["__cuMemcpy"] = <_cyb_intptr_t>__cuMemcpy
 
     global __cuMemcpyPeer
-    data["__cuMemcpyPeer"] = <intptr_t>__cuMemcpyPeer
+    data["__cuMemcpyPeer"] = <_cyb_intptr_t>__cuMemcpyPeer
 
     global __cuMemcpyHtoD_v2
-    data["__cuMemcpyHtoD_v2"] = <intptr_t>__cuMemcpyHtoD_v2
+    data["__cuMemcpyHtoD_v2"] = <_cyb_intptr_t>__cuMemcpyHtoD_v2
 
     global __cuMemcpyDtoH_v2
-    data["__cuMemcpyDtoH_v2"] = <intptr_t>__cuMemcpyDtoH_v2
+    data["__cuMemcpyDtoH_v2"] = <_cyb_intptr_t>__cuMemcpyDtoH_v2
 
     global __cuMemcpyDtoD_v2
-    data["__cuMemcpyDtoD_v2"] = <intptr_t>__cuMemcpyDtoD_v2
+    data["__cuMemcpyDtoD_v2"] = <_cyb_intptr_t>__cuMemcpyDtoD_v2
 
     global __cuMemcpyDtoA_v2
-    data["__cuMemcpyDtoA_v2"] = <intptr_t>__cuMemcpyDtoA_v2
+    data["__cuMemcpyDtoA_v2"] = <_cyb_intptr_t>__cuMemcpyDtoA_v2
 
     global __cuMemcpyAtoD_v2
-    data["__cuMemcpyAtoD_v2"] = <intptr_t>__cuMemcpyAtoD_v2
+    data["__cuMemcpyAtoD_v2"] = <_cyb_intptr_t>__cuMemcpyAtoD_v2
 
     global __cuMemcpyHtoA_v2
-    data["__cuMemcpyHtoA_v2"] = <intptr_t>__cuMemcpyHtoA_v2
+    data["__cuMemcpyHtoA_v2"] = <_cyb_intptr_t>__cuMemcpyHtoA_v2
 
     global __cuMemcpyAtoH_v2
-    data["__cuMemcpyAtoH_v2"] = <intptr_t>__cuMemcpyAtoH_v2
+    data["__cuMemcpyAtoH_v2"] = <_cyb_intptr_t>__cuMemcpyAtoH_v2
 
     global __cuMemcpyAtoA_v2
-    data["__cuMemcpyAtoA_v2"] = <intptr_t>__cuMemcpyAtoA_v2
+    data["__cuMemcpyAtoA_v2"] = <_cyb_intptr_t>__cuMemcpyAtoA_v2
 
     global __cuMemcpy2D_v2
-    data["__cuMemcpy2D_v2"] = <intptr_t>__cuMemcpy2D_v2
+    data["__cuMemcpy2D_v2"] = <_cyb_intptr_t>__cuMemcpy2D_v2
 
     global __cuMemcpy2DUnaligned_v2
-    data["__cuMemcpy2DUnaligned_v2"] = <intptr_t>__cuMemcpy2DUnaligned_v2
+    data["__cuMemcpy2DUnaligned_v2"] = <_cyb_intptr_t>__cuMemcpy2DUnaligned_v2
 
     global __cuMemcpy3D_v2
-    data["__cuMemcpy3D_v2"] = <intptr_t>__cuMemcpy3D_v2
+    data["__cuMemcpy3D_v2"] = <_cyb_intptr_t>__cuMemcpy3D_v2
 
     global __cuMemcpy3DPeer
-    data["__cuMemcpy3DPeer"] = <intptr_t>__cuMemcpy3DPeer
+    data["__cuMemcpy3DPeer"] = <_cyb_intptr_t>__cuMemcpy3DPeer
 
     global __cuMemcpyAsync
-    data["__cuMemcpyAsync"] = <intptr_t>__cuMemcpyAsync
+    data["__cuMemcpyAsync"] = <_cyb_intptr_t>__cuMemcpyAsync
 
     global __cuMemcpyPeerAsync
-    data["__cuMemcpyPeerAsync"] = <intptr_t>__cuMemcpyPeerAsync
+    data["__cuMemcpyPeerAsync"] = <_cyb_intptr_t>__cuMemcpyPeerAsync
 
     global __cuMemcpyHtoDAsync_v2
-    data["__cuMemcpyHtoDAsync_v2"] = <intptr_t>__cuMemcpyHtoDAsync_v2
+    data["__cuMemcpyHtoDAsync_v2"] = <_cyb_intptr_t>__cuMemcpyHtoDAsync_v2
 
     global __cuMemcpyDtoHAsync_v2
-    data["__cuMemcpyDtoHAsync_v2"] = <intptr_t>__cuMemcpyDtoHAsync_v2
+    data["__cuMemcpyDtoHAsync_v2"] = <_cyb_intptr_t>__cuMemcpyDtoHAsync_v2
 
     global __cuMemcpyDtoDAsync_v2
-    data["__cuMemcpyDtoDAsync_v2"] = <intptr_t>__cuMemcpyDtoDAsync_v2
+    data["__cuMemcpyDtoDAsync_v2"] = <_cyb_intptr_t>__cuMemcpyDtoDAsync_v2
 
     global __cuMemcpyHtoAAsync_v2
-    data["__cuMemcpyHtoAAsync_v2"] = <intptr_t>__cuMemcpyHtoAAsync_v2
+    data["__cuMemcpyHtoAAsync_v2"] = <_cyb_intptr_t>__cuMemcpyHtoAAsync_v2
 
     global __cuMemcpyAtoHAsync_v2
-    data["__cuMemcpyAtoHAsync_v2"] = <intptr_t>__cuMemcpyAtoHAsync_v2
+    data["__cuMemcpyAtoHAsync_v2"] = <_cyb_intptr_t>__cuMemcpyAtoHAsync_v2
 
     global __cuMemcpy2DAsync_v2
-    data["__cuMemcpy2DAsync_v2"] = <intptr_t>__cuMemcpy2DAsync_v2
+    data["__cuMemcpy2DAsync_v2"] = <_cyb_intptr_t>__cuMemcpy2DAsync_v2
 
     global __cuMemcpy3DAsync_v2
-    data["__cuMemcpy3DAsync_v2"] = <intptr_t>__cuMemcpy3DAsync_v2
+    data["__cuMemcpy3DAsync_v2"] = <_cyb_intptr_t>__cuMemcpy3DAsync_v2
 
     global __cuMemcpy3DPeerAsync
-    data["__cuMemcpy3DPeerAsync"] = <intptr_t>__cuMemcpy3DPeerAsync
+    data["__cuMemcpy3DPeerAsync"] = <_cyb_intptr_t>__cuMemcpy3DPeerAsync
 
     global __cuMemsetD8_v2
-    data["__cuMemsetD8_v2"] = <intptr_t>__cuMemsetD8_v2
+    data["__cuMemsetD8_v2"] = <_cyb_intptr_t>__cuMemsetD8_v2
 
     global __cuMemsetD16_v2
-    data["__cuMemsetD16_v2"] = <intptr_t>__cuMemsetD16_v2
+    data["__cuMemsetD16_v2"] = <_cyb_intptr_t>__cuMemsetD16_v2
 
     global __cuMemsetD32_v2
-    data["__cuMemsetD32_v2"] = <intptr_t>__cuMemsetD32_v2
+    data["__cuMemsetD32_v2"] = <_cyb_intptr_t>__cuMemsetD32_v2
 
     global __cuMemsetD2D8_v2
-    data["__cuMemsetD2D8_v2"] = <intptr_t>__cuMemsetD2D8_v2
+    data["__cuMemsetD2D8_v2"] = <_cyb_intptr_t>__cuMemsetD2D8_v2
 
     global __cuMemsetD2D16_v2
-    data["__cuMemsetD2D16_v2"] = <intptr_t>__cuMemsetD2D16_v2
+    data["__cuMemsetD2D16_v2"] = <_cyb_intptr_t>__cuMemsetD2D16_v2
 
     global __cuMemsetD2D32_v2
-    data["__cuMemsetD2D32_v2"] = <intptr_t>__cuMemsetD2D32_v2
+    data["__cuMemsetD2D32_v2"] = <_cyb_intptr_t>__cuMemsetD2D32_v2
 
     global __cuMemsetD8Async
-    data["__cuMemsetD8Async"] = <intptr_t>__cuMemsetD8Async
+    data["__cuMemsetD8Async"] = <_cyb_intptr_t>__cuMemsetD8Async
 
     global __cuMemsetD16Async
-    data["__cuMemsetD16Async"] = <intptr_t>__cuMemsetD16Async
+    data["__cuMemsetD16Async"] = <_cyb_intptr_t>__cuMemsetD16Async
 
     global __cuMemsetD32Async
-    data["__cuMemsetD32Async"] = <intptr_t>__cuMemsetD32Async
+    data["__cuMemsetD32Async"] = <_cyb_intptr_t>__cuMemsetD32Async
 
     global __cuMemsetD2D8Async
-    data["__cuMemsetD2D8Async"] = <intptr_t>__cuMemsetD2D8Async
+    data["__cuMemsetD2D8Async"] = <_cyb_intptr_t>__cuMemsetD2D8Async
 
     global __cuMemsetD2D16Async
-    data["__cuMemsetD2D16Async"] = <intptr_t>__cuMemsetD2D16Async
+    data["__cuMemsetD2D16Async"] = <_cyb_intptr_t>__cuMemsetD2D16Async
 
     global __cuMemsetD2D32Async
-    data["__cuMemsetD2D32Async"] = <intptr_t>__cuMemsetD2D32Async
+    data["__cuMemsetD2D32Async"] = <_cyb_intptr_t>__cuMemsetD2D32Async
 
     global __cuArrayCreate_v2
-    data["__cuArrayCreate_v2"] = <intptr_t>__cuArrayCreate_v2
+    data["__cuArrayCreate_v2"] = <_cyb_intptr_t>__cuArrayCreate_v2
 
     global __cuArrayGetDescriptor_v2
-    data["__cuArrayGetDescriptor_v2"] = <intptr_t>__cuArrayGetDescriptor_v2
+    data["__cuArrayGetDescriptor_v2"] = <_cyb_intptr_t>__cuArrayGetDescriptor_v2
 
     global __cuArrayGetSparseProperties
-    data["__cuArrayGetSparseProperties"] = <intptr_t>__cuArrayGetSparseProperties
+    data["__cuArrayGetSparseProperties"] = <_cyb_intptr_t>__cuArrayGetSparseProperties
 
     global __cuMipmappedArrayGetSparseProperties
-    data["__cuMipmappedArrayGetSparseProperties"] = <intptr_t>__cuMipmappedArrayGetSparseProperties
+    data["__cuMipmappedArrayGetSparseProperties"] = <_cyb_intptr_t>__cuMipmappedArrayGetSparseProperties
 
     global __cuArrayGetMemoryRequirements
-    data["__cuArrayGetMemoryRequirements"] = <intptr_t>__cuArrayGetMemoryRequirements
+    data["__cuArrayGetMemoryRequirements"] = <_cyb_intptr_t>__cuArrayGetMemoryRequirements
 
     global __cuMipmappedArrayGetMemoryRequirements
-    data["__cuMipmappedArrayGetMemoryRequirements"] = <intptr_t>__cuMipmappedArrayGetMemoryRequirements
+    data["__cuMipmappedArrayGetMemoryRequirements"] = <_cyb_intptr_t>__cuMipmappedArrayGetMemoryRequirements
 
     global __cuArrayGetPlane
-    data["__cuArrayGetPlane"] = <intptr_t>__cuArrayGetPlane
+    data["__cuArrayGetPlane"] = <_cyb_intptr_t>__cuArrayGetPlane
 
     global __cuArrayDestroy
-    data["__cuArrayDestroy"] = <intptr_t>__cuArrayDestroy
+    data["__cuArrayDestroy"] = <_cyb_intptr_t>__cuArrayDestroy
 
     global __cuArray3DCreate_v2
-    data["__cuArray3DCreate_v2"] = <intptr_t>__cuArray3DCreate_v2
+    data["__cuArray3DCreate_v2"] = <_cyb_intptr_t>__cuArray3DCreate_v2
 
     global __cuArray3DGetDescriptor_v2
-    data["__cuArray3DGetDescriptor_v2"] = <intptr_t>__cuArray3DGetDescriptor_v2
+    data["__cuArray3DGetDescriptor_v2"] = <_cyb_intptr_t>__cuArray3DGetDescriptor_v2
 
     global __cuMipmappedArrayCreate
-    data["__cuMipmappedArrayCreate"] = <intptr_t>__cuMipmappedArrayCreate
+    data["__cuMipmappedArrayCreate"] = <_cyb_intptr_t>__cuMipmappedArrayCreate
 
     global __cuMipmappedArrayGetLevel
-    data["__cuMipmappedArrayGetLevel"] = <intptr_t>__cuMipmappedArrayGetLevel
+    data["__cuMipmappedArrayGetLevel"] = <_cyb_intptr_t>__cuMipmappedArrayGetLevel
 
     global __cuMipmappedArrayDestroy
-    data["__cuMipmappedArrayDestroy"] = <intptr_t>__cuMipmappedArrayDestroy
+    data["__cuMipmappedArrayDestroy"] = <_cyb_intptr_t>__cuMipmappedArrayDestroy
 
     global __cuMemGetHandleForAddressRange
-    data["__cuMemGetHandleForAddressRange"] = <intptr_t>__cuMemGetHandleForAddressRange
+    data["__cuMemGetHandleForAddressRange"] = <_cyb_intptr_t>__cuMemGetHandleForAddressRange
 
     global __cuMemBatchDecompressAsync
-    data["__cuMemBatchDecompressAsync"] = <intptr_t>__cuMemBatchDecompressAsync
+    data["__cuMemBatchDecompressAsync"] = <_cyb_intptr_t>__cuMemBatchDecompressAsync
 
     global __cuMemAddressReserve
-    data["__cuMemAddressReserve"] = <intptr_t>__cuMemAddressReserve
+    data["__cuMemAddressReserve"] = <_cyb_intptr_t>__cuMemAddressReserve
 
     global __cuMemAddressFree
-    data["__cuMemAddressFree"] = <intptr_t>__cuMemAddressFree
+    data["__cuMemAddressFree"] = <_cyb_intptr_t>__cuMemAddressFree
 
     global __cuMemCreate
-    data["__cuMemCreate"] = <intptr_t>__cuMemCreate
+    data["__cuMemCreate"] = <_cyb_intptr_t>__cuMemCreate
 
     global __cuMemRelease
-    data["__cuMemRelease"] = <intptr_t>__cuMemRelease
+    data["__cuMemRelease"] = <_cyb_intptr_t>__cuMemRelease
 
     global __cuMemMap
-    data["__cuMemMap"] = <intptr_t>__cuMemMap
+    data["__cuMemMap"] = <_cyb_intptr_t>__cuMemMap
 
     global __cuMemMapArrayAsync
-    data["__cuMemMapArrayAsync"] = <intptr_t>__cuMemMapArrayAsync
+    data["__cuMemMapArrayAsync"] = <_cyb_intptr_t>__cuMemMapArrayAsync
 
     global __cuMemUnmap
-    data["__cuMemUnmap"] = <intptr_t>__cuMemUnmap
+    data["__cuMemUnmap"] = <_cyb_intptr_t>__cuMemUnmap
 
     global __cuMemSetAccess
-    data["__cuMemSetAccess"] = <intptr_t>__cuMemSetAccess
+    data["__cuMemSetAccess"] = <_cyb_intptr_t>__cuMemSetAccess
 
     global __cuMemGetAccess
-    data["__cuMemGetAccess"] = <intptr_t>__cuMemGetAccess
+    data["__cuMemGetAccess"] = <_cyb_intptr_t>__cuMemGetAccess
 
     global __cuMemExportToShareableHandle
-    data["__cuMemExportToShareableHandle"] = <intptr_t>__cuMemExportToShareableHandle
+    data["__cuMemExportToShareableHandle"] = <_cyb_intptr_t>__cuMemExportToShareableHandle
 
     global __cuMemImportFromShareableHandle
-    data["__cuMemImportFromShareableHandle"] = <intptr_t>__cuMemImportFromShareableHandle
+    data["__cuMemImportFromShareableHandle"] = <_cyb_intptr_t>__cuMemImportFromShareableHandle
 
     global __cuMemGetAllocationGranularity
-    data["__cuMemGetAllocationGranularity"] = <intptr_t>__cuMemGetAllocationGranularity
+    data["__cuMemGetAllocationGranularity"] = <_cyb_intptr_t>__cuMemGetAllocationGranularity
 
     global __cuMemGetAllocationPropertiesFromHandle
-    data["__cuMemGetAllocationPropertiesFromHandle"] = <intptr_t>__cuMemGetAllocationPropertiesFromHandle
+    data["__cuMemGetAllocationPropertiesFromHandle"] = <_cyb_intptr_t>__cuMemGetAllocationPropertiesFromHandle
 
     global __cuMemRetainAllocationHandle
-    data["__cuMemRetainAllocationHandle"] = <intptr_t>__cuMemRetainAllocationHandle
+    data["__cuMemRetainAllocationHandle"] = <_cyb_intptr_t>__cuMemRetainAllocationHandle
 
     global __cuMemFreeAsync
-    data["__cuMemFreeAsync"] = <intptr_t>__cuMemFreeAsync
+    data["__cuMemFreeAsync"] = <_cyb_intptr_t>__cuMemFreeAsync
 
     global __cuMemAllocAsync
-    data["__cuMemAllocAsync"] = <intptr_t>__cuMemAllocAsync
+    data["__cuMemAllocAsync"] = <_cyb_intptr_t>__cuMemAllocAsync
 
     global __cuMemPoolTrimTo
-    data["__cuMemPoolTrimTo"] = <intptr_t>__cuMemPoolTrimTo
+    data["__cuMemPoolTrimTo"] = <_cyb_intptr_t>__cuMemPoolTrimTo
 
     global __cuMemPoolSetAttribute
-    data["__cuMemPoolSetAttribute"] = <intptr_t>__cuMemPoolSetAttribute
+    data["__cuMemPoolSetAttribute"] = <_cyb_intptr_t>__cuMemPoolSetAttribute
 
     global __cuMemPoolGetAttribute
-    data["__cuMemPoolGetAttribute"] = <intptr_t>__cuMemPoolGetAttribute
+    data["__cuMemPoolGetAttribute"] = <_cyb_intptr_t>__cuMemPoolGetAttribute
 
     global __cuMemPoolSetAccess
-    data["__cuMemPoolSetAccess"] = <intptr_t>__cuMemPoolSetAccess
+    data["__cuMemPoolSetAccess"] = <_cyb_intptr_t>__cuMemPoolSetAccess
 
     global __cuMemPoolGetAccess
-    data["__cuMemPoolGetAccess"] = <intptr_t>__cuMemPoolGetAccess
+    data["__cuMemPoolGetAccess"] = <_cyb_intptr_t>__cuMemPoolGetAccess
 
     global __cuMemPoolCreate
-    data["__cuMemPoolCreate"] = <intptr_t>__cuMemPoolCreate
+    data["__cuMemPoolCreate"] = <_cyb_intptr_t>__cuMemPoolCreate
 
     global __cuMemPoolDestroy
-    data["__cuMemPoolDestroy"] = <intptr_t>__cuMemPoolDestroy
+    data["__cuMemPoolDestroy"] = <_cyb_intptr_t>__cuMemPoolDestroy
 
     global __cuMemAllocFromPoolAsync
-    data["__cuMemAllocFromPoolAsync"] = <intptr_t>__cuMemAllocFromPoolAsync
+    data["__cuMemAllocFromPoolAsync"] = <_cyb_intptr_t>__cuMemAllocFromPoolAsync
 
     global __cuMemPoolExportToShareableHandle
-    data["__cuMemPoolExportToShareableHandle"] = <intptr_t>__cuMemPoolExportToShareableHandle
+    data["__cuMemPoolExportToShareableHandle"] = <_cyb_intptr_t>__cuMemPoolExportToShareableHandle
 
     global __cuMemPoolImportFromShareableHandle
-    data["__cuMemPoolImportFromShareableHandle"] = <intptr_t>__cuMemPoolImportFromShareableHandle
+    data["__cuMemPoolImportFromShareableHandle"] = <_cyb_intptr_t>__cuMemPoolImportFromShareableHandle
 
     global __cuMemPoolExportPointer
-    data["__cuMemPoolExportPointer"] = <intptr_t>__cuMemPoolExportPointer
+    data["__cuMemPoolExportPointer"] = <_cyb_intptr_t>__cuMemPoolExportPointer
 
     global __cuMemPoolImportPointer
-    data["__cuMemPoolImportPointer"] = <intptr_t>__cuMemPoolImportPointer
+    data["__cuMemPoolImportPointer"] = <_cyb_intptr_t>__cuMemPoolImportPointer
 
     global __cuMulticastCreate
-    data["__cuMulticastCreate"] = <intptr_t>__cuMulticastCreate
+    data["__cuMulticastCreate"] = <_cyb_intptr_t>__cuMulticastCreate
 
     global __cuMulticastAddDevice
-    data["__cuMulticastAddDevice"] = <intptr_t>__cuMulticastAddDevice
+    data["__cuMulticastAddDevice"] = <_cyb_intptr_t>__cuMulticastAddDevice
 
     global __cuMulticastBindMem
-    data["__cuMulticastBindMem"] = <intptr_t>__cuMulticastBindMem
+    data["__cuMulticastBindMem"] = <_cyb_intptr_t>__cuMulticastBindMem
 
     global __cuMulticastBindAddr
-    data["__cuMulticastBindAddr"] = <intptr_t>__cuMulticastBindAddr
+    data["__cuMulticastBindAddr"] = <_cyb_intptr_t>__cuMulticastBindAddr
 
     global __cuMulticastUnbind
-    data["__cuMulticastUnbind"] = <intptr_t>__cuMulticastUnbind
+    data["__cuMulticastUnbind"] = <_cyb_intptr_t>__cuMulticastUnbind
 
     global __cuMulticastGetGranularity
-    data["__cuMulticastGetGranularity"] = <intptr_t>__cuMulticastGetGranularity
+    data["__cuMulticastGetGranularity"] = <_cyb_intptr_t>__cuMulticastGetGranularity
 
     global __cuPointerGetAttribute
-    data["__cuPointerGetAttribute"] = <intptr_t>__cuPointerGetAttribute
+    data["__cuPointerGetAttribute"] = <_cyb_intptr_t>__cuPointerGetAttribute
 
     global __cuMemPrefetchAsync_v2
-    data["__cuMemPrefetchAsync_v2"] = <intptr_t>__cuMemPrefetchAsync_v2
+    data["__cuMemPrefetchAsync_v2"] = <_cyb_intptr_t>__cuMemPrefetchAsync_v2
 
     global __cuMemAdvise_v2
-    data["__cuMemAdvise_v2"] = <intptr_t>__cuMemAdvise_v2
+    data["__cuMemAdvise_v2"] = <_cyb_intptr_t>__cuMemAdvise_v2
 
     global __cuMemRangeGetAttribute
-    data["__cuMemRangeGetAttribute"] = <intptr_t>__cuMemRangeGetAttribute
+    data["__cuMemRangeGetAttribute"] = <_cyb_intptr_t>__cuMemRangeGetAttribute
 
     global __cuMemRangeGetAttributes
-    data["__cuMemRangeGetAttributes"] = <intptr_t>__cuMemRangeGetAttributes
+    data["__cuMemRangeGetAttributes"] = <_cyb_intptr_t>__cuMemRangeGetAttributes
 
     global __cuPointerSetAttribute
-    data["__cuPointerSetAttribute"] = <intptr_t>__cuPointerSetAttribute
+    data["__cuPointerSetAttribute"] = <_cyb_intptr_t>__cuPointerSetAttribute
 
     global __cuPointerGetAttributes
-    data["__cuPointerGetAttributes"] = <intptr_t>__cuPointerGetAttributes
+    data["__cuPointerGetAttributes"] = <_cyb_intptr_t>__cuPointerGetAttributes
 
     global __cuStreamCreate
-    data["__cuStreamCreate"] = <intptr_t>__cuStreamCreate
+    data["__cuStreamCreate"] = <_cyb_intptr_t>__cuStreamCreate
 
     global __cuStreamCreateWithPriority
-    data["__cuStreamCreateWithPriority"] = <intptr_t>__cuStreamCreateWithPriority
+    data["__cuStreamCreateWithPriority"] = <_cyb_intptr_t>__cuStreamCreateWithPriority
 
     global __cuStreamGetPriority
-    data["__cuStreamGetPriority"] = <intptr_t>__cuStreamGetPriority
+    data["__cuStreamGetPriority"] = <_cyb_intptr_t>__cuStreamGetPriority
 
     global __cuStreamGetDevice
-    data["__cuStreamGetDevice"] = <intptr_t>__cuStreamGetDevice
+    data["__cuStreamGetDevice"] = <_cyb_intptr_t>__cuStreamGetDevice
 
     global __cuStreamGetFlags
-    data["__cuStreamGetFlags"] = <intptr_t>__cuStreamGetFlags
+    data["__cuStreamGetFlags"] = <_cyb_intptr_t>__cuStreamGetFlags
 
     global __cuStreamGetId
-    data["__cuStreamGetId"] = <intptr_t>__cuStreamGetId
+    data["__cuStreamGetId"] = <_cyb_intptr_t>__cuStreamGetId
 
     global __cuStreamGetCtx
-    data["__cuStreamGetCtx"] = <intptr_t>__cuStreamGetCtx
+    data["__cuStreamGetCtx"] = <_cyb_intptr_t>__cuStreamGetCtx
 
     global __cuStreamGetCtx_v2
-    data["__cuStreamGetCtx_v2"] = <intptr_t>__cuStreamGetCtx_v2
+    data["__cuStreamGetCtx_v2"] = <_cyb_intptr_t>__cuStreamGetCtx_v2
 
     global __cuStreamWaitEvent
-    data["__cuStreamWaitEvent"] = <intptr_t>__cuStreamWaitEvent
+    data["__cuStreamWaitEvent"] = <_cyb_intptr_t>__cuStreamWaitEvent
 
     global __cuStreamAddCallback
-    data["__cuStreamAddCallback"] = <intptr_t>__cuStreamAddCallback
+    data["__cuStreamAddCallback"] = <_cyb_intptr_t>__cuStreamAddCallback
 
     global __cuStreamBeginCapture_v2
-    data["__cuStreamBeginCapture_v2"] = <intptr_t>__cuStreamBeginCapture_v2
+    data["__cuStreamBeginCapture_v2"] = <_cyb_intptr_t>__cuStreamBeginCapture_v2
 
     global __cuStreamBeginCaptureToGraph
-    data["__cuStreamBeginCaptureToGraph"] = <intptr_t>__cuStreamBeginCaptureToGraph
+    data["__cuStreamBeginCaptureToGraph"] = <_cyb_intptr_t>__cuStreamBeginCaptureToGraph
 
     global __cuThreadExchangeStreamCaptureMode
-    data["__cuThreadExchangeStreamCaptureMode"] = <intptr_t>__cuThreadExchangeStreamCaptureMode
+    data["__cuThreadExchangeStreamCaptureMode"] = <_cyb_intptr_t>__cuThreadExchangeStreamCaptureMode
 
     global __cuStreamEndCapture
-    data["__cuStreamEndCapture"] = <intptr_t>__cuStreamEndCapture
+    data["__cuStreamEndCapture"] = <_cyb_intptr_t>__cuStreamEndCapture
 
     global __cuStreamIsCapturing
-    data["__cuStreamIsCapturing"] = <intptr_t>__cuStreamIsCapturing
+    data["__cuStreamIsCapturing"] = <_cyb_intptr_t>__cuStreamIsCapturing
 
     global __cuStreamGetCaptureInfo_v2
-    data["__cuStreamGetCaptureInfo_v2"] = <intptr_t>__cuStreamGetCaptureInfo_v2
+    data["__cuStreamGetCaptureInfo_v2"] = <_cyb_intptr_t>__cuStreamGetCaptureInfo_v2
 
     global __cuStreamGetCaptureInfo_v3
-    data["__cuStreamGetCaptureInfo_v3"] = <intptr_t>__cuStreamGetCaptureInfo_v3
+    data["__cuStreamGetCaptureInfo_v3"] = <_cyb_intptr_t>__cuStreamGetCaptureInfo_v3
 
     global __cuStreamUpdateCaptureDependencies_v2
-    data["__cuStreamUpdateCaptureDependencies_v2"] = <intptr_t>__cuStreamUpdateCaptureDependencies_v2
+    data["__cuStreamUpdateCaptureDependencies_v2"] = <_cyb_intptr_t>__cuStreamUpdateCaptureDependencies_v2
 
     global __cuStreamAttachMemAsync
-    data["__cuStreamAttachMemAsync"] = <intptr_t>__cuStreamAttachMemAsync
+    data["__cuStreamAttachMemAsync"] = <_cyb_intptr_t>__cuStreamAttachMemAsync
 
     global __cuStreamQuery
-    data["__cuStreamQuery"] = <intptr_t>__cuStreamQuery
+    data["__cuStreamQuery"] = <_cyb_intptr_t>__cuStreamQuery
 
     global __cuStreamSynchronize
-    data["__cuStreamSynchronize"] = <intptr_t>__cuStreamSynchronize
+    data["__cuStreamSynchronize"] = <_cyb_intptr_t>__cuStreamSynchronize
 
     global __cuStreamDestroy_v2
-    data["__cuStreamDestroy_v2"] = <intptr_t>__cuStreamDestroy_v2
+    data["__cuStreamDestroy_v2"] = <_cyb_intptr_t>__cuStreamDestroy_v2
 
     global __cuStreamCopyAttributes
-    data["__cuStreamCopyAttributes"] = <intptr_t>__cuStreamCopyAttributes
+    data["__cuStreamCopyAttributes"] = <_cyb_intptr_t>__cuStreamCopyAttributes
 
     global __cuStreamGetAttribute
-    data["__cuStreamGetAttribute"] = <intptr_t>__cuStreamGetAttribute
+    data["__cuStreamGetAttribute"] = <_cyb_intptr_t>__cuStreamGetAttribute
 
     global __cuStreamSetAttribute
-    data["__cuStreamSetAttribute"] = <intptr_t>__cuStreamSetAttribute
+    data["__cuStreamSetAttribute"] = <_cyb_intptr_t>__cuStreamSetAttribute
 
     global __cuEventCreate
-    data["__cuEventCreate"] = <intptr_t>__cuEventCreate
+    data["__cuEventCreate"] = <_cyb_intptr_t>__cuEventCreate
 
     global __cuEventRecord
-    data["__cuEventRecord"] = <intptr_t>__cuEventRecord
+    data["__cuEventRecord"] = <_cyb_intptr_t>__cuEventRecord
 
     global __cuEventRecordWithFlags
-    data["__cuEventRecordWithFlags"] = <intptr_t>__cuEventRecordWithFlags
+    data["__cuEventRecordWithFlags"] = <_cyb_intptr_t>__cuEventRecordWithFlags
 
     global __cuEventQuery
-    data["__cuEventQuery"] = <intptr_t>__cuEventQuery
+    data["__cuEventQuery"] = <_cyb_intptr_t>__cuEventQuery
 
     global __cuEventSynchronize
-    data["__cuEventSynchronize"] = <intptr_t>__cuEventSynchronize
+    data["__cuEventSynchronize"] = <_cyb_intptr_t>__cuEventSynchronize
 
     global __cuEventDestroy_v2
-    data["__cuEventDestroy_v2"] = <intptr_t>__cuEventDestroy_v2
+    data["__cuEventDestroy_v2"] = <_cyb_intptr_t>__cuEventDestroy_v2
 
     global __cuEventElapsedTime_v2
-    data["__cuEventElapsedTime_v2"] = <intptr_t>__cuEventElapsedTime_v2
+    data["__cuEventElapsedTime_v2"] = <_cyb_intptr_t>__cuEventElapsedTime_v2
 
     global __cuImportExternalMemory
-    data["__cuImportExternalMemory"] = <intptr_t>__cuImportExternalMemory
+    data["__cuImportExternalMemory"] = <_cyb_intptr_t>__cuImportExternalMemory
 
     global __cuExternalMemoryGetMappedBuffer
-    data["__cuExternalMemoryGetMappedBuffer"] = <intptr_t>__cuExternalMemoryGetMappedBuffer
+    data["__cuExternalMemoryGetMappedBuffer"] = <_cyb_intptr_t>__cuExternalMemoryGetMappedBuffer
 
     global __cuExternalMemoryGetMappedMipmappedArray
-    data["__cuExternalMemoryGetMappedMipmappedArray"] = <intptr_t>__cuExternalMemoryGetMappedMipmappedArray
+    data["__cuExternalMemoryGetMappedMipmappedArray"] = <_cyb_intptr_t>__cuExternalMemoryGetMappedMipmappedArray
 
     global __cuDestroyExternalMemory
-    data["__cuDestroyExternalMemory"] = <intptr_t>__cuDestroyExternalMemory
+    data["__cuDestroyExternalMemory"] = <_cyb_intptr_t>__cuDestroyExternalMemory
 
     global __cuImportExternalSemaphore
-    data["__cuImportExternalSemaphore"] = <intptr_t>__cuImportExternalSemaphore
+    data["__cuImportExternalSemaphore"] = <_cyb_intptr_t>__cuImportExternalSemaphore
 
     global __cuSignalExternalSemaphoresAsync
-    data["__cuSignalExternalSemaphoresAsync"] = <intptr_t>__cuSignalExternalSemaphoresAsync
+    data["__cuSignalExternalSemaphoresAsync"] = <_cyb_intptr_t>__cuSignalExternalSemaphoresAsync
 
     global __cuWaitExternalSemaphoresAsync
-    data["__cuWaitExternalSemaphoresAsync"] = <intptr_t>__cuWaitExternalSemaphoresAsync
+    data["__cuWaitExternalSemaphoresAsync"] = <_cyb_intptr_t>__cuWaitExternalSemaphoresAsync
 
     global __cuDestroyExternalSemaphore
-    data["__cuDestroyExternalSemaphore"] = <intptr_t>__cuDestroyExternalSemaphore
+    data["__cuDestroyExternalSemaphore"] = <_cyb_intptr_t>__cuDestroyExternalSemaphore
 
     global __cuStreamWaitValue32_v2
-    data["__cuStreamWaitValue32_v2"] = <intptr_t>__cuStreamWaitValue32_v2
+    data["__cuStreamWaitValue32_v2"] = <_cyb_intptr_t>__cuStreamWaitValue32_v2
 
     global __cuStreamWaitValue64_v2
-    data["__cuStreamWaitValue64_v2"] = <intptr_t>__cuStreamWaitValue64_v2
+    data["__cuStreamWaitValue64_v2"] = <_cyb_intptr_t>__cuStreamWaitValue64_v2
 
     global __cuStreamWriteValue32_v2
-    data["__cuStreamWriteValue32_v2"] = <intptr_t>__cuStreamWriteValue32_v2
+    data["__cuStreamWriteValue32_v2"] = <_cyb_intptr_t>__cuStreamWriteValue32_v2
 
     global __cuStreamWriteValue64_v2
-    data["__cuStreamWriteValue64_v2"] = <intptr_t>__cuStreamWriteValue64_v2
+    data["__cuStreamWriteValue64_v2"] = <_cyb_intptr_t>__cuStreamWriteValue64_v2
 
     global __cuStreamBatchMemOp_v2
-    data["__cuStreamBatchMemOp_v2"] = <intptr_t>__cuStreamBatchMemOp_v2
+    data["__cuStreamBatchMemOp_v2"] = <_cyb_intptr_t>__cuStreamBatchMemOp_v2
 
     global __cuFuncGetAttribute
-    data["__cuFuncGetAttribute"] = <intptr_t>__cuFuncGetAttribute
+    data["__cuFuncGetAttribute"] = <_cyb_intptr_t>__cuFuncGetAttribute
 
     global __cuFuncSetAttribute
-    data["__cuFuncSetAttribute"] = <intptr_t>__cuFuncSetAttribute
+    data["__cuFuncSetAttribute"] = <_cyb_intptr_t>__cuFuncSetAttribute
 
     global __cuFuncSetCacheConfig
-    data["__cuFuncSetCacheConfig"] = <intptr_t>__cuFuncSetCacheConfig
+    data["__cuFuncSetCacheConfig"] = <_cyb_intptr_t>__cuFuncSetCacheConfig
 
     global __cuFuncGetModule
-    data["__cuFuncGetModule"] = <intptr_t>__cuFuncGetModule
+    data["__cuFuncGetModule"] = <_cyb_intptr_t>__cuFuncGetModule
 
     global __cuFuncGetName
-    data["__cuFuncGetName"] = <intptr_t>__cuFuncGetName
+    data["__cuFuncGetName"] = <_cyb_intptr_t>__cuFuncGetName
 
     global __cuFuncGetParamInfo
-    data["__cuFuncGetParamInfo"] = <intptr_t>__cuFuncGetParamInfo
+    data["__cuFuncGetParamInfo"] = <_cyb_intptr_t>__cuFuncGetParamInfo
 
     global __cuFuncIsLoaded
-    data["__cuFuncIsLoaded"] = <intptr_t>__cuFuncIsLoaded
+    data["__cuFuncIsLoaded"] = <_cyb_intptr_t>__cuFuncIsLoaded
 
     global __cuFuncLoad
-    data["__cuFuncLoad"] = <intptr_t>__cuFuncLoad
+    data["__cuFuncLoad"] = <_cyb_intptr_t>__cuFuncLoad
 
     global __cuLaunchKernel
-    data["__cuLaunchKernel"] = <intptr_t>__cuLaunchKernel
+    data["__cuLaunchKernel"] = <_cyb_intptr_t>__cuLaunchKernel
 
     global __cuLaunchKernelEx
-    data["__cuLaunchKernelEx"] = <intptr_t>__cuLaunchKernelEx
+    data["__cuLaunchKernelEx"] = <_cyb_intptr_t>__cuLaunchKernelEx
 
     global __cuLaunchCooperativeKernel
-    data["__cuLaunchCooperativeKernel"] = <intptr_t>__cuLaunchCooperativeKernel
+    data["__cuLaunchCooperativeKernel"] = <_cyb_intptr_t>__cuLaunchCooperativeKernel
 
     global __cuLaunchCooperativeKernelMultiDevice
-    data["__cuLaunchCooperativeKernelMultiDevice"] = <intptr_t>__cuLaunchCooperativeKernelMultiDevice
+    data["__cuLaunchCooperativeKernelMultiDevice"] = <_cyb_intptr_t>__cuLaunchCooperativeKernelMultiDevice
 
     global __cuLaunchHostFunc
-    data["__cuLaunchHostFunc"] = <intptr_t>__cuLaunchHostFunc
+    data["__cuLaunchHostFunc"] = <_cyb_intptr_t>__cuLaunchHostFunc
 
     global __cuFuncSetBlockShape
-    data["__cuFuncSetBlockShape"] = <intptr_t>__cuFuncSetBlockShape
+    data["__cuFuncSetBlockShape"] = <_cyb_intptr_t>__cuFuncSetBlockShape
 
     global __cuFuncSetSharedSize
-    data["__cuFuncSetSharedSize"] = <intptr_t>__cuFuncSetSharedSize
+    data["__cuFuncSetSharedSize"] = <_cyb_intptr_t>__cuFuncSetSharedSize
 
     global __cuParamSetSize
-    data["__cuParamSetSize"] = <intptr_t>__cuParamSetSize
+    data["__cuParamSetSize"] = <_cyb_intptr_t>__cuParamSetSize
 
     global __cuParamSeti
-    data["__cuParamSeti"] = <intptr_t>__cuParamSeti
+    data["__cuParamSeti"] = <_cyb_intptr_t>__cuParamSeti
 
     global __cuParamSetf
-    data["__cuParamSetf"] = <intptr_t>__cuParamSetf
+    data["__cuParamSetf"] = <_cyb_intptr_t>__cuParamSetf
 
     global __cuParamSetv
-    data["__cuParamSetv"] = <intptr_t>__cuParamSetv
+    data["__cuParamSetv"] = <_cyb_intptr_t>__cuParamSetv
 
     global __cuLaunch
-    data["__cuLaunch"] = <intptr_t>__cuLaunch
+    data["__cuLaunch"] = <_cyb_intptr_t>__cuLaunch
 
     global __cuLaunchGrid
-    data["__cuLaunchGrid"] = <intptr_t>__cuLaunchGrid
+    data["__cuLaunchGrid"] = <_cyb_intptr_t>__cuLaunchGrid
 
     global __cuLaunchGridAsync
-    data["__cuLaunchGridAsync"] = <intptr_t>__cuLaunchGridAsync
+    data["__cuLaunchGridAsync"] = <_cyb_intptr_t>__cuLaunchGridAsync
 
     global __cuParamSetTexRef
-    data["__cuParamSetTexRef"] = <intptr_t>__cuParamSetTexRef
+    data["__cuParamSetTexRef"] = <_cyb_intptr_t>__cuParamSetTexRef
 
     global __cuFuncSetSharedMemConfig
-    data["__cuFuncSetSharedMemConfig"] = <intptr_t>__cuFuncSetSharedMemConfig
+    data["__cuFuncSetSharedMemConfig"] = <_cyb_intptr_t>__cuFuncSetSharedMemConfig
 
     global __cuGraphCreate
-    data["__cuGraphCreate"] = <intptr_t>__cuGraphCreate
+    data["__cuGraphCreate"] = <_cyb_intptr_t>__cuGraphCreate
 
     global __cuGraphAddKernelNode_v2
-    data["__cuGraphAddKernelNode_v2"] = <intptr_t>__cuGraphAddKernelNode_v2
+    data["__cuGraphAddKernelNode_v2"] = <_cyb_intptr_t>__cuGraphAddKernelNode_v2
 
     global __cuGraphKernelNodeGetParams_v2
-    data["__cuGraphKernelNodeGetParams_v2"] = <intptr_t>__cuGraphKernelNodeGetParams_v2
+    data["__cuGraphKernelNodeGetParams_v2"] = <_cyb_intptr_t>__cuGraphKernelNodeGetParams_v2
 
     global __cuGraphKernelNodeSetParams_v2
-    data["__cuGraphKernelNodeSetParams_v2"] = <intptr_t>__cuGraphKernelNodeSetParams_v2
+    data["__cuGraphKernelNodeSetParams_v2"] = <_cyb_intptr_t>__cuGraphKernelNodeSetParams_v2
 
     global __cuGraphAddMemcpyNode
-    data["__cuGraphAddMemcpyNode"] = <intptr_t>__cuGraphAddMemcpyNode
+    data["__cuGraphAddMemcpyNode"] = <_cyb_intptr_t>__cuGraphAddMemcpyNode
 
     global __cuGraphMemcpyNodeGetParams
-    data["__cuGraphMemcpyNodeGetParams"] = <intptr_t>__cuGraphMemcpyNodeGetParams
+    data["__cuGraphMemcpyNodeGetParams"] = <_cyb_intptr_t>__cuGraphMemcpyNodeGetParams
 
     global __cuGraphMemcpyNodeSetParams
-    data["__cuGraphMemcpyNodeSetParams"] = <intptr_t>__cuGraphMemcpyNodeSetParams
+    data["__cuGraphMemcpyNodeSetParams"] = <_cyb_intptr_t>__cuGraphMemcpyNodeSetParams
 
     global __cuGraphAddMemsetNode
-    data["__cuGraphAddMemsetNode"] = <intptr_t>__cuGraphAddMemsetNode
+    data["__cuGraphAddMemsetNode"] = <_cyb_intptr_t>__cuGraphAddMemsetNode
 
     global __cuGraphMemsetNodeGetParams
-    data["__cuGraphMemsetNodeGetParams"] = <intptr_t>__cuGraphMemsetNodeGetParams
+    data["__cuGraphMemsetNodeGetParams"] = <_cyb_intptr_t>__cuGraphMemsetNodeGetParams
 
     global __cuGraphMemsetNodeSetParams
-    data["__cuGraphMemsetNodeSetParams"] = <intptr_t>__cuGraphMemsetNodeSetParams
+    data["__cuGraphMemsetNodeSetParams"] = <_cyb_intptr_t>__cuGraphMemsetNodeSetParams
 
     global __cuGraphAddHostNode
-    data["__cuGraphAddHostNode"] = <intptr_t>__cuGraphAddHostNode
+    data["__cuGraphAddHostNode"] = <_cyb_intptr_t>__cuGraphAddHostNode
 
     global __cuGraphHostNodeGetParams
-    data["__cuGraphHostNodeGetParams"] = <intptr_t>__cuGraphHostNodeGetParams
+    data["__cuGraphHostNodeGetParams"] = <_cyb_intptr_t>__cuGraphHostNodeGetParams
 
     global __cuGraphHostNodeSetParams
-    data["__cuGraphHostNodeSetParams"] = <intptr_t>__cuGraphHostNodeSetParams
+    data["__cuGraphHostNodeSetParams"] = <_cyb_intptr_t>__cuGraphHostNodeSetParams
 
     global __cuGraphAddChildGraphNode
-    data["__cuGraphAddChildGraphNode"] = <intptr_t>__cuGraphAddChildGraphNode
+    data["__cuGraphAddChildGraphNode"] = <_cyb_intptr_t>__cuGraphAddChildGraphNode
 
     global __cuGraphChildGraphNodeGetGraph
-    data["__cuGraphChildGraphNodeGetGraph"] = <intptr_t>__cuGraphChildGraphNodeGetGraph
+    data["__cuGraphChildGraphNodeGetGraph"] = <_cyb_intptr_t>__cuGraphChildGraphNodeGetGraph
 
     global __cuGraphAddEmptyNode
-    data["__cuGraphAddEmptyNode"] = <intptr_t>__cuGraphAddEmptyNode
+    data["__cuGraphAddEmptyNode"] = <_cyb_intptr_t>__cuGraphAddEmptyNode
 
     global __cuGraphAddEventRecordNode
-    data["__cuGraphAddEventRecordNode"] = <intptr_t>__cuGraphAddEventRecordNode
+    data["__cuGraphAddEventRecordNode"] = <_cyb_intptr_t>__cuGraphAddEventRecordNode
 
     global __cuGraphEventRecordNodeGetEvent
-    data["__cuGraphEventRecordNodeGetEvent"] = <intptr_t>__cuGraphEventRecordNodeGetEvent
+    data["__cuGraphEventRecordNodeGetEvent"] = <_cyb_intptr_t>__cuGraphEventRecordNodeGetEvent
 
     global __cuGraphEventRecordNodeSetEvent
-    data["__cuGraphEventRecordNodeSetEvent"] = <intptr_t>__cuGraphEventRecordNodeSetEvent
+    data["__cuGraphEventRecordNodeSetEvent"] = <_cyb_intptr_t>__cuGraphEventRecordNodeSetEvent
 
     global __cuGraphAddEventWaitNode
-    data["__cuGraphAddEventWaitNode"] = <intptr_t>__cuGraphAddEventWaitNode
+    data["__cuGraphAddEventWaitNode"] = <_cyb_intptr_t>__cuGraphAddEventWaitNode
 
     global __cuGraphEventWaitNodeGetEvent
-    data["__cuGraphEventWaitNodeGetEvent"] = <intptr_t>__cuGraphEventWaitNodeGetEvent
+    data["__cuGraphEventWaitNodeGetEvent"] = <_cyb_intptr_t>__cuGraphEventWaitNodeGetEvent
 
     global __cuGraphEventWaitNodeSetEvent
-    data["__cuGraphEventWaitNodeSetEvent"] = <intptr_t>__cuGraphEventWaitNodeSetEvent
+    data["__cuGraphEventWaitNodeSetEvent"] = <_cyb_intptr_t>__cuGraphEventWaitNodeSetEvent
 
     global __cuGraphAddExternalSemaphoresSignalNode
-    data["__cuGraphAddExternalSemaphoresSignalNode"] = <intptr_t>__cuGraphAddExternalSemaphoresSignalNode
+    data["__cuGraphAddExternalSemaphoresSignalNode"] = <_cyb_intptr_t>__cuGraphAddExternalSemaphoresSignalNode
 
     global __cuGraphExternalSemaphoresSignalNodeGetParams
-    data["__cuGraphExternalSemaphoresSignalNodeGetParams"] = <intptr_t>__cuGraphExternalSemaphoresSignalNodeGetParams
+    data["__cuGraphExternalSemaphoresSignalNodeGetParams"] = <_cyb_intptr_t>__cuGraphExternalSemaphoresSignalNodeGetParams
 
     global __cuGraphExternalSemaphoresSignalNodeSetParams
-    data["__cuGraphExternalSemaphoresSignalNodeSetParams"] = <intptr_t>__cuGraphExternalSemaphoresSignalNodeSetParams
+    data["__cuGraphExternalSemaphoresSignalNodeSetParams"] = <_cyb_intptr_t>__cuGraphExternalSemaphoresSignalNodeSetParams
 
     global __cuGraphAddExternalSemaphoresWaitNode
-    data["__cuGraphAddExternalSemaphoresWaitNode"] = <intptr_t>__cuGraphAddExternalSemaphoresWaitNode
+    data["__cuGraphAddExternalSemaphoresWaitNode"] = <_cyb_intptr_t>__cuGraphAddExternalSemaphoresWaitNode
 
     global __cuGraphExternalSemaphoresWaitNodeGetParams
-    data["__cuGraphExternalSemaphoresWaitNodeGetParams"] = <intptr_t>__cuGraphExternalSemaphoresWaitNodeGetParams
+    data["__cuGraphExternalSemaphoresWaitNodeGetParams"] = <_cyb_intptr_t>__cuGraphExternalSemaphoresWaitNodeGetParams
 
     global __cuGraphExternalSemaphoresWaitNodeSetParams
-    data["__cuGraphExternalSemaphoresWaitNodeSetParams"] = <intptr_t>__cuGraphExternalSemaphoresWaitNodeSetParams
+    data["__cuGraphExternalSemaphoresWaitNodeSetParams"] = <_cyb_intptr_t>__cuGraphExternalSemaphoresWaitNodeSetParams
 
     global __cuGraphAddBatchMemOpNode
-    data["__cuGraphAddBatchMemOpNode"] = <intptr_t>__cuGraphAddBatchMemOpNode
+    data["__cuGraphAddBatchMemOpNode"] = <_cyb_intptr_t>__cuGraphAddBatchMemOpNode
 
     global __cuGraphBatchMemOpNodeGetParams
-    data["__cuGraphBatchMemOpNodeGetParams"] = <intptr_t>__cuGraphBatchMemOpNodeGetParams
+    data["__cuGraphBatchMemOpNodeGetParams"] = <_cyb_intptr_t>__cuGraphBatchMemOpNodeGetParams
 
     global __cuGraphBatchMemOpNodeSetParams
-    data["__cuGraphBatchMemOpNodeSetParams"] = <intptr_t>__cuGraphBatchMemOpNodeSetParams
+    data["__cuGraphBatchMemOpNodeSetParams"] = <_cyb_intptr_t>__cuGraphBatchMemOpNodeSetParams
 
     global __cuGraphExecBatchMemOpNodeSetParams
-    data["__cuGraphExecBatchMemOpNodeSetParams"] = <intptr_t>__cuGraphExecBatchMemOpNodeSetParams
+    data["__cuGraphExecBatchMemOpNodeSetParams"] = <_cyb_intptr_t>__cuGraphExecBatchMemOpNodeSetParams
 
     global __cuGraphAddMemAllocNode
-    data["__cuGraphAddMemAllocNode"] = <intptr_t>__cuGraphAddMemAllocNode
+    data["__cuGraphAddMemAllocNode"] = <_cyb_intptr_t>__cuGraphAddMemAllocNode
 
     global __cuGraphMemAllocNodeGetParams
-    data["__cuGraphMemAllocNodeGetParams"] = <intptr_t>__cuGraphMemAllocNodeGetParams
+    data["__cuGraphMemAllocNodeGetParams"] = <_cyb_intptr_t>__cuGraphMemAllocNodeGetParams
 
     global __cuGraphAddMemFreeNode
-    data["__cuGraphAddMemFreeNode"] = <intptr_t>__cuGraphAddMemFreeNode
+    data["__cuGraphAddMemFreeNode"] = <_cyb_intptr_t>__cuGraphAddMemFreeNode
 
     global __cuGraphMemFreeNodeGetParams
-    data["__cuGraphMemFreeNodeGetParams"] = <intptr_t>__cuGraphMemFreeNodeGetParams
+    data["__cuGraphMemFreeNodeGetParams"] = <_cyb_intptr_t>__cuGraphMemFreeNodeGetParams
 
     global __cuDeviceGraphMemTrim
-    data["__cuDeviceGraphMemTrim"] = <intptr_t>__cuDeviceGraphMemTrim
+    data["__cuDeviceGraphMemTrim"] = <_cyb_intptr_t>__cuDeviceGraphMemTrim
 
     global __cuDeviceGetGraphMemAttribute
-    data["__cuDeviceGetGraphMemAttribute"] = <intptr_t>__cuDeviceGetGraphMemAttribute
+    data["__cuDeviceGetGraphMemAttribute"] = <_cyb_intptr_t>__cuDeviceGetGraphMemAttribute
 
     global __cuDeviceSetGraphMemAttribute
-    data["__cuDeviceSetGraphMemAttribute"] = <intptr_t>__cuDeviceSetGraphMemAttribute
+    data["__cuDeviceSetGraphMemAttribute"] = <_cyb_intptr_t>__cuDeviceSetGraphMemAttribute
 
     global __cuGraphClone
-    data["__cuGraphClone"] = <intptr_t>__cuGraphClone
+    data["__cuGraphClone"] = <_cyb_intptr_t>__cuGraphClone
 
     global __cuGraphNodeFindInClone
-    data["__cuGraphNodeFindInClone"] = <intptr_t>__cuGraphNodeFindInClone
+    data["__cuGraphNodeFindInClone"] = <_cyb_intptr_t>__cuGraphNodeFindInClone
 
     global __cuGraphNodeGetType
-    data["__cuGraphNodeGetType"] = <intptr_t>__cuGraphNodeGetType
+    data["__cuGraphNodeGetType"] = <_cyb_intptr_t>__cuGraphNodeGetType
 
     global __cuGraphGetNodes
-    data["__cuGraphGetNodes"] = <intptr_t>__cuGraphGetNodes
+    data["__cuGraphGetNodes"] = <_cyb_intptr_t>__cuGraphGetNodes
 
     global __cuGraphGetRootNodes
-    data["__cuGraphGetRootNodes"] = <intptr_t>__cuGraphGetRootNodes
+    data["__cuGraphGetRootNodes"] = <_cyb_intptr_t>__cuGraphGetRootNodes
 
     global __cuGraphGetEdges_v2
-    data["__cuGraphGetEdges_v2"] = <intptr_t>__cuGraphGetEdges_v2
+    data["__cuGraphGetEdges_v2"] = <_cyb_intptr_t>__cuGraphGetEdges_v2
 
     global __cuGraphNodeGetDependencies_v2
-    data["__cuGraphNodeGetDependencies_v2"] = <intptr_t>__cuGraphNodeGetDependencies_v2
+    data["__cuGraphNodeGetDependencies_v2"] = <_cyb_intptr_t>__cuGraphNodeGetDependencies_v2
 
     global __cuGraphNodeGetDependentNodes_v2
-    data["__cuGraphNodeGetDependentNodes_v2"] = <intptr_t>__cuGraphNodeGetDependentNodes_v2
+    data["__cuGraphNodeGetDependentNodes_v2"] = <_cyb_intptr_t>__cuGraphNodeGetDependentNodes_v2
 
     global __cuGraphAddDependencies_v2
-    data["__cuGraphAddDependencies_v2"] = <intptr_t>__cuGraphAddDependencies_v2
+    data["__cuGraphAddDependencies_v2"] = <_cyb_intptr_t>__cuGraphAddDependencies_v2
 
     global __cuGraphRemoveDependencies_v2
-    data["__cuGraphRemoveDependencies_v2"] = <intptr_t>__cuGraphRemoveDependencies_v2
+    data["__cuGraphRemoveDependencies_v2"] = <_cyb_intptr_t>__cuGraphRemoveDependencies_v2
 
     global __cuGraphDestroyNode
-    data["__cuGraphDestroyNode"] = <intptr_t>__cuGraphDestroyNode
+    data["__cuGraphDestroyNode"] = <_cyb_intptr_t>__cuGraphDestroyNode
 
     global __cuGraphInstantiateWithFlags
-    data["__cuGraphInstantiateWithFlags"] = <intptr_t>__cuGraphInstantiateWithFlags
+    data["__cuGraphInstantiateWithFlags"] = <_cyb_intptr_t>__cuGraphInstantiateWithFlags
 
     global __cuGraphInstantiateWithParams
-    data["__cuGraphInstantiateWithParams"] = <intptr_t>__cuGraphInstantiateWithParams
+    data["__cuGraphInstantiateWithParams"] = <_cyb_intptr_t>__cuGraphInstantiateWithParams
 
     global __cuGraphExecGetFlags
-    data["__cuGraphExecGetFlags"] = <intptr_t>__cuGraphExecGetFlags
+    data["__cuGraphExecGetFlags"] = <_cyb_intptr_t>__cuGraphExecGetFlags
 
     global __cuGraphExecKernelNodeSetParams_v2
-    data["__cuGraphExecKernelNodeSetParams_v2"] = <intptr_t>__cuGraphExecKernelNodeSetParams_v2
+    data["__cuGraphExecKernelNodeSetParams_v2"] = <_cyb_intptr_t>__cuGraphExecKernelNodeSetParams_v2
 
     global __cuGraphExecMemcpyNodeSetParams
-    data["__cuGraphExecMemcpyNodeSetParams"] = <intptr_t>__cuGraphExecMemcpyNodeSetParams
+    data["__cuGraphExecMemcpyNodeSetParams"] = <_cyb_intptr_t>__cuGraphExecMemcpyNodeSetParams
 
     global __cuGraphExecMemsetNodeSetParams
-    data["__cuGraphExecMemsetNodeSetParams"] = <intptr_t>__cuGraphExecMemsetNodeSetParams
+    data["__cuGraphExecMemsetNodeSetParams"] = <_cyb_intptr_t>__cuGraphExecMemsetNodeSetParams
 
     global __cuGraphExecHostNodeSetParams
-    data["__cuGraphExecHostNodeSetParams"] = <intptr_t>__cuGraphExecHostNodeSetParams
+    data["__cuGraphExecHostNodeSetParams"] = <_cyb_intptr_t>__cuGraphExecHostNodeSetParams
 
     global __cuGraphExecChildGraphNodeSetParams
-    data["__cuGraphExecChildGraphNodeSetParams"] = <intptr_t>__cuGraphExecChildGraphNodeSetParams
+    data["__cuGraphExecChildGraphNodeSetParams"] = <_cyb_intptr_t>__cuGraphExecChildGraphNodeSetParams
 
     global __cuGraphExecEventRecordNodeSetEvent
-    data["__cuGraphExecEventRecordNodeSetEvent"] = <intptr_t>__cuGraphExecEventRecordNodeSetEvent
+    data["__cuGraphExecEventRecordNodeSetEvent"] = <_cyb_intptr_t>__cuGraphExecEventRecordNodeSetEvent
 
     global __cuGraphExecEventWaitNodeSetEvent
-    data["__cuGraphExecEventWaitNodeSetEvent"] = <intptr_t>__cuGraphExecEventWaitNodeSetEvent
+    data["__cuGraphExecEventWaitNodeSetEvent"] = <_cyb_intptr_t>__cuGraphExecEventWaitNodeSetEvent
 
     global __cuGraphExecExternalSemaphoresSignalNodeSetParams
-    data["__cuGraphExecExternalSemaphoresSignalNodeSetParams"] = <intptr_t>__cuGraphExecExternalSemaphoresSignalNodeSetParams
+    data["__cuGraphExecExternalSemaphoresSignalNodeSetParams"] = <_cyb_intptr_t>__cuGraphExecExternalSemaphoresSignalNodeSetParams
 
     global __cuGraphExecExternalSemaphoresWaitNodeSetParams
-    data["__cuGraphExecExternalSemaphoresWaitNodeSetParams"] = <intptr_t>__cuGraphExecExternalSemaphoresWaitNodeSetParams
+    data["__cuGraphExecExternalSemaphoresWaitNodeSetParams"] = <_cyb_intptr_t>__cuGraphExecExternalSemaphoresWaitNodeSetParams
 
     global __cuGraphNodeSetEnabled
-    data["__cuGraphNodeSetEnabled"] = <intptr_t>__cuGraphNodeSetEnabled
+    data["__cuGraphNodeSetEnabled"] = <_cyb_intptr_t>__cuGraphNodeSetEnabled
 
     global __cuGraphNodeGetEnabled
-    data["__cuGraphNodeGetEnabled"] = <intptr_t>__cuGraphNodeGetEnabled
+    data["__cuGraphNodeGetEnabled"] = <_cyb_intptr_t>__cuGraphNodeGetEnabled
 
     global __cuGraphUpload
-    data["__cuGraphUpload"] = <intptr_t>__cuGraphUpload
+    data["__cuGraphUpload"] = <_cyb_intptr_t>__cuGraphUpload
 
     global __cuGraphLaunch
-    data["__cuGraphLaunch"] = <intptr_t>__cuGraphLaunch
+    data["__cuGraphLaunch"] = <_cyb_intptr_t>__cuGraphLaunch
 
     global __cuGraphExecDestroy
-    data["__cuGraphExecDestroy"] = <intptr_t>__cuGraphExecDestroy
+    data["__cuGraphExecDestroy"] = <_cyb_intptr_t>__cuGraphExecDestroy
 
     global __cuGraphDestroy
-    data["__cuGraphDestroy"] = <intptr_t>__cuGraphDestroy
+    data["__cuGraphDestroy"] = <_cyb_intptr_t>__cuGraphDestroy
 
     global __cuGraphExecUpdate_v2
-    data["__cuGraphExecUpdate_v2"] = <intptr_t>__cuGraphExecUpdate_v2
+    data["__cuGraphExecUpdate_v2"] = <_cyb_intptr_t>__cuGraphExecUpdate_v2
 
     global __cuGraphKernelNodeCopyAttributes
-    data["__cuGraphKernelNodeCopyAttributes"] = <intptr_t>__cuGraphKernelNodeCopyAttributes
+    data["__cuGraphKernelNodeCopyAttributes"] = <_cyb_intptr_t>__cuGraphKernelNodeCopyAttributes
 
     global __cuGraphKernelNodeGetAttribute
-    data["__cuGraphKernelNodeGetAttribute"] = <intptr_t>__cuGraphKernelNodeGetAttribute
+    data["__cuGraphKernelNodeGetAttribute"] = <_cyb_intptr_t>__cuGraphKernelNodeGetAttribute
 
     global __cuGraphKernelNodeSetAttribute
-    data["__cuGraphKernelNodeSetAttribute"] = <intptr_t>__cuGraphKernelNodeSetAttribute
+    data["__cuGraphKernelNodeSetAttribute"] = <_cyb_intptr_t>__cuGraphKernelNodeSetAttribute
 
     global __cuGraphDebugDotPrint
-    data["__cuGraphDebugDotPrint"] = <intptr_t>__cuGraphDebugDotPrint
+    data["__cuGraphDebugDotPrint"] = <_cyb_intptr_t>__cuGraphDebugDotPrint
 
     global __cuUserObjectCreate
-    data["__cuUserObjectCreate"] = <intptr_t>__cuUserObjectCreate
+    data["__cuUserObjectCreate"] = <_cyb_intptr_t>__cuUserObjectCreate
 
     global __cuUserObjectRetain
-    data["__cuUserObjectRetain"] = <intptr_t>__cuUserObjectRetain
+    data["__cuUserObjectRetain"] = <_cyb_intptr_t>__cuUserObjectRetain
 
     global __cuUserObjectRelease
-    data["__cuUserObjectRelease"] = <intptr_t>__cuUserObjectRelease
+    data["__cuUserObjectRelease"] = <_cyb_intptr_t>__cuUserObjectRelease
 
     global __cuGraphRetainUserObject
-    data["__cuGraphRetainUserObject"] = <intptr_t>__cuGraphRetainUserObject
+    data["__cuGraphRetainUserObject"] = <_cyb_intptr_t>__cuGraphRetainUserObject
 
     global __cuGraphReleaseUserObject
-    data["__cuGraphReleaseUserObject"] = <intptr_t>__cuGraphReleaseUserObject
+    data["__cuGraphReleaseUserObject"] = <_cyb_intptr_t>__cuGraphReleaseUserObject
 
     global __cuGraphAddNode_v2
-    data["__cuGraphAddNode_v2"] = <intptr_t>__cuGraphAddNode_v2
+    data["__cuGraphAddNode_v2"] = <_cyb_intptr_t>__cuGraphAddNode_v2
 
     global __cuGraphNodeSetParams
-    data["__cuGraphNodeSetParams"] = <intptr_t>__cuGraphNodeSetParams
+    data["__cuGraphNodeSetParams"] = <_cyb_intptr_t>__cuGraphNodeSetParams
 
     global __cuGraphExecNodeSetParams
-    data["__cuGraphExecNodeSetParams"] = <intptr_t>__cuGraphExecNodeSetParams
+    data["__cuGraphExecNodeSetParams"] = <_cyb_intptr_t>__cuGraphExecNodeSetParams
 
     global __cuGraphConditionalHandleCreate
-    data["__cuGraphConditionalHandleCreate"] = <intptr_t>__cuGraphConditionalHandleCreate
+    data["__cuGraphConditionalHandleCreate"] = <_cyb_intptr_t>__cuGraphConditionalHandleCreate
 
     global __cuOccupancyMaxActiveBlocksPerMultiprocessor
-    data["__cuOccupancyMaxActiveBlocksPerMultiprocessor"] = <intptr_t>__cuOccupancyMaxActiveBlocksPerMultiprocessor
+    data["__cuOccupancyMaxActiveBlocksPerMultiprocessor"] = <_cyb_intptr_t>__cuOccupancyMaxActiveBlocksPerMultiprocessor
 
     global __cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags
-    data["__cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags"] = <intptr_t>__cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags
+    data["__cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags"] = <_cyb_intptr_t>__cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags
 
     global __cuOccupancyMaxPotentialBlockSize
-    data["__cuOccupancyMaxPotentialBlockSize"] = <intptr_t>__cuOccupancyMaxPotentialBlockSize
+    data["__cuOccupancyMaxPotentialBlockSize"] = <_cyb_intptr_t>__cuOccupancyMaxPotentialBlockSize
 
     global __cuOccupancyMaxPotentialBlockSizeWithFlags
-    data["__cuOccupancyMaxPotentialBlockSizeWithFlags"] = <intptr_t>__cuOccupancyMaxPotentialBlockSizeWithFlags
+    data["__cuOccupancyMaxPotentialBlockSizeWithFlags"] = <_cyb_intptr_t>__cuOccupancyMaxPotentialBlockSizeWithFlags
 
     global __cuOccupancyAvailableDynamicSMemPerBlock
-    data["__cuOccupancyAvailableDynamicSMemPerBlock"] = <intptr_t>__cuOccupancyAvailableDynamicSMemPerBlock
+    data["__cuOccupancyAvailableDynamicSMemPerBlock"] = <_cyb_intptr_t>__cuOccupancyAvailableDynamicSMemPerBlock
 
     global __cuOccupancyMaxPotentialClusterSize
-    data["__cuOccupancyMaxPotentialClusterSize"] = <intptr_t>__cuOccupancyMaxPotentialClusterSize
+    data["__cuOccupancyMaxPotentialClusterSize"] = <_cyb_intptr_t>__cuOccupancyMaxPotentialClusterSize
 
     global __cuOccupancyMaxActiveClusters
-    data["__cuOccupancyMaxActiveClusters"] = <intptr_t>__cuOccupancyMaxActiveClusters
+    data["__cuOccupancyMaxActiveClusters"] = <_cyb_intptr_t>__cuOccupancyMaxActiveClusters
 
     global __cuTexRefSetArray
-    data["__cuTexRefSetArray"] = <intptr_t>__cuTexRefSetArray
+    data["__cuTexRefSetArray"] = <_cyb_intptr_t>__cuTexRefSetArray
 
     global __cuTexRefSetMipmappedArray
-    data["__cuTexRefSetMipmappedArray"] = <intptr_t>__cuTexRefSetMipmappedArray
+    data["__cuTexRefSetMipmappedArray"] = <_cyb_intptr_t>__cuTexRefSetMipmappedArray
 
     global __cuTexRefSetAddress_v2
-    data["__cuTexRefSetAddress_v2"] = <intptr_t>__cuTexRefSetAddress_v2
+    data["__cuTexRefSetAddress_v2"] = <_cyb_intptr_t>__cuTexRefSetAddress_v2
 
     global __cuTexRefSetAddress2D_v3
-    data["__cuTexRefSetAddress2D_v3"] = <intptr_t>__cuTexRefSetAddress2D_v3
+    data["__cuTexRefSetAddress2D_v3"] = <_cyb_intptr_t>__cuTexRefSetAddress2D_v3
 
     global __cuTexRefSetFormat
-    data["__cuTexRefSetFormat"] = <intptr_t>__cuTexRefSetFormat
+    data["__cuTexRefSetFormat"] = <_cyb_intptr_t>__cuTexRefSetFormat
 
     global __cuTexRefSetAddressMode
-    data["__cuTexRefSetAddressMode"] = <intptr_t>__cuTexRefSetAddressMode
+    data["__cuTexRefSetAddressMode"] = <_cyb_intptr_t>__cuTexRefSetAddressMode
 
     global __cuTexRefSetFilterMode
-    data["__cuTexRefSetFilterMode"] = <intptr_t>__cuTexRefSetFilterMode
+    data["__cuTexRefSetFilterMode"] = <_cyb_intptr_t>__cuTexRefSetFilterMode
 
     global __cuTexRefSetMipmapFilterMode
-    data["__cuTexRefSetMipmapFilterMode"] = <intptr_t>__cuTexRefSetMipmapFilterMode
+    data["__cuTexRefSetMipmapFilterMode"] = <_cyb_intptr_t>__cuTexRefSetMipmapFilterMode
 
     global __cuTexRefSetMipmapLevelBias
-    data["__cuTexRefSetMipmapLevelBias"] = <intptr_t>__cuTexRefSetMipmapLevelBias
+    data["__cuTexRefSetMipmapLevelBias"] = <_cyb_intptr_t>__cuTexRefSetMipmapLevelBias
 
     global __cuTexRefSetMipmapLevelClamp
-    data["__cuTexRefSetMipmapLevelClamp"] = <intptr_t>__cuTexRefSetMipmapLevelClamp
+    data["__cuTexRefSetMipmapLevelClamp"] = <_cyb_intptr_t>__cuTexRefSetMipmapLevelClamp
 
     global __cuTexRefSetMaxAnisotropy
-    data["__cuTexRefSetMaxAnisotropy"] = <intptr_t>__cuTexRefSetMaxAnisotropy
+    data["__cuTexRefSetMaxAnisotropy"] = <_cyb_intptr_t>__cuTexRefSetMaxAnisotropy
 
     global __cuTexRefSetBorderColor
-    data["__cuTexRefSetBorderColor"] = <intptr_t>__cuTexRefSetBorderColor
+    data["__cuTexRefSetBorderColor"] = <_cyb_intptr_t>__cuTexRefSetBorderColor
 
     global __cuTexRefSetFlags
-    data["__cuTexRefSetFlags"] = <intptr_t>__cuTexRefSetFlags
+    data["__cuTexRefSetFlags"] = <_cyb_intptr_t>__cuTexRefSetFlags
 
     global __cuTexRefGetAddress_v2
-    data["__cuTexRefGetAddress_v2"] = <intptr_t>__cuTexRefGetAddress_v2
+    data["__cuTexRefGetAddress_v2"] = <_cyb_intptr_t>__cuTexRefGetAddress_v2
 
     global __cuTexRefGetArray
-    data["__cuTexRefGetArray"] = <intptr_t>__cuTexRefGetArray
+    data["__cuTexRefGetArray"] = <_cyb_intptr_t>__cuTexRefGetArray
 
     global __cuTexRefGetMipmappedArray
-    data["__cuTexRefGetMipmappedArray"] = <intptr_t>__cuTexRefGetMipmappedArray
+    data["__cuTexRefGetMipmappedArray"] = <_cyb_intptr_t>__cuTexRefGetMipmappedArray
 
     global __cuTexRefGetAddressMode
-    data["__cuTexRefGetAddressMode"] = <intptr_t>__cuTexRefGetAddressMode
+    data["__cuTexRefGetAddressMode"] = <_cyb_intptr_t>__cuTexRefGetAddressMode
 
     global __cuTexRefGetFilterMode
-    data["__cuTexRefGetFilterMode"] = <intptr_t>__cuTexRefGetFilterMode
+    data["__cuTexRefGetFilterMode"] = <_cyb_intptr_t>__cuTexRefGetFilterMode
 
     global __cuTexRefGetFormat
-    data["__cuTexRefGetFormat"] = <intptr_t>__cuTexRefGetFormat
+    data["__cuTexRefGetFormat"] = <_cyb_intptr_t>__cuTexRefGetFormat
 
     global __cuTexRefGetMipmapFilterMode
-    data["__cuTexRefGetMipmapFilterMode"] = <intptr_t>__cuTexRefGetMipmapFilterMode
+    data["__cuTexRefGetMipmapFilterMode"] = <_cyb_intptr_t>__cuTexRefGetMipmapFilterMode
 
     global __cuTexRefGetMipmapLevelBias
-    data["__cuTexRefGetMipmapLevelBias"] = <intptr_t>__cuTexRefGetMipmapLevelBias
+    data["__cuTexRefGetMipmapLevelBias"] = <_cyb_intptr_t>__cuTexRefGetMipmapLevelBias
 
     global __cuTexRefGetMipmapLevelClamp
-    data["__cuTexRefGetMipmapLevelClamp"] = <intptr_t>__cuTexRefGetMipmapLevelClamp
+    data["__cuTexRefGetMipmapLevelClamp"] = <_cyb_intptr_t>__cuTexRefGetMipmapLevelClamp
 
     global __cuTexRefGetMaxAnisotropy
-    data["__cuTexRefGetMaxAnisotropy"] = <intptr_t>__cuTexRefGetMaxAnisotropy
+    data["__cuTexRefGetMaxAnisotropy"] = <_cyb_intptr_t>__cuTexRefGetMaxAnisotropy
 
     global __cuTexRefGetBorderColor
-    data["__cuTexRefGetBorderColor"] = <intptr_t>__cuTexRefGetBorderColor
+    data["__cuTexRefGetBorderColor"] = <_cyb_intptr_t>__cuTexRefGetBorderColor
 
     global __cuTexRefGetFlags
-    data["__cuTexRefGetFlags"] = <intptr_t>__cuTexRefGetFlags
+    data["__cuTexRefGetFlags"] = <_cyb_intptr_t>__cuTexRefGetFlags
 
     global __cuTexRefCreate
-    data["__cuTexRefCreate"] = <intptr_t>__cuTexRefCreate
+    data["__cuTexRefCreate"] = <_cyb_intptr_t>__cuTexRefCreate
 
     global __cuTexRefDestroy
-    data["__cuTexRefDestroy"] = <intptr_t>__cuTexRefDestroy
+    data["__cuTexRefDestroy"] = <_cyb_intptr_t>__cuTexRefDestroy
 
     global __cuSurfRefSetArray
-    data["__cuSurfRefSetArray"] = <intptr_t>__cuSurfRefSetArray
+    data["__cuSurfRefSetArray"] = <_cyb_intptr_t>__cuSurfRefSetArray
 
     global __cuSurfRefGetArray
-    data["__cuSurfRefGetArray"] = <intptr_t>__cuSurfRefGetArray
+    data["__cuSurfRefGetArray"] = <_cyb_intptr_t>__cuSurfRefGetArray
 
     global __cuTexObjectCreate
-    data["__cuTexObjectCreate"] = <intptr_t>__cuTexObjectCreate
+    data["__cuTexObjectCreate"] = <_cyb_intptr_t>__cuTexObjectCreate
 
     global __cuTexObjectDestroy
-    data["__cuTexObjectDestroy"] = <intptr_t>__cuTexObjectDestroy
+    data["__cuTexObjectDestroy"] = <_cyb_intptr_t>__cuTexObjectDestroy
 
     global __cuTexObjectGetResourceDesc
-    data["__cuTexObjectGetResourceDesc"] = <intptr_t>__cuTexObjectGetResourceDesc
+    data["__cuTexObjectGetResourceDesc"] = <_cyb_intptr_t>__cuTexObjectGetResourceDesc
 
     global __cuTexObjectGetTextureDesc
-    data["__cuTexObjectGetTextureDesc"] = <intptr_t>__cuTexObjectGetTextureDesc
+    data["__cuTexObjectGetTextureDesc"] = <_cyb_intptr_t>__cuTexObjectGetTextureDesc
 
     global __cuTexObjectGetResourceViewDesc
-    data["__cuTexObjectGetResourceViewDesc"] = <intptr_t>__cuTexObjectGetResourceViewDesc
+    data["__cuTexObjectGetResourceViewDesc"] = <_cyb_intptr_t>__cuTexObjectGetResourceViewDesc
 
     global __cuSurfObjectCreate
-    data["__cuSurfObjectCreate"] = <intptr_t>__cuSurfObjectCreate
+    data["__cuSurfObjectCreate"] = <_cyb_intptr_t>__cuSurfObjectCreate
 
     global __cuSurfObjectDestroy
-    data["__cuSurfObjectDestroy"] = <intptr_t>__cuSurfObjectDestroy
+    data["__cuSurfObjectDestroy"] = <_cyb_intptr_t>__cuSurfObjectDestroy
 
     global __cuSurfObjectGetResourceDesc
-    data["__cuSurfObjectGetResourceDesc"] = <intptr_t>__cuSurfObjectGetResourceDesc
+    data["__cuSurfObjectGetResourceDesc"] = <_cyb_intptr_t>__cuSurfObjectGetResourceDesc
 
     global __cuTensorMapEncodeTiled
-    data["__cuTensorMapEncodeTiled"] = <intptr_t>__cuTensorMapEncodeTiled
+    data["__cuTensorMapEncodeTiled"] = <_cyb_intptr_t>__cuTensorMapEncodeTiled
 
     global __cuTensorMapEncodeIm2col
-    data["__cuTensorMapEncodeIm2col"] = <intptr_t>__cuTensorMapEncodeIm2col
+    data["__cuTensorMapEncodeIm2col"] = <_cyb_intptr_t>__cuTensorMapEncodeIm2col
 
     global __cuTensorMapEncodeIm2colWide
-    data["__cuTensorMapEncodeIm2colWide"] = <intptr_t>__cuTensorMapEncodeIm2colWide
+    data["__cuTensorMapEncodeIm2colWide"] = <_cyb_intptr_t>__cuTensorMapEncodeIm2colWide
 
     global __cuTensorMapReplaceAddress
-    data["__cuTensorMapReplaceAddress"] = <intptr_t>__cuTensorMapReplaceAddress
+    data["__cuTensorMapReplaceAddress"] = <_cyb_intptr_t>__cuTensorMapReplaceAddress
 
     global __cuDeviceCanAccessPeer
-    data["__cuDeviceCanAccessPeer"] = <intptr_t>__cuDeviceCanAccessPeer
+    data["__cuDeviceCanAccessPeer"] = <_cyb_intptr_t>__cuDeviceCanAccessPeer
 
     global __cuCtxEnablePeerAccess
-    data["__cuCtxEnablePeerAccess"] = <intptr_t>__cuCtxEnablePeerAccess
+    data["__cuCtxEnablePeerAccess"] = <_cyb_intptr_t>__cuCtxEnablePeerAccess
 
     global __cuCtxDisablePeerAccess
-    data["__cuCtxDisablePeerAccess"] = <intptr_t>__cuCtxDisablePeerAccess
+    data["__cuCtxDisablePeerAccess"] = <_cyb_intptr_t>__cuCtxDisablePeerAccess
 
     global __cuDeviceGetP2PAttribute
-    data["__cuDeviceGetP2PAttribute"] = <intptr_t>__cuDeviceGetP2PAttribute
+    data["__cuDeviceGetP2PAttribute"] = <_cyb_intptr_t>__cuDeviceGetP2PAttribute
 
     global __cuGraphicsUnregisterResource
-    data["__cuGraphicsUnregisterResource"] = <intptr_t>__cuGraphicsUnregisterResource
+    data["__cuGraphicsUnregisterResource"] = <_cyb_intptr_t>__cuGraphicsUnregisterResource
 
     global __cuGraphicsSubResourceGetMappedArray
-    data["__cuGraphicsSubResourceGetMappedArray"] = <intptr_t>__cuGraphicsSubResourceGetMappedArray
+    data["__cuGraphicsSubResourceGetMappedArray"] = <_cyb_intptr_t>__cuGraphicsSubResourceGetMappedArray
 
     global __cuGraphicsResourceGetMappedMipmappedArray
-    data["__cuGraphicsResourceGetMappedMipmappedArray"] = <intptr_t>__cuGraphicsResourceGetMappedMipmappedArray
+    data["__cuGraphicsResourceGetMappedMipmappedArray"] = <_cyb_intptr_t>__cuGraphicsResourceGetMappedMipmappedArray
 
     global __cuGraphicsResourceGetMappedPointer_v2
-    data["__cuGraphicsResourceGetMappedPointer_v2"] = <intptr_t>__cuGraphicsResourceGetMappedPointer_v2
+    data["__cuGraphicsResourceGetMappedPointer_v2"] = <_cyb_intptr_t>__cuGraphicsResourceGetMappedPointer_v2
 
     global __cuGraphicsResourceSetMapFlags_v2
-    data["__cuGraphicsResourceSetMapFlags_v2"] = <intptr_t>__cuGraphicsResourceSetMapFlags_v2
+    data["__cuGraphicsResourceSetMapFlags_v2"] = <_cyb_intptr_t>__cuGraphicsResourceSetMapFlags_v2
 
     global __cuGraphicsMapResources
-    data["__cuGraphicsMapResources"] = <intptr_t>__cuGraphicsMapResources
+    data["__cuGraphicsMapResources"] = <_cyb_intptr_t>__cuGraphicsMapResources
 
     global __cuGraphicsUnmapResources
-    data["__cuGraphicsUnmapResources"] = <intptr_t>__cuGraphicsUnmapResources
+    data["__cuGraphicsUnmapResources"] = <_cyb_intptr_t>__cuGraphicsUnmapResources
 
     global __cuGetProcAddress_v2
-    data["__cuGetProcAddress_v2"] = <intptr_t>__cuGetProcAddress_v2
+    data["__cuGetProcAddress_v2"] = <_cyb_intptr_t>__cuGetProcAddress_v2
 
     global __cuCoredumpGetAttribute
-    data["__cuCoredumpGetAttribute"] = <intptr_t>__cuCoredumpGetAttribute
+    data["__cuCoredumpGetAttribute"] = <_cyb_intptr_t>__cuCoredumpGetAttribute
 
     global __cuCoredumpGetAttributeGlobal
-    data["__cuCoredumpGetAttributeGlobal"] = <intptr_t>__cuCoredumpGetAttributeGlobal
+    data["__cuCoredumpGetAttributeGlobal"] = <_cyb_intptr_t>__cuCoredumpGetAttributeGlobal
 
     global __cuCoredumpSetAttribute
-    data["__cuCoredumpSetAttribute"] = <intptr_t>__cuCoredumpSetAttribute
+    data["__cuCoredumpSetAttribute"] = <_cyb_intptr_t>__cuCoredumpSetAttribute
 
     global __cuCoredumpSetAttributeGlobal
-    data["__cuCoredumpSetAttributeGlobal"] = <intptr_t>__cuCoredumpSetAttributeGlobal
+    data["__cuCoredumpSetAttributeGlobal"] = <_cyb_intptr_t>__cuCoredumpSetAttributeGlobal
 
     global __cuGetExportTable
-    data["__cuGetExportTable"] = <intptr_t>__cuGetExportTable
+    data["__cuGetExportTable"] = <_cyb_intptr_t>__cuGetExportTable
 
     global __cuGreenCtxCreate
-    data["__cuGreenCtxCreate"] = <intptr_t>__cuGreenCtxCreate
+    data["__cuGreenCtxCreate"] = <_cyb_intptr_t>__cuGreenCtxCreate
 
     global __cuGreenCtxDestroy
-    data["__cuGreenCtxDestroy"] = <intptr_t>__cuGreenCtxDestroy
+    data["__cuGreenCtxDestroy"] = <_cyb_intptr_t>__cuGreenCtxDestroy
 
     global __cuCtxFromGreenCtx
-    data["__cuCtxFromGreenCtx"] = <intptr_t>__cuCtxFromGreenCtx
+    data["__cuCtxFromGreenCtx"] = <_cyb_intptr_t>__cuCtxFromGreenCtx
 
     global __cuDeviceGetDevResource
-    data["__cuDeviceGetDevResource"] = <intptr_t>__cuDeviceGetDevResource
+    data["__cuDeviceGetDevResource"] = <_cyb_intptr_t>__cuDeviceGetDevResource
 
     global __cuCtxGetDevResource
-    data["__cuCtxGetDevResource"] = <intptr_t>__cuCtxGetDevResource
+    data["__cuCtxGetDevResource"] = <_cyb_intptr_t>__cuCtxGetDevResource
 
     global __cuGreenCtxGetDevResource
-    data["__cuGreenCtxGetDevResource"] = <intptr_t>__cuGreenCtxGetDevResource
+    data["__cuGreenCtxGetDevResource"] = <_cyb_intptr_t>__cuGreenCtxGetDevResource
 
     global __cuDevSmResourceSplitByCount
-    data["__cuDevSmResourceSplitByCount"] = <intptr_t>__cuDevSmResourceSplitByCount
+    data["__cuDevSmResourceSplitByCount"] = <_cyb_intptr_t>__cuDevSmResourceSplitByCount
 
     global __cuDevResourceGenerateDesc
-    data["__cuDevResourceGenerateDesc"] = <intptr_t>__cuDevResourceGenerateDesc
+    data["__cuDevResourceGenerateDesc"] = <_cyb_intptr_t>__cuDevResourceGenerateDesc
 
     global __cuGreenCtxRecordEvent
-    data["__cuGreenCtxRecordEvent"] = <intptr_t>__cuGreenCtxRecordEvent
+    data["__cuGreenCtxRecordEvent"] = <_cyb_intptr_t>__cuGreenCtxRecordEvent
 
     global __cuGreenCtxWaitEvent
-    data["__cuGreenCtxWaitEvent"] = <intptr_t>__cuGreenCtxWaitEvent
+    data["__cuGreenCtxWaitEvent"] = <_cyb_intptr_t>__cuGreenCtxWaitEvent
 
     global __cuStreamGetGreenCtx
-    data["__cuStreamGetGreenCtx"] = <intptr_t>__cuStreamGetGreenCtx
+    data["__cuStreamGetGreenCtx"] = <_cyb_intptr_t>__cuStreamGetGreenCtx
 
     global __cuGreenCtxStreamCreate
-    data["__cuGreenCtxStreamCreate"] = <intptr_t>__cuGreenCtxStreamCreate
+    data["__cuGreenCtxStreamCreate"] = <_cyb_intptr_t>__cuGreenCtxStreamCreate
 
     global __cuLogsRegisterCallback
-    data["__cuLogsRegisterCallback"] = <intptr_t>__cuLogsRegisterCallback
+    data["__cuLogsRegisterCallback"] = <_cyb_intptr_t>__cuLogsRegisterCallback
 
     global __cuLogsUnregisterCallback
-    data["__cuLogsUnregisterCallback"] = <intptr_t>__cuLogsUnregisterCallback
+    data["__cuLogsUnregisterCallback"] = <_cyb_intptr_t>__cuLogsUnregisterCallback
 
     global __cuLogsCurrent
-    data["__cuLogsCurrent"] = <intptr_t>__cuLogsCurrent
+    data["__cuLogsCurrent"] = <_cyb_intptr_t>__cuLogsCurrent
 
     global __cuLogsDumpToFile
-    data["__cuLogsDumpToFile"] = <intptr_t>__cuLogsDumpToFile
+    data["__cuLogsDumpToFile"] = <_cyb_intptr_t>__cuLogsDumpToFile
 
     global __cuLogsDumpToMemory
-    data["__cuLogsDumpToMemory"] = <intptr_t>__cuLogsDumpToMemory
+    data["__cuLogsDumpToMemory"] = <_cyb_intptr_t>__cuLogsDumpToMemory
 
     global __cuCheckpointProcessGetRestoreThreadId
-    data["__cuCheckpointProcessGetRestoreThreadId"] = <intptr_t>__cuCheckpointProcessGetRestoreThreadId
+    data["__cuCheckpointProcessGetRestoreThreadId"] = <_cyb_intptr_t>__cuCheckpointProcessGetRestoreThreadId
 
     global __cuCheckpointProcessGetState
-    data["__cuCheckpointProcessGetState"] = <intptr_t>__cuCheckpointProcessGetState
+    data["__cuCheckpointProcessGetState"] = <_cyb_intptr_t>__cuCheckpointProcessGetState
 
     global __cuCheckpointProcessLock
-    data["__cuCheckpointProcessLock"] = <intptr_t>__cuCheckpointProcessLock
+    data["__cuCheckpointProcessLock"] = <_cyb_intptr_t>__cuCheckpointProcessLock
 
     global __cuCheckpointProcessCheckpoint
-    data["__cuCheckpointProcessCheckpoint"] = <intptr_t>__cuCheckpointProcessCheckpoint
+    data["__cuCheckpointProcessCheckpoint"] = <_cyb_intptr_t>__cuCheckpointProcessCheckpoint
 
     global __cuCheckpointProcessRestore
-    data["__cuCheckpointProcessRestore"] = <intptr_t>__cuCheckpointProcessRestore
+    data["__cuCheckpointProcessRestore"] = <_cyb_intptr_t>__cuCheckpointProcessRestore
 
     global __cuCheckpointProcessUnlock
-    data["__cuCheckpointProcessUnlock"] = <intptr_t>__cuCheckpointProcessUnlock
+    data["__cuCheckpointProcessUnlock"] = <_cyb_intptr_t>__cuCheckpointProcessUnlock
 
     global __cuGraphicsEGLRegisterImage
-    data["__cuGraphicsEGLRegisterImage"] = <intptr_t>__cuGraphicsEGLRegisterImage
+    data["__cuGraphicsEGLRegisterImage"] = <_cyb_intptr_t>__cuGraphicsEGLRegisterImage
 
     global __cuEGLStreamConsumerConnect
-    data["__cuEGLStreamConsumerConnect"] = <intptr_t>__cuEGLStreamConsumerConnect
+    data["__cuEGLStreamConsumerConnect"] = <_cyb_intptr_t>__cuEGLStreamConsumerConnect
 
     global __cuEGLStreamConsumerConnectWithFlags
-    data["__cuEGLStreamConsumerConnectWithFlags"] = <intptr_t>__cuEGLStreamConsumerConnectWithFlags
+    data["__cuEGLStreamConsumerConnectWithFlags"] = <_cyb_intptr_t>__cuEGLStreamConsumerConnectWithFlags
 
     global __cuEGLStreamConsumerDisconnect
-    data["__cuEGLStreamConsumerDisconnect"] = <intptr_t>__cuEGLStreamConsumerDisconnect
+    data["__cuEGLStreamConsumerDisconnect"] = <_cyb_intptr_t>__cuEGLStreamConsumerDisconnect
 
     global __cuEGLStreamConsumerAcquireFrame
-    data["__cuEGLStreamConsumerAcquireFrame"] = <intptr_t>__cuEGLStreamConsumerAcquireFrame
+    data["__cuEGLStreamConsumerAcquireFrame"] = <_cyb_intptr_t>__cuEGLStreamConsumerAcquireFrame
 
     global __cuEGLStreamConsumerReleaseFrame
-    data["__cuEGLStreamConsumerReleaseFrame"] = <intptr_t>__cuEGLStreamConsumerReleaseFrame
+    data["__cuEGLStreamConsumerReleaseFrame"] = <_cyb_intptr_t>__cuEGLStreamConsumerReleaseFrame
 
     global __cuEGLStreamProducerConnect
-    data["__cuEGLStreamProducerConnect"] = <intptr_t>__cuEGLStreamProducerConnect
+    data["__cuEGLStreamProducerConnect"] = <_cyb_intptr_t>__cuEGLStreamProducerConnect
 
     global __cuEGLStreamProducerDisconnect
-    data["__cuEGLStreamProducerDisconnect"] = <intptr_t>__cuEGLStreamProducerDisconnect
+    data["__cuEGLStreamProducerDisconnect"] = <_cyb_intptr_t>__cuEGLStreamProducerDisconnect
 
     global __cuEGLStreamProducerPresentFrame
-    data["__cuEGLStreamProducerPresentFrame"] = <intptr_t>__cuEGLStreamProducerPresentFrame
+    data["__cuEGLStreamProducerPresentFrame"] = <_cyb_intptr_t>__cuEGLStreamProducerPresentFrame
 
     global __cuEGLStreamProducerReturnFrame
-    data["__cuEGLStreamProducerReturnFrame"] = <intptr_t>__cuEGLStreamProducerReturnFrame
+    data["__cuEGLStreamProducerReturnFrame"] = <_cyb_intptr_t>__cuEGLStreamProducerReturnFrame
 
     global __cuGraphicsResourceGetMappedEglFrame
-    data["__cuGraphicsResourceGetMappedEglFrame"] = <intptr_t>__cuGraphicsResourceGetMappedEglFrame
+    data["__cuGraphicsResourceGetMappedEglFrame"] = <_cyb_intptr_t>__cuGraphicsResourceGetMappedEglFrame
 
     global __cuEventCreateFromEGLSync
-    data["__cuEventCreateFromEGLSync"] = <intptr_t>__cuEventCreateFromEGLSync
+    data["__cuEventCreateFromEGLSync"] = <_cyb_intptr_t>__cuEventCreateFromEGLSync
 
     global __cuGraphicsGLRegisterBuffer
-    data["__cuGraphicsGLRegisterBuffer"] = <intptr_t>__cuGraphicsGLRegisterBuffer
+    data["__cuGraphicsGLRegisterBuffer"] = <_cyb_intptr_t>__cuGraphicsGLRegisterBuffer
 
     global __cuGraphicsGLRegisterImage
-    data["__cuGraphicsGLRegisterImage"] = <intptr_t>__cuGraphicsGLRegisterImage
+    data["__cuGraphicsGLRegisterImage"] = <_cyb_intptr_t>__cuGraphicsGLRegisterImage
 
     global __cuGLGetDevices_v2
-    data["__cuGLGetDevices_v2"] = <intptr_t>__cuGLGetDevices_v2
+    data["__cuGLGetDevices_v2"] = <_cyb_intptr_t>__cuGLGetDevices_v2
 
     global __cuGLCtxCreate_v2
-    data["__cuGLCtxCreate_v2"] = <intptr_t>__cuGLCtxCreate_v2
+    data["__cuGLCtxCreate_v2"] = <_cyb_intptr_t>__cuGLCtxCreate_v2
 
     global __cuGLInit
-    data["__cuGLInit"] = <intptr_t>__cuGLInit
+    data["__cuGLInit"] = <_cyb_intptr_t>__cuGLInit
 
     global __cuGLRegisterBufferObject
-    data["__cuGLRegisterBufferObject"] = <intptr_t>__cuGLRegisterBufferObject
+    data["__cuGLRegisterBufferObject"] = <_cyb_intptr_t>__cuGLRegisterBufferObject
 
     global __cuGLMapBufferObject_v2
-    data["__cuGLMapBufferObject_v2"] = <intptr_t>__cuGLMapBufferObject_v2
+    data["__cuGLMapBufferObject_v2"] = <_cyb_intptr_t>__cuGLMapBufferObject_v2
 
     global __cuGLUnmapBufferObject
-    data["__cuGLUnmapBufferObject"] = <intptr_t>__cuGLUnmapBufferObject
+    data["__cuGLUnmapBufferObject"] = <_cyb_intptr_t>__cuGLUnmapBufferObject
 
     global __cuGLUnregisterBufferObject
-    data["__cuGLUnregisterBufferObject"] = <intptr_t>__cuGLUnregisterBufferObject
+    data["__cuGLUnregisterBufferObject"] = <_cyb_intptr_t>__cuGLUnregisterBufferObject
 
     global __cuGLSetBufferObjectMapFlags
-    data["__cuGLSetBufferObjectMapFlags"] = <intptr_t>__cuGLSetBufferObjectMapFlags
+    data["__cuGLSetBufferObjectMapFlags"] = <_cyb_intptr_t>__cuGLSetBufferObjectMapFlags
 
     global __cuGLMapBufferObjectAsync_v2
-    data["__cuGLMapBufferObjectAsync_v2"] = <intptr_t>__cuGLMapBufferObjectAsync_v2
+    data["__cuGLMapBufferObjectAsync_v2"] = <_cyb_intptr_t>__cuGLMapBufferObjectAsync_v2
 
     global __cuGLUnmapBufferObjectAsync
-    data["__cuGLUnmapBufferObjectAsync"] = <intptr_t>__cuGLUnmapBufferObjectAsync
+    data["__cuGLUnmapBufferObjectAsync"] = <_cyb_intptr_t>__cuGLUnmapBufferObjectAsync
 
     global __cuProfilerInitialize
-    data["__cuProfilerInitialize"] = <intptr_t>__cuProfilerInitialize
+    data["__cuProfilerInitialize"] = <_cyb_intptr_t>__cuProfilerInitialize
 
     global __cuProfilerStart
-    data["__cuProfilerStart"] = <intptr_t>__cuProfilerStart
+    data["__cuProfilerStart"] = <_cyb_intptr_t>__cuProfilerStart
 
     global __cuProfilerStop
-    data["__cuProfilerStop"] = <intptr_t>__cuProfilerStop
+    data["__cuProfilerStop"] = <_cyb_intptr_t>__cuProfilerStop
 
     global __cuVDPAUGetDevice
-    data["__cuVDPAUGetDevice"] = <intptr_t>__cuVDPAUGetDevice
+    data["__cuVDPAUGetDevice"] = <_cyb_intptr_t>__cuVDPAUGetDevice
 
     global __cuVDPAUCtxCreate_v2
-    data["__cuVDPAUCtxCreate_v2"] = <intptr_t>__cuVDPAUCtxCreate_v2
+    data["__cuVDPAUCtxCreate_v2"] = <_cyb_intptr_t>__cuVDPAUCtxCreate_v2
 
     global __cuGraphicsVDPAURegisterVideoSurface
-    data["__cuGraphicsVDPAURegisterVideoSurface"] = <intptr_t>__cuGraphicsVDPAURegisterVideoSurface
+    data["__cuGraphicsVDPAURegisterVideoSurface"] = <_cyb_intptr_t>__cuGraphicsVDPAURegisterVideoSurface
 
     global __cuGraphicsVDPAURegisterOutputSurface
-    data["__cuGraphicsVDPAURegisterOutputSurface"] = <intptr_t>__cuGraphicsVDPAURegisterOutputSurface
+    data["__cuGraphicsVDPAURegisterOutputSurface"] = <_cyb_intptr_t>__cuGraphicsVDPAURegisterOutputSurface
 
     global __cuDeviceGetHostAtomicCapabilities
-    data["__cuDeviceGetHostAtomicCapabilities"] = <intptr_t>__cuDeviceGetHostAtomicCapabilities
+    data["__cuDeviceGetHostAtomicCapabilities"] = <_cyb_intptr_t>__cuDeviceGetHostAtomicCapabilities
 
     global __cuCtxGetDevice_v2
-    data["__cuCtxGetDevice_v2"] = <intptr_t>__cuCtxGetDevice_v2
+    data["__cuCtxGetDevice_v2"] = <_cyb_intptr_t>__cuCtxGetDevice_v2
 
     global __cuCtxSynchronize_v2
-    data["__cuCtxSynchronize_v2"] = <intptr_t>__cuCtxSynchronize_v2
+    data["__cuCtxSynchronize_v2"] = <_cyb_intptr_t>__cuCtxSynchronize_v2
 
     global __cuMemcpyBatchAsync_v2
-    data["__cuMemcpyBatchAsync_v2"] = <intptr_t>__cuMemcpyBatchAsync_v2
+    data["__cuMemcpyBatchAsync_v2"] = <_cyb_intptr_t>__cuMemcpyBatchAsync_v2
 
     global __cuMemcpy3DBatchAsync_v2
-    data["__cuMemcpy3DBatchAsync_v2"] = <intptr_t>__cuMemcpy3DBatchAsync_v2
+    data["__cuMemcpy3DBatchAsync_v2"] = <_cyb_intptr_t>__cuMemcpy3DBatchAsync_v2
 
     global __cuMemGetDefaultMemPool
-    data["__cuMemGetDefaultMemPool"] = <intptr_t>__cuMemGetDefaultMemPool
+    data["__cuMemGetDefaultMemPool"] = <_cyb_intptr_t>__cuMemGetDefaultMemPool
 
     global __cuMemGetMemPool
-    data["__cuMemGetMemPool"] = <intptr_t>__cuMemGetMemPool
+    data["__cuMemGetMemPool"] = <_cyb_intptr_t>__cuMemGetMemPool
 
     global __cuMemSetMemPool
-    data["__cuMemSetMemPool"] = <intptr_t>__cuMemSetMemPool
+    data["__cuMemSetMemPool"] = <_cyb_intptr_t>__cuMemSetMemPool
 
     global __cuMemPrefetchBatchAsync
-    data["__cuMemPrefetchBatchAsync"] = <intptr_t>__cuMemPrefetchBatchAsync
+    data["__cuMemPrefetchBatchAsync"] = <_cyb_intptr_t>__cuMemPrefetchBatchAsync
 
     global __cuMemDiscardBatchAsync
-    data["__cuMemDiscardBatchAsync"] = <intptr_t>__cuMemDiscardBatchAsync
+    data["__cuMemDiscardBatchAsync"] = <_cyb_intptr_t>__cuMemDiscardBatchAsync
 
     global __cuMemDiscardAndPrefetchBatchAsync
-    data["__cuMemDiscardAndPrefetchBatchAsync"] = <intptr_t>__cuMemDiscardAndPrefetchBatchAsync
+    data["__cuMemDiscardAndPrefetchBatchAsync"] = <_cyb_intptr_t>__cuMemDiscardAndPrefetchBatchAsync
 
     global __cuDeviceGetP2PAtomicCapabilities
-    data["__cuDeviceGetP2PAtomicCapabilities"] = <intptr_t>__cuDeviceGetP2PAtomicCapabilities
+    data["__cuDeviceGetP2PAtomicCapabilities"] = <_cyb_intptr_t>__cuDeviceGetP2PAtomicCapabilities
 
     global __cuGreenCtxGetId
-    data["__cuGreenCtxGetId"] = <intptr_t>__cuGreenCtxGetId
+    data["__cuGreenCtxGetId"] = <_cyb_intptr_t>__cuGreenCtxGetId
 
     global __cuMulticastBindMem_v2
-    data["__cuMulticastBindMem_v2"] = <intptr_t>__cuMulticastBindMem_v2
+    data["__cuMulticastBindMem_v2"] = <_cyb_intptr_t>__cuMulticastBindMem_v2
 
     global __cuMulticastBindAddr_v2
-    data["__cuMulticastBindAddr_v2"] = <intptr_t>__cuMulticastBindAddr_v2
+    data["__cuMulticastBindAddr_v2"] = <_cyb_intptr_t>__cuMulticastBindAddr_v2
 
     global __cuGraphNodeGetContainingGraph
-    data["__cuGraphNodeGetContainingGraph"] = <intptr_t>__cuGraphNodeGetContainingGraph
+    data["__cuGraphNodeGetContainingGraph"] = <_cyb_intptr_t>__cuGraphNodeGetContainingGraph
 
     global __cuGraphNodeGetLocalId
-    data["__cuGraphNodeGetLocalId"] = <intptr_t>__cuGraphNodeGetLocalId
+    data["__cuGraphNodeGetLocalId"] = <_cyb_intptr_t>__cuGraphNodeGetLocalId
 
     global __cuGraphNodeGetToolsId
-    data["__cuGraphNodeGetToolsId"] = <intptr_t>__cuGraphNodeGetToolsId
+    data["__cuGraphNodeGetToolsId"] = <_cyb_intptr_t>__cuGraphNodeGetToolsId
 
     global __cuGraphGetId
-    data["__cuGraphGetId"] = <intptr_t>__cuGraphGetId
+    data["__cuGraphGetId"] = <_cyb_intptr_t>__cuGraphGetId
 
     global __cuGraphExecGetId
-    data["__cuGraphExecGetId"] = <intptr_t>__cuGraphExecGetId
+    data["__cuGraphExecGetId"] = <_cyb_intptr_t>__cuGraphExecGetId
 
     global __cuDevSmResourceSplit
-    data["__cuDevSmResourceSplit"] = <intptr_t>__cuDevSmResourceSplit
+    data["__cuDevSmResourceSplit"] = <_cyb_intptr_t>__cuDevSmResourceSplit
 
     global __cuStreamGetDevResource
-    data["__cuStreamGetDevResource"] = <intptr_t>__cuStreamGetDevResource
+    data["__cuStreamGetDevResource"] = <_cyb_intptr_t>__cuStreamGetDevResource
 
     global __cuKernelGetParamCount
-    data["__cuKernelGetParamCount"] = <intptr_t>__cuKernelGetParamCount
+    data["__cuKernelGetParamCount"] = <_cyb_intptr_t>__cuKernelGetParamCount
 
     global __cuMemcpyWithAttributesAsync
-    data["__cuMemcpyWithAttributesAsync"] = <intptr_t>__cuMemcpyWithAttributesAsync
+    data["__cuMemcpyWithAttributesAsync"] = <_cyb_intptr_t>__cuMemcpyWithAttributesAsync
 
     global __cuMemcpy3DWithAttributesAsync
-    data["__cuMemcpy3DWithAttributesAsync"] = <intptr_t>__cuMemcpy3DWithAttributesAsync
+    data["__cuMemcpy3DWithAttributesAsync"] = <_cyb_intptr_t>__cuMemcpy3DWithAttributesAsync
 
     global __cuStreamBeginCaptureToCig
-    data["__cuStreamBeginCaptureToCig"] = <intptr_t>__cuStreamBeginCaptureToCig
+    data["__cuStreamBeginCaptureToCig"] = <_cyb_intptr_t>__cuStreamBeginCaptureToCig
 
     global __cuStreamEndCaptureToCig
-    data["__cuStreamEndCaptureToCig"] = <intptr_t>__cuStreamEndCaptureToCig
+    data["__cuStreamEndCaptureToCig"] = <_cyb_intptr_t>__cuStreamEndCaptureToCig
 
     global __cuFuncGetParamCount
-    data["__cuFuncGetParamCount"] = <intptr_t>__cuFuncGetParamCount
+    data["__cuFuncGetParamCount"] = <_cyb_intptr_t>__cuFuncGetParamCount
 
     global __cuLaunchHostFunc_v2
-    data["__cuLaunchHostFunc_v2"] = <intptr_t>__cuLaunchHostFunc_v2
+    data["__cuLaunchHostFunc_v2"] = <_cyb_intptr_t>__cuLaunchHostFunc_v2
 
     global __cuGraphNodeGetParams
-    data["__cuGraphNodeGetParams"] = <intptr_t>__cuGraphNodeGetParams
+    data["__cuGraphNodeGetParams"] = <_cyb_intptr_t>__cuGraphNodeGetParams
 
     global __cuCoredumpRegisterStartCallback
-    data["__cuCoredumpRegisterStartCallback"] = <intptr_t>__cuCoredumpRegisterStartCallback
+    data["__cuCoredumpRegisterStartCallback"] = <_cyb_intptr_t>__cuCoredumpRegisterStartCallback
 
     global __cuCoredumpRegisterCompleteCallback
-    data["__cuCoredumpRegisterCompleteCallback"] = <intptr_t>__cuCoredumpRegisterCompleteCallback
+    data["__cuCoredumpRegisterCompleteCallback"] = <_cyb_intptr_t>__cuCoredumpRegisterCompleteCallback
 
     global __cuCoredumpDeregisterStartCallback
-    data["__cuCoredumpDeregisterStartCallback"] = <intptr_t>__cuCoredumpDeregisterStartCallback
+    data["__cuCoredumpDeregisterStartCallback"] = <_cyb_intptr_t>__cuCoredumpDeregisterStartCallback
 
     global __cuCoredumpDeregisterCompleteCallback
-    data["__cuCoredumpDeregisterCompleteCallback"] = <intptr_t>__cuCoredumpDeregisterCompleteCallback
+    data["__cuCoredumpDeregisterCompleteCallback"] = <_cyb_intptr_t>__cuCoredumpDeregisterCompleteCallback
 
     global __cuLogicalEndpointIdReserve
-    data["__cuLogicalEndpointIdReserve"] = <intptr_t>__cuLogicalEndpointIdReserve
+    data["__cuLogicalEndpointIdReserve"] = <_cyb_intptr_t>__cuLogicalEndpointIdReserve
 
     global __cuLogicalEndpointIdRelease
-    data["__cuLogicalEndpointIdRelease"] = <intptr_t>__cuLogicalEndpointIdRelease
+    data["__cuLogicalEndpointIdRelease"] = <_cyb_intptr_t>__cuLogicalEndpointIdRelease
 
     global __cuLogicalEndpointCreate
-    data["__cuLogicalEndpointCreate"] = <intptr_t>__cuLogicalEndpointCreate
+    data["__cuLogicalEndpointCreate"] = <_cyb_intptr_t>__cuLogicalEndpointCreate
 
     global __cuLogicalEndpointAddDevice
-    data["__cuLogicalEndpointAddDevice"] = <intptr_t>__cuLogicalEndpointAddDevice
+    data["__cuLogicalEndpointAddDevice"] = <_cyb_intptr_t>__cuLogicalEndpointAddDevice
 
     global __cuLogicalEndpointDestroy
-    data["__cuLogicalEndpointDestroy"] = <intptr_t>__cuLogicalEndpointDestroy
+    data["__cuLogicalEndpointDestroy"] = <_cyb_intptr_t>__cuLogicalEndpointDestroy
 
     global __cuLogicalEndpointBindAddr
-    data["__cuLogicalEndpointBindAddr"] = <intptr_t>__cuLogicalEndpointBindAddr
+    data["__cuLogicalEndpointBindAddr"] = <_cyb_intptr_t>__cuLogicalEndpointBindAddr
 
     global __cuLogicalEndpointBindMem
-    data["__cuLogicalEndpointBindMem"] = <intptr_t>__cuLogicalEndpointBindMem
+    data["__cuLogicalEndpointBindMem"] = <_cyb_intptr_t>__cuLogicalEndpointBindMem
 
     global __cuLogicalEndpointUnbind
-    data["__cuLogicalEndpointUnbind"] = <intptr_t>__cuLogicalEndpointUnbind
+    data["__cuLogicalEndpointUnbind"] = <_cyb_intptr_t>__cuLogicalEndpointUnbind
 
     global __cuLogicalEndpointExport
-    data["__cuLogicalEndpointExport"] = <intptr_t>__cuLogicalEndpointExport
+    data["__cuLogicalEndpointExport"] = <_cyb_intptr_t>__cuLogicalEndpointExport
 
     global __cuLogicalEndpointImport
-    data["__cuLogicalEndpointImport"] = <intptr_t>__cuLogicalEndpointImport
+    data["__cuLogicalEndpointImport"] = <_cyb_intptr_t>__cuLogicalEndpointImport
 
     global __cuLogicalEndpointGetLimits
-    data["__cuLogicalEndpointGetLimits"] = <intptr_t>__cuLogicalEndpointGetLimits
+    data["__cuLogicalEndpointGetLimits"] = <_cyb_intptr_t>__cuLogicalEndpointGetLimits
 
     global __cuLogicalEndpointQuery
-    data["__cuLogicalEndpointQuery"] = <intptr_t>__cuLogicalEndpointQuery
+    data["__cuLogicalEndpointQuery"] = <_cyb_intptr_t>__cuLogicalEndpointQuery
 
     global __cuStreamBeginRecaptureToGraph
-    data["__cuStreamBeginRecaptureToGraph"] = <intptr_t>__cuStreamBeginRecaptureToGraph
-
-    func_ptrs = data
+    data["__cuStreamBeginRecaptureToGraph"] = <_cyb_intptr_t>__cuStreamBeginRecaptureToGraph
+    _cyb_func_ptrs = data
     return data
 
 
 cpdef _inspect_function_pointer(str name):
-    global func_ptrs
-    if func_ptrs is None:
-        func_ptrs = _inspect_function_pointers()
-    return func_ptrs[name]
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is None:
+        _cyb_func_ptrs = _inspect_function_pointers()
+    return _cyb_func_ptrs[name]
+
+
+
+
+cdef uintptr_t load_library() except* with gil:
+    cdef uintptr_t handle = load_nvidia_dynamic_lib("cuda")._handle_uint
+    return handle
 
 
 ###############################################################################

--- a/cuda_bindings/cuda/bindings/_internal/nvfatbin_linux.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvfatbin_linux.pyx
@@ -3,62 +3,34 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.4.1 to 13.3.0. Do not modify it directly.
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=8a025fac12ad4fa9dc651c68c1ab7948f78cbb4b9450935db8f930c9d44988f4
 
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=821fd26991431cd8e528f964b5035e1deafcddf44d2971a267d9ed11d80d5199
-from libc.stdint cimport intptr_t, uintptr_t
 
-import threading
+# <<<< PREAMBLE CONTENT >>>>
+
+cdef extern from "<dlfcn.h>":
+    void* _cyb_dlsym "dlsym"(void*, const char*) nogil
+    const void * _cyb_RTLD_DEFAULT "RTLD_DEFAULT"
+
+from libc.stdint cimport intptr_t as _cyb_intptr_t
+
+import threading as _cyb_threading
+
+cdef bint _cyb___py_nvfatbin_init = False
+cdef dict _cyb_func_ptrs = None
+cdef object _cyb_symbol_lock = _cyb_threading.Lock()
+
+# <<<< END OF PREAMBLE CONTENT >>>>
+
+from libc.stdint cimport uintptr_t
+
 from .utils import FunctionNotFoundError, NotSupportedError
-
 from cuda.pathfinder import load_nvidia_dynamic_lib
-
-
-###############################################################################
-# Extern
-###############################################################################
-
-# You must 'from .utils import NotSupportedError' before using this template
-
-cdef extern from "<dlfcn.h>" nogil:
-    void* dlopen(const char*, int)
-    char* dlerror()
-    void* dlsym(void*, const char*)
-    int dlclose(void*)
-
-    enum:
-        RTLD_LAZY
-        RTLD_NOW
-        RTLD_GLOBAL
-        RTLD_LOCAL
-
-    const void* RTLD_DEFAULT 'RTLD_DEFAULT'
-
-cdef int get_cuda_version():
-    cdef void* handle = NULL
-    cdef int err, driver_ver = 0
-
-    # Load driver to check version
-    handle = dlopen('libcuda.so.1', RTLD_NOW | RTLD_GLOBAL)
-    if handle == NULL:
-        err_msg = dlerror()
-        raise NotSupportedError(f'CUDA driver is not found ({err_msg.decode()})')
-    cuDriverGetVersion = dlsym(handle, "cuDriverGetVersion")
-    if cuDriverGetVersion == NULL:
-        raise RuntimeError('Did not find cuDriverGetVersion symbol in libcuda.so.1')
-    err = (<int (*)(int*) noexcept nogil>cuDriverGetVersion)(&driver_ver)
-    if err != 0:
-        raise RuntimeError(f'cuDriverGetVersion returned error code {err}')
-
-    return driver_ver
-
 
 
 ###############################################################################
 # Wrapper init
 ###############################################################################
-
-cdef object __symbol_lock = threading.Lock()
-cdef bint __py_nvfatbin_init = False
 
 cdef void* __nvFatbinGetErrorString = NULL
 cdef void* __nvFatbinCreate = NULL
@@ -73,173 +45,164 @@ cdef void* __nvFatbinAddIndex = NULL
 cdef void* __nvFatbinAddReloc = NULL
 cdef void* __nvFatbinAddTileIR = NULL
 
-
-cdef void* load_library() except* with gil:
-    cdef uintptr_t handle = load_nvidia_dynamic_lib("nvfatbin")._handle_uint
-    return <void*>handle
-
-
 cdef int _init_nvfatbin() except -1 nogil:
-    global __py_nvfatbin_init
-
+    global _cyb___py_nvfatbin_init
     cdef void* handle = NULL
+    with gil, _cyb_symbol_lock:
+        if _cyb___py_nvfatbin_init: return 0
 
-    with gil, __symbol_lock:
-        # Recheck the flag after obtaining the locks
-        if __py_nvfatbin_init:
-            return 0
-
-        # Load function
         global __nvFatbinGetErrorString
-        __nvFatbinGetErrorString = dlsym(RTLD_DEFAULT, 'nvFatbinGetErrorString')
+        __nvFatbinGetErrorString = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvFatbinGetErrorString')
         if __nvFatbinGetErrorString == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvFatbinGetErrorString = dlsym(handle, 'nvFatbinGetErrorString')
+            __nvFatbinGetErrorString = _cyb_dlsym(handle, 'nvFatbinGetErrorString')
 
         global __nvFatbinCreate
-        __nvFatbinCreate = dlsym(RTLD_DEFAULT, 'nvFatbinCreate')
+        __nvFatbinCreate = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvFatbinCreate')
         if __nvFatbinCreate == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvFatbinCreate = dlsym(handle, 'nvFatbinCreate')
+            __nvFatbinCreate = _cyb_dlsym(handle, 'nvFatbinCreate')
 
         global __nvFatbinDestroy
-        __nvFatbinDestroy = dlsym(RTLD_DEFAULT, 'nvFatbinDestroy')
+        __nvFatbinDestroy = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvFatbinDestroy')
         if __nvFatbinDestroy == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvFatbinDestroy = dlsym(handle, 'nvFatbinDestroy')
+            __nvFatbinDestroy = _cyb_dlsym(handle, 'nvFatbinDestroy')
 
         global __nvFatbinAddPTX
-        __nvFatbinAddPTX = dlsym(RTLD_DEFAULT, 'nvFatbinAddPTX')
+        __nvFatbinAddPTX = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvFatbinAddPTX')
         if __nvFatbinAddPTX == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvFatbinAddPTX = dlsym(handle, 'nvFatbinAddPTX')
+            __nvFatbinAddPTX = _cyb_dlsym(handle, 'nvFatbinAddPTX')
 
         global __nvFatbinAddCubin
-        __nvFatbinAddCubin = dlsym(RTLD_DEFAULT, 'nvFatbinAddCubin')
+        __nvFatbinAddCubin = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvFatbinAddCubin')
         if __nvFatbinAddCubin == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvFatbinAddCubin = dlsym(handle, 'nvFatbinAddCubin')
+            __nvFatbinAddCubin = _cyb_dlsym(handle, 'nvFatbinAddCubin')
 
         global __nvFatbinAddLTOIR
-        __nvFatbinAddLTOIR = dlsym(RTLD_DEFAULT, 'nvFatbinAddLTOIR')
+        __nvFatbinAddLTOIR = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvFatbinAddLTOIR')
         if __nvFatbinAddLTOIR == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvFatbinAddLTOIR = dlsym(handle, 'nvFatbinAddLTOIR')
+            __nvFatbinAddLTOIR = _cyb_dlsym(handle, 'nvFatbinAddLTOIR')
 
         global __nvFatbinSize
-        __nvFatbinSize = dlsym(RTLD_DEFAULT, 'nvFatbinSize')
+        __nvFatbinSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvFatbinSize')
         if __nvFatbinSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvFatbinSize = dlsym(handle, 'nvFatbinSize')
+            __nvFatbinSize = _cyb_dlsym(handle, 'nvFatbinSize')
 
         global __nvFatbinGet
-        __nvFatbinGet = dlsym(RTLD_DEFAULT, 'nvFatbinGet')
+        __nvFatbinGet = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvFatbinGet')
         if __nvFatbinGet == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvFatbinGet = dlsym(handle, 'nvFatbinGet')
+            __nvFatbinGet = _cyb_dlsym(handle, 'nvFatbinGet')
 
         global __nvFatbinVersion
-        __nvFatbinVersion = dlsym(RTLD_DEFAULT, 'nvFatbinVersion')
+        __nvFatbinVersion = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvFatbinVersion')
         if __nvFatbinVersion == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvFatbinVersion = dlsym(handle, 'nvFatbinVersion')
+            __nvFatbinVersion = _cyb_dlsym(handle, 'nvFatbinVersion')
 
         global __nvFatbinAddIndex
-        __nvFatbinAddIndex = dlsym(RTLD_DEFAULT, 'nvFatbinAddIndex')
+        __nvFatbinAddIndex = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvFatbinAddIndex')
         if __nvFatbinAddIndex == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvFatbinAddIndex = dlsym(handle, 'nvFatbinAddIndex')
+            __nvFatbinAddIndex = _cyb_dlsym(handle, 'nvFatbinAddIndex')
 
         global __nvFatbinAddReloc
-        __nvFatbinAddReloc = dlsym(RTLD_DEFAULT, 'nvFatbinAddReloc')
+        __nvFatbinAddReloc = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvFatbinAddReloc')
         if __nvFatbinAddReloc == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvFatbinAddReloc = dlsym(handle, 'nvFatbinAddReloc')
+            __nvFatbinAddReloc = _cyb_dlsym(handle, 'nvFatbinAddReloc')
 
         global __nvFatbinAddTileIR
-        __nvFatbinAddTileIR = dlsym(RTLD_DEFAULT, 'nvFatbinAddTileIR')
+        __nvFatbinAddTileIR = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvFatbinAddTileIR')
         if __nvFatbinAddTileIR == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvFatbinAddTileIR = dlsym(handle, 'nvFatbinAddTileIR')
+            __nvFatbinAddTileIR = _cyb_dlsym(handle, 'nvFatbinAddTileIR')
 
-        __py_nvfatbin_init = True
+        _cyb___py_nvfatbin_init = True
         return 0
 
-
 cdef inline int _check_or_init_nvfatbin() except -1 nogil:
-    if __py_nvfatbin_init:
+    if _cyb___py_nvfatbin_init:
         return 0
 
     return _init_nvfatbin()
 
-cdef dict func_ptrs = None
-
 
 cpdef dict _inspect_function_pointers():
-    global func_ptrs
-    if func_ptrs is not None:
-        return func_ptrs
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is not None:
+        return _cyb_func_ptrs
 
     _check_or_init_nvfatbin()
     cdef dict data = {}
-
     global __nvFatbinGetErrorString
-    data["__nvFatbinGetErrorString"] = <intptr_t>__nvFatbinGetErrorString
+    data["__nvFatbinGetErrorString"] = <_cyb_intptr_t>__nvFatbinGetErrorString
 
     global __nvFatbinCreate
-    data["__nvFatbinCreate"] = <intptr_t>__nvFatbinCreate
+    data["__nvFatbinCreate"] = <_cyb_intptr_t>__nvFatbinCreate
 
     global __nvFatbinDestroy
-    data["__nvFatbinDestroy"] = <intptr_t>__nvFatbinDestroy
+    data["__nvFatbinDestroy"] = <_cyb_intptr_t>__nvFatbinDestroy
 
     global __nvFatbinAddPTX
-    data["__nvFatbinAddPTX"] = <intptr_t>__nvFatbinAddPTX
+    data["__nvFatbinAddPTX"] = <_cyb_intptr_t>__nvFatbinAddPTX
 
     global __nvFatbinAddCubin
-    data["__nvFatbinAddCubin"] = <intptr_t>__nvFatbinAddCubin
+    data["__nvFatbinAddCubin"] = <_cyb_intptr_t>__nvFatbinAddCubin
 
     global __nvFatbinAddLTOIR
-    data["__nvFatbinAddLTOIR"] = <intptr_t>__nvFatbinAddLTOIR
+    data["__nvFatbinAddLTOIR"] = <_cyb_intptr_t>__nvFatbinAddLTOIR
 
     global __nvFatbinSize
-    data["__nvFatbinSize"] = <intptr_t>__nvFatbinSize
+    data["__nvFatbinSize"] = <_cyb_intptr_t>__nvFatbinSize
 
     global __nvFatbinGet
-    data["__nvFatbinGet"] = <intptr_t>__nvFatbinGet
+    data["__nvFatbinGet"] = <_cyb_intptr_t>__nvFatbinGet
 
     global __nvFatbinVersion
-    data["__nvFatbinVersion"] = <intptr_t>__nvFatbinVersion
+    data["__nvFatbinVersion"] = <_cyb_intptr_t>__nvFatbinVersion
 
     global __nvFatbinAddIndex
-    data["__nvFatbinAddIndex"] = <intptr_t>__nvFatbinAddIndex
+    data["__nvFatbinAddIndex"] = <_cyb_intptr_t>__nvFatbinAddIndex
 
     global __nvFatbinAddReloc
-    data["__nvFatbinAddReloc"] = <intptr_t>__nvFatbinAddReloc
+    data["__nvFatbinAddReloc"] = <_cyb_intptr_t>__nvFatbinAddReloc
 
     global __nvFatbinAddTileIR
-    data["__nvFatbinAddTileIR"] = <intptr_t>__nvFatbinAddTileIR
-
-    func_ptrs = data
+    data["__nvFatbinAddTileIR"] = <_cyb_intptr_t>__nvFatbinAddTileIR
+    _cyb_func_ptrs = data
     return data
 
 
 cpdef _inspect_function_pointer(str name):
-    global func_ptrs
-    if func_ptrs is None:
-        func_ptrs = _inspect_function_pointers()
-    return func_ptrs[name]
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is None:
+        _cyb_func_ptrs = _inspect_function_pointers()
+    return _cyb_func_ptrs[name]
+
+
+
+
+cdef void* load_library() except* with gil:
+    cdef uintptr_t handle = load_nvidia_dynamic_lib("nvfatbin")._handle_uint
+    return <void*>handle
 
 
 ###############################################################################

--- a/cuda_bindings/cuda/bindings/_internal/nvfatbin_windows.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvfatbin_windows.pyx
@@ -3,80 +3,31 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.4.1 to 13.3.0. Do not modify it directly.
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=c44272bf506dcc20b5771a20fb6efc77f920c9b9bb21a89b53e3a9e7d69ce1ef
 
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=2052c33a9bbfdef36b362c4eedc1284ce8fa2fc905a53ac9c366218ca99f5913
-from libc.stdint cimport intptr_t
 
-import threading
-from .utils import FunctionNotFoundError, NotSupportedError
+# <<<< PREAMBLE CONTENT >>>>
 
-from cuda.pathfinder import load_nvidia_dynamic_lib
-
-from libc.stddef cimport wchar_t
-from libc.stdint cimport uintptr_t
-from cpython cimport PyUnicode_AsWideCharString, PyMem_Free
-
-# You must 'from .utils import NotSupportedError' before using this template
-
-cdef extern from "windows.h" nogil:
+cdef extern from "<windows.h>":
     ctypedef void* HMODULE
-    ctypedef void* HANDLE
-    ctypedef void* FARPROC
-    ctypedef unsigned long DWORD
-    ctypedef const wchar_t *LPCWSTR
-    ctypedef const char *LPCSTR
+    void* _cyb_GetProcAddress "GetProcAddress"(HMODULE, const char*) nogil
 
-    cdef DWORD LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800
-    cdef DWORD LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000
-    cdef DWORD LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR = 0x00000100
+from libc.stdint cimport intptr_t as _cyb_intptr_t
 
-    HMODULE _LoadLibraryExW "LoadLibraryExW"(
-        LPCWSTR lpLibFileName,
-        HANDLE hFile,
-        DWORD dwFlags
-    )
+import threading as _cyb_threading
 
-    FARPROC _GetProcAddress "GetProcAddress"(HMODULE hModule, LPCSTR lpProcName)
+cdef bint _cyb___py_nvfatbin_init = False
+cdef dict _cyb_func_ptrs = None
+cdef object _cyb_symbol_lock = _cyb_threading.Lock()
 
-cdef inline uintptr_t LoadLibraryExW(str path, HANDLE hFile, DWORD dwFlags):
-    cdef uintptr_t result
-    cdef wchar_t* wpath = PyUnicode_AsWideCharString(path, NULL)
-    with nogil:
-        result = <uintptr_t>_LoadLibraryExW(
-            wpath,
-            hFile,
-            dwFlags
-        )
-    PyMem_Free(wpath)
-    return result
+# <<<< END OF PREAMBLE CONTENT >>>>
 
-cdef inline void *GetProcAddress(uintptr_t hModule, const char* lpProcName) nogil:
-    return _GetProcAddress(<HMODULE>hModule, lpProcName)
-
-cdef int get_cuda_version():
-    cdef int err, driver_ver = 0
-
-    # Load driver to check version
-    handle = LoadLibraryExW("nvcuda.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32)
-    if handle == 0:
-        raise NotSupportedError('CUDA driver is not found')
-    cuDriverGetVersion = GetProcAddress(handle, 'cuDriverGetVersion')
-    if cuDriverGetVersion == NULL:
-        raise RuntimeError('Did not find cuDriverGetVersion symbol in nvcuda.dll')
-    err = (<int (*)(int*) noexcept nogil>cuDriverGetVersion)(&driver_ver)
-    if err != 0:
-        raise RuntimeError(f'cuDriverGetVersion returned error code {err}')
-
-    return driver_ver
-
-
-
+from libc.stdint cimport uintptr_t
+from cuda.pathfinder import load_nvidia_dynamic_lib
+from .utils import FunctionNotFoundError, NotSupportedError
 ###############################################################################
 # Wrapper init
 ###############################################################################
-
-cdef object __symbol_lock = threading.Lock()
-cdef bint __py_nvfatbin_init = False
 
 cdef void* __nvFatbinGetErrorString = NULL
 cdef void* __nvFatbinCreate = NULL
@@ -91,122 +42,118 @@ cdef void* __nvFatbinAddIndex = NULL
 cdef void* __nvFatbinAddReloc = NULL
 cdef void* __nvFatbinAddTileIR = NULL
 
-
 cdef int _init_nvfatbin() except -1 nogil:
-    global __py_nvfatbin_init
+    global _cyb___py_nvfatbin_init
 
-    with gil, __symbol_lock:
-        # Recheck the flag after obtaining the locks
-        if __py_nvfatbin_init:
-            return 0
+    cdef int err
+    cdef uintptr_t handle
+    with gil, _cyb_symbol_lock:
+        if _cyb___py_nvfatbin_init: return 0
 
-        # Load library
-        handle = load_nvidia_dynamic_lib("nvfatbin")._handle_uint
-
-        # Load function
+        handle = load_library()
         global __nvFatbinGetErrorString
-        __nvFatbinGetErrorString = GetProcAddress(handle, 'nvFatbinGetErrorString')
+        __nvFatbinGetErrorString = _cyb_GetProcAddress(<HMODULE>handle, 'nvFatbinGetErrorString')
 
         global __nvFatbinCreate
-        __nvFatbinCreate = GetProcAddress(handle, 'nvFatbinCreate')
+        __nvFatbinCreate = _cyb_GetProcAddress(<HMODULE>handle, 'nvFatbinCreate')
 
         global __nvFatbinDestroy
-        __nvFatbinDestroy = GetProcAddress(handle, 'nvFatbinDestroy')
+        __nvFatbinDestroy = _cyb_GetProcAddress(<HMODULE>handle, 'nvFatbinDestroy')
 
         global __nvFatbinAddPTX
-        __nvFatbinAddPTX = GetProcAddress(handle, 'nvFatbinAddPTX')
+        __nvFatbinAddPTX = _cyb_GetProcAddress(<HMODULE>handle, 'nvFatbinAddPTX')
 
         global __nvFatbinAddCubin
-        __nvFatbinAddCubin = GetProcAddress(handle, 'nvFatbinAddCubin')
+        __nvFatbinAddCubin = _cyb_GetProcAddress(<HMODULE>handle, 'nvFatbinAddCubin')
 
         global __nvFatbinAddLTOIR
-        __nvFatbinAddLTOIR = GetProcAddress(handle, 'nvFatbinAddLTOIR')
+        __nvFatbinAddLTOIR = _cyb_GetProcAddress(<HMODULE>handle, 'nvFatbinAddLTOIR')
 
         global __nvFatbinSize
-        __nvFatbinSize = GetProcAddress(handle, 'nvFatbinSize')
+        __nvFatbinSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvFatbinSize')
 
         global __nvFatbinGet
-        __nvFatbinGet = GetProcAddress(handle, 'nvFatbinGet')
+        __nvFatbinGet = _cyb_GetProcAddress(<HMODULE>handle, 'nvFatbinGet')
 
         global __nvFatbinVersion
-        __nvFatbinVersion = GetProcAddress(handle, 'nvFatbinVersion')
+        __nvFatbinVersion = _cyb_GetProcAddress(<HMODULE>handle, 'nvFatbinVersion')
 
         global __nvFatbinAddIndex
-        __nvFatbinAddIndex = GetProcAddress(handle, 'nvFatbinAddIndex')
+        __nvFatbinAddIndex = _cyb_GetProcAddress(<HMODULE>handle, 'nvFatbinAddIndex')
 
         global __nvFatbinAddReloc
-        __nvFatbinAddReloc = GetProcAddress(handle, 'nvFatbinAddReloc')
+        __nvFatbinAddReloc = _cyb_GetProcAddress(<HMODULE>handle, 'nvFatbinAddReloc')
 
         global __nvFatbinAddTileIR
-        __nvFatbinAddTileIR = GetProcAddress(handle, 'nvFatbinAddTileIR')
+        __nvFatbinAddTileIR = _cyb_GetProcAddress(<HMODULE>handle, 'nvFatbinAddTileIR')
 
-        __py_nvfatbin_init = True
+        _cyb___py_nvfatbin_init = True
         return 0
 
-
 cdef inline int _check_or_init_nvfatbin() except -1 nogil:
-    if __py_nvfatbin_init:
+    if _cyb___py_nvfatbin_init:
         return 0
 
     return _init_nvfatbin()
 
 
-cdef dict func_ptrs = None
-
-
 cpdef dict _inspect_function_pointers():
-    global func_ptrs
-    if func_ptrs is not None:
-        return func_ptrs
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is not None:
+        return _cyb_func_ptrs
 
     _check_or_init_nvfatbin()
     cdef dict data = {}
-
     global __nvFatbinGetErrorString
-    data["__nvFatbinGetErrorString"] = <intptr_t>__nvFatbinGetErrorString
+    data["__nvFatbinGetErrorString"] = <_cyb_intptr_t>__nvFatbinGetErrorString
 
     global __nvFatbinCreate
-    data["__nvFatbinCreate"] = <intptr_t>__nvFatbinCreate
+    data["__nvFatbinCreate"] = <_cyb_intptr_t>__nvFatbinCreate
 
     global __nvFatbinDestroy
-    data["__nvFatbinDestroy"] = <intptr_t>__nvFatbinDestroy
+    data["__nvFatbinDestroy"] = <_cyb_intptr_t>__nvFatbinDestroy
 
     global __nvFatbinAddPTX
-    data["__nvFatbinAddPTX"] = <intptr_t>__nvFatbinAddPTX
+    data["__nvFatbinAddPTX"] = <_cyb_intptr_t>__nvFatbinAddPTX
 
     global __nvFatbinAddCubin
-    data["__nvFatbinAddCubin"] = <intptr_t>__nvFatbinAddCubin
+    data["__nvFatbinAddCubin"] = <_cyb_intptr_t>__nvFatbinAddCubin
 
     global __nvFatbinAddLTOIR
-    data["__nvFatbinAddLTOIR"] = <intptr_t>__nvFatbinAddLTOIR
+    data["__nvFatbinAddLTOIR"] = <_cyb_intptr_t>__nvFatbinAddLTOIR
 
     global __nvFatbinSize
-    data["__nvFatbinSize"] = <intptr_t>__nvFatbinSize
+    data["__nvFatbinSize"] = <_cyb_intptr_t>__nvFatbinSize
 
     global __nvFatbinGet
-    data["__nvFatbinGet"] = <intptr_t>__nvFatbinGet
+    data["__nvFatbinGet"] = <_cyb_intptr_t>__nvFatbinGet
 
     global __nvFatbinVersion
-    data["__nvFatbinVersion"] = <intptr_t>__nvFatbinVersion
+    data["__nvFatbinVersion"] = <_cyb_intptr_t>__nvFatbinVersion
 
     global __nvFatbinAddIndex
-    data["__nvFatbinAddIndex"] = <intptr_t>__nvFatbinAddIndex
+    data["__nvFatbinAddIndex"] = <_cyb_intptr_t>__nvFatbinAddIndex
 
     global __nvFatbinAddReloc
-    data["__nvFatbinAddReloc"] = <intptr_t>__nvFatbinAddReloc
+    data["__nvFatbinAddReloc"] = <_cyb_intptr_t>__nvFatbinAddReloc
 
     global __nvFatbinAddTileIR
-    data["__nvFatbinAddTileIR"] = <intptr_t>__nvFatbinAddTileIR
-
-    func_ptrs = data
+    data["__nvFatbinAddTileIR"] = <_cyb_intptr_t>__nvFatbinAddTileIR
+    _cyb_func_ptrs = data
     return data
 
 
 cpdef _inspect_function_pointer(str name):
-    global func_ptrs
-    if func_ptrs is None:
-        func_ptrs = _inspect_function_pointers()
-    return func_ptrs[name]
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is None:
+        _cyb_func_ptrs = _inspect_function_pointers()
+    return _cyb_func_ptrs[name]
+
+
+
+
+cdef uintptr_t load_library() except* with gil:
+    return load_nvidia_dynamic_lib("nvfatbin")._handle_uint
 
 
 ###############################################################################

--- a/cuda_bindings/cuda/bindings/_internal/nvjitlink_linux.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvjitlink_linux.pyx
@@ -3,62 +3,34 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.0.1 to 13.3.0. Do not modify it directly.
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=2a8907b5ab8df8ecb19b6d0fd3014dea67a9e76e7a2a0ee81fdf23f449402dd6
 
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=f6e8c32c0afa43fe218ae5c6f43f402bb85ab1e9898ad6270872c3e546eb4913
-from libc.stdint cimport intptr_t, uintptr_t
 
-import threading
+# <<<< PREAMBLE CONTENT >>>>
+
+cdef extern from "<dlfcn.h>":
+    void* _cyb_dlsym "dlsym"(void*, const char*) nogil
+    const void * _cyb_RTLD_DEFAULT "RTLD_DEFAULT"
+
+from libc.stdint cimport intptr_t as _cyb_intptr_t
+
+import threading as _cyb_threading
+
+cdef bint _cyb___py_nvjitlink_init = False
+cdef dict _cyb_func_ptrs = None
+cdef object _cyb_symbol_lock = _cyb_threading.Lock()
+
+# <<<< END OF PREAMBLE CONTENT >>>>
+
+from libc.stdint cimport uintptr_t
+
 from .utils import FunctionNotFoundError, NotSupportedError
-
 from cuda.pathfinder import load_nvidia_dynamic_lib
-
-
-###############################################################################
-# Extern
-###############################################################################
-
-# You must 'from .utils import NotSupportedError' before using this template
-
-cdef extern from "<dlfcn.h>" nogil:
-    void* dlopen(const char*, int)
-    char* dlerror()
-    void* dlsym(void*, const char*)
-    int dlclose(void*)
-
-    enum:
-        RTLD_LAZY
-        RTLD_NOW
-        RTLD_GLOBAL
-        RTLD_LOCAL
-
-    const void* RTLD_DEFAULT 'RTLD_DEFAULT'
-
-cdef int get_cuda_version():
-    cdef void* handle = NULL
-    cdef int err, driver_ver = 0
-
-    # Load driver to check version
-    handle = dlopen('libcuda.so.1', RTLD_NOW | RTLD_GLOBAL)
-    if handle == NULL:
-        err_msg = dlerror()
-        raise NotSupportedError(f'CUDA driver is not found ({err_msg.decode()})')
-    cuDriverGetVersion = dlsym(handle, "cuDriverGetVersion")
-    if cuDriverGetVersion == NULL:
-        raise RuntimeError('Did not find cuDriverGetVersion symbol in libcuda.so.1')
-    err = (<int (*)(int*) noexcept nogil>cuDriverGetVersion)(&driver_ver)
-    if err != 0:
-        raise RuntimeError(f'cuDriverGetVersion returned error code {err}')
-
-    return driver_ver
-
 
 
 ###############################################################################
 # Wrapper init
 ###############################################################################
-
-cdef object __symbol_lock = threading.Lock()
-cdef bint __py_nvjitlink_init = False
 
 cdef void* __nvJitLinkCreate = NULL
 cdef void* __nvJitLinkDestroy = NULL
@@ -77,213 +49,204 @@ cdef void* __nvJitLinkVersion = NULL
 cdef void* __nvJitLinkGetLinkedLTOIRSize = NULL
 cdef void* __nvJitLinkGetLinkedLTOIR = NULL
 
-
-cdef void* load_library() except* with gil:
-    cdef uintptr_t handle = load_nvidia_dynamic_lib("nvJitLink")._handle_uint
-    return <void*>handle
-
-
 cdef int _init_nvjitlink() except -1 nogil:
-    global __py_nvjitlink_init
-
+    global _cyb___py_nvjitlink_init
     cdef void* handle = NULL
+    with gil, _cyb_symbol_lock:
+        if _cyb___py_nvjitlink_init: return 0
 
-    with gil, __symbol_lock:
-        # Recheck the flag after obtaining the locks
-        if __py_nvjitlink_init:
-            return 0
-
-        # Load function
         global __nvJitLinkCreate
-        __nvJitLinkCreate = dlsym(RTLD_DEFAULT, 'nvJitLinkCreate')
+        __nvJitLinkCreate = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvJitLinkCreate')
         if __nvJitLinkCreate == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvJitLinkCreate = dlsym(handle, 'nvJitLinkCreate')
+            __nvJitLinkCreate = _cyb_dlsym(handle, 'nvJitLinkCreate')
 
         global __nvJitLinkDestroy
-        __nvJitLinkDestroy = dlsym(RTLD_DEFAULT, 'nvJitLinkDestroy')
+        __nvJitLinkDestroy = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvJitLinkDestroy')
         if __nvJitLinkDestroy == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvJitLinkDestroy = dlsym(handle, 'nvJitLinkDestroy')
+            __nvJitLinkDestroy = _cyb_dlsym(handle, 'nvJitLinkDestroy')
 
         global __nvJitLinkAddData
-        __nvJitLinkAddData = dlsym(RTLD_DEFAULT, 'nvJitLinkAddData')
+        __nvJitLinkAddData = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvJitLinkAddData')
         if __nvJitLinkAddData == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvJitLinkAddData = dlsym(handle, 'nvJitLinkAddData')
+            __nvJitLinkAddData = _cyb_dlsym(handle, 'nvJitLinkAddData')
 
         global __nvJitLinkAddFile
-        __nvJitLinkAddFile = dlsym(RTLD_DEFAULT, 'nvJitLinkAddFile')
+        __nvJitLinkAddFile = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvJitLinkAddFile')
         if __nvJitLinkAddFile == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvJitLinkAddFile = dlsym(handle, 'nvJitLinkAddFile')
+            __nvJitLinkAddFile = _cyb_dlsym(handle, 'nvJitLinkAddFile')
 
         global __nvJitLinkComplete
-        __nvJitLinkComplete = dlsym(RTLD_DEFAULT, 'nvJitLinkComplete')
+        __nvJitLinkComplete = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvJitLinkComplete')
         if __nvJitLinkComplete == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvJitLinkComplete = dlsym(handle, 'nvJitLinkComplete')
+            __nvJitLinkComplete = _cyb_dlsym(handle, 'nvJitLinkComplete')
 
         global __nvJitLinkGetLinkedCubinSize
-        __nvJitLinkGetLinkedCubinSize = dlsym(RTLD_DEFAULT, 'nvJitLinkGetLinkedCubinSize')
+        __nvJitLinkGetLinkedCubinSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvJitLinkGetLinkedCubinSize')
         if __nvJitLinkGetLinkedCubinSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvJitLinkGetLinkedCubinSize = dlsym(handle, 'nvJitLinkGetLinkedCubinSize')
+            __nvJitLinkGetLinkedCubinSize = _cyb_dlsym(handle, 'nvJitLinkGetLinkedCubinSize')
 
         global __nvJitLinkGetLinkedCubin
-        __nvJitLinkGetLinkedCubin = dlsym(RTLD_DEFAULT, 'nvJitLinkGetLinkedCubin')
+        __nvJitLinkGetLinkedCubin = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvJitLinkGetLinkedCubin')
         if __nvJitLinkGetLinkedCubin == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvJitLinkGetLinkedCubin = dlsym(handle, 'nvJitLinkGetLinkedCubin')
+            __nvJitLinkGetLinkedCubin = _cyb_dlsym(handle, 'nvJitLinkGetLinkedCubin')
 
         global __nvJitLinkGetLinkedPtxSize
-        __nvJitLinkGetLinkedPtxSize = dlsym(RTLD_DEFAULT, 'nvJitLinkGetLinkedPtxSize')
+        __nvJitLinkGetLinkedPtxSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvJitLinkGetLinkedPtxSize')
         if __nvJitLinkGetLinkedPtxSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvJitLinkGetLinkedPtxSize = dlsym(handle, 'nvJitLinkGetLinkedPtxSize')
+            __nvJitLinkGetLinkedPtxSize = _cyb_dlsym(handle, 'nvJitLinkGetLinkedPtxSize')
 
         global __nvJitLinkGetLinkedPtx
-        __nvJitLinkGetLinkedPtx = dlsym(RTLD_DEFAULT, 'nvJitLinkGetLinkedPtx')
+        __nvJitLinkGetLinkedPtx = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvJitLinkGetLinkedPtx')
         if __nvJitLinkGetLinkedPtx == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvJitLinkGetLinkedPtx = dlsym(handle, 'nvJitLinkGetLinkedPtx')
+            __nvJitLinkGetLinkedPtx = _cyb_dlsym(handle, 'nvJitLinkGetLinkedPtx')
 
         global __nvJitLinkGetErrorLogSize
-        __nvJitLinkGetErrorLogSize = dlsym(RTLD_DEFAULT, 'nvJitLinkGetErrorLogSize')
+        __nvJitLinkGetErrorLogSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvJitLinkGetErrorLogSize')
         if __nvJitLinkGetErrorLogSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvJitLinkGetErrorLogSize = dlsym(handle, 'nvJitLinkGetErrorLogSize')
+            __nvJitLinkGetErrorLogSize = _cyb_dlsym(handle, 'nvJitLinkGetErrorLogSize')
 
         global __nvJitLinkGetErrorLog
-        __nvJitLinkGetErrorLog = dlsym(RTLD_DEFAULT, 'nvJitLinkGetErrorLog')
+        __nvJitLinkGetErrorLog = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvJitLinkGetErrorLog')
         if __nvJitLinkGetErrorLog == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvJitLinkGetErrorLog = dlsym(handle, 'nvJitLinkGetErrorLog')
+            __nvJitLinkGetErrorLog = _cyb_dlsym(handle, 'nvJitLinkGetErrorLog')
 
         global __nvJitLinkGetInfoLogSize
-        __nvJitLinkGetInfoLogSize = dlsym(RTLD_DEFAULT, 'nvJitLinkGetInfoLogSize')
+        __nvJitLinkGetInfoLogSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvJitLinkGetInfoLogSize')
         if __nvJitLinkGetInfoLogSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvJitLinkGetInfoLogSize = dlsym(handle, 'nvJitLinkGetInfoLogSize')
+            __nvJitLinkGetInfoLogSize = _cyb_dlsym(handle, 'nvJitLinkGetInfoLogSize')
 
         global __nvJitLinkGetInfoLog
-        __nvJitLinkGetInfoLog = dlsym(RTLD_DEFAULT, 'nvJitLinkGetInfoLog')
+        __nvJitLinkGetInfoLog = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvJitLinkGetInfoLog')
         if __nvJitLinkGetInfoLog == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvJitLinkGetInfoLog = dlsym(handle, 'nvJitLinkGetInfoLog')
+            __nvJitLinkGetInfoLog = _cyb_dlsym(handle, 'nvJitLinkGetInfoLog')
 
         global __nvJitLinkVersion
-        __nvJitLinkVersion = dlsym(RTLD_DEFAULT, 'nvJitLinkVersion')
+        __nvJitLinkVersion = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvJitLinkVersion')
         if __nvJitLinkVersion == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvJitLinkVersion = dlsym(handle, 'nvJitLinkVersion')
+            __nvJitLinkVersion = _cyb_dlsym(handle, 'nvJitLinkVersion')
 
         global __nvJitLinkGetLinkedLTOIRSize
-        __nvJitLinkGetLinkedLTOIRSize = dlsym(RTLD_DEFAULT, 'nvJitLinkGetLinkedLTOIRSize')
+        __nvJitLinkGetLinkedLTOIRSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvJitLinkGetLinkedLTOIRSize')
         if __nvJitLinkGetLinkedLTOIRSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvJitLinkGetLinkedLTOIRSize = dlsym(handle, 'nvJitLinkGetLinkedLTOIRSize')
+            __nvJitLinkGetLinkedLTOIRSize = _cyb_dlsym(handle, 'nvJitLinkGetLinkedLTOIRSize')
 
         global __nvJitLinkGetLinkedLTOIR
-        __nvJitLinkGetLinkedLTOIR = dlsym(RTLD_DEFAULT, 'nvJitLinkGetLinkedLTOIR')
+        __nvJitLinkGetLinkedLTOIR = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvJitLinkGetLinkedLTOIR')
         if __nvJitLinkGetLinkedLTOIR == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvJitLinkGetLinkedLTOIR = dlsym(handle, 'nvJitLinkGetLinkedLTOIR')
+            __nvJitLinkGetLinkedLTOIR = _cyb_dlsym(handle, 'nvJitLinkGetLinkedLTOIR')
 
-        __py_nvjitlink_init = True
+        _cyb___py_nvjitlink_init = True
         return 0
 
-
 cdef inline int _check_or_init_nvjitlink() except -1 nogil:
-    if __py_nvjitlink_init:
+    if _cyb___py_nvjitlink_init:
         return 0
 
     return _init_nvjitlink()
 
-cdef dict func_ptrs = None
-
 
 cpdef dict _inspect_function_pointers():
-    global func_ptrs
-    if func_ptrs is not None:
-        return func_ptrs
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is not None:
+        return _cyb_func_ptrs
 
     _check_or_init_nvjitlink()
     cdef dict data = {}
-
     global __nvJitLinkCreate
-    data["__nvJitLinkCreate"] = <intptr_t>__nvJitLinkCreate
+    data["__nvJitLinkCreate"] = <_cyb_intptr_t>__nvJitLinkCreate
 
     global __nvJitLinkDestroy
-    data["__nvJitLinkDestroy"] = <intptr_t>__nvJitLinkDestroy
+    data["__nvJitLinkDestroy"] = <_cyb_intptr_t>__nvJitLinkDestroy
 
     global __nvJitLinkAddData
-    data["__nvJitLinkAddData"] = <intptr_t>__nvJitLinkAddData
+    data["__nvJitLinkAddData"] = <_cyb_intptr_t>__nvJitLinkAddData
 
     global __nvJitLinkAddFile
-    data["__nvJitLinkAddFile"] = <intptr_t>__nvJitLinkAddFile
+    data["__nvJitLinkAddFile"] = <_cyb_intptr_t>__nvJitLinkAddFile
 
     global __nvJitLinkComplete
-    data["__nvJitLinkComplete"] = <intptr_t>__nvJitLinkComplete
+    data["__nvJitLinkComplete"] = <_cyb_intptr_t>__nvJitLinkComplete
 
     global __nvJitLinkGetLinkedCubinSize
-    data["__nvJitLinkGetLinkedCubinSize"] = <intptr_t>__nvJitLinkGetLinkedCubinSize
+    data["__nvJitLinkGetLinkedCubinSize"] = <_cyb_intptr_t>__nvJitLinkGetLinkedCubinSize
 
     global __nvJitLinkGetLinkedCubin
-    data["__nvJitLinkGetLinkedCubin"] = <intptr_t>__nvJitLinkGetLinkedCubin
+    data["__nvJitLinkGetLinkedCubin"] = <_cyb_intptr_t>__nvJitLinkGetLinkedCubin
 
     global __nvJitLinkGetLinkedPtxSize
-    data["__nvJitLinkGetLinkedPtxSize"] = <intptr_t>__nvJitLinkGetLinkedPtxSize
+    data["__nvJitLinkGetLinkedPtxSize"] = <_cyb_intptr_t>__nvJitLinkGetLinkedPtxSize
 
     global __nvJitLinkGetLinkedPtx
-    data["__nvJitLinkGetLinkedPtx"] = <intptr_t>__nvJitLinkGetLinkedPtx
+    data["__nvJitLinkGetLinkedPtx"] = <_cyb_intptr_t>__nvJitLinkGetLinkedPtx
 
     global __nvJitLinkGetErrorLogSize
-    data["__nvJitLinkGetErrorLogSize"] = <intptr_t>__nvJitLinkGetErrorLogSize
+    data["__nvJitLinkGetErrorLogSize"] = <_cyb_intptr_t>__nvJitLinkGetErrorLogSize
 
     global __nvJitLinkGetErrorLog
-    data["__nvJitLinkGetErrorLog"] = <intptr_t>__nvJitLinkGetErrorLog
+    data["__nvJitLinkGetErrorLog"] = <_cyb_intptr_t>__nvJitLinkGetErrorLog
 
     global __nvJitLinkGetInfoLogSize
-    data["__nvJitLinkGetInfoLogSize"] = <intptr_t>__nvJitLinkGetInfoLogSize
+    data["__nvJitLinkGetInfoLogSize"] = <_cyb_intptr_t>__nvJitLinkGetInfoLogSize
 
     global __nvJitLinkGetInfoLog
-    data["__nvJitLinkGetInfoLog"] = <intptr_t>__nvJitLinkGetInfoLog
+    data["__nvJitLinkGetInfoLog"] = <_cyb_intptr_t>__nvJitLinkGetInfoLog
 
     global __nvJitLinkVersion
-    data["__nvJitLinkVersion"] = <intptr_t>__nvJitLinkVersion
+    data["__nvJitLinkVersion"] = <_cyb_intptr_t>__nvJitLinkVersion
 
     global __nvJitLinkGetLinkedLTOIRSize
-    data["__nvJitLinkGetLinkedLTOIRSize"] = <intptr_t>__nvJitLinkGetLinkedLTOIRSize
+    data["__nvJitLinkGetLinkedLTOIRSize"] = <_cyb_intptr_t>__nvJitLinkGetLinkedLTOIRSize
 
     global __nvJitLinkGetLinkedLTOIR
-    data["__nvJitLinkGetLinkedLTOIR"] = <intptr_t>__nvJitLinkGetLinkedLTOIR
-
-    func_ptrs = data
+    data["__nvJitLinkGetLinkedLTOIR"] = <_cyb_intptr_t>__nvJitLinkGetLinkedLTOIR
+    _cyb_func_ptrs = data
     return data
 
 
 cpdef _inspect_function_pointer(str name):
-    global func_ptrs
-    if func_ptrs is None:
-        func_ptrs = _inspect_function_pointers()
-    return func_ptrs[name]
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is None:
+        _cyb_func_ptrs = _inspect_function_pointers()
+    return _cyb_func_ptrs[name]
+
+
+
+
+cdef void* load_library() except* with gil:
+    cdef uintptr_t handle = load_nvidia_dynamic_lib("nvJitLink")._handle_uint
+    return <void*>handle
 
 
 ###############################################################################

--- a/cuda_bindings/cuda/bindings/_internal/nvjitlink_windows.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvjitlink_windows.pyx
@@ -3,80 +3,31 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.0.1 to 13.3.0. Do not modify it directly.
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=8f99393554faa677ab0ab8326185997a183259db6b26b55561ed2ab6250201a6
 
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=9043dd9e45a69e2bd6c7984832fca8cc1ccd7c66b605b384e4cff18b0c713027
-from libc.stdint cimport intptr_t
 
-import threading
-from .utils import FunctionNotFoundError, NotSupportedError
+# <<<< PREAMBLE CONTENT >>>>
 
-from cuda.pathfinder import load_nvidia_dynamic_lib
-
-from libc.stddef cimport wchar_t
-from libc.stdint cimport uintptr_t
-from cpython cimport PyUnicode_AsWideCharString, PyMem_Free
-
-# You must 'from .utils import NotSupportedError' before using this template
-
-cdef extern from "windows.h" nogil:
+cdef extern from "<windows.h>":
     ctypedef void* HMODULE
-    ctypedef void* HANDLE
-    ctypedef void* FARPROC
-    ctypedef unsigned long DWORD
-    ctypedef const wchar_t *LPCWSTR
-    ctypedef const char *LPCSTR
+    void* _cyb_GetProcAddress "GetProcAddress"(HMODULE, const char*) nogil
 
-    cdef DWORD LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800
-    cdef DWORD LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000
-    cdef DWORD LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR = 0x00000100
+from libc.stdint cimport intptr_t as _cyb_intptr_t
 
-    HMODULE _LoadLibraryExW "LoadLibraryExW"(
-        LPCWSTR lpLibFileName,
-        HANDLE hFile,
-        DWORD dwFlags
-    )
+import threading as _cyb_threading
 
-    FARPROC _GetProcAddress "GetProcAddress"(HMODULE hModule, LPCSTR lpProcName)
+cdef bint _cyb___py_nvjitlink_init = False
+cdef dict _cyb_func_ptrs = None
+cdef object _cyb_symbol_lock = _cyb_threading.Lock()
 
-cdef inline uintptr_t LoadLibraryExW(str path, HANDLE hFile, DWORD dwFlags):
-    cdef uintptr_t result
-    cdef wchar_t* wpath = PyUnicode_AsWideCharString(path, NULL)
-    with nogil:
-        result = <uintptr_t>_LoadLibraryExW(
-            wpath,
-            hFile,
-            dwFlags
-        )
-    PyMem_Free(wpath)
-    return result
+# <<<< END OF PREAMBLE CONTENT >>>>
 
-cdef inline void *GetProcAddress(uintptr_t hModule, const char* lpProcName) nogil:
-    return _GetProcAddress(<HMODULE>hModule, lpProcName)
-
-cdef int get_cuda_version():
-    cdef int err, driver_ver = 0
-
-    # Load driver to check version
-    handle = LoadLibraryExW("nvcuda.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32)
-    if handle == 0:
-        raise NotSupportedError('CUDA driver is not found')
-    cuDriverGetVersion = GetProcAddress(handle, 'cuDriverGetVersion')
-    if cuDriverGetVersion == NULL:
-        raise RuntimeError('Did not find cuDriverGetVersion symbol in nvcuda.dll')
-    err = (<int (*)(int*) noexcept nogil>cuDriverGetVersion)(&driver_ver)
-    if err != 0:
-        raise RuntimeError(f'cuDriverGetVersion returned error code {err}')
-
-    return driver_ver
-
-
-
+from libc.stdint cimport uintptr_t
+from cuda.pathfinder import load_nvidia_dynamic_lib
+from .utils import FunctionNotFoundError, NotSupportedError
 ###############################################################################
 # Wrapper init
 ###############################################################################
-
-cdef object __symbol_lock = threading.Lock()
-cdef bint __py_nvjitlink_init = False
 
 cdef void* __nvJitLinkCreate = NULL
 cdef void* __nvJitLinkDestroy = NULL
@@ -95,146 +46,142 @@ cdef void* __nvJitLinkVersion = NULL
 cdef void* __nvJitLinkGetLinkedLTOIRSize = NULL
 cdef void* __nvJitLinkGetLinkedLTOIR = NULL
 
-
 cdef int _init_nvjitlink() except -1 nogil:
-    global __py_nvjitlink_init
+    global _cyb___py_nvjitlink_init
 
-    with gil, __symbol_lock:
-        # Recheck the flag after obtaining the locks
-        if __py_nvjitlink_init:
-            return 0
+    cdef int err
+    cdef uintptr_t handle
+    with gil, _cyb_symbol_lock:
+        if _cyb___py_nvjitlink_init: return 0
 
-        # Load library
-        handle = load_nvidia_dynamic_lib("nvJitLink")._handle_uint
-
-        # Load function
+        handle = load_library()
         global __nvJitLinkCreate
-        __nvJitLinkCreate = GetProcAddress(handle, 'nvJitLinkCreate')
+        __nvJitLinkCreate = _cyb_GetProcAddress(<HMODULE>handle, 'nvJitLinkCreate')
 
         global __nvJitLinkDestroy
-        __nvJitLinkDestroy = GetProcAddress(handle, 'nvJitLinkDestroy')
+        __nvJitLinkDestroy = _cyb_GetProcAddress(<HMODULE>handle, 'nvJitLinkDestroy')
 
         global __nvJitLinkAddData
-        __nvJitLinkAddData = GetProcAddress(handle, 'nvJitLinkAddData')
+        __nvJitLinkAddData = _cyb_GetProcAddress(<HMODULE>handle, 'nvJitLinkAddData')
 
         global __nvJitLinkAddFile
-        __nvJitLinkAddFile = GetProcAddress(handle, 'nvJitLinkAddFile')
+        __nvJitLinkAddFile = _cyb_GetProcAddress(<HMODULE>handle, 'nvJitLinkAddFile')
 
         global __nvJitLinkComplete
-        __nvJitLinkComplete = GetProcAddress(handle, 'nvJitLinkComplete')
+        __nvJitLinkComplete = _cyb_GetProcAddress(<HMODULE>handle, 'nvJitLinkComplete')
 
         global __nvJitLinkGetLinkedCubinSize
-        __nvJitLinkGetLinkedCubinSize = GetProcAddress(handle, 'nvJitLinkGetLinkedCubinSize')
+        __nvJitLinkGetLinkedCubinSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvJitLinkGetLinkedCubinSize')
 
         global __nvJitLinkGetLinkedCubin
-        __nvJitLinkGetLinkedCubin = GetProcAddress(handle, 'nvJitLinkGetLinkedCubin')
+        __nvJitLinkGetLinkedCubin = _cyb_GetProcAddress(<HMODULE>handle, 'nvJitLinkGetLinkedCubin')
 
         global __nvJitLinkGetLinkedPtxSize
-        __nvJitLinkGetLinkedPtxSize = GetProcAddress(handle, 'nvJitLinkGetLinkedPtxSize')
+        __nvJitLinkGetLinkedPtxSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvJitLinkGetLinkedPtxSize')
 
         global __nvJitLinkGetLinkedPtx
-        __nvJitLinkGetLinkedPtx = GetProcAddress(handle, 'nvJitLinkGetLinkedPtx')
+        __nvJitLinkGetLinkedPtx = _cyb_GetProcAddress(<HMODULE>handle, 'nvJitLinkGetLinkedPtx')
 
         global __nvJitLinkGetErrorLogSize
-        __nvJitLinkGetErrorLogSize = GetProcAddress(handle, 'nvJitLinkGetErrorLogSize')
+        __nvJitLinkGetErrorLogSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvJitLinkGetErrorLogSize')
 
         global __nvJitLinkGetErrorLog
-        __nvJitLinkGetErrorLog = GetProcAddress(handle, 'nvJitLinkGetErrorLog')
+        __nvJitLinkGetErrorLog = _cyb_GetProcAddress(<HMODULE>handle, 'nvJitLinkGetErrorLog')
 
         global __nvJitLinkGetInfoLogSize
-        __nvJitLinkGetInfoLogSize = GetProcAddress(handle, 'nvJitLinkGetInfoLogSize')
+        __nvJitLinkGetInfoLogSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvJitLinkGetInfoLogSize')
 
         global __nvJitLinkGetInfoLog
-        __nvJitLinkGetInfoLog = GetProcAddress(handle, 'nvJitLinkGetInfoLog')
+        __nvJitLinkGetInfoLog = _cyb_GetProcAddress(<HMODULE>handle, 'nvJitLinkGetInfoLog')
 
         global __nvJitLinkVersion
-        __nvJitLinkVersion = GetProcAddress(handle, 'nvJitLinkVersion')
+        __nvJitLinkVersion = _cyb_GetProcAddress(<HMODULE>handle, 'nvJitLinkVersion')
 
         global __nvJitLinkGetLinkedLTOIRSize
-        __nvJitLinkGetLinkedLTOIRSize = GetProcAddress(handle, 'nvJitLinkGetLinkedLTOIRSize')
+        __nvJitLinkGetLinkedLTOIRSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvJitLinkGetLinkedLTOIRSize')
 
         global __nvJitLinkGetLinkedLTOIR
-        __nvJitLinkGetLinkedLTOIR = GetProcAddress(handle, 'nvJitLinkGetLinkedLTOIR')
+        __nvJitLinkGetLinkedLTOIR = _cyb_GetProcAddress(<HMODULE>handle, 'nvJitLinkGetLinkedLTOIR')
 
-        __py_nvjitlink_init = True
+        _cyb___py_nvjitlink_init = True
         return 0
 
-
 cdef inline int _check_or_init_nvjitlink() except -1 nogil:
-    if __py_nvjitlink_init:
+    if _cyb___py_nvjitlink_init:
         return 0
 
     return _init_nvjitlink()
 
 
-cdef dict func_ptrs = None
-
-
 cpdef dict _inspect_function_pointers():
-    global func_ptrs
-    if func_ptrs is not None:
-        return func_ptrs
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is not None:
+        return _cyb_func_ptrs
 
     _check_or_init_nvjitlink()
     cdef dict data = {}
-
     global __nvJitLinkCreate
-    data["__nvJitLinkCreate"] = <intptr_t>__nvJitLinkCreate
+    data["__nvJitLinkCreate"] = <_cyb_intptr_t>__nvJitLinkCreate
 
     global __nvJitLinkDestroy
-    data["__nvJitLinkDestroy"] = <intptr_t>__nvJitLinkDestroy
+    data["__nvJitLinkDestroy"] = <_cyb_intptr_t>__nvJitLinkDestroy
 
     global __nvJitLinkAddData
-    data["__nvJitLinkAddData"] = <intptr_t>__nvJitLinkAddData
+    data["__nvJitLinkAddData"] = <_cyb_intptr_t>__nvJitLinkAddData
 
     global __nvJitLinkAddFile
-    data["__nvJitLinkAddFile"] = <intptr_t>__nvJitLinkAddFile
+    data["__nvJitLinkAddFile"] = <_cyb_intptr_t>__nvJitLinkAddFile
 
     global __nvJitLinkComplete
-    data["__nvJitLinkComplete"] = <intptr_t>__nvJitLinkComplete
+    data["__nvJitLinkComplete"] = <_cyb_intptr_t>__nvJitLinkComplete
 
     global __nvJitLinkGetLinkedCubinSize
-    data["__nvJitLinkGetLinkedCubinSize"] = <intptr_t>__nvJitLinkGetLinkedCubinSize
+    data["__nvJitLinkGetLinkedCubinSize"] = <_cyb_intptr_t>__nvJitLinkGetLinkedCubinSize
 
     global __nvJitLinkGetLinkedCubin
-    data["__nvJitLinkGetLinkedCubin"] = <intptr_t>__nvJitLinkGetLinkedCubin
+    data["__nvJitLinkGetLinkedCubin"] = <_cyb_intptr_t>__nvJitLinkGetLinkedCubin
 
     global __nvJitLinkGetLinkedPtxSize
-    data["__nvJitLinkGetLinkedPtxSize"] = <intptr_t>__nvJitLinkGetLinkedPtxSize
+    data["__nvJitLinkGetLinkedPtxSize"] = <_cyb_intptr_t>__nvJitLinkGetLinkedPtxSize
 
     global __nvJitLinkGetLinkedPtx
-    data["__nvJitLinkGetLinkedPtx"] = <intptr_t>__nvJitLinkGetLinkedPtx
+    data["__nvJitLinkGetLinkedPtx"] = <_cyb_intptr_t>__nvJitLinkGetLinkedPtx
 
     global __nvJitLinkGetErrorLogSize
-    data["__nvJitLinkGetErrorLogSize"] = <intptr_t>__nvJitLinkGetErrorLogSize
+    data["__nvJitLinkGetErrorLogSize"] = <_cyb_intptr_t>__nvJitLinkGetErrorLogSize
 
     global __nvJitLinkGetErrorLog
-    data["__nvJitLinkGetErrorLog"] = <intptr_t>__nvJitLinkGetErrorLog
+    data["__nvJitLinkGetErrorLog"] = <_cyb_intptr_t>__nvJitLinkGetErrorLog
 
     global __nvJitLinkGetInfoLogSize
-    data["__nvJitLinkGetInfoLogSize"] = <intptr_t>__nvJitLinkGetInfoLogSize
+    data["__nvJitLinkGetInfoLogSize"] = <_cyb_intptr_t>__nvJitLinkGetInfoLogSize
 
     global __nvJitLinkGetInfoLog
-    data["__nvJitLinkGetInfoLog"] = <intptr_t>__nvJitLinkGetInfoLog
+    data["__nvJitLinkGetInfoLog"] = <_cyb_intptr_t>__nvJitLinkGetInfoLog
 
     global __nvJitLinkVersion
-    data["__nvJitLinkVersion"] = <intptr_t>__nvJitLinkVersion
+    data["__nvJitLinkVersion"] = <_cyb_intptr_t>__nvJitLinkVersion
 
     global __nvJitLinkGetLinkedLTOIRSize
-    data["__nvJitLinkGetLinkedLTOIRSize"] = <intptr_t>__nvJitLinkGetLinkedLTOIRSize
+    data["__nvJitLinkGetLinkedLTOIRSize"] = <_cyb_intptr_t>__nvJitLinkGetLinkedLTOIRSize
 
     global __nvJitLinkGetLinkedLTOIR
-    data["__nvJitLinkGetLinkedLTOIR"] = <intptr_t>__nvJitLinkGetLinkedLTOIR
-
-    func_ptrs = data
+    data["__nvJitLinkGetLinkedLTOIR"] = <_cyb_intptr_t>__nvJitLinkGetLinkedLTOIR
+    _cyb_func_ptrs = data
     return data
 
 
 cpdef _inspect_function_pointer(str name):
-    global func_ptrs
-    if func_ptrs is None:
-        func_ptrs = _inspect_function_pointers()
-    return func_ptrs[name]
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is None:
+        _cyb_func_ptrs = _inspect_function_pointers()
+    return _cyb_func_ptrs[name]
+
+
+
+
+cdef uintptr_t load_library() except* with gil:
+    return load_nvidia_dynamic_lib("nvJitLink")._handle_uint
 
 
 ###############################################################################

--- a/cuda_bindings/cuda/bindings/_internal/nvml_linux.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvml_linux.pyx
@@ -3,63 +3,34 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.9.1 to 13.3.0. Do not modify it directly.
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=27eba7e4fbbc2bca4f40e906d63b9386cce38cbabfcc50e6a2d7ad5bc0b68e91
 
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=bdb56d8618b22dfcdcb3da879bbe276c3caf7c07aae6e5aa2b76de817f4baa39
-from libc.stdint cimport intptr_t, uintptr_t
 
-import threading
+# <<<< PREAMBLE CONTENT >>>>
+
+cdef extern from "<dlfcn.h>":
+    void* _cyb_dlsym "dlsym"(void*, const char*) nogil
+    const void * _cyb_RTLD_DEFAULT "RTLD_DEFAULT"
+
+from libc.stdint cimport intptr_t as _cyb_intptr_t
+
+import threading as _cyb_threading
+
+cdef bint _cyb___py_nvml_init = False
+cdef dict _cyb_func_ptrs = None
+cdef object _cyb_symbol_lock = _cyb_threading.Lock()
+
+# <<<< END OF PREAMBLE CONTENT >>>>
+
+from libc.stdint cimport uintptr_t
 
 from .utils import FunctionNotFoundError, NotSupportedError
-
 from cuda.pathfinder import load_nvidia_dynamic_lib
-
-
-###############################################################################
-# Extern
-###############################################################################
-
-# You must 'from .utils import NotSupportedError' before using this template
-
-cdef extern from "<dlfcn.h>" nogil:
-    void* dlopen(const char*, int)
-    char* dlerror()
-    void* dlsym(void*, const char*)
-    int dlclose(void*)
-
-    enum:
-        RTLD_LAZY
-        RTLD_NOW
-        RTLD_GLOBAL
-        RTLD_LOCAL
-
-    const void* RTLD_DEFAULT 'RTLD_DEFAULT'
-
-cdef int get_cuda_version():
-    cdef void* handle = NULL
-    cdef int err, driver_ver = 0
-
-    # Load driver to check version
-    handle = dlopen('libcuda.so.1', RTLD_NOW | RTLD_GLOBAL)
-    if handle == NULL:
-        err_msg = dlerror()
-        raise NotSupportedError(f'CUDA driver is not found ({err_msg.decode()})')
-    cuDriverGetVersion = dlsym(handle, "cuDriverGetVersion")
-    if cuDriverGetVersion == NULL:
-        raise RuntimeError('Did not find cuDriverGetVersion symbol in libcuda.so.1')
-    err = (<int (*)(int*) noexcept nogil>cuDriverGetVersion)(&driver_ver)
-    if err != 0:
-        raise RuntimeError(f'cuDriverGetVersion returned error code {err}')
-
-    return driver_ver
-
 
 
 ###############################################################################
 # Wrapper init
 ###############################################################################
-
-cdef object __symbol_lock = threading.Lock()
-cdef bint __py_nvml_init = False
 
 cdef void* __nvmlInit_v2 = NULL
 cdef void* __nvmlInitWithFlags = NULL
@@ -413,3563 +384,3554 @@ cdef void* __nvmlGpuInstanceGetVgpuSchedulerLog_v2 = NULL
 cdef void* __nvmlDeviceSetVgpuSchedulerState_v2 = NULL
 cdef void* __nvmlGpuInstanceSetVgpuSchedulerState_v2 = NULL
 
-
-cdef void* load_library() except* with gil:
-    cdef uintptr_t handle = load_nvidia_dynamic_lib("nvml")._handle_uint
-    return <void*>handle
-
-
 cdef int _init_nvml() except -1 nogil:
-    global __py_nvml_init
+    global _cyb___py_nvml_init
     cdef void* handle = NULL
+    with gil, _cyb_symbol_lock:
+        if _cyb___py_nvml_init: return 0
 
-    with gil, __symbol_lock:
-        # Recheck the flag after obtaining the locks
-        if __py_nvml_init:
-            return 0
-
-        # Load function
         global __nvmlInit_v2
-        __nvmlInit_v2 = dlsym(RTLD_DEFAULT, 'nvmlInit_v2')
+        __nvmlInit_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlInit_v2')
         if __nvmlInit_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlInit_v2 = dlsym(handle, 'nvmlInit_v2')
+            __nvmlInit_v2 = _cyb_dlsym(handle, 'nvmlInit_v2')
 
         global __nvmlInitWithFlags
-        __nvmlInitWithFlags = dlsym(RTLD_DEFAULT, 'nvmlInitWithFlags')
+        __nvmlInitWithFlags = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlInitWithFlags')
         if __nvmlInitWithFlags == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlInitWithFlags = dlsym(handle, 'nvmlInitWithFlags')
+            __nvmlInitWithFlags = _cyb_dlsym(handle, 'nvmlInitWithFlags')
 
         global __nvmlShutdown
-        __nvmlShutdown = dlsym(RTLD_DEFAULT, 'nvmlShutdown')
+        __nvmlShutdown = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlShutdown')
         if __nvmlShutdown == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlShutdown = dlsym(handle, 'nvmlShutdown')
+            __nvmlShutdown = _cyb_dlsym(handle, 'nvmlShutdown')
 
         global __nvmlErrorString
-        __nvmlErrorString = dlsym(RTLD_DEFAULT, 'nvmlErrorString')
+        __nvmlErrorString = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlErrorString')
         if __nvmlErrorString == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlErrorString = dlsym(handle, 'nvmlErrorString')
+            __nvmlErrorString = _cyb_dlsym(handle, 'nvmlErrorString')
 
         global __nvmlSystemGetDriverVersion
-        __nvmlSystemGetDriverVersion = dlsym(RTLD_DEFAULT, 'nvmlSystemGetDriverVersion')
+        __nvmlSystemGetDriverVersion = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemGetDriverVersion')
         if __nvmlSystemGetDriverVersion == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemGetDriverVersion = dlsym(handle, 'nvmlSystemGetDriverVersion')
+            __nvmlSystemGetDriverVersion = _cyb_dlsym(handle, 'nvmlSystemGetDriverVersion')
 
         global __nvmlSystemGetNVMLVersion
-        __nvmlSystemGetNVMLVersion = dlsym(RTLD_DEFAULT, 'nvmlSystemGetNVMLVersion')
+        __nvmlSystemGetNVMLVersion = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemGetNVMLVersion')
         if __nvmlSystemGetNVMLVersion == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemGetNVMLVersion = dlsym(handle, 'nvmlSystemGetNVMLVersion')
+            __nvmlSystemGetNVMLVersion = _cyb_dlsym(handle, 'nvmlSystemGetNVMLVersion')
 
         global __nvmlSystemGetCudaDriverVersion
-        __nvmlSystemGetCudaDriverVersion = dlsym(RTLD_DEFAULT, 'nvmlSystemGetCudaDriverVersion')
+        __nvmlSystemGetCudaDriverVersion = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemGetCudaDriverVersion')
         if __nvmlSystemGetCudaDriverVersion == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemGetCudaDriverVersion = dlsym(handle, 'nvmlSystemGetCudaDriverVersion')
+            __nvmlSystemGetCudaDriverVersion = _cyb_dlsym(handle, 'nvmlSystemGetCudaDriverVersion')
 
         global __nvmlSystemGetCudaDriverVersion_v2
-        __nvmlSystemGetCudaDriverVersion_v2 = dlsym(RTLD_DEFAULT, 'nvmlSystemGetCudaDriverVersion_v2')
+        __nvmlSystemGetCudaDriverVersion_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemGetCudaDriverVersion_v2')
         if __nvmlSystemGetCudaDriverVersion_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemGetCudaDriverVersion_v2 = dlsym(handle, 'nvmlSystemGetCudaDriverVersion_v2')
+            __nvmlSystemGetCudaDriverVersion_v2 = _cyb_dlsym(handle, 'nvmlSystemGetCudaDriverVersion_v2')
 
         global __nvmlSystemGetProcessName
-        __nvmlSystemGetProcessName = dlsym(RTLD_DEFAULT, 'nvmlSystemGetProcessName')
+        __nvmlSystemGetProcessName = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemGetProcessName')
         if __nvmlSystemGetProcessName == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemGetProcessName = dlsym(handle, 'nvmlSystemGetProcessName')
+            __nvmlSystemGetProcessName = _cyb_dlsym(handle, 'nvmlSystemGetProcessName')
 
         global __nvmlSystemGetHicVersion
-        __nvmlSystemGetHicVersion = dlsym(RTLD_DEFAULT, 'nvmlSystemGetHicVersion')
+        __nvmlSystemGetHicVersion = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemGetHicVersion')
         if __nvmlSystemGetHicVersion == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemGetHicVersion = dlsym(handle, 'nvmlSystemGetHicVersion')
+            __nvmlSystemGetHicVersion = _cyb_dlsym(handle, 'nvmlSystemGetHicVersion')
 
         global __nvmlSystemGetTopologyGpuSet
-        __nvmlSystemGetTopologyGpuSet = dlsym(RTLD_DEFAULT, 'nvmlSystemGetTopologyGpuSet')
+        __nvmlSystemGetTopologyGpuSet = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemGetTopologyGpuSet')
         if __nvmlSystemGetTopologyGpuSet == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemGetTopologyGpuSet = dlsym(handle, 'nvmlSystemGetTopologyGpuSet')
+            __nvmlSystemGetTopologyGpuSet = _cyb_dlsym(handle, 'nvmlSystemGetTopologyGpuSet')
 
         global __nvmlSystemGetDriverBranch
-        __nvmlSystemGetDriverBranch = dlsym(RTLD_DEFAULT, 'nvmlSystemGetDriverBranch')
+        __nvmlSystemGetDriverBranch = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemGetDriverBranch')
         if __nvmlSystemGetDriverBranch == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemGetDriverBranch = dlsym(handle, 'nvmlSystemGetDriverBranch')
+            __nvmlSystemGetDriverBranch = _cyb_dlsym(handle, 'nvmlSystemGetDriverBranch')
 
         global __nvmlUnitGetCount
-        __nvmlUnitGetCount = dlsym(RTLD_DEFAULT, 'nvmlUnitGetCount')
+        __nvmlUnitGetCount = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlUnitGetCount')
         if __nvmlUnitGetCount == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlUnitGetCount = dlsym(handle, 'nvmlUnitGetCount')
+            __nvmlUnitGetCount = _cyb_dlsym(handle, 'nvmlUnitGetCount')
 
         global __nvmlUnitGetHandleByIndex
-        __nvmlUnitGetHandleByIndex = dlsym(RTLD_DEFAULT, 'nvmlUnitGetHandleByIndex')
+        __nvmlUnitGetHandleByIndex = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlUnitGetHandleByIndex')
         if __nvmlUnitGetHandleByIndex == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlUnitGetHandleByIndex = dlsym(handle, 'nvmlUnitGetHandleByIndex')
+            __nvmlUnitGetHandleByIndex = _cyb_dlsym(handle, 'nvmlUnitGetHandleByIndex')
 
         global __nvmlUnitGetUnitInfo
-        __nvmlUnitGetUnitInfo = dlsym(RTLD_DEFAULT, 'nvmlUnitGetUnitInfo')
+        __nvmlUnitGetUnitInfo = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlUnitGetUnitInfo')
         if __nvmlUnitGetUnitInfo == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlUnitGetUnitInfo = dlsym(handle, 'nvmlUnitGetUnitInfo')
+            __nvmlUnitGetUnitInfo = _cyb_dlsym(handle, 'nvmlUnitGetUnitInfo')
 
         global __nvmlUnitGetLedState
-        __nvmlUnitGetLedState = dlsym(RTLD_DEFAULT, 'nvmlUnitGetLedState')
+        __nvmlUnitGetLedState = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlUnitGetLedState')
         if __nvmlUnitGetLedState == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlUnitGetLedState = dlsym(handle, 'nvmlUnitGetLedState')
+            __nvmlUnitGetLedState = _cyb_dlsym(handle, 'nvmlUnitGetLedState')
 
         global __nvmlUnitGetPsuInfo
-        __nvmlUnitGetPsuInfo = dlsym(RTLD_DEFAULT, 'nvmlUnitGetPsuInfo')
+        __nvmlUnitGetPsuInfo = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlUnitGetPsuInfo')
         if __nvmlUnitGetPsuInfo == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlUnitGetPsuInfo = dlsym(handle, 'nvmlUnitGetPsuInfo')
+            __nvmlUnitGetPsuInfo = _cyb_dlsym(handle, 'nvmlUnitGetPsuInfo')
 
         global __nvmlUnitGetTemperature
-        __nvmlUnitGetTemperature = dlsym(RTLD_DEFAULT, 'nvmlUnitGetTemperature')
+        __nvmlUnitGetTemperature = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlUnitGetTemperature')
         if __nvmlUnitGetTemperature == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlUnitGetTemperature = dlsym(handle, 'nvmlUnitGetTemperature')
+            __nvmlUnitGetTemperature = _cyb_dlsym(handle, 'nvmlUnitGetTemperature')
 
         global __nvmlUnitGetFanSpeedInfo
-        __nvmlUnitGetFanSpeedInfo = dlsym(RTLD_DEFAULT, 'nvmlUnitGetFanSpeedInfo')
+        __nvmlUnitGetFanSpeedInfo = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlUnitGetFanSpeedInfo')
         if __nvmlUnitGetFanSpeedInfo == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlUnitGetFanSpeedInfo = dlsym(handle, 'nvmlUnitGetFanSpeedInfo')
+            __nvmlUnitGetFanSpeedInfo = _cyb_dlsym(handle, 'nvmlUnitGetFanSpeedInfo')
 
         global __nvmlUnitGetDevices
-        __nvmlUnitGetDevices = dlsym(RTLD_DEFAULT, 'nvmlUnitGetDevices')
+        __nvmlUnitGetDevices = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlUnitGetDevices')
         if __nvmlUnitGetDevices == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlUnitGetDevices = dlsym(handle, 'nvmlUnitGetDevices')
+            __nvmlUnitGetDevices = _cyb_dlsym(handle, 'nvmlUnitGetDevices')
 
         global __nvmlDeviceGetCount_v2
-        __nvmlDeviceGetCount_v2 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetCount_v2')
+        __nvmlDeviceGetCount_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetCount_v2')
         if __nvmlDeviceGetCount_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetCount_v2 = dlsym(handle, 'nvmlDeviceGetCount_v2')
+            __nvmlDeviceGetCount_v2 = _cyb_dlsym(handle, 'nvmlDeviceGetCount_v2')
 
         global __nvmlDeviceGetAttributes_v2
-        __nvmlDeviceGetAttributes_v2 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetAttributes_v2')
+        __nvmlDeviceGetAttributes_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetAttributes_v2')
         if __nvmlDeviceGetAttributes_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetAttributes_v2 = dlsym(handle, 'nvmlDeviceGetAttributes_v2')
+            __nvmlDeviceGetAttributes_v2 = _cyb_dlsym(handle, 'nvmlDeviceGetAttributes_v2')
 
         global __nvmlDeviceGetHandleByIndex_v2
-        __nvmlDeviceGetHandleByIndex_v2 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetHandleByIndex_v2')
+        __nvmlDeviceGetHandleByIndex_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetHandleByIndex_v2')
         if __nvmlDeviceGetHandleByIndex_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetHandleByIndex_v2 = dlsym(handle, 'nvmlDeviceGetHandleByIndex_v2')
+            __nvmlDeviceGetHandleByIndex_v2 = _cyb_dlsym(handle, 'nvmlDeviceGetHandleByIndex_v2')
 
         global __nvmlDeviceGetHandleBySerial
-        __nvmlDeviceGetHandleBySerial = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetHandleBySerial')
+        __nvmlDeviceGetHandleBySerial = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetHandleBySerial')
         if __nvmlDeviceGetHandleBySerial == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetHandleBySerial = dlsym(handle, 'nvmlDeviceGetHandleBySerial')
+            __nvmlDeviceGetHandleBySerial = _cyb_dlsym(handle, 'nvmlDeviceGetHandleBySerial')
 
         global __nvmlDeviceGetHandleByUUID
-        __nvmlDeviceGetHandleByUUID = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetHandleByUUID')
+        __nvmlDeviceGetHandleByUUID = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetHandleByUUID')
         if __nvmlDeviceGetHandleByUUID == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetHandleByUUID = dlsym(handle, 'nvmlDeviceGetHandleByUUID')
+            __nvmlDeviceGetHandleByUUID = _cyb_dlsym(handle, 'nvmlDeviceGetHandleByUUID')
 
         global __nvmlDeviceGetHandleByUUIDV
-        __nvmlDeviceGetHandleByUUIDV = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetHandleByUUIDV')
+        __nvmlDeviceGetHandleByUUIDV = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetHandleByUUIDV')
         if __nvmlDeviceGetHandleByUUIDV == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetHandleByUUIDV = dlsym(handle, 'nvmlDeviceGetHandleByUUIDV')
+            __nvmlDeviceGetHandleByUUIDV = _cyb_dlsym(handle, 'nvmlDeviceGetHandleByUUIDV')
 
         global __nvmlDeviceGetHandleByPciBusId_v2
-        __nvmlDeviceGetHandleByPciBusId_v2 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetHandleByPciBusId_v2')
+        __nvmlDeviceGetHandleByPciBusId_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetHandleByPciBusId_v2')
         if __nvmlDeviceGetHandleByPciBusId_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetHandleByPciBusId_v2 = dlsym(handle, 'nvmlDeviceGetHandleByPciBusId_v2')
+            __nvmlDeviceGetHandleByPciBusId_v2 = _cyb_dlsym(handle, 'nvmlDeviceGetHandleByPciBusId_v2')
 
         global __nvmlDeviceGetName
-        __nvmlDeviceGetName = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetName')
+        __nvmlDeviceGetName = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetName')
         if __nvmlDeviceGetName == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetName = dlsym(handle, 'nvmlDeviceGetName')
+            __nvmlDeviceGetName = _cyb_dlsym(handle, 'nvmlDeviceGetName')
 
         global __nvmlDeviceGetBrand
-        __nvmlDeviceGetBrand = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetBrand')
+        __nvmlDeviceGetBrand = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetBrand')
         if __nvmlDeviceGetBrand == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetBrand = dlsym(handle, 'nvmlDeviceGetBrand')
+            __nvmlDeviceGetBrand = _cyb_dlsym(handle, 'nvmlDeviceGetBrand')
 
         global __nvmlDeviceGetIndex
-        __nvmlDeviceGetIndex = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetIndex')
+        __nvmlDeviceGetIndex = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetIndex')
         if __nvmlDeviceGetIndex == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetIndex = dlsym(handle, 'nvmlDeviceGetIndex')
+            __nvmlDeviceGetIndex = _cyb_dlsym(handle, 'nvmlDeviceGetIndex')
 
         global __nvmlDeviceGetSerial
-        __nvmlDeviceGetSerial = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetSerial')
+        __nvmlDeviceGetSerial = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetSerial')
         if __nvmlDeviceGetSerial == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetSerial = dlsym(handle, 'nvmlDeviceGetSerial')
+            __nvmlDeviceGetSerial = _cyb_dlsym(handle, 'nvmlDeviceGetSerial')
 
         global __nvmlDeviceGetModuleId
-        __nvmlDeviceGetModuleId = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetModuleId')
+        __nvmlDeviceGetModuleId = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetModuleId')
         if __nvmlDeviceGetModuleId == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetModuleId = dlsym(handle, 'nvmlDeviceGetModuleId')
+            __nvmlDeviceGetModuleId = _cyb_dlsym(handle, 'nvmlDeviceGetModuleId')
 
         global __nvmlDeviceGetC2cModeInfoV
-        __nvmlDeviceGetC2cModeInfoV = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetC2cModeInfoV')
+        __nvmlDeviceGetC2cModeInfoV = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetC2cModeInfoV')
         if __nvmlDeviceGetC2cModeInfoV == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetC2cModeInfoV = dlsym(handle, 'nvmlDeviceGetC2cModeInfoV')
+            __nvmlDeviceGetC2cModeInfoV = _cyb_dlsym(handle, 'nvmlDeviceGetC2cModeInfoV')
 
         global __nvmlDeviceGetMemoryAffinity
-        __nvmlDeviceGetMemoryAffinity = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetMemoryAffinity')
+        __nvmlDeviceGetMemoryAffinity = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetMemoryAffinity')
         if __nvmlDeviceGetMemoryAffinity == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetMemoryAffinity = dlsym(handle, 'nvmlDeviceGetMemoryAffinity')
+            __nvmlDeviceGetMemoryAffinity = _cyb_dlsym(handle, 'nvmlDeviceGetMemoryAffinity')
 
         global __nvmlDeviceGetCpuAffinityWithinScope
-        __nvmlDeviceGetCpuAffinityWithinScope = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetCpuAffinityWithinScope')
+        __nvmlDeviceGetCpuAffinityWithinScope = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetCpuAffinityWithinScope')
         if __nvmlDeviceGetCpuAffinityWithinScope == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetCpuAffinityWithinScope = dlsym(handle, 'nvmlDeviceGetCpuAffinityWithinScope')
+            __nvmlDeviceGetCpuAffinityWithinScope = _cyb_dlsym(handle, 'nvmlDeviceGetCpuAffinityWithinScope')
 
         global __nvmlDeviceGetCpuAffinity
-        __nvmlDeviceGetCpuAffinity = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetCpuAffinity')
+        __nvmlDeviceGetCpuAffinity = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetCpuAffinity')
         if __nvmlDeviceGetCpuAffinity == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetCpuAffinity = dlsym(handle, 'nvmlDeviceGetCpuAffinity')
+            __nvmlDeviceGetCpuAffinity = _cyb_dlsym(handle, 'nvmlDeviceGetCpuAffinity')
 
         global __nvmlDeviceSetCpuAffinity
-        __nvmlDeviceSetCpuAffinity = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetCpuAffinity')
+        __nvmlDeviceSetCpuAffinity = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetCpuAffinity')
         if __nvmlDeviceSetCpuAffinity == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetCpuAffinity = dlsym(handle, 'nvmlDeviceSetCpuAffinity')
+            __nvmlDeviceSetCpuAffinity = _cyb_dlsym(handle, 'nvmlDeviceSetCpuAffinity')
 
         global __nvmlDeviceClearCpuAffinity
-        __nvmlDeviceClearCpuAffinity = dlsym(RTLD_DEFAULT, 'nvmlDeviceClearCpuAffinity')
+        __nvmlDeviceClearCpuAffinity = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceClearCpuAffinity')
         if __nvmlDeviceClearCpuAffinity == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceClearCpuAffinity = dlsym(handle, 'nvmlDeviceClearCpuAffinity')
+            __nvmlDeviceClearCpuAffinity = _cyb_dlsym(handle, 'nvmlDeviceClearCpuAffinity')
 
         global __nvmlDeviceGetNumaNodeId
-        __nvmlDeviceGetNumaNodeId = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetNumaNodeId')
+        __nvmlDeviceGetNumaNodeId = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetNumaNodeId')
         if __nvmlDeviceGetNumaNodeId == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetNumaNodeId = dlsym(handle, 'nvmlDeviceGetNumaNodeId')
+            __nvmlDeviceGetNumaNodeId = _cyb_dlsym(handle, 'nvmlDeviceGetNumaNodeId')
 
         global __nvmlDeviceGetTopologyCommonAncestor
-        __nvmlDeviceGetTopologyCommonAncestor = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetTopologyCommonAncestor')
+        __nvmlDeviceGetTopologyCommonAncestor = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetTopologyCommonAncestor')
         if __nvmlDeviceGetTopologyCommonAncestor == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetTopologyCommonAncestor = dlsym(handle, 'nvmlDeviceGetTopologyCommonAncestor')
+            __nvmlDeviceGetTopologyCommonAncestor = _cyb_dlsym(handle, 'nvmlDeviceGetTopologyCommonAncestor')
 
         global __nvmlDeviceGetTopologyNearestGpus
-        __nvmlDeviceGetTopologyNearestGpus = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetTopologyNearestGpus')
+        __nvmlDeviceGetTopologyNearestGpus = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetTopologyNearestGpus')
         if __nvmlDeviceGetTopologyNearestGpus == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetTopologyNearestGpus = dlsym(handle, 'nvmlDeviceGetTopologyNearestGpus')
+            __nvmlDeviceGetTopologyNearestGpus = _cyb_dlsym(handle, 'nvmlDeviceGetTopologyNearestGpus')
 
         global __nvmlDeviceGetP2PStatus
-        __nvmlDeviceGetP2PStatus = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetP2PStatus')
+        __nvmlDeviceGetP2PStatus = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetP2PStatus')
         if __nvmlDeviceGetP2PStatus == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetP2PStatus = dlsym(handle, 'nvmlDeviceGetP2PStatus')
+            __nvmlDeviceGetP2PStatus = _cyb_dlsym(handle, 'nvmlDeviceGetP2PStatus')
 
         global __nvmlDeviceGetUUID
-        __nvmlDeviceGetUUID = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetUUID')
+        __nvmlDeviceGetUUID = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetUUID')
         if __nvmlDeviceGetUUID == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetUUID = dlsym(handle, 'nvmlDeviceGetUUID')
+            __nvmlDeviceGetUUID = _cyb_dlsym(handle, 'nvmlDeviceGetUUID')
 
         global __nvmlDeviceGetMinorNumber
-        __nvmlDeviceGetMinorNumber = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetMinorNumber')
+        __nvmlDeviceGetMinorNumber = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetMinorNumber')
         if __nvmlDeviceGetMinorNumber == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetMinorNumber = dlsym(handle, 'nvmlDeviceGetMinorNumber')
+            __nvmlDeviceGetMinorNumber = _cyb_dlsym(handle, 'nvmlDeviceGetMinorNumber')
 
         global __nvmlDeviceGetBoardPartNumber
-        __nvmlDeviceGetBoardPartNumber = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetBoardPartNumber')
+        __nvmlDeviceGetBoardPartNumber = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetBoardPartNumber')
         if __nvmlDeviceGetBoardPartNumber == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetBoardPartNumber = dlsym(handle, 'nvmlDeviceGetBoardPartNumber')
+            __nvmlDeviceGetBoardPartNumber = _cyb_dlsym(handle, 'nvmlDeviceGetBoardPartNumber')
 
         global __nvmlDeviceGetInforomVersion
-        __nvmlDeviceGetInforomVersion = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetInforomVersion')
+        __nvmlDeviceGetInforomVersion = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetInforomVersion')
         if __nvmlDeviceGetInforomVersion == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetInforomVersion = dlsym(handle, 'nvmlDeviceGetInforomVersion')
+            __nvmlDeviceGetInforomVersion = _cyb_dlsym(handle, 'nvmlDeviceGetInforomVersion')
 
         global __nvmlDeviceGetInforomImageVersion
-        __nvmlDeviceGetInforomImageVersion = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetInforomImageVersion')
+        __nvmlDeviceGetInforomImageVersion = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetInforomImageVersion')
         if __nvmlDeviceGetInforomImageVersion == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetInforomImageVersion = dlsym(handle, 'nvmlDeviceGetInforomImageVersion')
+            __nvmlDeviceGetInforomImageVersion = _cyb_dlsym(handle, 'nvmlDeviceGetInforomImageVersion')
 
         global __nvmlDeviceGetInforomConfigurationChecksum
-        __nvmlDeviceGetInforomConfigurationChecksum = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetInforomConfigurationChecksum')
+        __nvmlDeviceGetInforomConfigurationChecksum = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetInforomConfigurationChecksum')
         if __nvmlDeviceGetInforomConfigurationChecksum == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetInforomConfigurationChecksum = dlsym(handle, 'nvmlDeviceGetInforomConfigurationChecksum')
+            __nvmlDeviceGetInforomConfigurationChecksum = _cyb_dlsym(handle, 'nvmlDeviceGetInforomConfigurationChecksum')
 
         global __nvmlDeviceValidateInforom
-        __nvmlDeviceValidateInforom = dlsym(RTLD_DEFAULT, 'nvmlDeviceValidateInforom')
+        __nvmlDeviceValidateInforom = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceValidateInforom')
         if __nvmlDeviceValidateInforom == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceValidateInforom = dlsym(handle, 'nvmlDeviceValidateInforom')
+            __nvmlDeviceValidateInforom = _cyb_dlsym(handle, 'nvmlDeviceValidateInforom')
 
         global __nvmlDeviceGetLastBBXFlushTime
-        __nvmlDeviceGetLastBBXFlushTime = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetLastBBXFlushTime')
+        __nvmlDeviceGetLastBBXFlushTime = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetLastBBXFlushTime')
         if __nvmlDeviceGetLastBBXFlushTime == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetLastBBXFlushTime = dlsym(handle, 'nvmlDeviceGetLastBBXFlushTime')
+            __nvmlDeviceGetLastBBXFlushTime = _cyb_dlsym(handle, 'nvmlDeviceGetLastBBXFlushTime')
 
         global __nvmlDeviceGetDisplayMode
-        __nvmlDeviceGetDisplayMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetDisplayMode')
+        __nvmlDeviceGetDisplayMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetDisplayMode')
         if __nvmlDeviceGetDisplayMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetDisplayMode = dlsym(handle, 'nvmlDeviceGetDisplayMode')
+            __nvmlDeviceGetDisplayMode = _cyb_dlsym(handle, 'nvmlDeviceGetDisplayMode')
 
         global __nvmlDeviceGetDisplayActive
-        __nvmlDeviceGetDisplayActive = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetDisplayActive')
+        __nvmlDeviceGetDisplayActive = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetDisplayActive')
         if __nvmlDeviceGetDisplayActive == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetDisplayActive = dlsym(handle, 'nvmlDeviceGetDisplayActive')
+            __nvmlDeviceGetDisplayActive = _cyb_dlsym(handle, 'nvmlDeviceGetDisplayActive')
 
         global __nvmlDeviceGetPersistenceMode
-        __nvmlDeviceGetPersistenceMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetPersistenceMode')
+        __nvmlDeviceGetPersistenceMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetPersistenceMode')
         if __nvmlDeviceGetPersistenceMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetPersistenceMode = dlsym(handle, 'nvmlDeviceGetPersistenceMode')
+            __nvmlDeviceGetPersistenceMode = _cyb_dlsym(handle, 'nvmlDeviceGetPersistenceMode')
 
         global __nvmlDeviceGetPciInfoExt
-        __nvmlDeviceGetPciInfoExt = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetPciInfoExt')
+        __nvmlDeviceGetPciInfoExt = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetPciInfoExt')
         if __nvmlDeviceGetPciInfoExt == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetPciInfoExt = dlsym(handle, 'nvmlDeviceGetPciInfoExt')
+            __nvmlDeviceGetPciInfoExt = _cyb_dlsym(handle, 'nvmlDeviceGetPciInfoExt')
 
         global __nvmlDeviceGetPciInfo_v3
-        __nvmlDeviceGetPciInfo_v3 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetPciInfo_v3')
+        __nvmlDeviceGetPciInfo_v3 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetPciInfo_v3')
         if __nvmlDeviceGetPciInfo_v3 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetPciInfo_v3 = dlsym(handle, 'nvmlDeviceGetPciInfo_v3')
+            __nvmlDeviceGetPciInfo_v3 = _cyb_dlsym(handle, 'nvmlDeviceGetPciInfo_v3')
 
         global __nvmlDeviceGetMaxPcieLinkGeneration
-        __nvmlDeviceGetMaxPcieLinkGeneration = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetMaxPcieLinkGeneration')
+        __nvmlDeviceGetMaxPcieLinkGeneration = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetMaxPcieLinkGeneration')
         if __nvmlDeviceGetMaxPcieLinkGeneration == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetMaxPcieLinkGeneration = dlsym(handle, 'nvmlDeviceGetMaxPcieLinkGeneration')
+            __nvmlDeviceGetMaxPcieLinkGeneration = _cyb_dlsym(handle, 'nvmlDeviceGetMaxPcieLinkGeneration')
 
         global __nvmlDeviceGetGpuMaxPcieLinkGeneration
-        __nvmlDeviceGetGpuMaxPcieLinkGeneration = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetGpuMaxPcieLinkGeneration')
+        __nvmlDeviceGetGpuMaxPcieLinkGeneration = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetGpuMaxPcieLinkGeneration')
         if __nvmlDeviceGetGpuMaxPcieLinkGeneration == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetGpuMaxPcieLinkGeneration = dlsym(handle, 'nvmlDeviceGetGpuMaxPcieLinkGeneration')
+            __nvmlDeviceGetGpuMaxPcieLinkGeneration = _cyb_dlsym(handle, 'nvmlDeviceGetGpuMaxPcieLinkGeneration')
 
         global __nvmlDeviceGetMaxPcieLinkWidth
-        __nvmlDeviceGetMaxPcieLinkWidth = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetMaxPcieLinkWidth')
+        __nvmlDeviceGetMaxPcieLinkWidth = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetMaxPcieLinkWidth')
         if __nvmlDeviceGetMaxPcieLinkWidth == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetMaxPcieLinkWidth = dlsym(handle, 'nvmlDeviceGetMaxPcieLinkWidth')
+            __nvmlDeviceGetMaxPcieLinkWidth = _cyb_dlsym(handle, 'nvmlDeviceGetMaxPcieLinkWidth')
 
         global __nvmlDeviceGetCurrPcieLinkGeneration
-        __nvmlDeviceGetCurrPcieLinkGeneration = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetCurrPcieLinkGeneration')
+        __nvmlDeviceGetCurrPcieLinkGeneration = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetCurrPcieLinkGeneration')
         if __nvmlDeviceGetCurrPcieLinkGeneration == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetCurrPcieLinkGeneration = dlsym(handle, 'nvmlDeviceGetCurrPcieLinkGeneration')
+            __nvmlDeviceGetCurrPcieLinkGeneration = _cyb_dlsym(handle, 'nvmlDeviceGetCurrPcieLinkGeneration')
 
         global __nvmlDeviceGetCurrPcieLinkWidth
-        __nvmlDeviceGetCurrPcieLinkWidth = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetCurrPcieLinkWidth')
+        __nvmlDeviceGetCurrPcieLinkWidth = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetCurrPcieLinkWidth')
         if __nvmlDeviceGetCurrPcieLinkWidth == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetCurrPcieLinkWidth = dlsym(handle, 'nvmlDeviceGetCurrPcieLinkWidth')
+            __nvmlDeviceGetCurrPcieLinkWidth = _cyb_dlsym(handle, 'nvmlDeviceGetCurrPcieLinkWidth')
 
         global __nvmlDeviceGetPcieThroughput
-        __nvmlDeviceGetPcieThroughput = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetPcieThroughput')
+        __nvmlDeviceGetPcieThroughput = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetPcieThroughput')
         if __nvmlDeviceGetPcieThroughput == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetPcieThroughput = dlsym(handle, 'nvmlDeviceGetPcieThroughput')
+            __nvmlDeviceGetPcieThroughput = _cyb_dlsym(handle, 'nvmlDeviceGetPcieThroughput')
 
         global __nvmlDeviceGetPcieReplayCounter
-        __nvmlDeviceGetPcieReplayCounter = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetPcieReplayCounter')
+        __nvmlDeviceGetPcieReplayCounter = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetPcieReplayCounter')
         if __nvmlDeviceGetPcieReplayCounter == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetPcieReplayCounter = dlsym(handle, 'nvmlDeviceGetPcieReplayCounter')
+            __nvmlDeviceGetPcieReplayCounter = _cyb_dlsym(handle, 'nvmlDeviceGetPcieReplayCounter')
 
         global __nvmlDeviceGetClockInfo
-        __nvmlDeviceGetClockInfo = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetClockInfo')
+        __nvmlDeviceGetClockInfo = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetClockInfo')
         if __nvmlDeviceGetClockInfo == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetClockInfo = dlsym(handle, 'nvmlDeviceGetClockInfo')
+            __nvmlDeviceGetClockInfo = _cyb_dlsym(handle, 'nvmlDeviceGetClockInfo')
 
         global __nvmlDeviceGetMaxClockInfo
-        __nvmlDeviceGetMaxClockInfo = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetMaxClockInfo')
+        __nvmlDeviceGetMaxClockInfo = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetMaxClockInfo')
         if __nvmlDeviceGetMaxClockInfo == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetMaxClockInfo = dlsym(handle, 'nvmlDeviceGetMaxClockInfo')
+            __nvmlDeviceGetMaxClockInfo = _cyb_dlsym(handle, 'nvmlDeviceGetMaxClockInfo')
 
         global __nvmlDeviceGetGpcClkVfOffset
-        __nvmlDeviceGetGpcClkVfOffset = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetGpcClkVfOffset')
+        __nvmlDeviceGetGpcClkVfOffset = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetGpcClkVfOffset')
         if __nvmlDeviceGetGpcClkVfOffset == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetGpcClkVfOffset = dlsym(handle, 'nvmlDeviceGetGpcClkVfOffset')
+            __nvmlDeviceGetGpcClkVfOffset = _cyb_dlsym(handle, 'nvmlDeviceGetGpcClkVfOffset')
 
         global __nvmlDeviceGetClock
-        __nvmlDeviceGetClock = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetClock')
+        __nvmlDeviceGetClock = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetClock')
         if __nvmlDeviceGetClock == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetClock = dlsym(handle, 'nvmlDeviceGetClock')
+            __nvmlDeviceGetClock = _cyb_dlsym(handle, 'nvmlDeviceGetClock')
 
         global __nvmlDeviceGetMaxCustomerBoostClock
-        __nvmlDeviceGetMaxCustomerBoostClock = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetMaxCustomerBoostClock')
+        __nvmlDeviceGetMaxCustomerBoostClock = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetMaxCustomerBoostClock')
         if __nvmlDeviceGetMaxCustomerBoostClock == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetMaxCustomerBoostClock = dlsym(handle, 'nvmlDeviceGetMaxCustomerBoostClock')
+            __nvmlDeviceGetMaxCustomerBoostClock = _cyb_dlsym(handle, 'nvmlDeviceGetMaxCustomerBoostClock')
 
         global __nvmlDeviceGetSupportedMemoryClocks
-        __nvmlDeviceGetSupportedMemoryClocks = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetSupportedMemoryClocks')
+        __nvmlDeviceGetSupportedMemoryClocks = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetSupportedMemoryClocks')
         if __nvmlDeviceGetSupportedMemoryClocks == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetSupportedMemoryClocks = dlsym(handle, 'nvmlDeviceGetSupportedMemoryClocks')
+            __nvmlDeviceGetSupportedMemoryClocks = _cyb_dlsym(handle, 'nvmlDeviceGetSupportedMemoryClocks')
 
         global __nvmlDeviceGetSupportedGraphicsClocks
-        __nvmlDeviceGetSupportedGraphicsClocks = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetSupportedGraphicsClocks')
+        __nvmlDeviceGetSupportedGraphicsClocks = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetSupportedGraphicsClocks')
         if __nvmlDeviceGetSupportedGraphicsClocks == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetSupportedGraphicsClocks = dlsym(handle, 'nvmlDeviceGetSupportedGraphicsClocks')
+            __nvmlDeviceGetSupportedGraphicsClocks = _cyb_dlsym(handle, 'nvmlDeviceGetSupportedGraphicsClocks')
 
         global __nvmlDeviceGetAutoBoostedClocksEnabled
-        __nvmlDeviceGetAutoBoostedClocksEnabled = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetAutoBoostedClocksEnabled')
+        __nvmlDeviceGetAutoBoostedClocksEnabled = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetAutoBoostedClocksEnabled')
         if __nvmlDeviceGetAutoBoostedClocksEnabled == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetAutoBoostedClocksEnabled = dlsym(handle, 'nvmlDeviceGetAutoBoostedClocksEnabled')
+            __nvmlDeviceGetAutoBoostedClocksEnabled = _cyb_dlsym(handle, 'nvmlDeviceGetAutoBoostedClocksEnabled')
 
         global __nvmlDeviceGetFanSpeed
-        __nvmlDeviceGetFanSpeed = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetFanSpeed')
+        __nvmlDeviceGetFanSpeed = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetFanSpeed')
         if __nvmlDeviceGetFanSpeed == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetFanSpeed = dlsym(handle, 'nvmlDeviceGetFanSpeed')
+            __nvmlDeviceGetFanSpeed = _cyb_dlsym(handle, 'nvmlDeviceGetFanSpeed')
 
         global __nvmlDeviceGetFanSpeed_v2
-        __nvmlDeviceGetFanSpeed_v2 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetFanSpeed_v2')
+        __nvmlDeviceGetFanSpeed_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetFanSpeed_v2')
         if __nvmlDeviceGetFanSpeed_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetFanSpeed_v2 = dlsym(handle, 'nvmlDeviceGetFanSpeed_v2')
+            __nvmlDeviceGetFanSpeed_v2 = _cyb_dlsym(handle, 'nvmlDeviceGetFanSpeed_v2')
 
         global __nvmlDeviceGetFanSpeedRPM
-        __nvmlDeviceGetFanSpeedRPM = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetFanSpeedRPM')
+        __nvmlDeviceGetFanSpeedRPM = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetFanSpeedRPM')
         if __nvmlDeviceGetFanSpeedRPM == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetFanSpeedRPM = dlsym(handle, 'nvmlDeviceGetFanSpeedRPM')
+            __nvmlDeviceGetFanSpeedRPM = _cyb_dlsym(handle, 'nvmlDeviceGetFanSpeedRPM')
 
         global __nvmlDeviceGetTargetFanSpeed
-        __nvmlDeviceGetTargetFanSpeed = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetTargetFanSpeed')
+        __nvmlDeviceGetTargetFanSpeed = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetTargetFanSpeed')
         if __nvmlDeviceGetTargetFanSpeed == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetTargetFanSpeed = dlsym(handle, 'nvmlDeviceGetTargetFanSpeed')
+            __nvmlDeviceGetTargetFanSpeed = _cyb_dlsym(handle, 'nvmlDeviceGetTargetFanSpeed')
 
         global __nvmlDeviceGetMinMaxFanSpeed
-        __nvmlDeviceGetMinMaxFanSpeed = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetMinMaxFanSpeed')
+        __nvmlDeviceGetMinMaxFanSpeed = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetMinMaxFanSpeed')
         if __nvmlDeviceGetMinMaxFanSpeed == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetMinMaxFanSpeed = dlsym(handle, 'nvmlDeviceGetMinMaxFanSpeed')
+            __nvmlDeviceGetMinMaxFanSpeed = _cyb_dlsym(handle, 'nvmlDeviceGetMinMaxFanSpeed')
 
         global __nvmlDeviceGetFanControlPolicy_v2
-        __nvmlDeviceGetFanControlPolicy_v2 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetFanControlPolicy_v2')
+        __nvmlDeviceGetFanControlPolicy_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetFanControlPolicy_v2')
         if __nvmlDeviceGetFanControlPolicy_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetFanControlPolicy_v2 = dlsym(handle, 'nvmlDeviceGetFanControlPolicy_v2')
+            __nvmlDeviceGetFanControlPolicy_v2 = _cyb_dlsym(handle, 'nvmlDeviceGetFanControlPolicy_v2')
 
         global __nvmlDeviceGetNumFans
-        __nvmlDeviceGetNumFans = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetNumFans')
+        __nvmlDeviceGetNumFans = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetNumFans')
         if __nvmlDeviceGetNumFans == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetNumFans = dlsym(handle, 'nvmlDeviceGetNumFans')
+            __nvmlDeviceGetNumFans = _cyb_dlsym(handle, 'nvmlDeviceGetNumFans')
 
         global __nvmlDeviceGetCoolerInfo
-        __nvmlDeviceGetCoolerInfo = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetCoolerInfo')
+        __nvmlDeviceGetCoolerInfo = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetCoolerInfo')
         if __nvmlDeviceGetCoolerInfo == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetCoolerInfo = dlsym(handle, 'nvmlDeviceGetCoolerInfo')
+            __nvmlDeviceGetCoolerInfo = _cyb_dlsym(handle, 'nvmlDeviceGetCoolerInfo')
 
         global __nvmlDeviceGetTemperatureV
-        __nvmlDeviceGetTemperatureV = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetTemperatureV')
+        __nvmlDeviceGetTemperatureV = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetTemperatureV')
         if __nvmlDeviceGetTemperatureV == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetTemperatureV = dlsym(handle, 'nvmlDeviceGetTemperatureV')
+            __nvmlDeviceGetTemperatureV = _cyb_dlsym(handle, 'nvmlDeviceGetTemperatureV')
 
         global __nvmlDeviceGetTemperatureThreshold
-        __nvmlDeviceGetTemperatureThreshold = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetTemperatureThreshold')
+        __nvmlDeviceGetTemperatureThreshold = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetTemperatureThreshold')
         if __nvmlDeviceGetTemperatureThreshold == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetTemperatureThreshold = dlsym(handle, 'nvmlDeviceGetTemperatureThreshold')
+            __nvmlDeviceGetTemperatureThreshold = _cyb_dlsym(handle, 'nvmlDeviceGetTemperatureThreshold')
 
         global __nvmlDeviceGetMarginTemperature
-        __nvmlDeviceGetMarginTemperature = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetMarginTemperature')
+        __nvmlDeviceGetMarginTemperature = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetMarginTemperature')
         if __nvmlDeviceGetMarginTemperature == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetMarginTemperature = dlsym(handle, 'nvmlDeviceGetMarginTemperature')
+            __nvmlDeviceGetMarginTemperature = _cyb_dlsym(handle, 'nvmlDeviceGetMarginTemperature')
 
         global __nvmlDeviceGetThermalSettings
-        __nvmlDeviceGetThermalSettings = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetThermalSettings')
+        __nvmlDeviceGetThermalSettings = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetThermalSettings')
         if __nvmlDeviceGetThermalSettings == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetThermalSettings = dlsym(handle, 'nvmlDeviceGetThermalSettings')
+            __nvmlDeviceGetThermalSettings = _cyb_dlsym(handle, 'nvmlDeviceGetThermalSettings')
 
         global __nvmlDeviceGetPerformanceState
-        __nvmlDeviceGetPerformanceState = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetPerformanceState')
+        __nvmlDeviceGetPerformanceState = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetPerformanceState')
         if __nvmlDeviceGetPerformanceState == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetPerformanceState = dlsym(handle, 'nvmlDeviceGetPerformanceState')
+            __nvmlDeviceGetPerformanceState = _cyb_dlsym(handle, 'nvmlDeviceGetPerformanceState')
 
         global __nvmlDeviceGetCurrentClocksEventReasons
-        __nvmlDeviceGetCurrentClocksEventReasons = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetCurrentClocksEventReasons')
+        __nvmlDeviceGetCurrentClocksEventReasons = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetCurrentClocksEventReasons')
         if __nvmlDeviceGetCurrentClocksEventReasons == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetCurrentClocksEventReasons = dlsym(handle, 'nvmlDeviceGetCurrentClocksEventReasons')
+            __nvmlDeviceGetCurrentClocksEventReasons = _cyb_dlsym(handle, 'nvmlDeviceGetCurrentClocksEventReasons')
 
         global __nvmlDeviceGetSupportedClocksEventReasons
-        __nvmlDeviceGetSupportedClocksEventReasons = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetSupportedClocksEventReasons')
+        __nvmlDeviceGetSupportedClocksEventReasons = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetSupportedClocksEventReasons')
         if __nvmlDeviceGetSupportedClocksEventReasons == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetSupportedClocksEventReasons = dlsym(handle, 'nvmlDeviceGetSupportedClocksEventReasons')
+            __nvmlDeviceGetSupportedClocksEventReasons = _cyb_dlsym(handle, 'nvmlDeviceGetSupportedClocksEventReasons')
 
         global __nvmlDeviceGetPowerState
-        __nvmlDeviceGetPowerState = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetPowerState')
+        __nvmlDeviceGetPowerState = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetPowerState')
         if __nvmlDeviceGetPowerState == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetPowerState = dlsym(handle, 'nvmlDeviceGetPowerState')
+            __nvmlDeviceGetPowerState = _cyb_dlsym(handle, 'nvmlDeviceGetPowerState')
 
         global __nvmlDeviceGetDynamicPstatesInfo
-        __nvmlDeviceGetDynamicPstatesInfo = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetDynamicPstatesInfo')
+        __nvmlDeviceGetDynamicPstatesInfo = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetDynamicPstatesInfo')
         if __nvmlDeviceGetDynamicPstatesInfo == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetDynamicPstatesInfo = dlsym(handle, 'nvmlDeviceGetDynamicPstatesInfo')
+            __nvmlDeviceGetDynamicPstatesInfo = _cyb_dlsym(handle, 'nvmlDeviceGetDynamicPstatesInfo')
 
         global __nvmlDeviceGetMemClkVfOffset
-        __nvmlDeviceGetMemClkVfOffset = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetMemClkVfOffset')
+        __nvmlDeviceGetMemClkVfOffset = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetMemClkVfOffset')
         if __nvmlDeviceGetMemClkVfOffset == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetMemClkVfOffset = dlsym(handle, 'nvmlDeviceGetMemClkVfOffset')
+            __nvmlDeviceGetMemClkVfOffset = _cyb_dlsym(handle, 'nvmlDeviceGetMemClkVfOffset')
 
         global __nvmlDeviceGetMinMaxClockOfPState
-        __nvmlDeviceGetMinMaxClockOfPState = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetMinMaxClockOfPState')
+        __nvmlDeviceGetMinMaxClockOfPState = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetMinMaxClockOfPState')
         if __nvmlDeviceGetMinMaxClockOfPState == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetMinMaxClockOfPState = dlsym(handle, 'nvmlDeviceGetMinMaxClockOfPState')
+            __nvmlDeviceGetMinMaxClockOfPState = _cyb_dlsym(handle, 'nvmlDeviceGetMinMaxClockOfPState')
 
         global __nvmlDeviceGetSupportedPerformanceStates
-        __nvmlDeviceGetSupportedPerformanceStates = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetSupportedPerformanceStates')
+        __nvmlDeviceGetSupportedPerformanceStates = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetSupportedPerformanceStates')
         if __nvmlDeviceGetSupportedPerformanceStates == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetSupportedPerformanceStates = dlsym(handle, 'nvmlDeviceGetSupportedPerformanceStates')
+            __nvmlDeviceGetSupportedPerformanceStates = _cyb_dlsym(handle, 'nvmlDeviceGetSupportedPerformanceStates')
 
         global __nvmlDeviceGetGpcClkMinMaxVfOffset
-        __nvmlDeviceGetGpcClkMinMaxVfOffset = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetGpcClkMinMaxVfOffset')
+        __nvmlDeviceGetGpcClkMinMaxVfOffset = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetGpcClkMinMaxVfOffset')
         if __nvmlDeviceGetGpcClkMinMaxVfOffset == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetGpcClkMinMaxVfOffset = dlsym(handle, 'nvmlDeviceGetGpcClkMinMaxVfOffset')
+            __nvmlDeviceGetGpcClkMinMaxVfOffset = _cyb_dlsym(handle, 'nvmlDeviceGetGpcClkMinMaxVfOffset')
 
         global __nvmlDeviceGetMemClkMinMaxVfOffset
-        __nvmlDeviceGetMemClkMinMaxVfOffset = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetMemClkMinMaxVfOffset')
+        __nvmlDeviceGetMemClkMinMaxVfOffset = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetMemClkMinMaxVfOffset')
         if __nvmlDeviceGetMemClkMinMaxVfOffset == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetMemClkMinMaxVfOffset = dlsym(handle, 'nvmlDeviceGetMemClkMinMaxVfOffset')
+            __nvmlDeviceGetMemClkMinMaxVfOffset = _cyb_dlsym(handle, 'nvmlDeviceGetMemClkMinMaxVfOffset')
 
         global __nvmlDeviceGetClockOffsets
-        __nvmlDeviceGetClockOffsets = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetClockOffsets')
+        __nvmlDeviceGetClockOffsets = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetClockOffsets')
         if __nvmlDeviceGetClockOffsets == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetClockOffsets = dlsym(handle, 'nvmlDeviceGetClockOffsets')
+            __nvmlDeviceGetClockOffsets = _cyb_dlsym(handle, 'nvmlDeviceGetClockOffsets')
 
         global __nvmlDeviceSetClockOffsets
-        __nvmlDeviceSetClockOffsets = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetClockOffsets')
+        __nvmlDeviceSetClockOffsets = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetClockOffsets')
         if __nvmlDeviceSetClockOffsets == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetClockOffsets = dlsym(handle, 'nvmlDeviceSetClockOffsets')
+            __nvmlDeviceSetClockOffsets = _cyb_dlsym(handle, 'nvmlDeviceSetClockOffsets')
 
         global __nvmlDeviceGetPerformanceModes
-        __nvmlDeviceGetPerformanceModes = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetPerformanceModes')
+        __nvmlDeviceGetPerformanceModes = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetPerformanceModes')
         if __nvmlDeviceGetPerformanceModes == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetPerformanceModes = dlsym(handle, 'nvmlDeviceGetPerformanceModes')
+            __nvmlDeviceGetPerformanceModes = _cyb_dlsym(handle, 'nvmlDeviceGetPerformanceModes')
 
         global __nvmlDeviceGetCurrentClockFreqs
-        __nvmlDeviceGetCurrentClockFreqs = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetCurrentClockFreqs')
+        __nvmlDeviceGetCurrentClockFreqs = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetCurrentClockFreqs')
         if __nvmlDeviceGetCurrentClockFreqs == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetCurrentClockFreqs = dlsym(handle, 'nvmlDeviceGetCurrentClockFreqs')
+            __nvmlDeviceGetCurrentClockFreqs = _cyb_dlsym(handle, 'nvmlDeviceGetCurrentClockFreqs')
 
         global __nvmlDeviceGetPowerManagementLimit
-        __nvmlDeviceGetPowerManagementLimit = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetPowerManagementLimit')
+        __nvmlDeviceGetPowerManagementLimit = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetPowerManagementLimit')
         if __nvmlDeviceGetPowerManagementLimit == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetPowerManagementLimit = dlsym(handle, 'nvmlDeviceGetPowerManagementLimit')
+            __nvmlDeviceGetPowerManagementLimit = _cyb_dlsym(handle, 'nvmlDeviceGetPowerManagementLimit')
 
         global __nvmlDeviceGetPowerManagementLimitConstraints
-        __nvmlDeviceGetPowerManagementLimitConstraints = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetPowerManagementLimitConstraints')
+        __nvmlDeviceGetPowerManagementLimitConstraints = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetPowerManagementLimitConstraints')
         if __nvmlDeviceGetPowerManagementLimitConstraints == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetPowerManagementLimitConstraints = dlsym(handle, 'nvmlDeviceGetPowerManagementLimitConstraints')
+            __nvmlDeviceGetPowerManagementLimitConstraints = _cyb_dlsym(handle, 'nvmlDeviceGetPowerManagementLimitConstraints')
 
         global __nvmlDeviceGetPowerManagementDefaultLimit
-        __nvmlDeviceGetPowerManagementDefaultLimit = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetPowerManagementDefaultLimit')
+        __nvmlDeviceGetPowerManagementDefaultLimit = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetPowerManagementDefaultLimit')
         if __nvmlDeviceGetPowerManagementDefaultLimit == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetPowerManagementDefaultLimit = dlsym(handle, 'nvmlDeviceGetPowerManagementDefaultLimit')
+            __nvmlDeviceGetPowerManagementDefaultLimit = _cyb_dlsym(handle, 'nvmlDeviceGetPowerManagementDefaultLimit')
 
         global __nvmlDeviceGetPowerUsage
-        __nvmlDeviceGetPowerUsage = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetPowerUsage')
+        __nvmlDeviceGetPowerUsage = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetPowerUsage')
         if __nvmlDeviceGetPowerUsage == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetPowerUsage = dlsym(handle, 'nvmlDeviceGetPowerUsage')
+            __nvmlDeviceGetPowerUsage = _cyb_dlsym(handle, 'nvmlDeviceGetPowerUsage')
 
         global __nvmlDeviceGetTotalEnergyConsumption
-        __nvmlDeviceGetTotalEnergyConsumption = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetTotalEnergyConsumption')
+        __nvmlDeviceGetTotalEnergyConsumption = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetTotalEnergyConsumption')
         if __nvmlDeviceGetTotalEnergyConsumption == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetTotalEnergyConsumption = dlsym(handle, 'nvmlDeviceGetTotalEnergyConsumption')
+            __nvmlDeviceGetTotalEnergyConsumption = _cyb_dlsym(handle, 'nvmlDeviceGetTotalEnergyConsumption')
 
         global __nvmlDeviceGetEnforcedPowerLimit
-        __nvmlDeviceGetEnforcedPowerLimit = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetEnforcedPowerLimit')
+        __nvmlDeviceGetEnforcedPowerLimit = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetEnforcedPowerLimit')
         if __nvmlDeviceGetEnforcedPowerLimit == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetEnforcedPowerLimit = dlsym(handle, 'nvmlDeviceGetEnforcedPowerLimit')
+            __nvmlDeviceGetEnforcedPowerLimit = _cyb_dlsym(handle, 'nvmlDeviceGetEnforcedPowerLimit')
 
         global __nvmlDeviceGetGpuOperationMode
-        __nvmlDeviceGetGpuOperationMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetGpuOperationMode')
+        __nvmlDeviceGetGpuOperationMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetGpuOperationMode')
         if __nvmlDeviceGetGpuOperationMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetGpuOperationMode = dlsym(handle, 'nvmlDeviceGetGpuOperationMode')
+            __nvmlDeviceGetGpuOperationMode = _cyb_dlsym(handle, 'nvmlDeviceGetGpuOperationMode')
 
         global __nvmlDeviceGetMemoryInfo_v2
-        __nvmlDeviceGetMemoryInfo_v2 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetMemoryInfo_v2')
+        __nvmlDeviceGetMemoryInfo_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetMemoryInfo_v2')
         if __nvmlDeviceGetMemoryInfo_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetMemoryInfo_v2 = dlsym(handle, 'nvmlDeviceGetMemoryInfo_v2')
+            __nvmlDeviceGetMemoryInfo_v2 = _cyb_dlsym(handle, 'nvmlDeviceGetMemoryInfo_v2')
 
         global __nvmlDeviceGetComputeMode
-        __nvmlDeviceGetComputeMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetComputeMode')
+        __nvmlDeviceGetComputeMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetComputeMode')
         if __nvmlDeviceGetComputeMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetComputeMode = dlsym(handle, 'nvmlDeviceGetComputeMode')
+            __nvmlDeviceGetComputeMode = _cyb_dlsym(handle, 'nvmlDeviceGetComputeMode')
 
         global __nvmlDeviceGetCudaComputeCapability
-        __nvmlDeviceGetCudaComputeCapability = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetCudaComputeCapability')
+        __nvmlDeviceGetCudaComputeCapability = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetCudaComputeCapability')
         if __nvmlDeviceGetCudaComputeCapability == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetCudaComputeCapability = dlsym(handle, 'nvmlDeviceGetCudaComputeCapability')
+            __nvmlDeviceGetCudaComputeCapability = _cyb_dlsym(handle, 'nvmlDeviceGetCudaComputeCapability')
 
         global __nvmlDeviceGetDramEncryptionMode
-        __nvmlDeviceGetDramEncryptionMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetDramEncryptionMode')
+        __nvmlDeviceGetDramEncryptionMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetDramEncryptionMode')
         if __nvmlDeviceGetDramEncryptionMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetDramEncryptionMode = dlsym(handle, 'nvmlDeviceGetDramEncryptionMode')
+            __nvmlDeviceGetDramEncryptionMode = _cyb_dlsym(handle, 'nvmlDeviceGetDramEncryptionMode')
 
         global __nvmlDeviceSetDramEncryptionMode
-        __nvmlDeviceSetDramEncryptionMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetDramEncryptionMode')
+        __nvmlDeviceSetDramEncryptionMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetDramEncryptionMode')
         if __nvmlDeviceSetDramEncryptionMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetDramEncryptionMode = dlsym(handle, 'nvmlDeviceSetDramEncryptionMode')
+            __nvmlDeviceSetDramEncryptionMode = _cyb_dlsym(handle, 'nvmlDeviceSetDramEncryptionMode')
 
         global __nvmlDeviceGetEccMode
-        __nvmlDeviceGetEccMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetEccMode')
+        __nvmlDeviceGetEccMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetEccMode')
         if __nvmlDeviceGetEccMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetEccMode = dlsym(handle, 'nvmlDeviceGetEccMode')
+            __nvmlDeviceGetEccMode = _cyb_dlsym(handle, 'nvmlDeviceGetEccMode')
 
         global __nvmlDeviceGetDefaultEccMode
-        __nvmlDeviceGetDefaultEccMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetDefaultEccMode')
+        __nvmlDeviceGetDefaultEccMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetDefaultEccMode')
         if __nvmlDeviceGetDefaultEccMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetDefaultEccMode = dlsym(handle, 'nvmlDeviceGetDefaultEccMode')
+            __nvmlDeviceGetDefaultEccMode = _cyb_dlsym(handle, 'nvmlDeviceGetDefaultEccMode')
 
         global __nvmlDeviceGetBoardId
-        __nvmlDeviceGetBoardId = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetBoardId')
+        __nvmlDeviceGetBoardId = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetBoardId')
         if __nvmlDeviceGetBoardId == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetBoardId = dlsym(handle, 'nvmlDeviceGetBoardId')
+            __nvmlDeviceGetBoardId = _cyb_dlsym(handle, 'nvmlDeviceGetBoardId')
 
         global __nvmlDeviceGetMultiGpuBoard
-        __nvmlDeviceGetMultiGpuBoard = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetMultiGpuBoard')
+        __nvmlDeviceGetMultiGpuBoard = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetMultiGpuBoard')
         if __nvmlDeviceGetMultiGpuBoard == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetMultiGpuBoard = dlsym(handle, 'nvmlDeviceGetMultiGpuBoard')
+            __nvmlDeviceGetMultiGpuBoard = _cyb_dlsym(handle, 'nvmlDeviceGetMultiGpuBoard')
 
         global __nvmlDeviceGetTotalEccErrors
-        __nvmlDeviceGetTotalEccErrors = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetTotalEccErrors')
+        __nvmlDeviceGetTotalEccErrors = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetTotalEccErrors')
         if __nvmlDeviceGetTotalEccErrors == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetTotalEccErrors = dlsym(handle, 'nvmlDeviceGetTotalEccErrors')
+            __nvmlDeviceGetTotalEccErrors = _cyb_dlsym(handle, 'nvmlDeviceGetTotalEccErrors')
 
         global __nvmlDeviceGetMemoryErrorCounter
-        __nvmlDeviceGetMemoryErrorCounter = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetMemoryErrorCounter')
+        __nvmlDeviceGetMemoryErrorCounter = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetMemoryErrorCounter')
         if __nvmlDeviceGetMemoryErrorCounter == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetMemoryErrorCounter = dlsym(handle, 'nvmlDeviceGetMemoryErrorCounter')
+            __nvmlDeviceGetMemoryErrorCounter = _cyb_dlsym(handle, 'nvmlDeviceGetMemoryErrorCounter')
 
         global __nvmlDeviceGetUtilizationRates
-        __nvmlDeviceGetUtilizationRates = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetUtilizationRates')
+        __nvmlDeviceGetUtilizationRates = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetUtilizationRates')
         if __nvmlDeviceGetUtilizationRates == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetUtilizationRates = dlsym(handle, 'nvmlDeviceGetUtilizationRates')
+            __nvmlDeviceGetUtilizationRates = _cyb_dlsym(handle, 'nvmlDeviceGetUtilizationRates')
 
         global __nvmlDeviceGetEncoderUtilization
-        __nvmlDeviceGetEncoderUtilization = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetEncoderUtilization')
+        __nvmlDeviceGetEncoderUtilization = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetEncoderUtilization')
         if __nvmlDeviceGetEncoderUtilization == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetEncoderUtilization = dlsym(handle, 'nvmlDeviceGetEncoderUtilization')
+            __nvmlDeviceGetEncoderUtilization = _cyb_dlsym(handle, 'nvmlDeviceGetEncoderUtilization')
 
         global __nvmlDeviceGetEncoderCapacity
-        __nvmlDeviceGetEncoderCapacity = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetEncoderCapacity')
+        __nvmlDeviceGetEncoderCapacity = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetEncoderCapacity')
         if __nvmlDeviceGetEncoderCapacity == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetEncoderCapacity = dlsym(handle, 'nvmlDeviceGetEncoderCapacity')
+            __nvmlDeviceGetEncoderCapacity = _cyb_dlsym(handle, 'nvmlDeviceGetEncoderCapacity')
 
         global __nvmlDeviceGetEncoderStats
-        __nvmlDeviceGetEncoderStats = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetEncoderStats')
+        __nvmlDeviceGetEncoderStats = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetEncoderStats')
         if __nvmlDeviceGetEncoderStats == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetEncoderStats = dlsym(handle, 'nvmlDeviceGetEncoderStats')
+            __nvmlDeviceGetEncoderStats = _cyb_dlsym(handle, 'nvmlDeviceGetEncoderStats')
 
         global __nvmlDeviceGetEncoderSessions
-        __nvmlDeviceGetEncoderSessions = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetEncoderSessions')
+        __nvmlDeviceGetEncoderSessions = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetEncoderSessions')
         if __nvmlDeviceGetEncoderSessions == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetEncoderSessions = dlsym(handle, 'nvmlDeviceGetEncoderSessions')
+            __nvmlDeviceGetEncoderSessions = _cyb_dlsym(handle, 'nvmlDeviceGetEncoderSessions')
 
         global __nvmlDeviceGetDecoderUtilization
-        __nvmlDeviceGetDecoderUtilization = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetDecoderUtilization')
+        __nvmlDeviceGetDecoderUtilization = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetDecoderUtilization')
         if __nvmlDeviceGetDecoderUtilization == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetDecoderUtilization = dlsym(handle, 'nvmlDeviceGetDecoderUtilization')
+            __nvmlDeviceGetDecoderUtilization = _cyb_dlsym(handle, 'nvmlDeviceGetDecoderUtilization')
 
         global __nvmlDeviceGetJpgUtilization
-        __nvmlDeviceGetJpgUtilization = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetJpgUtilization')
+        __nvmlDeviceGetJpgUtilization = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetJpgUtilization')
         if __nvmlDeviceGetJpgUtilization == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetJpgUtilization = dlsym(handle, 'nvmlDeviceGetJpgUtilization')
+            __nvmlDeviceGetJpgUtilization = _cyb_dlsym(handle, 'nvmlDeviceGetJpgUtilization')
 
         global __nvmlDeviceGetOfaUtilization
-        __nvmlDeviceGetOfaUtilization = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetOfaUtilization')
+        __nvmlDeviceGetOfaUtilization = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetOfaUtilization')
         if __nvmlDeviceGetOfaUtilization == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetOfaUtilization = dlsym(handle, 'nvmlDeviceGetOfaUtilization')
+            __nvmlDeviceGetOfaUtilization = _cyb_dlsym(handle, 'nvmlDeviceGetOfaUtilization')
 
         global __nvmlDeviceGetFBCStats
-        __nvmlDeviceGetFBCStats = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetFBCStats')
+        __nvmlDeviceGetFBCStats = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetFBCStats')
         if __nvmlDeviceGetFBCStats == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetFBCStats = dlsym(handle, 'nvmlDeviceGetFBCStats')
+            __nvmlDeviceGetFBCStats = _cyb_dlsym(handle, 'nvmlDeviceGetFBCStats')
 
         global __nvmlDeviceGetFBCSessions
-        __nvmlDeviceGetFBCSessions = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetFBCSessions')
+        __nvmlDeviceGetFBCSessions = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetFBCSessions')
         if __nvmlDeviceGetFBCSessions == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetFBCSessions = dlsym(handle, 'nvmlDeviceGetFBCSessions')
+            __nvmlDeviceGetFBCSessions = _cyb_dlsym(handle, 'nvmlDeviceGetFBCSessions')
 
         global __nvmlDeviceGetDriverModel_v2
-        __nvmlDeviceGetDriverModel_v2 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetDriverModel_v2')
+        __nvmlDeviceGetDriverModel_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetDriverModel_v2')
         if __nvmlDeviceGetDriverModel_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetDriverModel_v2 = dlsym(handle, 'nvmlDeviceGetDriverModel_v2')
+            __nvmlDeviceGetDriverModel_v2 = _cyb_dlsym(handle, 'nvmlDeviceGetDriverModel_v2')
 
         global __nvmlDeviceGetVbiosVersion
-        __nvmlDeviceGetVbiosVersion = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetVbiosVersion')
+        __nvmlDeviceGetVbiosVersion = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetVbiosVersion')
         if __nvmlDeviceGetVbiosVersion == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetVbiosVersion = dlsym(handle, 'nvmlDeviceGetVbiosVersion')
+            __nvmlDeviceGetVbiosVersion = _cyb_dlsym(handle, 'nvmlDeviceGetVbiosVersion')
 
         global __nvmlDeviceGetBridgeChipInfo
-        __nvmlDeviceGetBridgeChipInfo = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetBridgeChipInfo')
+        __nvmlDeviceGetBridgeChipInfo = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetBridgeChipInfo')
         if __nvmlDeviceGetBridgeChipInfo == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetBridgeChipInfo = dlsym(handle, 'nvmlDeviceGetBridgeChipInfo')
+            __nvmlDeviceGetBridgeChipInfo = _cyb_dlsym(handle, 'nvmlDeviceGetBridgeChipInfo')
 
         global __nvmlDeviceGetComputeRunningProcesses_v3
-        __nvmlDeviceGetComputeRunningProcesses_v3 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetComputeRunningProcesses_v3')
+        __nvmlDeviceGetComputeRunningProcesses_v3 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetComputeRunningProcesses_v3')
         if __nvmlDeviceGetComputeRunningProcesses_v3 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetComputeRunningProcesses_v3 = dlsym(handle, 'nvmlDeviceGetComputeRunningProcesses_v3')
+            __nvmlDeviceGetComputeRunningProcesses_v3 = _cyb_dlsym(handle, 'nvmlDeviceGetComputeRunningProcesses_v3')
 
         global __nvmlDeviceGetGraphicsRunningProcesses_v3
-        __nvmlDeviceGetGraphicsRunningProcesses_v3 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetGraphicsRunningProcesses_v3')
+        __nvmlDeviceGetGraphicsRunningProcesses_v3 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetGraphicsRunningProcesses_v3')
         if __nvmlDeviceGetGraphicsRunningProcesses_v3 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetGraphicsRunningProcesses_v3 = dlsym(handle, 'nvmlDeviceGetGraphicsRunningProcesses_v3')
+            __nvmlDeviceGetGraphicsRunningProcesses_v3 = _cyb_dlsym(handle, 'nvmlDeviceGetGraphicsRunningProcesses_v3')
 
         global __nvmlDeviceGetMPSComputeRunningProcesses_v3
-        __nvmlDeviceGetMPSComputeRunningProcesses_v3 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetMPSComputeRunningProcesses_v3')
+        __nvmlDeviceGetMPSComputeRunningProcesses_v3 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetMPSComputeRunningProcesses_v3')
         if __nvmlDeviceGetMPSComputeRunningProcesses_v3 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetMPSComputeRunningProcesses_v3 = dlsym(handle, 'nvmlDeviceGetMPSComputeRunningProcesses_v3')
+            __nvmlDeviceGetMPSComputeRunningProcesses_v3 = _cyb_dlsym(handle, 'nvmlDeviceGetMPSComputeRunningProcesses_v3')
 
         global __nvmlDeviceGetRunningProcessDetailList
-        __nvmlDeviceGetRunningProcessDetailList = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetRunningProcessDetailList')
+        __nvmlDeviceGetRunningProcessDetailList = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetRunningProcessDetailList')
         if __nvmlDeviceGetRunningProcessDetailList == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetRunningProcessDetailList = dlsym(handle, 'nvmlDeviceGetRunningProcessDetailList')
+            __nvmlDeviceGetRunningProcessDetailList = _cyb_dlsym(handle, 'nvmlDeviceGetRunningProcessDetailList')
 
         global __nvmlDeviceOnSameBoard
-        __nvmlDeviceOnSameBoard = dlsym(RTLD_DEFAULT, 'nvmlDeviceOnSameBoard')
+        __nvmlDeviceOnSameBoard = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceOnSameBoard')
         if __nvmlDeviceOnSameBoard == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceOnSameBoard = dlsym(handle, 'nvmlDeviceOnSameBoard')
+            __nvmlDeviceOnSameBoard = _cyb_dlsym(handle, 'nvmlDeviceOnSameBoard')
 
         global __nvmlDeviceGetAPIRestriction
-        __nvmlDeviceGetAPIRestriction = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetAPIRestriction')
+        __nvmlDeviceGetAPIRestriction = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetAPIRestriction')
         if __nvmlDeviceGetAPIRestriction == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetAPIRestriction = dlsym(handle, 'nvmlDeviceGetAPIRestriction')
+            __nvmlDeviceGetAPIRestriction = _cyb_dlsym(handle, 'nvmlDeviceGetAPIRestriction')
 
         global __nvmlDeviceGetSamples
-        __nvmlDeviceGetSamples = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetSamples')
+        __nvmlDeviceGetSamples = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetSamples')
         if __nvmlDeviceGetSamples == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetSamples = dlsym(handle, 'nvmlDeviceGetSamples')
+            __nvmlDeviceGetSamples = _cyb_dlsym(handle, 'nvmlDeviceGetSamples')
 
         global __nvmlDeviceGetBAR1MemoryInfo
-        __nvmlDeviceGetBAR1MemoryInfo = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetBAR1MemoryInfo')
+        __nvmlDeviceGetBAR1MemoryInfo = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetBAR1MemoryInfo')
         if __nvmlDeviceGetBAR1MemoryInfo == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetBAR1MemoryInfo = dlsym(handle, 'nvmlDeviceGetBAR1MemoryInfo')
+            __nvmlDeviceGetBAR1MemoryInfo = _cyb_dlsym(handle, 'nvmlDeviceGetBAR1MemoryInfo')
 
         global __nvmlDeviceGetIrqNum
-        __nvmlDeviceGetIrqNum = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetIrqNum')
+        __nvmlDeviceGetIrqNum = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetIrqNum')
         if __nvmlDeviceGetIrqNum == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetIrqNum = dlsym(handle, 'nvmlDeviceGetIrqNum')
+            __nvmlDeviceGetIrqNum = _cyb_dlsym(handle, 'nvmlDeviceGetIrqNum')
 
         global __nvmlDeviceGetNumGpuCores
-        __nvmlDeviceGetNumGpuCores = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetNumGpuCores')
+        __nvmlDeviceGetNumGpuCores = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetNumGpuCores')
         if __nvmlDeviceGetNumGpuCores == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetNumGpuCores = dlsym(handle, 'nvmlDeviceGetNumGpuCores')
+            __nvmlDeviceGetNumGpuCores = _cyb_dlsym(handle, 'nvmlDeviceGetNumGpuCores')
 
         global __nvmlDeviceGetPowerSource
-        __nvmlDeviceGetPowerSource = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetPowerSource')
+        __nvmlDeviceGetPowerSource = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetPowerSource')
         if __nvmlDeviceGetPowerSource == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetPowerSource = dlsym(handle, 'nvmlDeviceGetPowerSource')
+            __nvmlDeviceGetPowerSource = _cyb_dlsym(handle, 'nvmlDeviceGetPowerSource')
 
         global __nvmlDeviceGetMemoryBusWidth
-        __nvmlDeviceGetMemoryBusWidth = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetMemoryBusWidth')
+        __nvmlDeviceGetMemoryBusWidth = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetMemoryBusWidth')
         if __nvmlDeviceGetMemoryBusWidth == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetMemoryBusWidth = dlsym(handle, 'nvmlDeviceGetMemoryBusWidth')
+            __nvmlDeviceGetMemoryBusWidth = _cyb_dlsym(handle, 'nvmlDeviceGetMemoryBusWidth')
 
         global __nvmlDeviceGetPcieLinkMaxSpeed
-        __nvmlDeviceGetPcieLinkMaxSpeed = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetPcieLinkMaxSpeed')
+        __nvmlDeviceGetPcieLinkMaxSpeed = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetPcieLinkMaxSpeed')
         if __nvmlDeviceGetPcieLinkMaxSpeed == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetPcieLinkMaxSpeed = dlsym(handle, 'nvmlDeviceGetPcieLinkMaxSpeed')
+            __nvmlDeviceGetPcieLinkMaxSpeed = _cyb_dlsym(handle, 'nvmlDeviceGetPcieLinkMaxSpeed')
 
         global __nvmlDeviceGetPcieSpeed
-        __nvmlDeviceGetPcieSpeed = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetPcieSpeed')
+        __nvmlDeviceGetPcieSpeed = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetPcieSpeed')
         if __nvmlDeviceGetPcieSpeed == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetPcieSpeed = dlsym(handle, 'nvmlDeviceGetPcieSpeed')
+            __nvmlDeviceGetPcieSpeed = _cyb_dlsym(handle, 'nvmlDeviceGetPcieSpeed')
 
         global __nvmlDeviceGetAdaptiveClockInfoStatus
-        __nvmlDeviceGetAdaptiveClockInfoStatus = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetAdaptiveClockInfoStatus')
+        __nvmlDeviceGetAdaptiveClockInfoStatus = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetAdaptiveClockInfoStatus')
         if __nvmlDeviceGetAdaptiveClockInfoStatus == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetAdaptiveClockInfoStatus = dlsym(handle, 'nvmlDeviceGetAdaptiveClockInfoStatus')
+            __nvmlDeviceGetAdaptiveClockInfoStatus = _cyb_dlsym(handle, 'nvmlDeviceGetAdaptiveClockInfoStatus')
 
         global __nvmlDeviceGetBusType
-        __nvmlDeviceGetBusType = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetBusType')
+        __nvmlDeviceGetBusType = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetBusType')
         if __nvmlDeviceGetBusType == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetBusType = dlsym(handle, 'nvmlDeviceGetBusType')
+            __nvmlDeviceGetBusType = _cyb_dlsym(handle, 'nvmlDeviceGetBusType')
 
         global __nvmlDeviceGetGpuFabricInfoV
-        __nvmlDeviceGetGpuFabricInfoV = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetGpuFabricInfoV')
+        __nvmlDeviceGetGpuFabricInfoV = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetGpuFabricInfoV')
         if __nvmlDeviceGetGpuFabricInfoV == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetGpuFabricInfoV = dlsym(handle, 'nvmlDeviceGetGpuFabricInfoV')
+            __nvmlDeviceGetGpuFabricInfoV = _cyb_dlsym(handle, 'nvmlDeviceGetGpuFabricInfoV')
 
         global __nvmlSystemGetConfComputeCapabilities
-        __nvmlSystemGetConfComputeCapabilities = dlsym(RTLD_DEFAULT, 'nvmlSystemGetConfComputeCapabilities')
+        __nvmlSystemGetConfComputeCapabilities = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemGetConfComputeCapabilities')
         if __nvmlSystemGetConfComputeCapabilities == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemGetConfComputeCapabilities = dlsym(handle, 'nvmlSystemGetConfComputeCapabilities')
+            __nvmlSystemGetConfComputeCapabilities = _cyb_dlsym(handle, 'nvmlSystemGetConfComputeCapabilities')
 
         global __nvmlSystemGetConfComputeState
-        __nvmlSystemGetConfComputeState = dlsym(RTLD_DEFAULT, 'nvmlSystemGetConfComputeState')
+        __nvmlSystemGetConfComputeState = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemGetConfComputeState')
         if __nvmlSystemGetConfComputeState == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemGetConfComputeState = dlsym(handle, 'nvmlSystemGetConfComputeState')
+            __nvmlSystemGetConfComputeState = _cyb_dlsym(handle, 'nvmlSystemGetConfComputeState')
 
         global __nvmlDeviceGetConfComputeMemSizeInfo
-        __nvmlDeviceGetConfComputeMemSizeInfo = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetConfComputeMemSizeInfo')
+        __nvmlDeviceGetConfComputeMemSizeInfo = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetConfComputeMemSizeInfo')
         if __nvmlDeviceGetConfComputeMemSizeInfo == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetConfComputeMemSizeInfo = dlsym(handle, 'nvmlDeviceGetConfComputeMemSizeInfo')
+            __nvmlDeviceGetConfComputeMemSizeInfo = _cyb_dlsym(handle, 'nvmlDeviceGetConfComputeMemSizeInfo')
 
         global __nvmlSystemGetConfComputeGpusReadyState
-        __nvmlSystemGetConfComputeGpusReadyState = dlsym(RTLD_DEFAULT, 'nvmlSystemGetConfComputeGpusReadyState')
+        __nvmlSystemGetConfComputeGpusReadyState = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemGetConfComputeGpusReadyState')
         if __nvmlSystemGetConfComputeGpusReadyState == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemGetConfComputeGpusReadyState = dlsym(handle, 'nvmlSystemGetConfComputeGpusReadyState')
+            __nvmlSystemGetConfComputeGpusReadyState = _cyb_dlsym(handle, 'nvmlSystemGetConfComputeGpusReadyState')
 
         global __nvmlDeviceGetConfComputeProtectedMemoryUsage
-        __nvmlDeviceGetConfComputeProtectedMemoryUsage = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetConfComputeProtectedMemoryUsage')
+        __nvmlDeviceGetConfComputeProtectedMemoryUsage = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetConfComputeProtectedMemoryUsage')
         if __nvmlDeviceGetConfComputeProtectedMemoryUsage == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetConfComputeProtectedMemoryUsage = dlsym(handle, 'nvmlDeviceGetConfComputeProtectedMemoryUsage')
+            __nvmlDeviceGetConfComputeProtectedMemoryUsage = _cyb_dlsym(handle, 'nvmlDeviceGetConfComputeProtectedMemoryUsage')
 
         global __nvmlDeviceGetConfComputeGpuCertificate
-        __nvmlDeviceGetConfComputeGpuCertificate = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetConfComputeGpuCertificate')
+        __nvmlDeviceGetConfComputeGpuCertificate = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetConfComputeGpuCertificate')
         if __nvmlDeviceGetConfComputeGpuCertificate == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetConfComputeGpuCertificate = dlsym(handle, 'nvmlDeviceGetConfComputeGpuCertificate')
+            __nvmlDeviceGetConfComputeGpuCertificate = _cyb_dlsym(handle, 'nvmlDeviceGetConfComputeGpuCertificate')
 
         global __nvmlDeviceGetConfComputeGpuAttestationReport
-        __nvmlDeviceGetConfComputeGpuAttestationReport = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetConfComputeGpuAttestationReport')
+        __nvmlDeviceGetConfComputeGpuAttestationReport = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetConfComputeGpuAttestationReport')
         if __nvmlDeviceGetConfComputeGpuAttestationReport == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetConfComputeGpuAttestationReport = dlsym(handle, 'nvmlDeviceGetConfComputeGpuAttestationReport')
+            __nvmlDeviceGetConfComputeGpuAttestationReport = _cyb_dlsym(handle, 'nvmlDeviceGetConfComputeGpuAttestationReport')
 
         global __nvmlSystemGetConfComputeKeyRotationThresholdInfo
-        __nvmlSystemGetConfComputeKeyRotationThresholdInfo = dlsym(RTLD_DEFAULT, 'nvmlSystemGetConfComputeKeyRotationThresholdInfo')
+        __nvmlSystemGetConfComputeKeyRotationThresholdInfo = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemGetConfComputeKeyRotationThresholdInfo')
         if __nvmlSystemGetConfComputeKeyRotationThresholdInfo == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemGetConfComputeKeyRotationThresholdInfo = dlsym(handle, 'nvmlSystemGetConfComputeKeyRotationThresholdInfo')
+            __nvmlSystemGetConfComputeKeyRotationThresholdInfo = _cyb_dlsym(handle, 'nvmlSystemGetConfComputeKeyRotationThresholdInfo')
 
         global __nvmlDeviceSetConfComputeUnprotectedMemSize
-        __nvmlDeviceSetConfComputeUnprotectedMemSize = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetConfComputeUnprotectedMemSize')
+        __nvmlDeviceSetConfComputeUnprotectedMemSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetConfComputeUnprotectedMemSize')
         if __nvmlDeviceSetConfComputeUnprotectedMemSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetConfComputeUnprotectedMemSize = dlsym(handle, 'nvmlDeviceSetConfComputeUnprotectedMemSize')
+            __nvmlDeviceSetConfComputeUnprotectedMemSize = _cyb_dlsym(handle, 'nvmlDeviceSetConfComputeUnprotectedMemSize')
 
         global __nvmlSystemSetConfComputeGpusReadyState
-        __nvmlSystemSetConfComputeGpusReadyState = dlsym(RTLD_DEFAULT, 'nvmlSystemSetConfComputeGpusReadyState')
+        __nvmlSystemSetConfComputeGpusReadyState = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemSetConfComputeGpusReadyState')
         if __nvmlSystemSetConfComputeGpusReadyState == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemSetConfComputeGpusReadyState = dlsym(handle, 'nvmlSystemSetConfComputeGpusReadyState')
+            __nvmlSystemSetConfComputeGpusReadyState = _cyb_dlsym(handle, 'nvmlSystemSetConfComputeGpusReadyState')
 
         global __nvmlSystemSetConfComputeKeyRotationThresholdInfo
-        __nvmlSystemSetConfComputeKeyRotationThresholdInfo = dlsym(RTLD_DEFAULT, 'nvmlSystemSetConfComputeKeyRotationThresholdInfo')
+        __nvmlSystemSetConfComputeKeyRotationThresholdInfo = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemSetConfComputeKeyRotationThresholdInfo')
         if __nvmlSystemSetConfComputeKeyRotationThresholdInfo == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemSetConfComputeKeyRotationThresholdInfo = dlsym(handle, 'nvmlSystemSetConfComputeKeyRotationThresholdInfo')
+            __nvmlSystemSetConfComputeKeyRotationThresholdInfo = _cyb_dlsym(handle, 'nvmlSystemSetConfComputeKeyRotationThresholdInfo')
 
         global __nvmlSystemGetConfComputeSettings
-        __nvmlSystemGetConfComputeSettings = dlsym(RTLD_DEFAULT, 'nvmlSystemGetConfComputeSettings')
+        __nvmlSystemGetConfComputeSettings = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemGetConfComputeSettings')
         if __nvmlSystemGetConfComputeSettings == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemGetConfComputeSettings = dlsym(handle, 'nvmlSystemGetConfComputeSettings')
+            __nvmlSystemGetConfComputeSettings = _cyb_dlsym(handle, 'nvmlSystemGetConfComputeSettings')
 
         global __nvmlDeviceGetGspFirmwareVersion
-        __nvmlDeviceGetGspFirmwareVersion = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetGspFirmwareVersion')
+        __nvmlDeviceGetGspFirmwareVersion = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetGspFirmwareVersion')
         if __nvmlDeviceGetGspFirmwareVersion == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetGspFirmwareVersion = dlsym(handle, 'nvmlDeviceGetGspFirmwareVersion')
+            __nvmlDeviceGetGspFirmwareVersion = _cyb_dlsym(handle, 'nvmlDeviceGetGspFirmwareVersion')
 
         global __nvmlDeviceGetGspFirmwareMode
-        __nvmlDeviceGetGspFirmwareMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetGspFirmwareMode')
+        __nvmlDeviceGetGspFirmwareMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetGspFirmwareMode')
         if __nvmlDeviceGetGspFirmwareMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetGspFirmwareMode = dlsym(handle, 'nvmlDeviceGetGspFirmwareMode')
+            __nvmlDeviceGetGspFirmwareMode = _cyb_dlsym(handle, 'nvmlDeviceGetGspFirmwareMode')
 
         global __nvmlDeviceGetSramEccErrorStatus
-        __nvmlDeviceGetSramEccErrorStatus = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetSramEccErrorStatus')
+        __nvmlDeviceGetSramEccErrorStatus = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetSramEccErrorStatus')
         if __nvmlDeviceGetSramEccErrorStatus == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetSramEccErrorStatus = dlsym(handle, 'nvmlDeviceGetSramEccErrorStatus')
+            __nvmlDeviceGetSramEccErrorStatus = _cyb_dlsym(handle, 'nvmlDeviceGetSramEccErrorStatus')
 
         global __nvmlDeviceGetAccountingMode
-        __nvmlDeviceGetAccountingMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetAccountingMode')
+        __nvmlDeviceGetAccountingMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetAccountingMode')
         if __nvmlDeviceGetAccountingMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetAccountingMode = dlsym(handle, 'nvmlDeviceGetAccountingMode')
+            __nvmlDeviceGetAccountingMode = _cyb_dlsym(handle, 'nvmlDeviceGetAccountingMode')
 
         global __nvmlDeviceGetAccountingStats
-        __nvmlDeviceGetAccountingStats = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetAccountingStats')
+        __nvmlDeviceGetAccountingStats = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetAccountingStats')
         if __nvmlDeviceGetAccountingStats == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetAccountingStats = dlsym(handle, 'nvmlDeviceGetAccountingStats')
+            __nvmlDeviceGetAccountingStats = _cyb_dlsym(handle, 'nvmlDeviceGetAccountingStats')
 
         global __nvmlDeviceGetAccountingPids
-        __nvmlDeviceGetAccountingPids = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetAccountingPids')
+        __nvmlDeviceGetAccountingPids = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetAccountingPids')
         if __nvmlDeviceGetAccountingPids == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetAccountingPids = dlsym(handle, 'nvmlDeviceGetAccountingPids')
+            __nvmlDeviceGetAccountingPids = _cyb_dlsym(handle, 'nvmlDeviceGetAccountingPids')
 
         global __nvmlDeviceGetAccountingBufferSize
-        __nvmlDeviceGetAccountingBufferSize = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetAccountingBufferSize')
+        __nvmlDeviceGetAccountingBufferSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetAccountingBufferSize')
         if __nvmlDeviceGetAccountingBufferSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetAccountingBufferSize = dlsym(handle, 'nvmlDeviceGetAccountingBufferSize')
+            __nvmlDeviceGetAccountingBufferSize = _cyb_dlsym(handle, 'nvmlDeviceGetAccountingBufferSize')
 
         global __nvmlDeviceGetRetiredPages
-        __nvmlDeviceGetRetiredPages = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetRetiredPages')
+        __nvmlDeviceGetRetiredPages = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetRetiredPages')
         if __nvmlDeviceGetRetiredPages == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetRetiredPages = dlsym(handle, 'nvmlDeviceGetRetiredPages')
+            __nvmlDeviceGetRetiredPages = _cyb_dlsym(handle, 'nvmlDeviceGetRetiredPages')
 
         global __nvmlDeviceGetRetiredPages_v2
-        __nvmlDeviceGetRetiredPages_v2 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetRetiredPages_v2')
+        __nvmlDeviceGetRetiredPages_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetRetiredPages_v2')
         if __nvmlDeviceGetRetiredPages_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetRetiredPages_v2 = dlsym(handle, 'nvmlDeviceGetRetiredPages_v2')
+            __nvmlDeviceGetRetiredPages_v2 = _cyb_dlsym(handle, 'nvmlDeviceGetRetiredPages_v2')
 
         global __nvmlDeviceGetRetiredPagesPendingStatus
-        __nvmlDeviceGetRetiredPagesPendingStatus = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetRetiredPagesPendingStatus')
+        __nvmlDeviceGetRetiredPagesPendingStatus = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetRetiredPagesPendingStatus')
         if __nvmlDeviceGetRetiredPagesPendingStatus == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetRetiredPagesPendingStatus = dlsym(handle, 'nvmlDeviceGetRetiredPagesPendingStatus')
+            __nvmlDeviceGetRetiredPagesPendingStatus = _cyb_dlsym(handle, 'nvmlDeviceGetRetiredPagesPendingStatus')
 
         global __nvmlDeviceGetRemappedRows
-        __nvmlDeviceGetRemappedRows = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetRemappedRows')
+        __nvmlDeviceGetRemappedRows = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetRemappedRows')
         if __nvmlDeviceGetRemappedRows == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetRemappedRows = dlsym(handle, 'nvmlDeviceGetRemappedRows')
+            __nvmlDeviceGetRemappedRows = _cyb_dlsym(handle, 'nvmlDeviceGetRemappedRows')
 
         global __nvmlDeviceGetRowRemapperHistogram
-        __nvmlDeviceGetRowRemapperHistogram = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetRowRemapperHistogram')
+        __nvmlDeviceGetRowRemapperHistogram = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetRowRemapperHistogram')
         if __nvmlDeviceGetRowRemapperHistogram == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetRowRemapperHistogram = dlsym(handle, 'nvmlDeviceGetRowRemapperHistogram')
+            __nvmlDeviceGetRowRemapperHistogram = _cyb_dlsym(handle, 'nvmlDeviceGetRowRemapperHistogram')
 
         global __nvmlDeviceGetArchitecture
-        __nvmlDeviceGetArchitecture = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetArchitecture')
+        __nvmlDeviceGetArchitecture = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetArchitecture')
         if __nvmlDeviceGetArchitecture == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetArchitecture = dlsym(handle, 'nvmlDeviceGetArchitecture')
+            __nvmlDeviceGetArchitecture = _cyb_dlsym(handle, 'nvmlDeviceGetArchitecture')
 
         global __nvmlDeviceGetClkMonStatus
-        __nvmlDeviceGetClkMonStatus = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetClkMonStatus')
+        __nvmlDeviceGetClkMonStatus = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetClkMonStatus')
         if __nvmlDeviceGetClkMonStatus == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetClkMonStatus = dlsym(handle, 'nvmlDeviceGetClkMonStatus')
+            __nvmlDeviceGetClkMonStatus = _cyb_dlsym(handle, 'nvmlDeviceGetClkMonStatus')
 
         global __nvmlDeviceGetProcessUtilization
-        __nvmlDeviceGetProcessUtilization = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetProcessUtilization')
+        __nvmlDeviceGetProcessUtilization = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetProcessUtilization')
         if __nvmlDeviceGetProcessUtilization == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetProcessUtilization = dlsym(handle, 'nvmlDeviceGetProcessUtilization')
+            __nvmlDeviceGetProcessUtilization = _cyb_dlsym(handle, 'nvmlDeviceGetProcessUtilization')
 
         global __nvmlDeviceGetProcessesUtilizationInfo
-        __nvmlDeviceGetProcessesUtilizationInfo = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetProcessesUtilizationInfo')
+        __nvmlDeviceGetProcessesUtilizationInfo = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetProcessesUtilizationInfo')
         if __nvmlDeviceGetProcessesUtilizationInfo == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetProcessesUtilizationInfo = dlsym(handle, 'nvmlDeviceGetProcessesUtilizationInfo')
+            __nvmlDeviceGetProcessesUtilizationInfo = _cyb_dlsym(handle, 'nvmlDeviceGetProcessesUtilizationInfo')
 
         global __nvmlDeviceGetPlatformInfo
-        __nvmlDeviceGetPlatformInfo = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetPlatformInfo')
+        __nvmlDeviceGetPlatformInfo = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetPlatformInfo')
         if __nvmlDeviceGetPlatformInfo == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetPlatformInfo = dlsym(handle, 'nvmlDeviceGetPlatformInfo')
+            __nvmlDeviceGetPlatformInfo = _cyb_dlsym(handle, 'nvmlDeviceGetPlatformInfo')
 
         global __nvmlUnitSetLedState
-        __nvmlUnitSetLedState = dlsym(RTLD_DEFAULT, 'nvmlUnitSetLedState')
+        __nvmlUnitSetLedState = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlUnitSetLedState')
         if __nvmlUnitSetLedState == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlUnitSetLedState = dlsym(handle, 'nvmlUnitSetLedState')
+            __nvmlUnitSetLedState = _cyb_dlsym(handle, 'nvmlUnitSetLedState')
 
         global __nvmlDeviceSetPersistenceMode
-        __nvmlDeviceSetPersistenceMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetPersistenceMode')
+        __nvmlDeviceSetPersistenceMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetPersistenceMode')
         if __nvmlDeviceSetPersistenceMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetPersistenceMode = dlsym(handle, 'nvmlDeviceSetPersistenceMode')
+            __nvmlDeviceSetPersistenceMode = _cyb_dlsym(handle, 'nvmlDeviceSetPersistenceMode')
 
         global __nvmlDeviceSetComputeMode
-        __nvmlDeviceSetComputeMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetComputeMode')
+        __nvmlDeviceSetComputeMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetComputeMode')
         if __nvmlDeviceSetComputeMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetComputeMode = dlsym(handle, 'nvmlDeviceSetComputeMode')
+            __nvmlDeviceSetComputeMode = _cyb_dlsym(handle, 'nvmlDeviceSetComputeMode')
 
         global __nvmlDeviceSetEccMode
-        __nvmlDeviceSetEccMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetEccMode')
+        __nvmlDeviceSetEccMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetEccMode')
         if __nvmlDeviceSetEccMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetEccMode = dlsym(handle, 'nvmlDeviceSetEccMode')
+            __nvmlDeviceSetEccMode = _cyb_dlsym(handle, 'nvmlDeviceSetEccMode')
 
         global __nvmlDeviceClearEccErrorCounts
-        __nvmlDeviceClearEccErrorCounts = dlsym(RTLD_DEFAULT, 'nvmlDeviceClearEccErrorCounts')
+        __nvmlDeviceClearEccErrorCounts = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceClearEccErrorCounts')
         if __nvmlDeviceClearEccErrorCounts == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceClearEccErrorCounts = dlsym(handle, 'nvmlDeviceClearEccErrorCounts')
+            __nvmlDeviceClearEccErrorCounts = _cyb_dlsym(handle, 'nvmlDeviceClearEccErrorCounts')
 
         global __nvmlDeviceSetDriverModel
-        __nvmlDeviceSetDriverModel = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetDriverModel')
+        __nvmlDeviceSetDriverModel = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetDriverModel')
         if __nvmlDeviceSetDriverModel == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetDriverModel = dlsym(handle, 'nvmlDeviceSetDriverModel')
+            __nvmlDeviceSetDriverModel = _cyb_dlsym(handle, 'nvmlDeviceSetDriverModel')
 
         global __nvmlDeviceSetGpuLockedClocks
-        __nvmlDeviceSetGpuLockedClocks = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetGpuLockedClocks')
+        __nvmlDeviceSetGpuLockedClocks = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetGpuLockedClocks')
         if __nvmlDeviceSetGpuLockedClocks == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetGpuLockedClocks = dlsym(handle, 'nvmlDeviceSetGpuLockedClocks')
+            __nvmlDeviceSetGpuLockedClocks = _cyb_dlsym(handle, 'nvmlDeviceSetGpuLockedClocks')
 
         global __nvmlDeviceResetGpuLockedClocks
-        __nvmlDeviceResetGpuLockedClocks = dlsym(RTLD_DEFAULT, 'nvmlDeviceResetGpuLockedClocks')
+        __nvmlDeviceResetGpuLockedClocks = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceResetGpuLockedClocks')
         if __nvmlDeviceResetGpuLockedClocks == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceResetGpuLockedClocks = dlsym(handle, 'nvmlDeviceResetGpuLockedClocks')
+            __nvmlDeviceResetGpuLockedClocks = _cyb_dlsym(handle, 'nvmlDeviceResetGpuLockedClocks')
 
         global __nvmlDeviceSetMemoryLockedClocks
-        __nvmlDeviceSetMemoryLockedClocks = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetMemoryLockedClocks')
+        __nvmlDeviceSetMemoryLockedClocks = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetMemoryLockedClocks')
         if __nvmlDeviceSetMemoryLockedClocks == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetMemoryLockedClocks = dlsym(handle, 'nvmlDeviceSetMemoryLockedClocks')
+            __nvmlDeviceSetMemoryLockedClocks = _cyb_dlsym(handle, 'nvmlDeviceSetMemoryLockedClocks')
 
         global __nvmlDeviceResetMemoryLockedClocks
-        __nvmlDeviceResetMemoryLockedClocks = dlsym(RTLD_DEFAULT, 'nvmlDeviceResetMemoryLockedClocks')
+        __nvmlDeviceResetMemoryLockedClocks = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceResetMemoryLockedClocks')
         if __nvmlDeviceResetMemoryLockedClocks == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceResetMemoryLockedClocks = dlsym(handle, 'nvmlDeviceResetMemoryLockedClocks')
+            __nvmlDeviceResetMemoryLockedClocks = _cyb_dlsym(handle, 'nvmlDeviceResetMemoryLockedClocks')
 
         global __nvmlDeviceSetAutoBoostedClocksEnabled
-        __nvmlDeviceSetAutoBoostedClocksEnabled = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetAutoBoostedClocksEnabled')
+        __nvmlDeviceSetAutoBoostedClocksEnabled = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetAutoBoostedClocksEnabled')
         if __nvmlDeviceSetAutoBoostedClocksEnabled == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetAutoBoostedClocksEnabled = dlsym(handle, 'nvmlDeviceSetAutoBoostedClocksEnabled')
+            __nvmlDeviceSetAutoBoostedClocksEnabled = _cyb_dlsym(handle, 'nvmlDeviceSetAutoBoostedClocksEnabled')
 
         global __nvmlDeviceSetDefaultAutoBoostedClocksEnabled
-        __nvmlDeviceSetDefaultAutoBoostedClocksEnabled = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetDefaultAutoBoostedClocksEnabled')
+        __nvmlDeviceSetDefaultAutoBoostedClocksEnabled = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetDefaultAutoBoostedClocksEnabled')
         if __nvmlDeviceSetDefaultAutoBoostedClocksEnabled == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetDefaultAutoBoostedClocksEnabled = dlsym(handle, 'nvmlDeviceSetDefaultAutoBoostedClocksEnabled')
+            __nvmlDeviceSetDefaultAutoBoostedClocksEnabled = _cyb_dlsym(handle, 'nvmlDeviceSetDefaultAutoBoostedClocksEnabled')
 
         global __nvmlDeviceSetDefaultFanSpeed_v2
-        __nvmlDeviceSetDefaultFanSpeed_v2 = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetDefaultFanSpeed_v2')
+        __nvmlDeviceSetDefaultFanSpeed_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetDefaultFanSpeed_v2')
         if __nvmlDeviceSetDefaultFanSpeed_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetDefaultFanSpeed_v2 = dlsym(handle, 'nvmlDeviceSetDefaultFanSpeed_v2')
+            __nvmlDeviceSetDefaultFanSpeed_v2 = _cyb_dlsym(handle, 'nvmlDeviceSetDefaultFanSpeed_v2')
 
         global __nvmlDeviceSetFanControlPolicy
-        __nvmlDeviceSetFanControlPolicy = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetFanControlPolicy')
+        __nvmlDeviceSetFanControlPolicy = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetFanControlPolicy')
         if __nvmlDeviceSetFanControlPolicy == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetFanControlPolicy = dlsym(handle, 'nvmlDeviceSetFanControlPolicy')
+            __nvmlDeviceSetFanControlPolicy = _cyb_dlsym(handle, 'nvmlDeviceSetFanControlPolicy')
 
         global __nvmlDeviceSetTemperatureThreshold
-        __nvmlDeviceSetTemperatureThreshold = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetTemperatureThreshold')
+        __nvmlDeviceSetTemperatureThreshold = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetTemperatureThreshold')
         if __nvmlDeviceSetTemperatureThreshold == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetTemperatureThreshold = dlsym(handle, 'nvmlDeviceSetTemperatureThreshold')
+            __nvmlDeviceSetTemperatureThreshold = _cyb_dlsym(handle, 'nvmlDeviceSetTemperatureThreshold')
 
         global __nvmlDeviceSetGpuOperationMode
-        __nvmlDeviceSetGpuOperationMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetGpuOperationMode')
+        __nvmlDeviceSetGpuOperationMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetGpuOperationMode')
         if __nvmlDeviceSetGpuOperationMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetGpuOperationMode = dlsym(handle, 'nvmlDeviceSetGpuOperationMode')
+            __nvmlDeviceSetGpuOperationMode = _cyb_dlsym(handle, 'nvmlDeviceSetGpuOperationMode')
 
         global __nvmlDeviceSetAPIRestriction
-        __nvmlDeviceSetAPIRestriction = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetAPIRestriction')
+        __nvmlDeviceSetAPIRestriction = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetAPIRestriction')
         if __nvmlDeviceSetAPIRestriction == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetAPIRestriction = dlsym(handle, 'nvmlDeviceSetAPIRestriction')
+            __nvmlDeviceSetAPIRestriction = _cyb_dlsym(handle, 'nvmlDeviceSetAPIRestriction')
 
         global __nvmlDeviceSetFanSpeed_v2
-        __nvmlDeviceSetFanSpeed_v2 = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetFanSpeed_v2')
+        __nvmlDeviceSetFanSpeed_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetFanSpeed_v2')
         if __nvmlDeviceSetFanSpeed_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetFanSpeed_v2 = dlsym(handle, 'nvmlDeviceSetFanSpeed_v2')
+            __nvmlDeviceSetFanSpeed_v2 = _cyb_dlsym(handle, 'nvmlDeviceSetFanSpeed_v2')
 
         global __nvmlDeviceSetAccountingMode
-        __nvmlDeviceSetAccountingMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetAccountingMode')
+        __nvmlDeviceSetAccountingMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetAccountingMode')
         if __nvmlDeviceSetAccountingMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetAccountingMode = dlsym(handle, 'nvmlDeviceSetAccountingMode')
+            __nvmlDeviceSetAccountingMode = _cyb_dlsym(handle, 'nvmlDeviceSetAccountingMode')
 
         global __nvmlDeviceClearAccountingPids
-        __nvmlDeviceClearAccountingPids = dlsym(RTLD_DEFAULT, 'nvmlDeviceClearAccountingPids')
+        __nvmlDeviceClearAccountingPids = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceClearAccountingPids')
         if __nvmlDeviceClearAccountingPids == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceClearAccountingPids = dlsym(handle, 'nvmlDeviceClearAccountingPids')
+            __nvmlDeviceClearAccountingPids = _cyb_dlsym(handle, 'nvmlDeviceClearAccountingPids')
 
         global __nvmlDeviceSetPowerManagementLimit_v2
-        __nvmlDeviceSetPowerManagementLimit_v2 = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetPowerManagementLimit_v2')
+        __nvmlDeviceSetPowerManagementLimit_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetPowerManagementLimit_v2')
         if __nvmlDeviceSetPowerManagementLimit_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetPowerManagementLimit_v2 = dlsym(handle, 'nvmlDeviceSetPowerManagementLimit_v2')
+            __nvmlDeviceSetPowerManagementLimit_v2 = _cyb_dlsym(handle, 'nvmlDeviceSetPowerManagementLimit_v2')
 
         global __nvmlDeviceGetNvLinkState
-        __nvmlDeviceGetNvLinkState = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetNvLinkState')
+        __nvmlDeviceGetNvLinkState = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetNvLinkState')
         if __nvmlDeviceGetNvLinkState == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetNvLinkState = dlsym(handle, 'nvmlDeviceGetNvLinkState')
+            __nvmlDeviceGetNvLinkState = _cyb_dlsym(handle, 'nvmlDeviceGetNvLinkState')
 
         global __nvmlDeviceGetNvLinkVersion
-        __nvmlDeviceGetNvLinkVersion = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetNvLinkVersion')
+        __nvmlDeviceGetNvLinkVersion = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetNvLinkVersion')
         if __nvmlDeviceGetNvLinkVersion == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetNvLinkVersion = dlsym(handle, 'nvmlDeviceGetNvLinkVersion')
+            __nvmlDeviceGetNvLinkVersion = _cyb_dlsym(handle, 'nvmlDeviceGetNvLinkVersion')
 
         global __nvmlDeviceGetNvLinkCapability
-        __nvmlDeviceGetNvLinkCapability = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetNvLinkCapability')
+        __nvmlDeviceGetNvLinkCapability = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetNvLinkCapability')
         if __nvmlDeviceGetNvLinkCapability == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetNvLinkCapability = dlsym(handle, 'nvmlDeviceGetNvLinkCapability')
+            __nvmlDeviceGetNvLinkCapability = _cyb_dlsym(handle, 'nvmlDeviceGetNvLinkCapability')
 
         global __nvmlDeviceGetNvLinkRemotePciInfo_v2
-        __nvmlDeviceGetNvLinkRemotePciInfo_v2 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetNvLinkRemotePciInfo_v2')
+        __nvmlDeviceGetNvLinkRemotePciInfo_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetNvLinkRemotePciInfo_v2')
         if __nvmlDeviceGetNvLinkRemotePciInfo_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetNvLinkRemotePciInfo_v2 = dlsym(handle, 'nvmlDeviceGetNvLinkRemotePciInfo_v2')
+            __nvmlDeviceGetNvLinkRemotePciInfo_v2 = _cyb_dlsym(handle, 'nvmlDeviceGetNvLinkRemotePciInfo_v2')
 
         global __nvmlDeviceGetNvLinkErrorCounter
-        __nvmlDeviceGetNvLinkErrorCounter = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetNvLinkErrorCounter')
+        __nvmlDeviceGetNvLinkErrorCounter = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetNvLinkErrorCounter')
         if __nvmlDeviceGetNvLinkErrorCounter == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetNvLinkErrorCounter = dlsym(handle, 'nvmlDeviceGetNvLinkErrorCounter')
+            __nvmlDeviceGetNvLinkErrorCounter = _cyb_dlsym(handle, 'nvmlDeviceGetNvLinkErrorCounter')
 
         global __nvmlDeviceResetNvLinkErrorCounters
-        __nvmlDeviceResetNvLinkErrorCounters = dlsym(RTLD_DEFAULT, 'nvmlDeviceResetNvLinkErrorCounters')
+        __nvmlDeviceResetNvLinkErrorCounters = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceResetNvLinkErrorCounters')
         if __nvmlDeviceResetNvLinkErrorCounters == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceResetNvLinkErrorCounters = dlsym(handle, 'nvmlDeviceResetNvLinkErrorCounters')
+            __nvmlDeviceResetNvLinkErrorCounters = _cyb_dlsym(handle, 'nvmlDeviceResetNvLinkErrorCounters')
 
         global __nvmlDeviceGetNvLinkRemoteDeviceType
-        __nvmlDeviceGetNvLinkRemoteDeviceType = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetNvLinkRemoteDeviceType')
+        __nvmlDeviceGetNvLinkRemoteDeviceType = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetNvLinkRemoteDeviceType')
         if __nvmlDeviceGetNvLinkRemoteDeviceType == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetNvLinkRemoteDeviceType = dlsym(handle, 'nvmlDeviceGetNvLinkRemoteDeviceType')
+            __nvmlDeviceGetNvLinkRemoteDeviceType = _cyb_dlsym(handle, 'nvmlDeviceGetNvLinkRemoteDeviceType')
 
         global __nvmlDeviceSetNvLinkDeviceLowPowerThreshold
-        __nvmlDeviceSetNvLinkDeviceLowPowerThreshold = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetNvLinkDeviceLowPowerThreshold')
+        __nvmlDeviceSetNvLinkDeviceLowPowerThreshold = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetNvLinkDeviceLowPowerThreshold')
         if __nvmlDeviceSetNvLinkDeviceLowPowerThreshold == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetNvLinkDeviceLowPowerThreshold = dlsym(handle, 'nvmlDeviceSetNvLinkDeviceLowPowerThreshold')
+            __nvmlDeviceSetNvLinkDeviceLowPowerThreshold = _cyb_dlsym(handle, 'nvmlDeviceSetNvLinkDeviceLowPowerThreshold')
 
         global __nvmlSystemSetNvlinkBwMode
-        __nvmlSystemSetNvlinkBwMode = dlsym(RTLD_DEFAULT, 'nvmlSystemSetNvlinkBwMode')
+        __nvmlSystemSetNvlinkBwMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemSetNvlinkBwMode')
         if __nvmlSystemSetNvlinkBwMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemSetNvlinkBwMode = dlsym(handle, 'nvmlSystemSetNvlinkBwMode')
+            __nvmlSystemSetNvlinkBwMode = _cyb_dlsym(handle, 'nvmlSystemSetNvlinkBwMode')
 
         global __nvmlSystemGetNvlinkBwMode
-        __nvmlSystemGetNvlinkBwMode = dlsym(RTLD_DEFAULT, 'nvmlSystemGetNvlinkBwMode')
+        __nvmlSystemGetNvlinkBwMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemGetNvlinkBwMode')
         if __nvmlSystemGetNvlinkBwMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemGetNvlinkBwMode = dlsym(handle, 'nvmlSystemGetNvlinkBwMode')
+            __nvmlSystemGetNvlinkBwMode = _cyb_dlsym(handle, 'nvmlSystemGetNvlinkBwMode')
 
         global __nvmlDeviceGetNvlinkSupportedBwModes
-        __nvmlDeviceGetNvlinkSupportedBwModes = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetNvlinkSupportedBwModes')
+        __nvmlDeviceGetNvlinkSupportedBwModes = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetNvlinkSupportedBwModes')
         if __nvmlDeviceGetNvlinkSupportedBwModes == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetNvlinkSupportedBwModes = dlsym(handle, 'nvmlDeviceGetNvlinkSupportedBwModes')
+            __nvmlDeviceGetNvlinkSupportedBwModes = _cyb_dlsym(handle, 'nvmlDeviceGetNvlinkSupportedBwModes')
 
         global __nvmlDeviceGetNvlinkBwMode
-        __nvmlDeviceGetNvlinkBwMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetNvlinkBwMode')
+        __nvmlDeviceGetNvlinkBwMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetNvlinkBwMode')
         if __nvmlDeviceGetNvlinkBwMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetNvlinkBwMode = dlsym(handle, 'nvmlDeviceGetNvlinkBwMode')
+            __nvmlDeviceGetNvlinkBwMode = _cyb_dlsym(handle, 'nvmlDeviceGetNvlinkBwMode')
 
         global __nvmlDeviceSetNvlinkBwMode
-        __nvmlDeviceSetNvlinkBwMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetNvlinkBwMode')
+        __nvmlDeviceSetNvlinkBwMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetNvlinkBwMode')
         if __nvmlDeviceSetNvlinkBwMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetNvlinkBwMode = dlsym(handle, 'nvmlDeviceSetNvlinkBwMode')
+            __nvmlDeviceSetNvlinkBwMode = _cyb_dlsym(handle, 'nvmlDeviceSetNvlinkBwMode')
 
         global __nvmlEventSetCreate
-        __nvmlEventSetCreate = dlsym(RTLD_DEFAULT, 'nvmlEventSetCreate')
+        __nvmlEventSetCreate = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlEventSetCreate')
         if __nvmlEventSetCreate == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlEventSetCreate = dlsym(handle, 'nvmlEventSetCreate')
+            __nvmlEventSetCreate = _cyb_dlsym(handle, 'nvmlEventSetCreate')
 
         global __nvmlDeviceRegisterEvents
-        __nvmlDeviceRegisterEvents = dlsym(RTLD_DEFAULT, 'nvmlDeviceRegisterEvents')
+        __nvmlDeviceRegisterEvents = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceRegisterEvents')
         if __nvmlDeviceRegisterEvents == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceRegisterEvents = dlsym(handle, 'nvmlDeviceRegisterEvents')
+            __nvmlDeviceRegisterEvents = _cyb_dlsym(handle, 'nvmlDeviceRegisterEvents')
 
         global __nvmlDeviceGetSupportedEventTypes
-        __nvmlDeviceGetSupportedEventTypes = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetSupportedEventTypes')
+        __nvmlDeviceGetSupportedEventTypes = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetSupportedEventTypes')
         if __nvmlDeviceGetSupportedEventTypes == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetSupportedEventTypes = dlsym(handle, 'nvmlDeviceGetSupportedEventTypes')
+            __nvmlDeviceGetSupportedEventTypes = _cyb_dlsym(handle, 'nvmlDeviceGetSupportedEventTypes')
 
         global __nvmlEventSetWait_v2
-        __nvmlEventSetWait_v2 = dlsym(RTLD_DEFAULT, 'nvmlEventSetWait_v2')
+        __nvmlEventSetWait_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlEventSetWait_v2')
         if __nvmlEventSetWait_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlEventSetWait_v2 = dlsym(handle, 'nvmlEventSetWait_v2')
+            __nvmlEventSetWait_v2 = _cyb_dlsym(handle, 'nvmlEventSetWait_v2')
 
         global __nvmlEventSetFree
-        __nvmlEventSetFree = dlsym(RTLD_DEFAULT, 'nvmlEventSetFree')
+        __nvmlEventSetFree = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlEventSetFree')
         if __nvmlEventSetFree == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlEventSetFree = dlsym(handle, 'nvmlEventSetFree')
+            __nvmlEventSetFree = _cyb_dlsym(handle, 'nvmlEventSetFree')
 
         global __nvmlSystemEventSetCreate
-        __nvmlSystemEventSetCreate = dlsym(RTLD_DEFAULT, 'nvmlSystemEventSetCreate')
+        __nvmlSystemEventSetCreate = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemEventSetCreate')
         if __nvmlSystemEventSetCreate == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemEventSetCreate = dlsym(handle, 'nvmlSystemEventSetCreate')
+            __nvmlSystemEventSetCreate = _cyb_dlsym(handle, 'nvmlSystemEventSetCreate')
 
         global __nvmlSystemEventSetFree
-        __nvmlSystemEventSetFree = dlsym(RTLD_DEFAULT, 'nvmlSystemEventSetFree')
+        __nvmlSystemEventSetFree = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemEventSetFree')
         if __nvmlSystemEventSetFree == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemEventSetFree = dlsym(handle, 'nvmlSystemEventSetFree')
+            __nvmlSystemEventSetFree = _cyb_dlsym(handle, 'nvmlSystemEventSetFree')
 
         global __nvmlSystemRegisterEvents
-        __nvmlSystemRegisterEvents = dlsym(RTLD_DEFAULT, 'nvmlSystemRegisterEvents')
+        __nvmlSystemRegisterEvents = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemRegisterEvents')
         if __nvmlSystemRegisterEvents == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemRegisterEvents = dlsym(handle, 'nvmlSystemRegisterEvents')
+            __nvmlSystemRegisterEvents = _cyb_dlsym(handle, 'nvmlSystemRegisterEvents')
 
         global __nvmlSystemEventSetWait
-        __nvmlSystemEventSetWait = dlsym(RTLD_DEFAULT, 'nvmlSystemEventSetWait')
+        __nvmlSystemEventSetWait = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSystemEventSetWait')
         if __nvmlSystemEventSetWait == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSystemEventSetWait = dlsym(handle, 'nvmlSystemEventSetWait')
+            __nvmlSystemEventSetWait = _cyb_dlsym(handle, 'nvmlSystemEventSetWait')
 
         global __nvmlDeviceModifyDrainState
-        __nvmlDeviceModifyDrainState = dlsym(RTLD_DEFAULT, 'nvmlDeviceModifyDrainState')
+        __nvmlDeviceModifyDrainState = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceModifyDrainState')
         if __nvmlDeviceModifyDrainState == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceModifyDrainState = dlsym(handle, 'nvmlDeviceModifyDrainState')
+            __nvmlDeviceModifyDrainState = _cyb_dlsym(handle, 'nvmlDeviceModifyDrainState')
 
         global __nvmlDeviceQueryDrainState
-        __nvmlDeviceQueryDrainState = dlsym(RTLD_DEFAULT, 'nvmlDeviceQueryDrainState')
+        __nvmlDeviceQueryDrainState = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceQueryDrainState')
         if __nvmlDeviceQueryDrainState == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceQueryDrainState = dlsym(handle, 'nvmlDeviceQueryDrainState')
+            __nvmlDeviceQueryDrainState = _cyb_dlsym(handle, 'nvmlDeviceQueryDrainState')
 
         global __nvmlDeviceRemoveGpu_v2
-        __nvmlDeviceRemoveGpu_v2 = dlsym(RTLD_DEFAULT, 'nvmlDeviceRemoveGpu_v2')
+        __nvmlDeviceRemoveGpu_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceRemoveGpu_v2')
         if __nvmlDeviceRemoveGpu_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceRemoveGpu_v2 = dlsym(handle, 'nvmlDeviceRemoveGpu_v2')
+            __nvmlDeviceRemoveGpu_v2 = _cyb_dlsym(handle, 'nvmlDeviceRemoveGpu_v2')
 
         global __nvmlDeviceDiscoverGpus
-        __nvmlDeviceDiscoverGpus = dlsym(RTLD_DEFAULT, 'nvmlDeviceDiscoverGpus')
+        __nvmlDeviceDiscoverGpus = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceDiscoverGpus')
         if __nvmlDeviceDiscoverGpus == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceDiscoverGpus = dlsym(handle, 'nvmlDeviceDiscoverGpus')
+            __nvmlDeviceDiscoverGpus = _cyb_dlsym(handle, 'nvmlDeviceDiscoverGpus')
 
         global __nvmlDeviceGetFieldValues
-        __nvmlDeviceGetFieldValues = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetFieldValues')
+        __nvmlDeviceGetFieldValues = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetFieldValues')
         if __nvmlDeviceGetFieldValues == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetFieldValues = dlsym(handle, 'nvmlDeviceGetFieldValues')
+            __nvmlDeviceGetFieldValues = _cyb_dlsym(handle, 'nvmlDeviceGetFieldValues')
 
         global __nvmlDeviceClearFieldValues
-        __nvmlDeviceClearFieldValues = dlsym(RTLD_DEFAULT, 'nvmlDeviceClearFieldValues')
+        __nvmlDeviceClearFieldValues = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceClearFieldValues')
         if __nvmlDeviceClearFieldValues == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceClearFieldValues = dlsym(handle, 'nvmlDeviceClearFieldValues')
+            __nvmlDeviceClearFieldValues = _cyb_dlsym(handle, 'nvmlDeviceClearFieldValues')
 
         global __nvmlDeviceGetVirtualizationMode
-        __nvmlDeviceGetVirtualizationMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetVirtualizationMode')
+        __nvmlDeviceGetVirtualizationMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetVirtualizationMode')
         if __nvmlDeviceGetVirtualizationMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetVirtualizationMode = dlsym(handle, 'nvmlDeviceGetVirtualizationMode')
+            __nvmlDeviceGetVirtualizationMode = _cyb_dlsym(handle, 'nvmlDeviceGetVirtualizationMode')
 
         global __nvmlDeviceGetHostVgpuMode
-        __nvmlDeviceGetHostVgpuMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetHostVgpuMode')
+        __nvmlDeviceGetHostVgpuMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetHostVgpuMode')
         if __nvmlDeviceGetHostVgpuMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetHostVgpuMode = dlsym(handle, 'nvmlDeviceGetHostVgpuMode')
+            __nvmlDeviceGetHostVgpuMode = _cyb_dlsym(handle, 'nvmlDeviceGetHostVgpuMode')
 
         global __nvmlDeviceSetVirtualizationMode
-        __nvmlDeviceSetVirtualizationMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetVirtualizationMode')
+        __nvmlDeviceSetVirtualizationMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetVirtualizationMode')
         if __nvmlDeviceSetVirtualizationMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetVirtualizationMode = dlsym(handle, 'nvmlDeviceSetVirtualizationMode')
+            __nvmlDeviceSetVirtualizationMode = _cyb_dlsym(handle, 'nvmlDeviceSetVirtualizationMode')
 
         global __nvmlDeviceGetVgpuHeterogeneousMode
-        __nvmlDeviceGetVgpuHeterogeneousMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetVgpuHeterogeneousMode')
+        __nvmlDeviceGetVgpuHeterogeneousMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetVgpuHeterogeneousMode')
         if __nvmlDeviceGetVgpuHeterogeneousMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetVgpuHeterogeneousMode = dlsym(handle, 'nvmlDeviceGetVgpuHeterogeneousMode')
+            __nvmlDeviceGetVgpuHeterogeneousMode = _cyb_dlsym(handle, 'nvmlDeviceGetVgpuHeterogeneousMode')
 
         global __nvmlDeviceSetVgpuHeterogeneousMode
-        __nvmlDeviceSetVgpuHeterogeneousMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetVgpuHeterogeneousMode')
+        __nvmlDeviceSetVgpuHeterogeneousMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetVgpuHeterogeneousMode')
         if __nvmlDeviceSetVgpuHeterogeneousMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetVgpuHeterogeneousMode = dlsym(handle, 'nvmlDeviceSetVgpuHeterogeneousMode')
+            __nvmlDeviceSetVgpuHeterogeneousMode = _cyb_dlsym(handle, 'nvmlDeviceSetVgpuHeterogeneousMode')
 
         global __nvmlVgpuInstanceGetPlacementId
-        __nvmlVgpuInstanceGetPlacementId = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetPlacementId')
+        __nvmlVgpuInstanceGetPlacementId = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetPlacementId')
         if __nvmlVgpuInstanceGetPlacementId == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetPlacementId = dlsym(handle, 'nvmlVgpuInstanceGetPlacementId')
+            __nvmlVgpuInstanceGetPlacementId = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetPlacementId')
 
         global __nvmlDeviceGetVgpuTypeSupportedPlacements
-        __nvmlDeviceGetVgpuTypeSupportedPlacements = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetVgpuTypeSupportedPlacements')
+        __nvmlDeviceGetVgpuTypeSupportedPlacements = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetVgpuTypeSupportedPlacements')
         if __nvmlDeviceGetVgpuTypeSupportedPlacements == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetVgpuTypeSupportedPlacements = dlsym(handle, 'nvmlDeviceGetVgpuTypeSupportedPlacements')
+            __nvmlDeviceGetVgpuTypeSupportedPlacements = _cyb_dlsym(handle, 'nvmlDeviceGetVgpuTypeSupportedPlacements')
 
         global __nvmlDeviceGetVgpuTypeCreatablePlacements
-        __nvmlDeviceGetVgpuTypeCreatablePlacements = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetVgpuTypeCreatablePlacements')
+        __nvmlDeviceGetVgpuTypeCreatablePlacements = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetVgpuTypeCreatablePlacements')
         if __nvmlDeviceGetVgpuTypeCreatablePlacements == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetVgpuTypeCreatablePlacements = dlsym(handle, 'nvmlDeviceGetVgpuTypeCreatablePlacements')
+            __nvmlDeviceGetVgpuTypeCreatablePlacements = _cyb_dlsym(handle, 'nvmlDeviceGetVgpuTypeCreatablePlacements')
 
         global __nvmlVgpuTypeGetGspHeapSize
-        __nvmlVgpuTypeGetGspHeapSize = dlsym(RTLD_DEFAULT, 'nvmlVgpuTypeGetGspHeapSize')
+        __nvmlVgpuTypeGetGspHeapSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuTypeGetGspHeapSize')
         if __nvmlVgpuTypeGetGspHeapSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuTypeGetGspHeapSize = dlsym(handle, 'nvmlVgpuTypeGetGspHeapSize')
+            __nvmlVgpuTypeGetGspHeapSize = _cyb_dlsym(handle, 'nvmlVgpuTypeGetGspHeapSize')
 
         global __nvmlVgpuTypeGetFbReservation
-        __nvmlVgpuTypeGetFbReservation = dlsym(RTLD_DEFAULT, 'nvmlVgpuTypeGetFbReservation')
+        __nvmlVgpuTypeGetFbReservation = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuTypeGetFbReservation')
         if __nvmlVgpuTypeGetFbReservation == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuTypeGetFbReservation = dlsym(handle, 'nvmlVgpuTypeGetFbReservation')
+            __nvmlVgpuTypeGetFbReservation = _cyb_dlsym(handle, 'nvmlVgpuTypeGetFbReservation')
 
         global __nvmlVgpuInstanceGetRuntimeStateSize
-        __nvmlVgpuInstanceGetRuntimeStateSize = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetRuntimeStateSize')
+        __nvmlVgpuInstanceGetRuntimeStateSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetRuntimeStateSize')
         if __nvmlVgpuInstanceGetRuntimeStateSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetRuntimeStateSize = dlsym(handle, 'nvmlVgpuInstanceGetRuntimeStateSize')
+            __nvmlVgpuInstanceGetRuntimeStateSize = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetRuntimeStateSize')
 
         global __nvmlDeviceSetVgpuCapabilities
-        __nvmlDeviceSetVgpuCapabilities = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetVgpuCapabilities')
+        __nvmlDeviceSetVgpuCapabilities = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetVgpuCapabilities')
         if __nvmlDeviceSetVgpuCapabilities == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetVgpuCapabilities = dlsym(handle, 'nvmlDeviceSetVgpuCapabilities')
+            __nvmlDeviceSetVgpuCapabilities = _cyb_dlsym(handle, 'nvmlDeviceSetVgpuCapabilities')
 
         global __nvmlDeviceGetGridLicensableFeatures_v4
-        __nvmlDeviceGetGridLicensableFeatures_v4 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetGridLicensableFeatures_v4')
+        __nvmlDeviceGetGridLicensableFeatures_v4 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetGridLicensableFeatures_v4')
         if __nvmlDeviceGetGridLicensableFeatures_v4 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetGridLicensableFeatures_v4 = dlsym(handle, 'nvmlDeviceGetGridLicensableFeatures_v4')
+            __nvmlDeviceGetGridLicensableFeatures_v4 = _cyb_dlsym(handle, 'nvmlDeviceGetGridLicensableFeatures_v4')
 
         global __nvmlGetVgpuDriverCapabilities
-        __nvmlGetVgpuDriverCapabilities = dlsym(RTLD_DEFAULT, 'nvmlGetVgpuDriverCapabilities')
+        __nvmlGetVgpuDriverCapabilities = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGetVgpuDriverCapabilities')
         if __nvmlGetVgpuDriverCapabilities == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGetVgpuDriverCapabilities = dlsym(handle, 'nvmlGetVgpuDriverCapabilities')
+            __nvmlGetVgpuDriverCapabilities = _cyb_dlsym(handle, 'nvmlGetVgpuDriverCapabilities')
 
         global __nvmlDeviceGetVgpuCapabilities
-        __nvmlDeviceGetVgpuCapabilities = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetVgpuCapabilities')
+        __nvmlDeviceGetVgpuCapabilities = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetVgpuCapabilities')
         if __nvmlDeviceGetVgpuCapabilities == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetVgpuCapabilities = dlsym(handle, 'nvmlDeviceGetVgpuCapabilities')
+            __nvmlDeviceGetVgpuCapabilities = _cyb_dlsym(handle, 'nvmlDeviceGetVgpuCapabilities')
 
         global __nvmlDeviceGetSupportedVgpus
-        __nvmlDeviceGetSupportedVgpus = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetSupportedVgpus')
+        __nvmlDeviceGetSupportedVgpus = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetSupportedVgpus')
         if __nvmlDeviceGetSupportedVgpus == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetSupportedVgpus = dlsym(handle, 'nvmlDeviceGetSupportedVgpus')
+            __nvmlDeviceGetSupportedVgpus = _cyb_dlsym(handle, 'nvmlDeviceGetSupportedVgpus')
 
         global __nvmlDeviceGetCreatableVgpus
-        __nvmlDeviceGetCreatableVgpus = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetCreatableVgpus')
+        __nvmlDeviceGetCreatableVgpus = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetCreatableVgpus')
         if __nvmlDeviceGetCreatableVgpus == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetCreatableVgpus = dlsym(handle, 'nvmlDeviceGetCreatableVgpus')
+            __nvmlDeviceGetCreatableVgpus = _cyb_dlsym(handle, 'nvmlDeviceGetCreatableVgpus')
 
         global __nvmlVgpuTypeGetClass
-        __nvmlVgpuTypeGetClass = dlsym(RTLD_DEFAULT, 'nvmlVgpuTypeGetClass')
+        __nvmlVgpuTypeGetClass = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuTypeGetClass')
         if __nvmlVgpuTypeGetClass == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuTypeGetClass = dlsym(handle, 'nvmlVgpuTypeGetClass')
+            __nvmlVgpuTypeGetClass = _cyb_dlsym(handle, 'nvmlVgpuTypeGetClass')
 
         global __nvmlVgpuTypeGetName
-        __nvmlVgpuTypeGetName = dlsym(RTLD_DEFAULT, 'nvmlVgpuTypeGetName')
+        __nvmlVgpuTypeGetName = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuTypeGetName')
         if __nvmlVgpuTypeGetName == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuTypeGetName = dlsym(handle, 'nvmlVgpuTypeGetName')
+            __nvmlVgpuTypeGetName = _cyb_dlsym(handle, 'nvmlVgpuTypeGetName')
 
         global __nvmlVgpuTypeGetGpuInstanceProfileId
-        __nvmlVgpuTypeGetGpuInstanceProfileId = dlsym(RTLD_DEFAULT, 'nvmlVgpuTypeGetGpuInstanceProfileId')
+        __nvmlVgpuTypeGetGpuInstanceProfileId = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuTypeGetGpuInstanceProfileId')
         if __nvmlVgpuTypeGetGpuInstanceProfileId == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuTypeGetGpuInstanceProfileId = dlsym(handle, 'nvmlVgpuTypeGetGpuInstanceProfileId')
+            __nvmlVgpuTypeGetGpuInstanceProfileId = _cyb_dlsym(handle, 'nvmlVgpuTypeGetGpuInstanceProfileId')
 
         global __nvmlVgpuTypeGetDeviceID
-        __nvmlVgpuTypeGetDeviceID = dlsym(RTLD_DEFAULT, 'nvmlVgpuTypeGetDeviceID')
+        __nvmlVgpuTypeGetDeviceID = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuTypeGetDeviceID')
         if __nvmlVgpuTypeGetDeviceID == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuTypeGetDeviceID = dlsym(handle, 'nvmlVgpuTypeGetDeviceID')
+            __nvmlVgpuTypeGetDeviceID = _cyb_dlsym(handle, 'nvmlVgpuTypeGetDeviceID')
 
         global __nvmlVgpuTypeGetFramebufferSize
-        __nvmlVgpuTypeGetFramebufferSize = dlsym(RTLD_DEFAULT, 'nvmlVgpuTypeGetFramebufferSize')
+        __nvmlVgpuTypeGetFramebufferSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuTypeGetFramebufferSize')
         if __nvmlVgpuTypeGetFramebufferSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuTypeGetFramebufferSize = dlsym(handle, 'nvmlVgpuTypeGetFramebufferSize')
+            __nvmlVgpuTypeGetFramebufferSize = _cyb_dlsym(handle, 'nvmlVgpuTypeGetFramebufferSize')
 
         global __nvmlVgpuTypeGetNumDisplayHeads
-        __nvmlVgpuTypeGetNumDisplayHeads = dlsym(RTLD_DEFAULT, 'nvmlVgpuTypeGetNumDisplayHeads')
+        __nvmlVgpuTypeGetNumDisplayHeads = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuTypeGetNumDisplayHeads')
         if __nvmlVgpuTypeGetNumDisplayHeads == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuTypeGetNumDisplayHeads = dlsym(handle, 'nvmlVgpuTypeGetNumDisplayHeads')
+            __nvmlVgpuTypeGetNumDisplayHeads = _cyb_dlsym(handle, 'nvmlVgpuTypeGetNumDisplayHeads')
 
         global __nvmlVgpuTypeGetResolution
-        __nvmlVgpuTypeGetResolution = dlsym(RTLD_DEFAULT, 'nvmlVgpuTypeGetResolution')
+        __nvmlVgpuTypeGetResolution = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuTypeGetResolution')
         if __nvmlVgpuTypeGetResolution == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuTypeGetResolution = dlsym(handle, 'nvmlVgpuTypeGetResolution')
+            __nvmlVgpuTypeGetResolution = _cyb_dlsym(handle, 'nvmlVgpuTypeGetResolution')
 
         global __nvmlVgpuTypeGetLicense
-        __nvmlVgpuTypeGetLicense = dlsym(RTLD_DEFAULT, 'nvmlVgpuTypeGetLicense')
+        __nvmlVgpuTypeGetLicense = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuTypeGetLicense')
         if __nvmlVgpuTypeGetLicense == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuTypeGetLicense = dlsym(handle, 'nvmlVgpuTypeGetLicense')
+            __nvmlVgpuTypeGetLicense = _cyb_dlsym(handle, 'nvmlVgpuTypeGetLicense')
 
         global __nvmlVgpuTypeGetFrameRateLimit
-        __nvmlVgpuTypeGetFrameRateLimit = dlsym(RTLD_DEFAULT, 'nvmlVgpuTypeGetFrameRateLimit')
+        __nvmlVgpuTypeGetFrameRateLimit = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuTypeGetFrameRateLimit')
         if __nvmlVgpuTypeGetFrameRateLimit == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuTypeGetFrameRateLimit = dlsym(handle, 'nvmlVgpuTypeGetFrameRateLimit')
+            __nvmlVgpuTypeGetFrameRateLimit = _cyb_dlsym(handle, 'nvmlVgpuTypeGetFrameRateLimit')
 
         global __nvmlVgpuTypeGetMaxInstances
-        __nvmlVgpuTypeGetMaxInstances = dlsym(RTLD_DEFAULT, 'nvmlVgpuTypeGetMaxInstances')
+        __nvmlVgpuTypeGetMaxInstances = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuTypeGetMaxInstances')
         if __nvmlVgpuTypeGetMaxInstances == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuTypeGetMaxInstances = dlsym(handle, 'nvmlVgpuTypeGetMaxInstances')
+            __nvmlVgpuTypeGetMaxInstances = _cyb_dlsym(handle, 'nvmlVgpuTypeGetMaxInstances')
 
         global __nvmlVgpuTypeGetMaxInstancesPerVm
-        __nvmlVgpuTypeGetMaxInstancesPerVm = dlsym(RTLD_DEFAULT, 'nvmlVgpuTypeGetMaxInstancesPerVm')
+        __nvmlVgpuTypeGetMaxInstancesPerVm = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuTypeGetMaxInstancesPerVm')
         if __nvmlVgpuTypeGetMaxInstancesPerVm == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuTypeGetMaxInstancesPerVm = dlsym(handle, 'nvmlVgpuTypeGetMaxInstancesPerVm')
+            __nvmlVgpuTypeGetMaxInstancesPerVm = _cyb_dlsym(handle, 'nvmlVgpuTypeGetMaxInstancesPerVm')
 
         global __nvmlVgpuTypeGetBAR1Info
-        __nvmlVgpuTypeGetBAR1Info = dlsym(RTLD_DEFAULT, 'nvmlVgpuTypeGetBAR1Info')
+        __nvmlVgpuTypeGetBAR1Info = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuTypeGetBAR1Info')
         if __nvmlVgpuTypeGetBAR1Info == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuTypeGetBAR1Info = dlsym(handle, 'nvmlVgpuTypeGetBAR1Info')
+            __nvmlVgpuTypeGetBAR1Info = _cyb_dlsym(handle, 'nvmlVgpuTypeGetBAR1Info')
 
         global __nvmlDeviceGetActiveVgpus
-        __nvmlDeviceGetActiveVgpus = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetActiveVgpus')
+        __nvmlDeviceGetActiveVgpus = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetActiveVgpus')
         if __nvmlDeviceGetActiveVgpus == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetActiveVgpus = dlsym(handle, 'nvmlDeviceGetActiveVgpus')
+            __nvmlDeviceGetActiveVgpus = _cyb_dlsym(handle, 'nvmlDeviceGetActiveVgpus')
 
         global __nvmlVgpuInstanceGetVmID
-        __nvmlVgpuInstanceGetVmID = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetVmID')
+        __nvmlVgpuInstanceGetVmID = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetVmID')
         if __nvmlVgpuInstanceGetVmID == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetVmID = dlsym(handle, 'nvmlVgpuInstanceGetVmID')
+            __nvmlVgpuInstanceGetVmID = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetVmID')
 
         global __nvmlVgpuInstanceGetUUID
-        __nvmlVgpuInstanceGetUUID = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetUUID')
+        __nvmlVgpuInstanceGetUUID = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetUUID')
         if __nvmlVgpuInstanceGetUUID == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetUUID = dlsym(handle, 'nvmlVgpuInstanceGetUUID')
+            __nvmlVgpuInstanceGetUUID = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetUUID')
 
         global __nvmlVgpuInstanceGetVmDriverVersion
-        __nvmlVgpuInstanceGetVmDriverVersion = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetVmDriverVersion')
+        __nvmlVgpuInstanceGetVmDriverVersion = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetVmDriverVersion')
         if __nvmlVgpuInstanceGetVmDriverVersion == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetVmDriverVersion = dlsym(handle, 'nvmlVgpuInstanceGetVmDriverVersion')
+            __nvmlVgpuInstanceGetVmDriverVersion = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetVmDriverVersion')
 
         global __nvmlVgpuInstanceGetFbUsage
-        __nvmlVgpuInstanceGetFbUsage = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetFbUsage')
+        __nvmlVgpuInstanceGetFbUsage = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetFbUsage')
         if __nvmlVgpuInstanceGetFbUsage == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetFbUsage = dlsym(handle, 'nvmlVgpuInstanceGetFbUsage')
+            __nvmlVgpuInstanceGetFbUsage = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetFbUsage')
 
         global __nvmlVgpuInstanceGetLicenseStatus
-        __nvmlVgpuInstanceGetLicenseStatus = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetLicenseStatus')
+        __nvmlVgpuInstanceGetLicenseStatus = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetLicenseStatus')
         if __nvmlVgpuInstanceGetLicenseStatus == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetLicenseStatus = dlsym(handle, 'nvmlVgpuInstanceGetLicenseStatus')
+            __nvmlVgpuInstanceGetLicenseStatus = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetLicenseStatus')
 
         global __nvmlVgpuInstanceGetType
-        __nvmlVgpuInstanceGetType = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetType')
+        __nvmlVgpuInstanceGetType = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetType')
         if __nvmlVgpuInstanceGetType == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetType = dlsym(handle, 'nvmlVgpuInstanceGetType')
+            __nvmlVgpuInstanceGetType = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetType')
 
         global __nvmlVgpuInstanceGetFrameRateLimit
-        __nvmlVgpuInstanceGetFrameRateLimit = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetFrameRateLimit')
+        __nvmlVgpuInstanceGetFrameRateLimit = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetFrameRateLimit')
         if __nvmlVgpuInstanceGetFrameRateLimit == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetFrameRateLimit = dlsym(handle, 'nvmlVgpuInstanceGetFrameRateLimit')
+            __nvmlVgpuInstanceGetFrameRateLimit = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetFrameRateLimit')
 
         global __nvmlVgpuInstanceGetEccMode
-        __nvmlVgpuInstanceGetEccMode = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetEccMode')
+        __nvmlVgpuInstanceGetEccMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetEccMode')
         if __nvmlVgpuInstanceGetEccMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetEccMode = dlsym(handle, 'nvmlVgpuInstanceGetEccMode')
+            __nvmlVgpuInstanceGetEccMode = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetEccMode')
 
         global __nvmlVgpuInstanceGetEncoderCapacity
-        __nvmlVgpuInstanceGetEncoderCapacity = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetEncoderCapacity')
+        __nvmlVgpuInstanceGetEncoderCapacity = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetEncoderCapacity')
         if __nvmlVgpuInstanceGetEncoderCapacity == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetEncoderCapacity = dlsym(handle, 'nvmlVgpuInstanceGetEncoderCapacity')
+            __nvmlVgpuInstanceGetEncoderCapacity = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetEncoderCapacity')
 
         global __nvmlVgpuInstanceSetEncoderCapacity
-        __nvmlVgpuInstanceSetEncoderCapacity = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceSetEncoderCapacity')
+        __nvmlVgpuInstanceSetEncoderCapacity = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceSetEncoderCapacity')
         if __nvmlVgpuInstanceSetEncoderCapacity == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceSetEncoderCapacity = dlsym(handle, 'nvmlVgpuInstanceSetEncoderCapacity')
+            __nvmlVgpuInstanceSetEncoderCapacity = _cyb_dlsym(handle, 'nvmlVgpuInstanceSetEncoderCapacity')
 
         global __nvmlVgpuInstanceGetEncoderStats
-        __nvmlVgpuInstanceGetEncoderStats = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetEncoderStats')
+        __nvmlVgpuInstanceGetEncoderStats = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetEncoderStats')
         if __nvmlVgpuInstanceGetEncoderStats == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetEncoderStats = dlsym(handle, 'nvmlVgpuInstanceGetEncoderStats')
+            __nvmlVgpuInstanceGetEncoderStats = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetEncoderStats')
 
         global __nvmlVgpuInstanceGetEncoderSessions
-        __nvmlVgpuInstanceGetEncoderSessions = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetEncoderSessions')
+        __nvmlVgpuInstanceGetEncoderSessions = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetEncoderSessions')
         if __nvmlVgpuInstanceGetEncoderSessions == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetEncoderSessions = dlsym(handle, 'nvmlVgpuInstanceGetEncoderSessions')
+            __nvmlVgpuInstanceGetEncoderSessions = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetEncoderSessions')
 
         global __nvmlVgpuInstanceGetFBCStats
-        __nvmlVgpuInstanceGetFBCStats = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetFBCStats')
+        __nvmlVgpuInstanceGetFBCStats = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetFBCStats')
         if __nvmlVgpuInstanceGetFBCStats == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetFBCStats = dlsym(handle, 'nvmlVgpuInstanceGetFBCStats')
+            __nvmlVgpuInstanceGetFBCStats = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetFBCStats')
 
         global __nvmlVgpuInstanceGetFBCSessions
-        __nvmlVgpuInstanceGetFBCSessions = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetFBCSessions')
+        __nvmlVgpuInstanceGetFBCSessions = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetFBCSessions')
         if __nvmlVgpuInstanceGetFBCSessions == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetFBCSessions = dlsym(handle, 'nvmlVgpuInstanceGetFBCSessions')
+            __nvmlVgpuInstanceGetFBCSessions = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetFBCSessions')
 
         global __nvmlVgpuInstanceGetGpuInstanceId
-        __nvmlVgpuInstanceGetGpuInstanceId = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetGpuInstanceId')
+        __nvmlVgpuInstanceGetGpuInstanceId = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetGpuInstanceId')
         if __nvmlVgpuInstanceGetGpuInstanceId == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetGpuInstanceId = dlsym(handle, 'nvmlVgpuInstanceGetGpuInstanceId')
+            __nvmlVgpuInstanceGetGpuInstanceId = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetGpuInstanceId')
 
         global __nvmlVgpuInstanceGetGpuPciId
-        __nvmlVgpuInstanceGetGpuPciId = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetGpuPciId')
+        __nvmlVgpuInstanceGetGpuPciId = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetGpuPciId')
         if __nvmlVgpuInstanceGetGpuPciId == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetGpuPciId = dlsym(handle, 'nvmlVgpuInstanceGetGpuPciId')
+            __nvmlVgpuInstanceGetGpuPciId = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetGpuPciId')
 
         global __nvmlVgpuTypeGetCapabilities
-        __nvmlVgpuTypeGetCapabilities = dlsym(RTLD_DEFAULT, 'nvmlVgpuTypeGetCapabilities')
+        __nvmlVgpuTypeGetCapabilities = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuTypeGetCapabilities')
         if __nvmlVgpuTypeGetCapabilities == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuTypeGetCapabilities = dlsym(handle, 'nvmlVgpuTypeGetCapabilities')
+            __nvmlVgpuTypeGetCapabilities = _cyb_dlsym(handle, 'nvmlVgpuTypeGetCapabilities')
 
         global __nvmlVgpuInstanceGetMdevUUID
-        __nvmlVgpuInstanceGetMdevUUID = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetMdevUUID')
+        __nvmlVgpuInstanceGetMdevUUID = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetMdevUUID')
         if __nvmlVgpuInstanceGetMdevUUID == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetMdevUUID = dlsym(handle, 'nvmlVgpuInstanceGetMdevUUID')
+            __nvmlVgpuInstanceGetMdevUUID = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetMdevUUID')
 
         global __nvmlGpuInstanceGetCreatableVgpus
-        __nvmlGpuInstanceGetCreatableVgpus = dlsym(RTLD_DEFAULT, 'nvmlGpuInstanceGetCreatableVgpus')
+        __nvmlGpuInstanceGetCreatableVgpus = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGpuInstanceGetCreatableVgpus')
         if __nvmlGpuInstanceGetCreatableVgpus == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGpuInstanceGetCreatableVgpus = dlsym(handle, 'nvmlGpuInstanceGetCreatableVgpus')
+            __nvmlGpuInstanceGetCreatableVgpus = _cyb_dlsym(handle, 'nvmlGpuInstanceGetCreatableVgpus')
 
         global __nvmlVgpuTypeGetMaxInstancesPerGpuInstance
-        __nvmlVgpuTypeGetMaxInstancesPerGpuInstance = dlsym(RTLD_DEFAULT, 'nvmlVgpuTypeGetMaxInstancesPerGpuInstance')
+        __nvmlVgpuTypeGetMaxInstancesPerGpuInstance = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuTypeGetMaxInstancesPerGpuInstance')
         if __nvmlVgpuTypeGetMaxInstancesPerGpuInstance == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuTypeGetMaxInstancesPerGpuInstance = dlsym(handle, 'nvmlVgpuTypeGetMaxInstancesPerGpuInstance')
+            __nvmlVgpuTypeGetMaxInstancesPerGpuInstance = _cyb_dlsym(handle, 'nvmlVgpuTypeGetMaxInstancesPerGpuInstance')
 
         global __nvmlGpuInstanceGetActiveVgpus
-        __nvmlGpuInstanceGetActiveVgpus = dlsym(RTLD_DEFAULT, 'nvmlGpuInstanceGetActiveVgpus')
+        __nvmlGpuInstanceGetActiveVgpus = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGpuInstanceGetActiveVgpus')
         if __nvmlGpuInstanceGetActiveVgpus == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGpuInstanceGetActiveVgpus = dlsym(handle, 'nvmlGpuInstanceGetActiveVgpus')
+            __nvmlGpuInstanceGetActiveVgpus = _cyb_dlsym(handle, 'nvmlGpuInstanceGetActiveVgpus')
 
         global __nvmlGpuInstanceSetVgpuSchedulerState
-        __nvmlGpuInstanceSetVgpuSchedulerState = dlsym(RTLD_DEFAULT, 'nvmlGpuInstanceSetVgpuSchedulerState')
+        __nvmlGpuInstanceSetVgpuSchedulerState = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGpuInstanceSetVgpuSchedulerState')
         if __nvmlGpuInstanceSetVgpuSchedulerState == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGpuInstanceSetVgpuSchedulerState = dlsym(handle, 'nvmlGpuInstanceSetVgpuSchedulerState')
+            __nvmlGpuInstanceSetVgpuSchedulerState = _cyb_dlsym(handle, 'nvmlGpuInstanceSetVgpuSchedulerState')
 
         global __nvmlGpuInstanceGetVgpuSchedulerState
-        __nvmlGpuInstanceGetVgpuSchedulerState = dlsym(RTLD_DEFAULT, 'nvmlGpuInstanceGetVgpuSchedulerState')
+        __nvmlGpuInstanceGetVgpuSchedulerState = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGpuInstanceGetVgpuSchedulerState')
         if __nvmlGpuInstanceGetVgpuSchedulerState == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGpuInstanceGetVgpuSchedulerState = dlsym(handle, 'nvmlGpuInstanceGetVgpuSchedulerState')
+            __nvmlGpuInstanceGetVgpuSchedulerState = _cyb_dlsym(handle, 'nvmlGpuInstanceGetVgpuSchedulerState')
 
         global __nvmlGpuInstanceGetVgpuSchedulerLog
-        __nvmlGpuInstanceGetVgpuSchedulerLog = dlsym(RTLD_DEFAULT, 'nvmlGpuInstanceGetVgpuSchedulerLog')
+        __nvmlGpuInstanceGetVgpuSchedulerLog = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGpuInstanceGetVgpuSchedulerLog')
         if __nvmlGpuInstanceGetVgpuSchedulerLog == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGpuInstanceGetVgpuSchedulerLog = dlsym(handle, 'nvmlGpuInstanceGetVgpuSchedulerLog')
+            __nvmlGpuInstanceGetVgpuSchedulerLog = _cyb_dlsym(handle, 'nvmlGpuInstanceGetVgpuSchedulerLog')
 
         global __nvmlGpuInstanceGetVgpuTypeCreatablePlacements
-        __nvmlGpuInstanceGetVgpuTypeCreatablePlacements = dlsym(RTLD_DEFAULT, 'nvmlGpuInstanceGetVgpuTypeCreatablePlacements')
+        __nvmlGpuInstanceGetVgpuTypeCreatablePlacements = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGpuInstanceGetVgpuTypeCreatablePlacements')
         if __nvmlGpuInstanceGetVgpuTypeCreatablePlacements == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGpuInstanceGetVgpuTypeCreatablePlacements = dlsym(handle, 'nvmlGpuInstanceGetVgpuTypeCreatablePlacements')
+            __nvmlGpuInstanceGetVgpuTypeCreatablePlacements = _cyb_dlsym(handle, 'nvmlGpuInstanceGetVgpuTypeCreatablePlacements')
 
         global __nvmlGpuInstanceGetVgpuHeterogeneousMode
-        __nvmlGpuInstanceGetVgpuHeterogeneousMode = dlsym(RTLD_DEFAULT, 'nvmlGpuInstanceGetVgpuHeterogeneousMode')
+        __nvmlGpuInstanceGetVgpuHeterogeneousMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGpuInstanceGetVgpuHeterogeneousMode')
         if __nvmlGpuInstanceGetVgpuHeterogeneousMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGpuInstanceGetVgpuHeterogeneousMode = dlsym(handle, 'nvmlGpuInstanceGetVgpuHeterogeneousMode')
+            __nvmlGpuInstanceGetVgpuHeterogeneousMode = _cyb_dlsym(handle, 'nvmlGpuInstanceGetVgpuHeterogeneousMode')
 
         global __nvmlGpuInstanceSetVgpuHeterogeneousMode
-        __nvmlGpuInstanceSetVgpuHeterogeneousMode = dlsym(RTLD_DEFAULT, 'nvmlGpuInstanceSetVgpuHeterogeneousMode')
+        __nvmlGpuInstanceSetVgpuHeterogeneousMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGpuInstanceSetVgpuHeterogeneousMode')
         if __nvmlGpuInstanceSetVgpuHeterogeneousMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGpuInstanceSetVgpuHeterogeneousMode = dlsym(handle, 'nvmlGpuInstanceSetVgpuHeterogeneousMode')
+            __nvmlGpuInstanceSetVgpuHeterogeneousMode = _cyb_dlsym(handle, 'nvmlGpuInstanceSetVgpuHeterogeneousMode')
 
         global __nvmlVgpuInstanceGetMetadata
-        __nvmlVgpuInstanceGetMetadata = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetMetadata')
+        __nvmlVgpuInstanceGetMetadata = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetMetadata')
         if __nvmlVgpuInstanceGetMetadata == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetMetadata = dlsym(handle, 'nvmlVgpuInstanceGetMetadata')
+            __nvmlVgpuInstanceGetMetadata = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetMetadata')
 
         global __nvmlDeviceGetVgpuMetadata
-        __nvmlDeviceGetVgpuMetadata = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetVgpuMetadata')
+        __nvmlDeviceGetVgpuMetadata = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetVgpuMetadata')
         if __nvmlDeviceGetVgpuMetadata == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetVgpuMetadata = dlsym(handle, 'nvmlDeviceGetVgpuMetadata')
+            __nvmlDeviceGetVgpuMetadata = _cyb_dlsym(handle, 'nvmlDeviceGetVgpuMetadata')
 
         global __nvmlGetVgpuCompatibility
-        __nvmlGetVgpuCompatibility = dlsym(RTLD_DEFAULT, 'nvmlGetVgpuCompatibility')
+        __nvmlGetVgpuCompatibility = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGetVgpuCompatibility')
         if __nvmlGetVgpuCompatibility == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGetVgpuCompatibility = dlsym(handle, 'nvmlGetVgpuCompatibility')
+            __nvmlGetVgpuCompatibility = _cyb_dlsym(handle, 'nvmlGetVgpuCompatibility')
 
         global __nvmlDeviceGetPgpuMetadataString
-        __nvmlDeviceGetPgpuMetadataString = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetPgpuMetadataString')
+        __nvmlDeviceGetPgpuMetadataString = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetPgpuMetadataString')
         if __nvmlDeviceGetPgpuMetadataString == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetPgpuMetadataString = dlsym(handle, 'nvmlDeviceGetPgpuMetadataString')
+            __nvmlDeviceGetPgpuMetadataString = _cyb_dlsym(handle, 'nvmlDeviceGetPgpuMetadataString')
 
         global __nvmlDeviceGetVgpuSchedulerLog
-        __nvmlDeviceGetVgpuSchedulerLog = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetVgpuSchedulerLog')
+        __nvmlDeviceGetVgpuSchedulerLog = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetVgpuSchedulerLog')
         if __nvmlDeviceGetVgpuSchedulerLog == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetVgpuSchedulerLog = dlsym(handle, 'nvmlDeviceGetVgpuSchedulerLog')
+            __nvmlDeviceGetVgpuSchedulerLog = _cyb_dlsym(handle, 'nvmlDeviceGetVgpuSchedulerLog')
 
         global __nvmlDeviceGetVgpuSchedulerState
-        __nvmlDeviceGetVgpuSchedulerState = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetVgpuSchedulerState')
+        __nvmlDeviceGetVgpuSchedulerState = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetVgpuSchedulerState')
         if __nvmlDeviceGetVgpuSchedulerState == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetVgpuSchedulerState = dlsym(handle, 'nvmlDeviceGetVgpuSchedulerState')
+            __nvmlDeviceGetVgpuSchedulerState = _cyb_dlsym(handle, 'nvmlDeviceGetVgpuSchedulerState')
 
         global __nvmlDeviceGetVgpuSchedulerCapabilities
-        __nvmlDeviceGetVgpuSchedulerCapabilities = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetVgpuSchedulerCapabilities')
+        __nvmlDeviceGetVgpuSchedulerCapabilities = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetVgpuSchedulerCapabilities')
         if __nvmlDeviceGetVgpuSchedulerCapabilities == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetVgpuSchedulerCapabilities = dlsym(handle, 'nvmlDeviceGetVgpuSchedulerCapabilities')
+            __nvmlDeviceGetVgpuSchedulerCapabilities = _cyb_dlsym(handle, 'nvmlDeviceGetVgpuSchedulerCapabilities')
 
         global __nvmlDeviceSetVgpuSchedulerState
-        __nvmlDeviceSetVgpuSchedulerState = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetVgpuSchedulerState')
+        __nvmlDeviceSetVgpuSchedulerState = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetVgpuSchedulerState')
         if __nvmlDeviceSetVgpuSchedulerState == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetVgpuSchedulerState = dlsym(handle, 'nvmlDeviceSetVgpuSchedulerState')
+            __nvmlDeviceSetVgpuSchedulerState = _cyb_dlsym(handle, 'nvmlDeviceSetVgpuSchedulerState')
 
         global __nvmlGetVgpuVersion
-        __nvmlGetVgpuVersion = dlsym(RTLD_DEFAULT, 'nvmlGetVgpuVersion')
+        __nvmlGetVgpuVersion = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGetVgpuVersion')
         if __nvmlGetVgpuVersion == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGetVgpuVersion = dlsym(handle, 'nvmlGetVgpuVersion')
+            __nvmlGetVgpuVersion = _cyb_dlsym(handle, 'nvmlGetVgpuVersion')
 
         global __nvmlSetVgpuVersion
-        __nvmlSetVgpuVersion = dlsym(RTLD_DEFAULT, 'nvmlSetVgpuVersion')
+        __nvmlSetVgpuVersion = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlSetVgpuVersion')
         if __nvmlSetVgpuVersion == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlSetVgpuVersion = dlsym(handle, 'nvmlSetVgpuVersion')
+            __nvmlSetVgpuVersion = _cyb_dlsym(handle, 'nvmlSetVgpuVersion')
 
         global __nvmlDeviceGetVgpuUtilization
-        __nvmlDeviceGetVgpuUtilization = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetVgpuUtilization')
+        __nvmlDeviceGetVgpuUtilization = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetVgpuUtilization')
         if __nvmlDeviceGetVgpuUtilization == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetVgpuUtilization = dlsym(handle, 'nvmlDeviceGetVgpuUtilization')
+            __nvmlDeviceGetVgpuUtilization = _cyb_dlsym(handle, 'nvmlDeviceGetVgpuUtilization')
 
         global __nvmlDeviceGetVgpuInstancesUtilizationInfo
-        __nvmlDeviceGetVgpuInstancesUtilizationInfo = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetVgpuInstancesUtilizationInfo')
+        __nvmlDeviceGetVgpuInstancesUtilizationInfo = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetVgpuInstancesUtilizationInfo')
         if __nvmlDeviceGetVgpuInstancesUtilizationInfo == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetVgpuInstancesUtilizationInfo = dlsym(handle, 'nvmlDeviceGetVgpuInstancesUtilizationInfo')
+            __nvmlDeviceGetVgpuInstancesUtilizationInfo = _cyb_dlsym(handle, 'nvmlDeviceGetVgpuInstancesUtilizationInfo')
 
         global __nvmlDeviceGetVgpuProcessUtilization
-        __nvmlDeviceGetVgpuProcessUtilization = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetVgpuProcessUtilization')
+        __nvmlDeviceGetVgpuProcessUtilization = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetVgpuProcessUtilization')
         if __nvmlDeviceGetVgpuProcessUtilization == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetVgpuProcessUtilization = dlsym(handle, 'nvmlDeviceGetVgpuProcessUtilization')
+            __nvmlDeviceGetVgpuProcessUtilization = _cyb_dlsym(handle, 'nvmlDeviceGetVgpuProcessUtilization')
 
         global __nvmlDeviceGetVgpuProcessesUtilizationInfo
-        __nvmlDeviceGetVgpuProcessesUtilizationInfo = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetVgpuProcessesUtilizationInfo')
+        __nvmlDeviceGetVgpuProcessesUtilizationInfo = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetVgpuProcessesUtilizationInfo')
         if __nvmlDeviceGetVgpuProcessesUtilizationInfo == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetVgpuProcessesUtilizationInfo = dlsym(handle, 'nvmlDeviceGetVgpuProcessesUtilizationInfo')
+            __nvmlDeviceGetVgpuProcessesUtilizationInfo = _cyb_dlsym(handle, 'nvmlDeviceGetVgpuProcessesUtilizationInfo')
 
         global __nvmlVgpuInstanceGetAccountingMode
-        __nvmlVgpuInstanceGetAccountingMode = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetAccountingMode')
+        __nvmlVgpuInstanceGetAccountingMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetAccountingMode')
         if __nvmlVgpuInstanceGetAccountingMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetAccountingMode = dlsym(handle, 'nvmlVgpuInstanceGetAccountingMode')
+            __nvmlVgpuInstanceGetAccountingMode = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetAccountingMode')
 
         global __nvmlVgpuInstanceGetAccountingPids
-        __nvmlVgpuInstanceGetAccountingPids = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetAccountingPids')
+        __nvmlVgpuInstanceGetAccountingPids = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetAccountingPids')
         if __nvmlVgpuInstanceGetAccountingPids == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetAccountingPids = dlsym(handle, 'nvmlVgpuInstanceGetAccountingPids')
+            __nvmlVgpuInstanceGetAccountingPids = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetAccountingPids')
 
         global __nvmlVgpuInstanceGetAccountingStats
-        __nvmlVgpuInstanceGetAccountingStats = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetAccountingStats')
+        __nvmlVgpuInstanceGetAccountingStats = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetAccountingStats')
         if __nvmlVgpuInstanceGetAccountingStats == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetAccountingStats = dlsym(handle, 'nvmlVgpuInstanceGetAccountingStats')
+            __nvmlVgpuInstanceGetAccountingStats = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetAccountingStats')
 
         global __nvmlVgpuInstanceClearAccountingPids
-        __nvmlVgpuInstanceClearAccountingPids = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceClearAccountingPids')
+        __nvmlVgpuInstanceClearAccountingPids = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceClearAccountingPids')
         if __nvmlVgpuInstanceClearAccountingPids == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceClearAccountingPids = dlsym(handle, 'nvmlVgpuInstanceClearAccountingPids')
+            __nvmlVgpuInstanceClearAccountingPids = _cyb_dlsym(handle, 'nvmlVgpuInstanceClearAccountingPids')
 
         global __nvmlVgpuInstanceGetLicenseInfo_v2
-        __nvmlVgpuInstanceGetLicenseInfo_v2 = dlsym(RTLD_DEFAULT, 'nvmlVgpuInstanceGetLicenseInfo_v2')
+        __nvmlVgpuInstanceGetLicenseInfo_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlVgpuInstanceGetLicenseInfo_v2')
         if __nvmlVgpuInstanceGetLicenseInfo_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlVgpuInstanceGetLicenseInfo_v2 = dlsym(handle, 'nvmlVgpuInstanceGetLicenseInfo_v2')
+            __nvmlVgpuInstanceGetLicenseInfo_v2 = _cyb_dlsym(handle, 'nvmlVgpuInstanceGetLicenseInfo_v2')
 
         global __nvmlGetExcludedDeviceCount
-        __nvmlGetExcludedDeviceCount = dlsym(RTLD_DEFAULT, 'nvmlGetExcludedDeviceCount')
+        __nvmlGetExcludedDeviceCount = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGetExcludedDeviceCount')
         if __nvmlGetExcludedDeviceCount == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGetExcludedDeviceCount = dlsym(handle, 'nvmlGetExcludedDeviceCount')
+            __nvmlGetExcludedDeviceCount = _cyb_dlsym(handle, 'nvmlGetExcludedDeviceCount')
 
         global __nvmlGetExcludedDeviceInfoByIndex
-        __nvmlGetExcludedDeviceInfoByIndex = dlsym(RTLD_DEFAULT, 'nvmlGetExcludedDeviceInfoByIndex')
+        __nvmlGetExcludedDeviceInfoByIndex = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGetExcludedDeviceInfoByIndex')
         if __nvmlGetExcludedDeviceInfoByIndex == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGetExcludedDeviceInfoByIndex = dlsym(handle, 'nvmlGetExcludedDeviceInfoByIndex')
+            __nvmlGetExcludedDeviceInfoByIndex = _cyb_dlsym(handle, 'nvmlGetExcludedDeviceInfoByIndex')
 
         global __nvmlDeviceSetMigMode
-        __nvmlDeviceSetMigMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetMigMode')
+        __nvmlDeviceSetMigMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetMigMode')
         if __nvmlDeviceSetMigMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetMigMode = dlsym(handle, 'nvmlDeviceSetMigMode')
+            __nvmlDeviceSetMigMode = _cyb_dlsym(handle, 'nvmlDeviceSetMigMode')
 
         global __nvmlDeviceGetMigMode
-        __nvmlDeviceGetMigMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetMigMode')
+        __nvmlDeviceGetMigMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetMigMode')
         if __nvmlDeviceGetMigMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetMigMode = dlsym(handle, 'nvmlDeviceGetMigMode')
+            __nvmlDeviceGetMigMode = _cyb_dlsym(handle, 'nvmlDeviceGetMigMode')
 
         global __nvmlDeviceGetGpuInstanceProfileInfoV
-        __nvmlDeviceGetGpuInstanceProfileInfoV = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetGpuInstanceProfileInfoV')
+        __nvmlDeviceGetGpuInstanceProfileInfoV = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetGpuInstanceProfileInfoV')
         if __nvmlDeviceGetGpuInstanceProfileInfoV == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetGpuInstanceProfileInfoV = dlsym(handle, 'nvmlDeviceGetGpuInstanceProfileInfoV')
+            __nvmlDeviceGetGpuInstanceProfileInfoV = _cyb_dlsym(handle, 'nvmlDeviceGetGpuInstanceProfileInfoV')
 
         global __nvmlDeviceGetGpuInstancePossiblePlacements_v2
-        __nvmlDeviceGetGpuInstancePossiblePlacements_v2 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetGpuInstancePossiblePlacements_v2')
+        __nvmlDeviceGetGpuInstancePossiblePlacements_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetGpuInstancePossiblePlacements_v2')
         if __nvmlDeviceGetGpuInstancePossiblePlacements_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetGpuInstancePossiblePlacements_v2 = dlsym(handle, 'nvmlDeviceGetGpuInstancePossiblePlacements_v2')
+            __nvmlDeviceGetGpuInstancePossiblePlacements_v2 = _cyb_dlsym(handle, 'nvmlDeviceGetGpuInstancePossiblePlacements_v2')
 
         global __nvmlDeviceGetGpuInstanceRemainingCapacity
-        __nvmlDeviceGetGpuInstanceRemainingCapacity = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetGpuInstanceRemainingCapacity')
+        __nvmlDeviceGetGpuInstanceRemainingCapacity = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetGpuInstanceRemainingCapacity')
         if __nvmlDeviceGetGpuInstanceRemainingCapacity == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetGpuInstanceRemainingCapacity = dlsym(handle, 'nvmlDeviceGetGpuInstanceRemainingCapacity')
+            __nvmlDeviceGetGpuInstanceRemainingCapacity = _cyb_dlsym(handle, 'nvmlDeviceGetGpuInstanceRemainingCapacity')
 
         global __nvmlDeviceCreateGpuInstance
-        __nvmlDeviceCreateGpuInstance = dlsym(RTLD_DEFAULT, 'nvmlDeviceCreateGpuInstance')
+        __nvmlDeviceCreateGpuInstance = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceCreateGpuInstance')
         if __nvmlDeviceCreateGpuInstance == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceCreateGpuInstance = dlsym(handle, 'nvmlDeviceCreateGpuInstance')
+            __nvmlDeviceCreateGpuInstance = _cyb_dlsym(handle, 'nvmlDeviceCreateGpuInstance')
 
         global __nvmlDeviceCreateGpuInstanceWithPlacement
-        __nvmlDeviceCreateGpuInstanceWithPlacement = dlsym(RTLD_DEFAULT, 'nvmlDeviceCreateGpuInstanceWithPlacement')
+        __nvmlDeviceCreateGpuInstanceWithPlacement = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceCreateGpuInstanceWithPlacement')
         if __nvmlDeviceCreateGpuInstanceWithPlacement == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceCreateGpuInstanceWithPlacement = dlsym(handle, 'nvmlDeviceCreateGpuInstanceWithPlacement')
+            __nvmlDeviceCreateGpuInstanceWithPlacement = _cyb_dlsym(handle, 'nvmlDeviceCreateGpuInstanceWithPlacement')
 
         global __nvmlGpuInstanceDestroy
-        __nvmlGpuInstanceDestroy = dlsym(RTLD_DEFAULT, 'nvmlGpuInstanceDestroy')
+        __nvmlGpuInstanceDestroy = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGpuInstanceDestroy')
         if __nvmlGpuInstanceDestroy == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGpuInstanceDestroy = dlsym(handle, 'nvmlGpuInstanceDestroy')
+            __nvmlGpuInstanceDestroy = _cyb_dlsym(handle, 'nvmlGpuInstanceDestroy')
 
         global __nvmlDeviceGetGpuInstances
-        __nvmlDeviceGetGpuInstances = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetGpuInstances')
+        __nvmlDeviceGetGpuInstances = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetGpuInstances')
         if __nvmlDeviceGetGpuInstances == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetGpuInstances = dlsym(handle, 'nvmlDeviceGetGpuInstances')
+            __nvmlDeviceGetGpuInstances = _cyb_dlsym(handle, 'nvmlDeviceGetGpuInstances')
 
         global __nvmlDeviceGetGpuInstanceById
-        __nvmlDeviceGetGpuInstanceById = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetGpuInstanceById')
+        __nvmlDeviceGetGpuInstanceById = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetGpuInstanceById')
         if __nvmlDeviceGetGpuInstanceById == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetGpuInstanceById = dlsym(handle, 'nvmlDeviceGetGpuInstanceById')
+            __nvmlDeviceGetGpuInstanceById = _cyb_dlsym(handle, 'nvmlDeviceGetGpuInstanceById')
 
         global __nvmlGpuInstanceGetInfo
-        __nvmlGpuInstanceGetInfo = dlsym(RTLD_DEFAULT, 'nvmlGpuInstanceGetInfo')
+        __nvmlGpuInstanceGetInfo = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGpuInstanceGetInfo')
         if __nvmlGpuInstanceGetInfo == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGpuInstanceGetInfo = dlsym(handle, 'nvmlGpuInstanceGetInfo')
+            __nvmlGpuInstanceGetInfo = _cyb_dlsym(handle, 'nvmlGpuInstanceGetInfo')
 
         global __nvmlGpuInstanceGetComputeInstanceProfileInfoV
-        __nvmlGpuInstanceGetComputeInstanceProfileInfoV = dlsym(RTLD_DEFAULT, 'nvmlGpuInstanceGetComputeInstanceProfileInfoV')
+        __nvmlGpuInstanceGetComputeInstanceProfileInfoV = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGpuInstanceGetComputeInstanceProfileInfoV')
         if __nvmlGpuInstanceGetComputeInstanceProfileInfoV == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGpuInstanceGetComputeInstanceProfileInfoV = dlsym(handle, 'nvmlGpuInstanceGetComputeInstanceProfileInfoV')
+            __nvmlGpuInstanceGetComputeInstanceProfileInfoV = _cyb_dlsym(handle, 'nvmlGpuInstanceGetComputeInstanceProfileInfoV')
 
         global __nvmlGpuInstanceGetComputeInstanceRemainingCapacity
-        __nvmlGpuInstanceGetComputeInstanceRemainingCapacity = dlsym(RTLD_DEFAULT, 'nvmlGpuInstanceGetComputeInstanceRemainingCapacity')
+        __nvmlGpuInstanceGetComputeInstanceRemainingCapacity = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGpuInstanceGetComputeInstanceRemainingCapacity')
         if __nvmlGpuInstanceGetComputeInstanceRemainingCapacity == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGpuInstanceGetComputeInstanceRemainingCapacity = dlsym(handle, 'nvmlGpuInstanceGetComputeInstanceRemainingCapacity')
+            __nvmlGpuInstanceGetComputeInstanceRemainingCapacity = _cyb_dlsym(handle, 'nvmlGpuInstanceGetComputeInstanceRemainingCapacity')
 
         global __nvmlGpuInstanceGetComputeInstancePossiblePlacements
-        __nvmlGpuInstanceGetComputeInstancePossiblePlacements = dlsym(RTLD_DEFAULT, 'nvmlGpuInstanceGetComputeInstancePossiblePlacements')
+        __nvmlGpuInstanceGetComputeInstancePossiblePlacements = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGpuInstanceGetComputeInstancePossiblePlacements')
         if __nvmlGpuInstanceGetComputeInstancePossiblePlacements == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGpuInstanceGetComputeInstancePossiblePlacements = dlsym(handle, 'nvmlGpuInstanceGetComputeInstancePossiblePlacements')
+            __nvmlGpuInstanceGetComputeInstancePossiblePlacements = _cyb_dlsym(handle, 'nvmlGpuInstanceGetComputeInstancePossiblePlacements')
 
         global __nvmlGpuInstanceCreateComputeInstance
-        __nvmlGpuInstanceCreateComputeInstance = dlsym(RTLD_DEFAULT, 'nvmlGpuInstanceCreateComputeInstance')
+        __nvmlGpuInstanceCreateComputeInstance = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGpuInstanceCreateComputeInstance')
         if __nvmlGpuInstanceCreateComputeInstance == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGpuInstanceCreateComputeInstance = dlsym(handle, 'nvmlGpuInstanceCreateComputeInstance')
+            __nvmlGpuInstanceCreateComputeInstance = _cyb_dlsym(handle, 'nvmlGpuInstanceCreateComputeInstance')
 
         global __nvmlGpuInstanceCreateComputeInstanceWithPlacement
-        __nvmlGpuInstanceCreateComputeInstanceWithPlacement = dlsym(RTLD_DEFAULT, 'nvmlGpuInstanceCreateComputeInstanceWithPlacement')
+        __nvmlGpuInstanceCreateComputeInstanceWithPlacement = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGpuInstanceCreateComputeInstanceWithPlacement')
         if __nvmlGpuInstanceCreateComputeInstanceWithPlacement == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGpuInstanceCreateComputeInstanceWithPlacement = dlsym(handle, 'nvmlGpuInstanceCreateComputeInstanceWithPlacement')
+            __nvmlGpuInstanceCreateComputeInstanceWithPlacement = _cyb_dlsym(handle, 'nvmlGpuInstanceCreateComputeInstanceWithPlacement')
 
         global __nvmlComputeInstanceDestroy
-        __nvmlComputeInstanceDestroy = dlsym(RTLD_DEFAULT, 'nvmlComputeInstanceDestroy')
+        __nvmlComputeInstanceDestroy = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlComputeInstanceDestroy')
         if __nvmlComputeInstanceDestroy == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlComputeInstanceDestroy = dlsym(handle, 'nvmlComputeInstanceDestroy')
+            __nvmlComputeInstanceDestroy = _cyb_dlsym(handle, 'nvmlComputeInstanceDestroy')
 
         global __nvmlGpuInstanceGetComputeInstances
-        __nvmlGpuInstanceGetComputeInstances = dlsym(RTLD_DEFAULT, 'nvmlGpuInstanceGetComputeInstances')
+        __nvmlGpuInstanceGetComputeInstances = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGpuInstanceGetComputeInstances')
         if __nvmlGpuInstanceGetComputeInstances == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGpuInstanceGetComputeInstances = dlsym(handle, 'nvmlGpuInstanceGetComputeInstances')
+            __nvmlGpuInstanceGetComputeInstances = _cyb_dlsym(handle, 'nvmlGpuInstanceGetComputeInstances')
 
         global __nvmlGpuInstanceGetComputeInstanceById
-        __nvmlGpuInstanceGetComputeInstanceById = dlsym(RTLD_DEFAULT, 'nvmlGpuInstanceGetComputeInstanceById')
+        __nvmlGpuInstanceGetComputeInstanceById = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGpuInstanceGetComputeInstanceById')
         if __nvmlGpuInstanceGetComputeInstanceById == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGpuInstanceGetComputeInstanceById = dlsym(handle, 'nvmlGpuInstanceGetComputeInstanceById')
+            __nvmlGpuInstanceGetComputeInstanceById = _cyb_dlsym(handle, 'nvmlGpuInstanceGetComputeInstanceById')
 
         global __nvmlComputeInstanceGetInfo_v2
-        __nvmlComputeInstanceGetInfo_v2 = dlsym(RTLD_DEFAULT, 'nvmlComputeInstanceGetInfo_v2')
+        __nvmlComputeInstanceGetInfo_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlComputeInstanceGetInfo_v2')
         if __nvmlComputeInstanceGetInfo_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlComputeInstanceGetInfo_v2 = dlsym(handle, 'nvmlComputeInstanceGetInfo_v2')
+            __nvmlComputeInstanceGetInfo_v2 = _cyb_dlsym(handle, 'nvmlComputeInstanceGetInfo_v2')
 
         global __nvmlDeviceIsMigDeviceHandle
-        __nvmlDeviceIsMigDeviceHandle = dlsym(RTLD_DEFAULT, 'nvmlDeviceIsMigDeviceHandle')
+        __nvmlDeviceIsMigDeviceHandle = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceIsMigDeviceHandle')
         if __nvmlDeviceIsMigDeviceHandle == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceIsMigDeviceHandle = dlsym(handle, 'nvmlDeviceIsMigDeviceHandle')
+            __nvmlDeviceIsMigDeviceHandle = _cyb_dlsym(handle, 'nvmlDeviceIsMigDeviceHandle')
 
         global __nvmlDeviceGetGpuInstanceId
-        __nvmlDeviceGetGpuInstanceId = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetGpuInstanceId')
+        __nvmlDeviceGetGpuInstanceId = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetGpuInstanceId')
         if __nvmlDeviceGetGpuInstanceId == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetGpuInstanceId = dlsym(handle, 'nvmlDeviceGetGpuInstanceId')
+            __nvmlDeviceGetGpuInstanceId = _cyb_dlsym(handle, 'nvmlDeviceGetGpuInstanceId')
 
         global __nvmlDeviceGetComputeInstanceId
-        __nvmlDeviceGetComputeInstanceId = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetComputeInstanceId')
+        __nvmlDeviceGetComputeInstanceId = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetComputeInstanceId')
         if __nvmlDeviceGetComputeInstanceId == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetComputeInstanceId = dlsym(handle, 'nvmlDeviceGetComputeInstanceId')
+            __nvmlDeviceGetComputeInstanceId = _cyb_dlsym(handle, 'nvmlDeviceGetComputeInstanceId')
 
         global __nvmlDeviceGetMaxMigDeviceCount
-        __nvmlDeviceGetMaxMigDeviceCount = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetMaxMigDeviceCount')
+        __nvmlDeviceGetMaxMigDeviceCount = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetMaxMigDeviceCount')
         if __nvmlDeviceGetMaxMigDeviceCount == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetMaxMigDeviceCount = dlsym(handle, 'nvmlDeviceGetMaxMigDeviceCount')
+            __nvmlDeviceGetMaxMigDeviceCount = _cyb_dlsym(handle, 'nvmlDeviceGetMaxMigDeviceCount')
 
         global __nvmlDeviceGetMigDeviceHandleByIndex
-        __nvmlDeviceGetMigDeviceHandleByIndex = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetMigDeviceHandleByIndex')
+        __nvmlDeviceGetMigDeviceHandleByIndex = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetMigDeviceHandleByIndex')
         if __nvmlDeviceGetMigDeviceHandleByIndex == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetMigDeviceHandleByIndex = dlsym(handle, 'nvmlDeviceGetMigDeviceHandleByIndex')
+            __nvmlDeviceGetMigDeviceHandleByIndex = _cyb_dlsym(handle, 'nvmlDeviceGetMigDeviceHandleByIndex')
 
         global __nvmlDeviceGetDeviceHandleFromMigDeviceHandle
-        __nvmlDeviceGetDeviceHandleFromMigDeviceHandle = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetDeviceHandleFromMigDeviceHandle')
+        __nvmlDeviceGetDeviceHandleFromMigDeviceHandle = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetDeviceHandleFromMigDeviceHandle')
         if __nvmlDeviceGetDeviceHandleFromMigDeviceHandle == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetDeviceHandleFromMigDeviceHandle = dlsym(handle, 'nvmlDeviceGetDeviceHandleFromMigDeviceHandle')
+            __nvmlDeviceGetDeviceHandleFromMigDeviceHandle = _cyb_dlsym(handle, 'nvmlDeviceGetDeviceHandleFromMigDeviceHandle')
 
         global __nvmlDeviceGetCapabilities
-        __nvmlDeviceGetCapabilities = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetCapabilities')
+        __nvmlDeviceGetCapabilities = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetCapabilities')
         if __nvmlDeviceGetCapabilities == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetCapabilities = dlsym(handle, 'nvmlDeviceGetCapabilities')
+            __nvmlDeviceGetCapabilities = _cyb_dlsym(handle, 'nvmlDeviceGetCapabilities')
 
         global __nvmlDevicePowerSmoothingActivatePresetProfile
-        __nvmlDevicePowerSmoothingActivatePresetProfile = dlsym(RTLD_DEFAULT, 'nvmlDevicePowerSmoothingActivatePresetProfile')
+        __nvmlDevicePowerSmoothingActivatePresetProfile = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDevicePowerSmoothingActivatePresetProfile')
         if __nvmlDevicePowerSmoothingActivatePresetProfile == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDevicePowerSmoothingActivatePresetProfile = dlsym(handle, 'nvmlDevicePowerSmoothingActivatePresetProfile')
+            __nvmlDevicePowerSmoothingActivatePresetProfile = _cyb_dlsym(handle, 'nvmlDevicePowerSmoothingActivatePresetProfile')
 
         global __nvmlDevicePowerSmoothingUpdatePresetProfileParam
-        __nvmlDevicePowerSmoothingUpdatePresetProfileParam = dlsym(RTLD_DEFAULT, 'nvmlDevicePowerSmoothingUpdatePresetProfileParam')
+        __nvmlDevicePowerSmoothingUpdatePresetProfileParam = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDevicePowerSmoothingUpdatePresetProfileParam')
         if __nvmlDevicePowerSmoothingUpdatePresetProfileParam == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDevicePowerSmoothingUpdatePresetProfileParam = dlsym(handle, 'nvmlDevicePowerSmoothingUpdatePresetProfileParam')
+            __nvmlDevicePowerSmoothingUpdatePresetProfileParam = _cyb_dlsym(handle, 'nvmlDevicePowerSmoothingUpdatePresetProfileParam')
 
         global __nvmlDevicePowerSmoothingSetState
-        __nvmlDevicePowerSmoothingSetState = dlsym(RTLD_DEFAULT, 'nvmlDevicePowerSmoothingSetState')
+        __nvmlDevicePowerSmoothingSetState = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDevicePowerSmoothingSetState')
         if __nvmlDevicePowerSmoothingSetState == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDevicePowerSmoothingSetState = dlsym(handle, 'nvmlDevicePowerSmoothingSetState')
+            __nvmlDevicePowerSmoothingSetState = _cyb_dlsym(handle, 'nvmlDevicePowerSmoothingSetState')
 
         global __nvmlDeviceGetAddressingMode
-        __nvmlDeviceGetAddressingMode = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetAddressingMode')
+        __nvmlDeviceGetAddressingMode = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetAddressingMode')
         if __nvmlDeviceGetAddressingMode == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetAddressingMode = dlsym(handle, 'nvmlDeviceGetAddressingMode')
+            __nvmlDeviceGetAddressingMode = _cyb_dlsym(handle, 'nvmlDeviceGetAddressingMode')
 
         global __nvmlDeviceGetRepairStatus
-        __nvmlDeviceGetRepairStatus = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetRepairStatus')
+        __nvmlDeviceGetRepairStatus = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetRepairStatus')
         if __nvmlDeviceGetRepairStatus == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetRepairStatus = dlsym(handle, 'nvmlDeviceGetRepairStatus')
+            __nvmlDeviceGetRepairStatus = _cyb_dlsym(handle, 'nvmlDeviceGetRepairStatus')
 
         global __nvmlDeviceGetPowerMizerMode_v1
-        __nvmlDeviceGetPowerMizerMode_v1 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetPowerMizerMode_v1')
+        __nvmlDeviceGetPowerMizerMode_v1 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetPowerMizerMode_v1')
         if __nvmlDeviceGetPowerMizerMode_v1 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetPowerMizerMode_v1 = dlsym(handle, 'nvmlDeviceGetPowerMizerMode_v1')
+            __nvmlDeviceGetPowerMizerMode_v1 = _cyb_dlsym(handle, 'nvmlDeviceGetPowerMizerMode_v1')
 
         global __nvmlDeviceSetPowerMizerMode_v1
-        __nvmlDeviceSetPowerMizerMode_v1 = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetPowerMizerMode_v1')
+        __nvmlDeviceSetPowerMizerMode_v1 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetPowerMizerMode_v1')
         if __nvmlDeviceSetPowerMizerMode_v1 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetPowerMizerMode_v1 = dlsym(handle, 'nvmlDeviceSetPowerMizerMode_v1')
+            __nvmlDeviceSetPowerMizerMode_v1 = _cyb_dlsym(handle, 'nvmlDeviceSetPowerMizerMode_v1')
 
         global __nvmlDeviceGetPdi
-        __nvmlDeviceGetPdi = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetPdi')
+        __nvmlDeviceGetPdi = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetPdi')
         if __nvmlDeviceGetPdi == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetPdi = dlsym(handle, 'nvmlDeviceGetPdi')
+            __nvmlDeviceGetPdi = _cyb_dlsym(handle, 'nvmlDeviceGetPdi')
 
         global __nvmlDeviceSetHostname_v1
-        __nvmlDeviceSetHostname_v1 = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetHostname_v1')
+        __nvmlDeviceSetHostname_v1 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetHostname_v1')
         if __nvmlDeviceSetHostname_v1 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetHostname_v1 = dlsym(handle, 'nvmlDeviceSetHostname_v1')
+            __nvmlDeviceSetHostname_v1 = _cyb_dlsym(handle, 'nvmlDeviceSetHostname_v1')
 
         global __nvmlDeviceGetHostname_v1
-        __nvmlDeviceGetHostname_v1 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetHostname_v1')
+        __nvmlDeviceGetHostname_v1 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetHostname_v1')
         if __nvmlDeviceGetHostname_v1 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetHostname_v1 = dlsym(handle, 'nvmlDeviceGetHostname_v1')
+            __nvmlDeviceGetHostname_v1 = _cyb_dlsym(handle, 'nvmlDeviceGetHostname_v1')
 
         global __nvmlDeviceGetNvLinkInfo
-        __nvmlDeviceGetNvLinkInfo = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetNvLinkInfo')
+        __nvmlDeviceGetNvLinkInfo = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetNvLinkInfo')
         if __nvmlDeviceGetNvLinkInfo == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetNvLinkInfo = dlsym(handle, 'nvmlDeviceGetNvLinkInfo')
+            __nvmlDeviceGetNvLinkInfo = _cyb_dlsym(handle, 'nvmlDeviceGetNvLinkInfo')
 
         global __nvmlDeviceReadWritePRM_v1
-        __nvmlDeviceReadWritePRM_v1 = dlsym(RTLD_DEFAULT, 'nvmlDeviceReadWritePRM_v1')
+        __nvmlDeviceReadWritePRM_v1 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceReadWritePRM_v1')
         if __nvmlDeviceReadWritePRM_v1 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceReadWritePRM_v1 = dlsym(handle, 'nvmlDeviceReadWritePRM_v1')
+            __nvmlDeviceReadWritePRM_v1 = _cyb_dlsym(handle, 'nvmlDeviceReadWritePRM_v1')
 
         global __nvmlDeviceGetGpuInstanceProfileInfoByIdV
-        __nvmlDeviceGetGpuInstanceProfileInfoByIdV = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetGpuInstanceProfileInfoByIdV')
+        __nvmlDeviceGetGpuInstanceProfileInfoByIdV = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetGpuInstanceProfileInfoByIdV')
         if __nvmlDeviceGetGpuInstanceProfileInfoByIdV == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetGpuInstanceProfileInfoByIdV = dlsym(handle, 'nvmlDeviceGetGpuInstanceProfileInfoByIdV')
+            __nvmlDeviceGetGpuInstanceProfileInfoByIdV = _cyb_dlsym(handle, 'nvmlDeviceGetGpuInstanceProfileInfoByIdV')
 
         global __nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts
-        __nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts')
+        __nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts')
         if __nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts = dlsym(handle, 'nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts')
+            __nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts = _cyb_dlsym(handle, 'nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts')
 
         global __nvmlDeviceGetUnrepairableMemoryFlag_v1
-        __nvmlDeviceGetUnrepairableMemoryFlag_v1 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetUnrepairableMemoryFlag_v1')
+        __nvmlDeviceGetUnrepairableMemoryFlag_v1 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetUnrepairableMemoryFlag_v1')
         if __nvmlDeviceGetUnrepairableMemoryFlag_v1 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetUnrepairableMemoryFlag_v1 = dlsym(handle, 'nvmlDeviceGetUnrepairableMemoryFlag_v1')
+            __nvmlDeviceGetUnrepairableMemoryFlag_v1 = _cyb_dlsym(handle, 'nvmlDeviceGetUnrepairableMemoryFlag_v1')
 
         global __nvmlDeviceReadPRMCounters_v1
-        __nvmlDeviceReadPRMCounters_v1 = dlsym(RTLD_DEFAULT, 'nvmlDeviceReadPRMCounters_v1')
+        __nvmlDeviceReadPRMCounters_v1 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceReadPRMCounters_v1')
         if __nvmlDeviceReadPRMCounters_v1 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceReadPRMCounters_v1 = dlsym(handle, 'nvmlDeviceReadPRMCounters_v1')
+            __nvmlDeviceReadPRMCounters_v1 = _cyb_dlsym(handle, 'nvmlDeviceReadPRMCounters_v1')
 
         global __nvmlDeviceSetRusdSettings_v1
-        __nvmlDeviceSetRusdSettings_v1 = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetRusdSettings_v1')
+        __nvmlDeviceSetRusdSettings_v1 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetRusdSettings_v1')
         if __nvmlDeviceSetRusdSettings_v1 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetRusdSettings_v1 = dlsym(handle, 'nvmlDeviceSetRusdSettings_v1')
+            __nvmlDeviceSetRusdSettings_v1 = _cyb_dlsym(handle, 'nvmlDeviceSetRusdSettings_v1')
 
         global __nvmlDeviceVgpuForceGspUnload
-        __nvmlDeviceVgpuForceGspUnload = dlsym(RTLD_DEFAULT, 'nvmlDeviceVgpuForceGspUnload')
+        __nvmlDeviceVgpuForceGspUnload = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceVgpuForceGspUnload')
         if __nvmlDeviceVgpuForceGspUnload == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceVgpuForceGspUnload = dlsym(handle, 'nvmlDeviceVgpuForceGspUnload')
+            __nvmlDeviceVgpuForceGspUnload = _cyb_dlsym(handle, 'nvmlDeviceVgpuForceGspUnload')
 
         global __nvmlDeviceGetVgpuSchedulerState_v2
-        __nvmlDeviceGetVgpuSchedulerState_v2 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetVgpuSchedulerState_v2')
+        __nvmlDeviceGetVgpuSchedulerState_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetVgpuSchedulerState_v2')
         if __nvmlDeviceGetVgpuSchedulerState_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetVgpuSchedulerState_v2 = dlsym(handle, 'nvmlDeviceGetVgpuSchedulerState_v2')
+            __nvmlDeviceGetVgpuSchedulerState_v2 = _cyb_dlsym(handle, 'nvmlDeviceGetVgpuSchedulerState_v2')
 
         global __nvmlGpuInstanceGetVgpuSchedulerState_v2
-        __nvmlGpuInstanceGetVgpuSchedulerState_v2 = dlsym(RTLD_DEFAULT, 'nvmlGpuInstanceGetVgpuSchedulerState_v2')
+        __nvmlGpuInstanceGetVgpuSchedulerState_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGpuInstanceGetVgpuSchedulerState_v2')
         if __nvmlGpuInstanceGetVgpuSchedulerState_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGpuInstanceGetVgpuSchedulerState_v2 = dlsym(handle, 'nvmlGpuInstanceGetVgpuSchedulerState_v2')
+            __nvmlGpuInstanceGetVgpuSchedulerState_v2 = _cyb_dlsym(handle, 'nvmlGpuInstanceGetVgpuSchedulerState_v2')
 
         global __nvmlDeviceGetVgpuSchedulerLog_v2
-        __nvmlDeviceGetVgpuSchedulerLog_v2 = dlsym(RTLD_DEFAULT, 'nvmlDeviceGetVgpuSchedulerLog_v2')
+        __nvmlDeviceGetVgpuSchedulerLog_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceGetVgpuSchedulerLog_v2')
         if __nvmlDeviceGetVgpuSchedulerLog_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceGetVgpuSchedulerLog_v2 = dlsym(handle, 'nvmlDeviceGetVgpuSchedulerLog_v2')
+            __nvmlDeviceGetVgpuSchedulerLog_v2 = _cyb_dlsym(handle, 'nvmlDeviceGetVgpuSchedulerLog_v2')
 
         global __nvmlGpuInstanceGetVgpuSchedulerLog_v2
-        __nvmlGpuInstanceGetVgpuSchedulerLog_v2 = dlsym(RTLD_DEFAULT, 'nvmlGpuInstanceGetVgpuSchedulerLog_v2')
+        __nvmlGpuInstanceGetVgpuSchedulerLog_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGpuInstanceGetVgpuSchedulerLog_v2')
         if __nvmlGpuInstanceGetVgpuSchedulerLog_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGpuInstanceGetVgpuSchedulerLog_v2 = dlsym(handle, 'nvmlGpuInstanceGetVgpuSchedulerLog_v2')
+            __nvmlGpuInstanceGetVgpuSchedulerLog_v2 = _cyb_dlsym(handle, 'nvmlGpuInstanceGetVgpuSchedulerLog_v2')
 
         global __nvmlDeviceSetVgpuSchedulerState_v2
-        __nvmlDeviceSetVgpuSchedulerState_v2 = dlsym(RTLD_DEFAULT, 'nvmlDeviceSetVgpuSchedulerState_v2')
+        __nvmlDeviceSetVgpuSchedulerState_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlDeviceSetVgpuSchedulerState_v2')
         if __nvmlDeviceSetVgpuSchedulerState_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlDeviceSetVgpuSchedulerState_v2 = dlsym(handle, 'nvmlDeviceSetVgpuSchedulerState_v2')
+            __nvmlDeviceSetVgpuSchedulerState_v2 = _cyb_dlsym(handle, 'nvmlDeviceSetVgpuSchedulerState_v2')
 
         global __nvmlGpuInstanceSetVgpuSchedulerState_v2
-        __nvmlGpuInstanceSetVgpuSchedulerState_v2 = dlsym(RTLD_DEFAULT, 'nvmlGpuInstanceSetVgpuSchedulerState_v2')
+        __nvmlGpuInstanceSetVgpuSchedulerState_v2 = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvmlGpuInstanceSetVgpuSchedulerState_v2')
         if __nvmlGpuInstanceSetVgpuSchedulerState_v2 == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvmlGpuInstanceSetVgpuSchedulerState_v2 = dlsym(handle, 'nvmlGpuInstanceSetVgpuSchedulerState_v2')
+            __nvmlGpuInstanceSetVgpuSchedulerState_v2 = _cyb_dlsym(handle, 'nvmlGpuInstanceSetVgpuSchedulerState_v2')
 
-        __py_nvml_init = True
+        _cyb___py_nvml_init = True
         return 0
 
-
 cdef inline int _check_or_init_nvml() except -1 nogil:
-    if __py_nvml_init:
+    if _cyb___py_nvml_init:
         return 0
 
     return _init_nvml()
 
 
-cdef dict func_ptrs = None
-
-
 cpdef dict _inspect_function_pointers():
-    global func_ptrs
-    if func_ptrs is not None:
-        return func_ptrs
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is not None:
+        return _cyb_func_ptrs
 
     _check_or_init_nvml()
     cdef dict data = {}
-
     global __nvmlInit_v2
-    data["__nvmlInit_v2"] = <intptr_t>__nvmlInit_v2
+    data["__nvmlInit_v2"] = <_cyb_intptr_t>__nvmlInit_v2
 
     global __nvmlInitWithFlags
-    data["__nvmlInitWithFlags"] = <intptr_t>__nvmlInitWithFlags
+    data["__nvmlInitWithFlags"] = <_cyb_intptr_t>__nvmlInitWithFlags
 
     global __nvmlShutdown
-    data["__nvmlShutdown"] = <intptr_t>__nvmlShutdown
+    data["__nvmlShutdown"] = <_cyb_intptr_t>__nvmlShutdown
 
     global __nvmlErrorString
-    data["__nvmlErrorString"] = <intptr_t>__nvmlErrorString
+    data["__nvmlErrorString"] = <_cyb_intptr_t>__nvmlErrorString
 
     global __nvmlSystemGetDriverVersion
-    data["__nvmlSystemGetDriverVersion"] = <intptr_t>__nvmlSystemGetDriverVersion
+    data["__nvmlSystemGetDriverVersion"] = <_cyb_intptr_t>__nvmlSystemGetDriverVersion
 
     global __nvmlSystemGetNVMLVersion
-    data["__nvmlSystemGetNVMLVersion"] = <intptr_t>__nvmlSystemGetNVMLVersion
+    data["__nvmlSystemGetNVMLVersion"] = <_cyb_intptr_t>__nvmlSystemGetNVMLVersion
 
     global __nvmlSystemGetCudaDriverVersion
-    data["__nvmlSystemGetCudaDriverVersion"] = <intptr_t>__nvmlSystemGetCudaDriverVersion
+    data["__nvmlSystemGetCudaDriverVersion"] = <_cyb_intptr_t>__nvmlSystemGetCudaDriverVersion
 
     global __nvmlSystemGetCudaDriverVersion_v2
-    data["__nvmlSystemGetCudaDriverVersion_v2"] = <intptr_t>__nvmlSystemGetCudaDriverVersion_v2
+    data["__nvmlSystemGetCudaDriverVersion_v2"] = <_cyb_intptr_t>__nvmlSystemGetCudaDriverVersion_v2
 
     global __nvmlSystemGetProcessName
-    data["__nvmlSystemGetProcessName"] = <intptr_t>__nvmlSystemGetProcessName
+    data["__nvmlSystemGetProcessName"] = <_cyb_intptr_t>__nvmlSystemGetProcessName
 
     global __nvmlSystemGetHicVersion
-    data["__nvmlSystemGetHicVersion"] = <intptr_t>__nvmlSystemGetHicVersion
+    data["__nvmlSystemGetHicVersion"] = <_cyb_intptr_t>__nvmlSystemGetHicVersion
 
     global __nvmlSystemGetTopologyGpuSet
-    data["__nvmlSystemGetTopologyGpuSet"] = <intptr_t>__nvmlSystemGetTopologyGpuSet
+    data["__nvmlSystemGetTopologyGpuSet"] = <_cyb_intptr_t>__nvmlSystemGetTopologyGpuSet
 
     global __nvmlSystemGetDriverBranch
-    data["__nvmlSystemGetDriverBranch"] = <intptr_t>__nvmlSystemGetDriverBranch
+    data["__nvmlSystemGetDriverBranch"] = <_cyb_intptr_t>__nvmlSystemGetDriverBranch
 
     global __nvmlUnitGetCount
-    data["__nvmlUnitGetCount"] = <intptr_t>__nvmlUnitGetCount
+    data["__nvmlUnitGetCount"] = <_cyb_intptr_t>__nvmlUnitGetCount
 
     global __nvmlUnitGetHandleByIndex
-    data["__nvmlUnitGetHandleByIndex"] = <intptr_t>__nvmlUnitGetHandleByIndex
+    data["__nvmlUnitGetHandleByIndex"] = <_cyb_intptr_t>__nvmlUnitGetHandleByIndex
 
     global __nvmlUnitGetUnitInfo
-    data["__nvmlUnitGetUnitInfo"] = <intptr_t>__nvmlUnitGetUnitInfo
+    data["__nvmlUnitGetUnitInfo"] = <_cyb_intptr_t>__nvmlUnitGetUnitInfo
 
     global __nvmlUnitGetLedState
-    data["__nvmlUnitGetLedState"] = <intptr_t>__nvmlUnitGetLedState
+    data["__nvmlUnitGetLedState"] = <_cyb_intptr_t>__nvmlUnitGetLedState
 
     global __nvmlUnitGetPsuInfo
-    data["__nvmlUnitGetPsuInfo"] = <intptr_t>__nvmlUnitGetPsuInfo
+    data["__nvmlUnitGetPsuInfo"] = <_cyb_intptr_t>__nvmlUnitGetPsuInfo
 
     global __nvmlUnitGetTemperature
-    data["__nvmlUnitGetTemperature"] = <intptr_t>__nvmlUnitGetTemperature
+    data["__nvmlUnitGetTemperature"] = <_cyb_intptr_t>__nvmlUnitGetTemperature
 
     global __nvmlUnitGetFanSpeedInfo
-    data["__nvmlUnitGetFanSpeedInfo"] = <intptr_t>__nvmlUnitGetFanSpeedInfo
+    data["__nvmlUnitGetFanSpeedInfo"] = <_cyb_intptr_t>__nvmlUnitGetFanSpeedInfo
 
     global __nvmlUnitGetDevices
-    data["__nvmlUnitGetDevices"] = <intptr_t>__nvmlUnitGetDevices
+    data["__nvmlUnitGetDevices"] = <_cyb_intptr_t>__nvmlUnitGetDevices
 
     global __nvmlDeviceGetCount_v2
-    data["__nvmlDeviceGetCount_v2"] = <intptr_t>__nvmlDeviceGetCount_v2
+    data["__nvmlDeviceGetCount_v2"] = <_cyb_intptr_t>__nvmlDeviceGetCount_v2
 
     global __nvmlDeviceGetAttributes_v2
-    data["__nvmlDeviceGetAttributes_v2"] = <intptr_t>__nvmlDeviceGetAttributes_v2
+    data["__nvmlDeviceGetAttributes_v2"] = <_cyb_intptr_t>__nvmlDeviceGetAttributes_v2
 
     global __nvmlDeviceGetHandleByIndex_v2
-    data["__nvmlDeviceGetHandleByIndex_v2"] = <intptr_t>__nvmlDeviceGetHandleByIndex_v2
+    data["__nvmlDeviceGetHandleByIndex_v2"] = <_cyb_intptr_t>__nvmlDeviceGetHandleByIndex_v2
 
     global __nvmlDeviceGetHandleBySerial
-    data["__nvmlDeviceGetHandleBySerial"] = <intptr_t>__nvmlDeviceGetHandleBySerial
+    data["__nvmlDeviceGetHandleBySerial"] = <_cyb_intptr_t>__nvmlDeviceGetHandleBySerial
 
     global __nvmlDeviceGetHandleByUUID
-    data["__nvmlDeviceGetHandleByUUID"] = <intptr_t>__nvmlDeviceGetHandleByUUID
+    data["__nvmlDeviceGetHandleByUUID"] = <_cyb_intptr_t>__nvmlDeviceGetHandleByUUID
 
     global __nvmlDeviceGetHandleByUUIDV
-    data["__nvmlDeviceGetHandleByUUIDV"] = <intptr_t>__nvmlDeviceGetHandleByUUIDV
+    data["__nvmlDeviceGetHandleByUUIDV"] = <_cyb_intptr_t>__nvmlDeviceGetHandleByUUIDV
 
     global __nvmlDeviceGetHandleByPciBusId_v2
-    data["__nvmlDeviceGetHandleByPciBusId_v2"] = <intptr_t>__nvmlDeviceGetHandleByPciBusId_v2
+    data["__nvmlDeviceGetHandleByPciBusId_v2"] = <_cyb_intptr_t>__nvmlDeviceGetHandleByPciBusId_v2
 
     global __nvmlDeviceGetName
-    data["__nvmlDeviceGetName"] = <intptr_t>__nvmlDeviceGetName
+    data["__nvmlDeviceGetName"] = <_cyb_intptr_t>__nvmlDeviceGetName
 
     global __nvmlDeviceGetBrand
-    data["__nvmlDeviceGetBrand"] = <intptr_t>__nvmlDeviceGetBrand
+    data["__nvmlDeviceGetBrand"] = <_cyb_intptr_t>__nvmlDeviceGetBrand
 
     global __nvmlDeviceGetIndex
-    data["__nvmlDeviceGetIndex"] = <intptr_t>__nvmlDeviceGetIndex
+    data["__nvmlDeviceGetIndex"] = <_cyb_intptr_t>__nvmlDeviceGetIndex
 
     global __nvmlDeviceGetSerial
-    data["__nvmlDeviceGetSerial"] = <intptr_t>__nvmlDeviceGetSerial
+    data["__nvmlDeviceGetSerial"] = <_cyb_intptr_t>__nvmlDeviceGetSerial
 
     global __nvmlDeviceGetModuleId
-    data["__nvmlDeviceGetModuleId"] = <intptr_t>__nvmlDeviceGetModuleId
+    data["__nvmlDeviceGetModuleId"] = <_cyb_intptr_t>__nvmlDeviceGetModuleId
 
     global __nvmlDeviceGetC2cModeInfoV
-    data["__nvmlDeviceGetC2cModeInfoV"] = <intptr_t>__nvmlDeviceGetC2cModeInfoV
+    data["__nvmlDeviceGetC2cModeInfoV"] = <_cyb_intptr_t>__nvmlDeviceGetC2cModeInfoV
 
     global __nvmlDeviceGetMemoryAffinity
-    data["__nvmlDeviceGetMemoryAffinity"] = <intptr_t>__nvmlDeviceGetMemoryAffinity
+    data["__nvmlDeviceGetMemoryAffinity"] = <_cyb_intptr_t>__nvmlDeviceGetMemoryAffinity
 
     global __nvmlDeviceGetCpuAffinityWithinScope
-    data["__nvmlDeviceGetCpuAffinityWithinScope"] = <intptr_t>__nvmlDeviceGetCpuAffinityWithinScope
+    data["__nvmlDeviceGetCpuAffinityWithinScope"] = <_cyb_intptr_t>__nvmlDeviceGetCpuAffinityWithinScope
 
     global __nvmlDeviceGetCpuAffinity
-    data["__nvmlDeviceGetCpuAffinity"] = <intptr_t>__nvmlDeviceGetCpuAffinity
+    data["__nvmlDeviceGetCpuAffinity"] = <_cyb_intptr_t>__nvmlDeviceGetCpuAffinity
 
     global __nvmlDeviceSetCpuAffinity
-    data["__nvmlDeviceSetCpuAffinity"] = <intptr_t>__nvmlDeviceSetCpuAffinity
+    data["__nvmlDeviceSetCpuAffinity"] = <_cyb_intptr_t>__nvmlDeviceSetCpuAffinity
 
     global __nvmlDeviceClearCpuAffinity
-    data["__nvmlDeviceClearCpuAffinity"] = <intptr_t>__nvmlDeviceClearCpuAffinity
+    data["__nvmlDeviceClearCpuAffinity"] = <_cyb_intptr_t>__nvmlDeviceClearCpuAffinity
 
     global __nvmlDeviceGetNumaNodeId
-    data["__nvmlDeviceGetNumaNodeId"] = <intptr_t>__nvmlDeviceGetNumaNodeId
+    data["__nvmlDeviceGetNumaNodeId"] = <_cyb_intptr_t>__nvmlDeviceGetNumaNodeId
 
     global __nvmlDeviceGetTopologyCommonAncestor
-    data["__nvmlDeviceGetTopologyCommonAncestor"] = <intptr_t>__nvmlDeviceGetTopologyCommonAncestor
+    data["__nvmlDeviceGetTopologyCommonAncestor"] = <_cyb_intptr_t>__nvmlDeviceGetTopologyCommonAncestor
 
     global __nvmlDeviceGetTopologyNearestGpus
-    data["__nvmlDeviceGetTopologyNearestGpus"] = <intptr_t>__nvmlDeviceGetTopologyNearestGpus
+    data["__nvmlDeviceGetTopologyNearestGpus"] = <_cyb_intptr_t>__nvmlDeviceGetTopologyNearestGpus
 
     global __nvmlDeviceGetP2PStatus
-    data["__nvmlDeviceGetP2PStatus"] = <intptr_t>__nvmlDeviceGetP2PStatus
+    data["__nvmlDeviceGetP2PStatus"] = <_cyb_intptr_t>__nvmlDeviceGetP2PStatus
 
     global __nvmlDeviceGetUUID
-    data["__nvmlDeviceGetUUID"] = <intptr_t>__nvmlDeviceGetUUID
+    data["__nvmlDeviceGetUUID"] = <_cyb_intptr_t>__nvmlDeviceGetUUID
 
     global __nvmlDeviceGetMinorNumber
-    data["__nvmlDeviceGetMinorNumber"] = <intptr_t>__nvmlDeviceGetMinorNumber
+    data["__nvmlDeviceGetMinorNumber"] = <_cyb_intptr_t>__nvmlDeviceGetMinorNumber
 
     global __nvmlDeviceGetBoardPartNumber
-    data["__nvmlDeviceGetBoardPartNumber"] = <intptr_t>__nvmlDeviceGetBoardPartNumber
+    data["__nvmlDeviceGetBoardPartNumber"] = <_cyb_intptr_t>__nvmlDeviceGetBoardPartNumber
 
     global __nvmlDeviceGetInforomVersion
-    data["__nvmlDeviceGetInforomVersion"] = <intptr_t>__nvmlDeviceGetInforomVersion
+    data["__nvmlDeviceGetInforomVersion"] = <_cyb_intptr_t>__nvmlDeviceGetInforomVersion
 
     global __nvmlDeviceGetInforomImageVersion
-    data["__nvmlDeviceGetInforomImageVersion"] = <intptr_t>__nvmlDeviceGetInforomImageVersion
+    data["__nvmlDeviceGetInforomImageVersion"] = <_cyb_intptr_t>__nvmlDeviceGetInforomImageVersion
 
     global __nvmlDeviceGetInforomConfigurationChecksum
-    data["__nvmlDeviceGetInforomConfigurationChecksum"] = <intptr_t>__nvmlDeviceGetInforomConfigurationChecksum
+    data["__nvmlDeviceGetInforomConfigurationChecksum"] = <_cyb_intptr_t>__nvmlDeviceGetInforomConfigurationChecksum
 
     global __nvmlDeviceValidateInforom
-    data["__nvmlDeviceValidateInforom"] = <intptr_t>__nvmlDeviceValidateInforom
+    data["__nvmlDeviceValidateInforom"] = <_cyb_intptr_t>__nvmlDeviceValidateInforom
 
     global __nvmlDeviceGetLastBBXFlushTime
-    data["__nvmlDeviceGetLastBBXFlushTime"] = <intptr_t>__nvmlDeviceGetLastBBXFlushTime
+    data["__nvmlDeviceGetLastBBXFlushTime"] = <_cyb_intptr_t>__nvmlDeviceGetLastBBXFlushTime
 
     global __nvmlDeviceGetDisplayMode
-    data["__nvmlDeviceGetDisplayMode"] = <intptr_t>__nvmlDeviceGetDisplayMode
+    data["__nvmlDeviceGetDisplayMode"] = <_cyb_intptr_t>__nvmlDeviceGetDisplayMode
 
     global __nvmlDeviceGetDisplayActive
-    data["__nvmlDeviceGetDisplayActive"] = <intptr_t>__nvmlDeviceGetDisplayActive
+    data["__nvmlDeviceGetDisplayActive"] = <_cyb_intptr_t>__nvmlDeviceGetDisplayActive
 
     global __nvmlDeviceGetPersistenceMode
-    data["__nvmlDeviceGetPersistenceMode"] = <intptr_t>__nvmlDeviceGetPersistenceMode
+    data["__nvmlDeviceGetPersistenceMode"] = <_cyb_intptr_t>__nvmlDeviceGetPersistenceMode
 
     global __nvmlDeviceGetPciInfoExt
-    data["__nvmlDeviceGetPciInfoExt"] = <intptr_t>__nvmlDeviceGetPciInfoExt
+    data["__nvmlDeviceGetPciInfoExt"] = <_cyb_intptr_t>__nvmlDeviceGetPciInfoExt
 
     global __nvmlDeviceGetPciInfo_v3
-    data["__nvmlDeviceGetPciInfo_v3"] = <intptr_t>__nvmlDeviceGetPciInfo_v3
+    data["__nvmlDeviceGetPciInfo_v3"] = <_cyb_intptr_t>__nvmlDeviceGetPciInfo_v3
 
     global __nvmlDeviceGetMaxPcieLinkGeneration
-    data["__nvmlDeviceGetMaxPcieLinkGeneration"] = <intptr_t>__nvmlDeviceGetMaxPcieLinkGeneration
+    data["__nvmlDeviceGetMaxPcieLinkGeneration"] = <_cyb_intptr_t>__nvmlDeviceGetMaxPcieLinkGeneration
 
     global __nvmlDeviceGetGpuMaxPcieLinkGeneration
-    data["__nvmlDeviceGetGpuMaxPcieLinkGeneration"] = <intptr_t>__nvmlDeviceGetGpuMaxPcieLinkGeneration
+    data["__nvmlDeviceGetGpuMaxPcieLinkGeneration"] = <_cyb_intptr_t>__nvmlDeviceGetGpuMaxPcieLinkGeneration
 
     global __nvmlDeviceGetMaxPcieLinkWidth
-    data["__nvmlDeviceGetMaxPcieLinkWidth"] = <intptr_t>__nvmlDeviceGetMaxPcieLinkWidth
+    data["__nvmlDeviceGetMaxPcieLinkWidth"] = <_cyb_intptr_t>__nvmlDeviceGetMaxPcieLinkWidth
 
     global __nvmlDeviceGetCurrPcieLinkGeneration
-    data["__nvmlDeviceGetCurrPcieLinkGeneration"] = <intptr_t>__nvmlDeviceGetCurrPcieLinkGeneration
+    data["__nvmlDeviceGetCurrPcieLinkGeneration"] = <_cyb_intptr_t>__nvmlDeviceGetCurrPcieLinkGeneration
 
     global __nvmlDeviceGetCurrPcieLinkWidth
-    data["__nvmlDeviceGetCurrPcieLinkWidth"] = <intptr_t>__nvmlDeviceGetCurrPcieLinkWidth
+    data["__nvmlDeviceGetCurrPcieLinkWidth"] = <_cyb_intptr_t>__nvmlDeviceGetCurrPcieLinkWidth
 
     global __nvmlDeviceGetPcieThroughput
-    data["__nvmlDeviceGetPcieThroughput"] = <intptr_t>__nvmlDeviceGetPcieThroughput
+    data["__nvmlDeviceGetPcieThroughput"] = <_cyb_intptr_t>__nvmlDeviceGetPcieThroughput
 
     global __nvmlDeviceGetPcieReplayCounter
-    data["__nvmlDeviceGetPcieReplayCounter"] = <intptr_t>__nvmlDeviceGetPcieReplayCounter
+    data["__nvmlDeviceGetPcieReplayCounter"] = <_cyb_intptr_t>__nvmlDeviceGetPcieReplayCounter
 
     global __nvmlDeviceGetClockInfo
-    data["__nvmlDeviceGetClockInfo"] = <intptr_t>__nvmlDeviceGetClockInfo
+    data["__nvmlDeviceGetClockInfo"] = <_cyb_intptr_t>__nvmlDeviceGetClockInfo
 
     global __nvmlDeviceGetMaxClockInfo
-    data["__nvmlDeviceGetMaxClockInfo"] = <intptr_t>__nvmlDeviceGetMaxClockInfo
+    data["__nvmlDeviceGetMaxClockInfo"] = <_cyb_intptr_t>__nvmlDeviceGetMaxClockInfo
 
     global __nvmlDeviceGetGpcClkVfOffset
-    data["__nvmlDeviceGetGpcClkVfOffset"] = <intptr_t>__nvmlDeviceGetGpcClkVfOffset
+    data["__nvmlDeviceGetGpcClkVfOffset"] = <_cyb_intptr_t>__nvmlDeviceGetGpcClkVfOffset
 
     global __nvmlDeviceGetClock
-    data["__nvmlDeviceGetClock"] = <intptr_t>__nvmlDeviceGetClock
+    data["__nvmlDeviceGetClock"] = <_cyb_intptr_t>__nvmlDeviceGetClock
 
     global __nvmlDeviceGetMaxCustomerBoostClock
-    data["__nvmlDeviceGetMaxCustomerBoostClock"] = <intptr_t>__nvmlDeviceGetMaxCustomerBoostClock
+    data["__nvmlDeviceGetMaxCustomerBoostClock"] = <_cyb_intptr_t>__nvmlDeviceGetMaxCustomerBoostClock
 
     global __nvmlDeviceGetSupportedMemoryClocks
-    data["__nvmlDeviceGetSupportedMemoryClocks"] = <intptr_t>__nvmlDeviceGetSupportedMemoryClocks
+    data["__nvmlDeviceGetSupportedMemoryClocks"] = <_cyb_intptr_t>__nvmlDeviceGetSupportedMemoryClocks
 
     global __nvmlDeviceGetSupportedGraphicsClocks
-    data["__nvmlDeviceGetSupportedGraphicsClocks"] = <intptr_t>__nvmlDeviceGetSupportedGraphicsClocks
+    data["__nvmlDeviceGetSupportedGraphicsClocks"] = <_cyb_intptr_t>__nvmlDeviceGetSupportedGraphicsClocks
 
     global __nvmlDeviceGetAutoBoostedClocksEnabled
-    data["__nvmlDeviceGetAutoBoostedClocksEnabled"] = <intptr_t>__nvmlDeviceGetAutoBoostedClocksEnabled
+    data["__nvmlDeviceGetAutoBoostedClocksEnabled"] = <_cyb_intptr_t>__nvmlDeviceGetAutoBoostedClocksEnabled
 
     global __nvmlDeviceGetFanSpeed
-    data["__nvmlDeviceGetFanSpeed"] = <intptr_t>__nvmlDeviceGetFanSpeed
+    data["__nvmlDeviceGetFanSpeed"] = <_cyb_intptr_t>__nvmlDeviceGetFanSpeed
 
     global __nvmlDeviceGetFanSpeed_v2
-    data["__nvmlDeviceGetFanSpeed_v2"] = <intptr_t>__nvmlDeviceGetFanSpeed_v2
+    data["__nvmlDeviceGetFanSpeed_v2"] = <_cyb_intptr_t>__nvmlDeviceGetFanSpeed_v2
 
     global __nvmlDeviceGetFanSpeedRPM
-    data["__nvmlDeviceGetFanSpeedRPM"] = <intptr_t>__nvmlDeviceGetFanSpeedRPM
+    data["__nvmlDeviceGetFanSpeedRPM"] = <_cyb_intptr_t>__nvmlDeviceGetFanSpeedRPM
 
     global __nvmlDeviceGetTargetFanSpeed
-    data["__nvmlDeviceGetTargetFanSpeed"] = <intptr_t>__nvmlDeviceGetTargetFanSpeed
+    data["__nvmlDeviceGetTargetFanSpeed"] = <_cyb_intptr_t>__nvmlDeviceGetTargetFanSpeed
 
     global __nvmlDeviceGetMinMaxFanSpeed
-    data["__nvmlDeviceGetMinMaxFanSpeed"] = <intptr_t>__nvmlDeviceGetMinMaxFanSpeed
+    data["__nvmlDeviceGetMinMaxFanSpeed"] = <_cyb_intptr_t>__nvmlDeviceGetMinMaxFanSpeed
 
     global __nvmlDeviceGetFanControlPolicy_v2
-    data["__nvmlDeviceGetFanControlPolicy_v2"] = <intptr_t>__nvmlDeviceGetFanControlPolicy_v2
+    data["__nvmlDeviceGetFanControlPolicy_v2"] = <_cyb_intptr_t>__nvmlDeviceGetFanControlPolicy_v2
 
     global __nvmlDeviceGetNumFans
-    data["__nvmlDeviceGetNumFans"] = <intptr_t>__nvmlDeviceGetNumFans
+    data["__nvmlDeviceGetNumFans"] = <_cyb_intptr_t>__nvmlDeviceGetNumFans
 
     global __nvmlDeviceGetCoolerInfo
-    data["__nvmlDeviceGetCoolerInfo"] = <intptr_t>__nvmlDeviceGetCoolerInfo
+    data["__nvmlDeviceGetCoolerInfo"] = <_cyb_intptr_t>__nvmlDeviceGetCoolerInfo
 
     global __nvmlDeviceGetTemperatureV
-    data["__nvmlDeviceGetTemperatureV"] = <intptr_t>__nvmlDeviceGetTemperatureV
+    data["__nvmlDeviceGetTemperatureV"] = <_cyb_intptr_t>__nvmlDeviceGetTemperatureV
 
     global __nvmlDeviceGetTemperatureThreshold
-    data["__nvmlDeviceGetTemperatureThreshold"] = <intptr_t>__nvmlDeviceGetTemperatureThreshold
+    data["__nvmlDeviceGetTemperatureThreshold"] = <_cyb_intptr_t>__nvmlDeviceGetTemperatureThreshold
 
     global __nvmlDeviceGetMarginTemperature
-    data["__nvmlDeviceGetMarginTemperature"] = <intptr_t>__nvmlDeviceGetMarginTemperature
+    data["__nvmlDeviceGetMarginTemperature"] = <_cyb_intptr_t>__nvmlDeviceGetMarginTemperature
 
     global __nvmlDeviceGetThermalSettings
-    data["__nvmlDeviceGetThermalSettings"] = <intptr_t>__nvmlDeviceGetThermalSettings
+    data["__nvmlDeviceGetThermalSettings"] = <_cyb_intptr_t>__nvmlDeviceGetThermalSettings
 
     global __nvmlDeviceGetPerformanceState
-    data["__nvmlDeviceGetPerformanceState"] = <intptr_t>__nvmlDeviceGetPerformanceState
+    data["__nvmlDeviceGetPerformanceState"] = <_cyb_intptr_t>__nvmlDeviceGetPerformanceState
 
     global __nvmlDeviceGetCurrentClocksEventReasons
-    data["__nvmlDeviceGetCurrentClocksEventReasons"] = <intptr_t>__nvmlDeviceGetCurrentClocksEventReasons
+    data["__nvmlDeviceGetCurrentClocksEventReasons"] = <_cyb_intptr_t>__nvmlDeviceGetCurrentClocksEventReasons
 
     global __nvmlDeviceGetSupportedClocksEventReasons
-    data["__nvmlDeviceGetSupportedClocksEventReasons"] = <intptr_t>__nvmlDeviceGetSupportedClocksEventReasons
+    data["__nvmlDeviceGetSupportedClocksEventReasons"] = <_cyb_intptr_t>__nvmlDeviceGetSupportedClocksEventReasons
 
     global __nvmlDeviceGetPowerState
-    data["__nvmlDeviceGetPowerState"] = <intptr_t>__nvmlDeviceGetPowerState
+    data["__nvmlDeviceGetPowerState"] = <_cyb_intptr_t>__nvmlDeviceGetPowerState
 
     global __nvmlDeviceGetDynamicPstatesInfo
-    data["__nvmlDeviceGetDynamicPstatesInfo"] = <intptr_t>__nvmlDeviceGetDynamicPstatesInfo
+    data["__nvmlDeviceGetDynamicPstatesInfo"] = <_cyb_intptr_t>__nvmlDeviceGetDynamicPstatesInfo
 
     global __nvmlDeviceGetMemClkVfOffset
-    data["__nvmlDeviceGetMemClkVfOffset"] = <intptr_t>__nvmlDeviceGetMemClkVfOffset
+    data["__nvmlDeviceGetMemClkVfOffset"] = <_cyb_intptr_t>__nvmlDeviceGetMemClkVfOffset
 
     global __nvmlDeviceGetMinMaxClockOfPState
-    data["__nvmlDeviceGetMinMaxClockOfPState"] = <intptr_t>__nvmlDeviceGetMinMaxClockOfPState
+    data["__nvmlDeviceGetMinMaxClockOfPState"] = <_cyb_intptr_t>__nvmlDeviceGetMinMaxClockOfPState
 
     global __nvmlDeviceGetSupportedPerformanceStates
-    data["__nvmlDeviceGetSupportedPerformanceStates"] = <intptr_t>__nvmlDeviceGetSupportedPerformanceStates
+    data["__nvmlDeviceGetSupportedPerformanceStates"] = <_cyb_intptr_t>__nvmlDeviceGetSupportedPerformanceStates
 
     global __nvmlDeviceGetGpcClkMinMaxVfOffset
-    data["__nvmlDeviceGetGpcClkMinMaxVfOffset"] = <intptr_t>__nvmlDeviceGetGpcClkMinMaxVfOffset
+    data["__nvmlDeviceGetGpcClkMinMaxVfOffset"] = <_cyb_intptr_t>__nvmlDeviceGetGpcClkMinMaxVfOffset
 
     global __nvmlDeviceGetMemClkMinMaxVfOffset
-    data["__nvmlDeviceGetMemClkMinMaxVfOffset"] = <intptr_t>__nvmlDeviceGetMemClkMinMaxVfOffset
+    data["__nvmlDeviceGetMemClkMinMaxVfOffset"] = <_cyb_intptr_t>__nvmlDeviceGetMemClkMinMaxVfOffset
 
     global __nvmlDeviceGetClockOffsets
-    data["__nvmlDeviceGetClockOffsets"] = <intptr_t>__nvmlDeviceGetClockOffsets
+    data["__nvmlDeviceGetClockOffsets"] = <_cyb_intptr_t>__nvmlDeviceGetClockOffsets
 
     global __nvmlDeviceSetClockOffsets
-    data["__nvmlDeviceSetClockOffsets"] = <intptr_t>__nvmlDeviceSetClockOffsets
+    data["__nvmlDeviceSetClockOffsets"] = <_cyb_intptr_t>__nvmlDeviceSetClockOffsets
 
     global __nvmlDeviceGetPerformanceModes
-    data["__nvmlDeviceGetPerformanceModes"] = <intptr_t>__nvmlDeviceGetPerformanceModes
+    data["__nvmlDeviceGetPerformanceModes"] = <_cyb_intptr_t>__nvmlDeviceGetPerformanceModes
 
     global __nvmlDeviceGetCurrentClockFreqs
-    data["__nvmlDeviceGetCurrentClockFreqs"] = <intptr_t>__nvmlDeviceGetCurrentClockFreqs
+    data["__nvmlDeviceGetCurrentClockFreqs"] = <_cyb_intptr_t>__nvmlDeviceGetCurrentClockFreqs
 
     global __nvmlDeviceGetPowerManagementLimit
-    data["__nvmlDeviceGetPowerManagementLimit"] = <intptr_t>__nvmlDeviceGetPowerManagementLimit
+    data["__nvmlDeviceGetPowerManagementLimit"] = <_cyb_intptr_t>__nvmlDeviceGetPowerManagementLimit
 
     global __nvmlDeviceGetPowerManagementLimitConstraints
-    data["__nvmlDeviceGetPowerManagementLimitConstraints"] = <intptr_t>__nvmlDeviceGetPowerManagementLimitConstraints
+    data["__nvmlDeviceGetPowerManagementLimitConstraints"] = <_cyb_intptr_t>__nvmlDeviceGetPowerManagementLimitConstraints
 
     global __nvmlDeviceGetPowerManagementDefaultLimit
-    data["__nvmlDeviceGetPowerManagementDefaultLimit"] = <intptr_t>__nvmlDeviceGetPowerManagementDefaultLimit
+    data["__nvmlDeviceGetPowerManagementDefaultLimit"] = <_cyb_intptr_t>__nvmlDeviceGetPowerManagementDefaultLimit
 
     global __nvmlDeviceGetPowerUsage
-    data["__nvmlDeviceGetPowerUsage"] = <intptr_t>__nvmlDeviceGetPowerUsage
+    data["__nvmlDeviceGetPowerUsage"] = <_cyb_intptr_t>__nvmlDeviceGetPowerUsage
 
     global __nvmlDeviceGetTotalEnergyConsumption
-    data["__nvmlDeviceGetTotalEnergyConsumption"] = <intptr_t>__nvmlDeviceGetTotalEnergyConsumption
+    data["__nvmlDeviceGetTotalEnergyConsumption"] = <_cyb_intptr_t>__nvmlDeviceGetTotalEnergyConsumption
 
     global __nvmlDeviceGetEnforcedPowerLimit
-    data["__nvmlDeviceGetEnforcedPowerLimit"] = <intptr_t>__nvmlDeviceGetEnforcedPowerLimit
+    data["__nvmlDeviceGetEnforcedPowerLimit"] = <_cyb_intptr_t>__nvmlDeviceGetEnforcedPowerLimit
 
     global __nvmlDeviceGetGpuOperationMode
-    data["__nvmlDeviceGetGpuOperationMode"] = <intptr_t>__nvmlDeviceGetGpuOperationMode
+    data["__nvmlDeviceGetGpuOperationMode"] = <_cyb_intptr_t>__nvmlDeviceGetGpuOperationMode
 
     global __nvmlDeviceGetMemoryInfo_v2
-    data["__nvmlDeviceGetMemoryInfo_v2"] = <intptr_t>__nvmlDeviceGetMemoryInfo_v2
+    data["__nvmlDeviceGetMemoryInfo_v2"] = <_cyb_intptr_t>__nvmlDeviceGetMemoryInfo_v2
 
     global __nvmlDeviceGetComputeMode
-    data["__nvmlDeviceGetComputeMode"] = <intptr_t>__nvmlDeviceGetComputeMode
+    data["__nvmlDeviceGetComputeMode"] = <_cyb_intptr_t>__nvmlDeviceGetComputeMode
 
     global __nvmlDeviceGetCudaComputeCapability
-    data["__nvmlDeviceGetCudaComputeCapability"] = <intptr_t>__nvmlDeviceGetCudaComputeCapability
+    data["__nvmlDeviceGetCudaComputeCapability"] = <_cyb_intptr_t>__nvmlDeviceGetCudaComputeCapability
 
     global __nvmlDeviceGetDramEncryptionMode
-    data["__nvmlDeviceGetDramEncryptionMode"] = <intptr_t>__nvmlDeviceGetDramEncryptionMode
+    data["__nvmlDeviceGetDramEncryptionMode"] = <_cyb_intptr_t>__nvmlDeviceGetDramEncryptionMode
 
     global __nvmlDeviceSetDramEncryptionMode
-    data["__nvmlDeviceSetDramEncryptionMode"] = <intptr_t>__nvmlDeviceSetDramEncryptionMode
+    data["__nvmlDeviceSetDramEncryptionMode"] = <_cyb_intptr_t>__nvmlDeviceSetDramEncryptionMode
 
     global __nvmlDeviceGetEccMode
-    data["__nvmlDeviceGetEccMode"] = <intptr_t>__nvmlDeviceGetEccMode
+    data["__nvmlDeviceGetEccMode"] = <_cyb_intptr_t>__nvmlDeviceGetEccMode
 
     global __nvmlDeviceGetDefaultEccMode
-    data["__nvmlDeviceGetDefaultEccMode"] = <intptr_t>__nvmlDeviceGetDefaultEccMode
+    data["__nvmlDeviceGetDefaultEccMode"] = <_cyb_intptr_t>__nvmlDeviceGetDefaultEccMode
 
     global __nvmlDeviceGetBoardId
-    data["__nvmlDeviceGetBoardId"] = <intptr_t>__nvmlDeviceGetBoardId
+    data["__nvmlDeviceGetBoardId"] = <_cyb_intptr_t>__nvmlDeviceGetBoardId
 
     global __nvmlDeviceGetMultiGpuBoard
-    data["__nvmlDeviceGetMultiGpuBoard"] = <intptr_t>__nvmlDeviceGetMultiGpuBoard
+    data["__nvmlDeviceGetMultiGpuBoard"] = <_cyb_intptr_t>__nvmlDeviceGetMultiGpuBoard
 
     global __nvmlDeviceGetTotalEccErrors
-    data["__nvmlDeviceGetTotalEccErrors"] = <intptr_t>__nvmlDeviceGetTotalEccErrors
+    data["__nvmlDeviceGetTotalEccErrors"] = <_cyb_intptr_t>__nvmlDeviceGetTotalEccErrors
 
     global __nvmlDeviceGetMemoryErrorCounter
-    data["__nvmlDeviceGetMemoryErrorCounter"] = <intptr_t>__nvmlDeviceGetMemoryErrorCounter
+    data["__nvmlDeviceGetMemoryErrorCounter"] = <_cyb_intptr_t>__nvmlDeviceGetMemoryErrorCounter
 
     global __nvmlDeviceGetUtilizationRates
-    data["__nvmlDeviceGetUtilizationRates"] = <intptr_t>__nvmlDeviceGetUtilizationRates
+    data["__nvmlDeviceGetUtilizationRates"] = <_cyb_intptr_t>__nvmlDeviceGetUtilizationRates
 
     global __nvmlDeviceGetEncoderUtilization
-    data["__nvmlDeviceGetEncoderUtilization"] = <intptr_t>__nvmlDeviceGetEncoderUtilization
+    data["__nvmlDeviceGetEncoderUtilization"] = <_cyb_intptr_t>__nvmlDeviceGetEncoderUtilization
 
     global __nvmlDeviceGetEncoderCapacity
-    data["__nvmlDeviceGetEncoderCapacity"] = <intptr_t>__nvmlDeviceGetEncoderCapacity
+    data["__nvmlDeviceGetEncoderCapacity"] = <_cyb_intptr_t>__nvmlDeviceGetEncoderCapacity
 
     global __nvmlDeviceGetEncoderStats
-    data["__nvmlDeviceGetEncoderStats"] = <intptr_t>__nvmlDeviceGetEncoderStats
+    data["__nvmlDeviceGetEncoderStats"] = <_cyb_intptr_t>__nvmlDeviceGetEncoderStats
 
     global __nvmlDeviceGetEncoderSessions
-    data["__nvmlDeviceGetEncoderSessions"] = <intptr_t>__nvmlDeviceGetEncoderSessions
+    data["__nvmlDeviceGetEncoderSessions"] = <_cyb_intptr_t>__nvmlDeviceGetEncoderSessions
 
     global __nvmlDeviceGetDecoderUtilization
-    data["__nvmlDeviceGetDecoderUtilization"] = <intptr_t>__nvmlDeviceGetDecoderUtilization
+    data["__nvmlDeviceGetDecoderUtilization"] = <_cyb_intptr_t>__nvmlDeviceGetDecoderUtilization
 
     global __nvmlDeviceGetJpgUtilization
-    data["__nvmlDeviceGetJpgUtilization"] = <intptr_t>__nvmlDeviceGetJpgUtilization
+    data["__nvmlDeviceGetJpgUtilization"] = <_cyb_intptr_t>__nvmlDeviceGetJpgUtilization
 
     global __nvmlDeviceGetOfaUtilization
-    data["__nvmlDeviceGetOfaUtilization"] = <intptr_t>__nvmlDeviceGetOfaUtilization
+    data["__nvmlDeviceGetOfaUtilization"] = <_cyb_intptr_t>__nvmlDeviceGetOfaUtilization
 
     global __nvmlDeviceGetFBCStats
-    data["__nvmlDeviceGetFBCStats"] = <intptr_t>__nvmlDeviceGetFBCStats
+    data["__nvmlDeviceGetFBCStats"] = <_cyb_intptr_t>__nvmlDeviceGetFBCStats
 
     global __nvmlDeviceGetFBCSessions
-    data["__nvmlDeviceGetFBCSessions"] = <intptr_t>__nvmlDeviceGetFBCSessions
+    data["__nvmlDeviceGetFBCSessions"] = <_cyb_intptr_t>__nvmlDeviceGetFBCSessions
 
     global __nvmlDeviceGetDriverModel_v2
-    data["__nvmlDeviceGetDriverModel_v2"] = <intptr_t>__nvmlDeviceGetDriverModel_v2
+    data["__nvmlDeviceGetDriverModel_v2"] = <_cyb_intptr_t>__nvmlDeviceGetDriverModel_v2
 
     global __nvmlDeviceGetVbiosVersion
-    data["__nvmlDeviceGetVbiosVersion"] = <intptr_t>__nvmlDeviceGetVbiosVersion
+    data["__nvmlDeviceGetVbiosVersion"] = <_cyb_intptr_t>__nvmlDeviceGetVbiosVersion
 
     global __nvmlDeviceGetBridgeChipInfo
-    data["__nvmlDeviceGetBridgeChipInfo"] = <intptr_t>__nvmlDeviceGetBridgeChipInfo
+    data["__nvmlDeviceGetBridgeChipInfo"] = <_cyb_intptr_t>__nvmlDeviceGetBridgeChipInfo
 
     global __nvmlDeviceGetComputeRunningProcesses_v3
-    data["__nvmlDeviceGetComputeRunningProcesses_v3"] = <intptr_t>__nvmlDeviceGetComputeRunningProcesses_v3
+    data["__nvmlDeviceGetComputeRunningProcesses_v3"] = <_cyb_intptr_t>__nvmlDeviceGetComputeRunningProcesses_v3
 
     global __nvmlDeviceGetGraphicsRunningProcesses_v3
-    data["__nvmlDeviceGetGraphicsRunningProcesses_v3"] = <intptr_t>__nvmlDeviceGetGraphicsRunningProcesses_v3
+    data["__nvmlDeviceGetGraphicsRunningProcesses_v3"] = <_cyb_intptr_t>__nvmlDeviceGetGraphicsRunningProcesses_v3
 
     global __nvmlDeviceGetMPSComputeRunningProcesses_v3
-    data["__nvmlDeviceGetMPSComputeRunningProcesses_v3"] = <intptr_t>__nvmlDeviceGetMPSComputeRunningProcesses_v3
+    data["__nvmlDeviceGetMPSComputeRunningProcesses_v3"] = <_cyb_intptr_t>__nvmlDeviceGetMPSComputeRunningProcesses_v3
 
     global __nvmlDeviceGetRunningProcessDetailList
-    data["__nvmlDeviceGetRunningProcessDetailList"] = <intptr_t>__nvmlDeviceGetRunningProcessDetailList
+    data["__nvmlDeviceGetRunningProcessDetailList"] = <_cyb_intptr_t>__nvmlDeviceGetRunningProcessDetailList
 
     global __nvmlDeviceOnSameBoard
-    data["__nvmlDeviceOnSameBoard"] = <intptr_t>__nvmlDeviceOnSameBoard
+    data["__nvmlDeviceOnSameBoard"] = <_cyb_intptr_t>__nvmlDeviceOnSameBoard
 
     global __nvmlDeviceGetAPIRestriction
-    data["__nvmlDeviceGetAPIRestriction"] = <intptr_t>__nvmlDeviceGetAPIRestriction
+    data["__nvmlDeviceGetAPIRestriction"] = <_cyb_intptr_t>__nvmlDeviceGetAPIRestriction
 
     global __nvmlDeviceGetSamples
-    data["__nvmlDeviceGetSamples"] = <intptr_t>__nvmlDeviceGetSamples
+    data["__nvmlDeviceGetSamples"] = <_cyb_intptr_t>__nvmlDeviceGetSamples
 
     global __nvmlDeviceGetBAR1MemoryInfo
-    data["__nvmlDeviceGetBAR1MemoryInfo"] = <intptr_t>__nvmlDeviceGetBAR1MemoryInfo
+    data["__nvmlDeviceGetBAR1MemoryInfo"] = <_cyb_intptr_t>__nvmlDeviceGetBAR1MemoryInfo
 
     global __nvmlDeviceGetIrqNum
-    data["__nvmlDeviceGetIrqNum"] = <intptr_t>__nvmlDeviceGetIrqNum
+    data["__nvmlDeviceGetIrqNum"] = <_cyb_intptr_t>__nvmlDeviceGetIrqNum
 
     global __nvmlDeviceGetNumGpuCores
-    data["__nvmlDeviceGetNumGpuCores"] = <intptr_t>__nvmlDeviceGetNumGpuCores
+    data["__nvmlDeviceGetNumGpuCores"] = <_cyb_intptr_t>__nvmlDeviceGetNumGpuCores
 
     global __nvmlDeviceGetPowerSource
-    data["__nvmlDeviceGetPowerSource"] = <intptr_t>__nvmlDeviceGetPowerSource
+    data["__nvmlDeviceGetPowerSource"] = <_cyb_intptr_t>__nvmlDeviceGetPowerSource
 
     global __nvmlDeviceGetMemoryBusWidth
-    data["__nvmlDeviceGetMemoryBusWidth"] = <intptr_t>__nvmlDeviceGetMemoryBusWidth
+    data["__nvmlDeviceGetMemoryBusWidth"] = <_cyb_intptr_t>__nvmlDeviceGetMemoryBusWidth
 
     global __nvmlDeviceGetPcieLinkMaxSpeed
-    data["__nvmlDeviceGetPcieLinkMaxSpeed"] = <intptr_t>__nvmlDeviceGetPcieLinkMaxSpeed
+    data["__nvmlDeviceGetPcieLinkMaxSpeed"] = <_cyb_intptr_t>__nvmlDeviceGetPcieLinkMaxSpeed
 
     global __nvmlDeviceGetPcieSpeed
-    data["__nvmlDeviceGetPcieSpeed"] = <intptr_t>__nvmlDeviceGetPcieSpeed
+    data["__nvmlDeviceGetPcieSpeed"] = <_cyb_intptr_t>__nvmlDeviceGetPcieSpeed
 
     global __nvmlDeviceGetAdaptiveClockInfoStatus
-    data["__nvmlDeviceGetAdaptiveClockInfoStatus"] = <intptr_t>__nvmlDeviceGetAdaptiveClockInfoStatus
+    data["__nvmlDeviceGetAdaptiveClockInfoStatus"] = <_cyb_intptr_t>__nvmlDeviceGetAdaptiveClockInfoStatus
 
     global __nvmlDeviceGetBusType
-    data["__nvmlDeviceGetBusType"] = <intptr_t>__nvmlDeviceGetBusType
+    data["__nvmlDeviceGetBusType"] = <_cyb_intptr_t>__nvmlDeviceGetBusType
 
     global __nvmlDeviceGetGpuFabricInfoV
-    data["__nvmlDeviceGetGpuFabricInfoV"] = <intptr_t>__nvmlDeviceGetGpuFabricInfoV
+    data["__nvmlDeviceGetGpuFabricInfoV"] = <_cyb_intptr_t>__nvmlDeviceGetGpuFabricInfoV
 
     global __nvmlSystemGetConfComputeCapabilities
-    data["__nvmlSystemGetConfComputeCapabilities"] = <intptr_t>__nvmlSystemGetConfComputeCapabilities
+    data["__nvmlSystemGetConfComputeCapabilities"] = <_cyb_intptr_t>__nvmlSystemGetConfComputeCapabilities
 
     global __nvmlSystemGetConfComputeState
-    data["__nvmlSystemGetConfComputeState"] = <intptr_t>__nvmlSystemGetConfComputeState
+    data["__nvmlSystemGetConfComputeState"] = <_cyb_intptr_t>__nvmlSystemGetConfComputeState
 
     global __nvmlDeviceGetConfComputeMemSizeInfo
-    data["__nvmlDeviceGetConfComputeMemSizeInfo"] = <intptr_t>__nvmlDeviceGetConfComputeMemSizeInfo
+    data["__nvmlDeviceGetConfComputeMemSizeInfo"] = <_cyb_intptr_t>__nvmlDeviceGetConfComputeMemSizeInfo
 
     global __nvmlSystemGetConfComputeGpusReadyState
-    data["__nvmlSystemGetConfComputeGpusReadyState"] = <intptr_t>__nvmlSystemGetConfComputeGpusReadyState
+    data["__nvmlSystemGetConfComputeGpusReadyState"] = <_cyb_intptr_t>__nvmlSystemGetConfComputeGpusReadyState
 
     global __nvmlDeviceGetConfComputeProtectedMemoryUsage
-    data["__nvmlDeviceGetConfComputeProtectedMemoryUsage"] = <intptr_t>__nvmlDeviceGetConfComputeProtectedMemoryUsage
+    data["__nvmlDeviceGetConfComputeProtectedMemoryUsage"] = <_cyb_intptr_t>__nvmlDeviceGetConfComputeProtectedMemoryUsage
 
     global __nvmlDeviceGetConfComputeGpuCertificate
-    data["__nvmlDeviceGetConfComputeGpuCertificate"] = <intptr_t>__nvmlDeviceGetConfComputeGpuCertificate
+    data["__nvmlDeviceGetConfComputeGpuCertificate"] = <_cyb_intptr_t>__nvmlDeviceGetConfComputeGpuCertificate
 
     global __nvmlDeviceGetConfComputeGpuAttestationReport
-    data["__nvmlDeviceGetConfComputeGpuAttestationReport"] = <intptr_t>__nvmlDeviceGetConfComputeGpuAttestationReport
+    data["__nvmlDeviceGetConfComputeGpuAttestationReport"] = <_cyb_intptr_t>__nvmlDeviceGetConfComputeGpuAttestationReport
 
     global __nvmlSystemGetConfComputeKeyRotationThresholdInfo
-    data["__nvmlSystemGetConfComputeKeyRotationThresholdInfo"] = <intptr_t>__nvmlSystemGetConfComputeKeyRotationThresholdInfo
+    data["__nvmlSystemGetConfComputeKeyRotationThresholdInfo"] = <_cyb_intptr_t>__nvmlSystemGetConfComputeKeyRotationThresholdInfo
 
     global __nvmlDeviceSetConfComputeUnprotectedMemSize
-    data["__nvmlDeviceSetConfComputeUnprotectedMemSize"] = <intptr_t>__nvmlDeviceSetConfComputeUnprotectedMemSize
+    data["__nvmlDeviceSetConfComputeUnprotectedMemSize"] = <_cyb_intptr_t>__nvmlDeviceSetConfComputeUnprotectedMemSize
 
     global __nvmlSystemSetConfComputeGpusReadyState
-    data["__nvmlSystemSetConfComputeGpusReadyState"] = <intptr_t>__nvmlSystemSetConfComputeGpusReadyState
+    data["__nvmlSystemSetConfComputeGpusReadyState"] = <_cyb_intptr_t>__nvmlSystemSetConfComputeGpusReadyState
 
     global __nvmlSystemSetConfComputeKeyRotationThresholdInfo
-    data["__nvmlSystemSetConfComputeKeyRotationThresholdInfo"] = <intptr_t>__nvmlSystemSetConfComputeKeyRotationThresholdInfo
+    data["__nvmlSystemSetConfComputeKeyRotationThresholdInfo"] = <_cyb_intptr_t>__nvmlSystemSetConfComputeKeyRotationThresholdInfo
 
     global __nvmlSystemGetConfComputeSettings
-    data["__nvmlSystemGetConfComputeSettings"] = <intptr_t>__nvmlSystemGetConfComputeSettings
+    data["__nvmlSystemGetConfComputeSettings"] = <_cyb_intptr_t>__nvmlSystemGetConfComputeSettings
 
     global __nvmlDeviceGetGspFirmwareVersion
-    data["__nvmlDeviceGetGspFirmwareVersion"] = <intptr_t>__nvmlDeviceGetGspFirmwareVersion
+    data["__nvmlDeviceGetGspFirmwareVersion"] = <_cyb_intptr_t>__nvmlDeviceGetGspFirmwareVersion
 
     global __nvmlDeviceGetGspFirmwareMode
-    data["__nvmlDeviceGetGspFirmwareMode"] = <intptr_t>__nvmlDeviceGetGspFirmwareMode
+    data["__nvmlDeviceGetGspFirmwareMode"] = <_cyb_intptr_t>__nvmlDeviceGetGspFirmwareMode
 
     global __nvmlDeviceGetSramEccErrorStatus
-    data["__nvmlDeviceGetSramEccErrorStatus"] = <intptr_t>__nvmlDeviceGetSramEccErrorStatus
+    data["__nvmlDeviceGetSramEccErrorStatus"] = <_cyb_intptr_t>__nvmlDeviceGetSramEccErrorStatus
 
     global __nvmlDeviceGetAccountingMode
-    data["__nvmlDeviceGetAccountingMode"] = <intptr_t>__nvmlDeviceGetAccountingMode
+    data["__nvmlDeviceGetAccountingMode"] = <_cyb_intptr_t>__nvmlDeviceGetAccountingMode
 
     global __nvmlDeviceGetAccountingStats
-    data["__nvmlDeviceGetAccountingStats"] = <intptr_t>__nvmlDeviceGetAccountingStats
+    data["__nvmlDeviceGetAccountingStats"] = <_cyb_intptr_t>__nvmlDeviceGetAccountingStats
 
     global __nvmlDeviceGetAccountingPids
-    data["__nvmlDeviceGetAccountingPids"] = <intptr_t>__nvmlDeviceGetAccountingPids
+    data["__nvmlDeviceGetAccountingPids"] = <_cyb_intptr_t>__nvmlDeviceGetAccountingPids
 
     global __nvmlDeviceGetAccountingBufferSize
-    data["__nvmlDeviceGetAccountingBufferSize"] = <intptr_t>__nvmlDeviceGetAccountingBufferSize
+    data["__nvmlDeviceGetAccountingBufferSize"] = <_cyb_intptr_t>__nvmlDeviceGetAccountingBufferSize
 
     global __nvmlDeviceGetRetiredPages
-    data["__nvmlDeviceGetRetiredPages"] = <intptr_t>__nvmlDeviceGetRetiredPages
+    data["__nvmlDeviceGetRetiredPages"] = <_cyb_intptr_t>__nvmlDeviceGetRetiredPages
 
     global __nvmlDeviceGetRetiredPages_v2
-    data["__nvmlDeviceGetRetiredPages_v2"] = <intptr_t>__nvmlDeviceGetRetiredPages_v2
+    data["__nvmlDeviceGetRetiredPages_v2"] = <_cyb_intptr_t>__nvmlDeviceGetRetiredPages_v2
 
     global __nvmlDeviceGetRetiredPagesPendingStatus
-    data["__nvmlDeviceGetRetiredPagesPendingStatus"] = <intptr_t>__nvmlDeviceGetRetiredPagesPendingStatus
+    data["__nvmlDeviceGetRetiredPagesPendingStatus"] = <_cyb_intptr_t>__nvmlDeviceGetRetiredPagesPendingStatus
 
     global __nvmlDeviceGetRemappedRows
-    data["__nvmlDeviceGetRemappedRows"] = <intptr_t>__nvmlDeviceGetRemappedRows
+    data["__nvmlDeviceGetRemappedRows"] = <_cyb_intptr_t>__nvmlDeviceGetRemappedRows
 
     global __nvmlDeviceGetRowRemapperHistogram
-    data["__nvmlDeviceGetRowRemapperHistogram"] = <intptr_t>__nvmlDeviceGetRowRemapperHistogram
+    data["__nvmlDeviceGetRowRemapperHistogram"] = <_cyb_intptr_t>__nvmlDeviceGetRowRemapperHistogram
 
     global __nvmlDeviceGetArchitecture
-    data["__nvmlDeviceGetArchitecture"] = <intptr_t>__nvmlDeviceGetArchitecture
+    data["__nvmlDeviceGetArchitecture"] = <_cyb_intptr_t>__nvmlDeviceGetArchitecture
 
     global __nvmlDeviceGetClkMonStatus
-    data["__nvmlDeviceGetClkMonStatus"] = <intptr_t>__nvmlDeviceGetClkMonStatus
+    data["__nvmlDeviceGetClkMonStatus"] = <_cyb_intptr_t>__nvmlDeviceGetClkMonStatus
 
     global __nvmlDeviceGetProcessUtilization
-    data["__nvmlDeviceGetProcessUtilization"] = <intptr_t>__nvmlDeviceGetProcessUtilization
+    data["__nvmlDeviceGetProcessUtilization"] = <_cyb_intptr_t>__nvmlDeviceGetProcessUtilization
 
     global __nvmlDeviceGetProcessesUtilizationInfo
-    data["__nvmlDeviceGetProcessesUtilizationInfo"] = <intptr_t>__nvmlDeviceGetProcessesUtilizationInfo
+    data["__nvmlDeviceGetProcessesUtilizationInfo"] = <_cyb_intptr_t>__nvmlDeviceGetProcessesUtilizationInfo
 
     global __nvmlDeviceGetPlatformInfo
-    data["__nvmlDeviceGetPlatformInfo"] = <intptr_t>__nvmlDeviceGetPlatformInfo
+    data["__nvmlDeviceGetPlatformInfo"] = <_cyb_intptr_t>__nvmlDeviceGetPlatformInfo
 
     global __nvmlUnitSetLedState
-    data["__nvmlUnitSetLedState"] = <intptr_t>__nvmlUnitSetLedState
+    data["__nvmlUnitSetLedState"] = <_cyb_intptr_t>__nvmlUnitSetLedState
 
     global __nvmlDeviceSetPersistenceMode
-    data["__nvmlDeviceSetPersistenceMode"] = <intptr_t>__nvmlDeviceSetPersistenceMode
+    data["__nvmlDeviceSetPersistenceMode"] = <_cyb_intptr_t>__nvmlDeviceSetPersistenceMode
 
     global __nvmlDeviceSetComputeMode
-    data["__nvmlDeviceSetComputeMode"] = <intptr_t>__nvmlDeviceSetComputeMode
+    data["__nvmlDeviceSetComputeMode"] = <_cyb_intptr_t>__nvmlDeviceSetComputeMode
 
     global __nvmlDeviceSetEccMode
-    data["__nvmlDeviceSetEccMode"] = <intptr_t>__nvmlDeviceSetEccMode
+    data["__nvmlDeviceSetEccMode"] = <_cyb_intptr_t>__nvmlDeviceSetEccMode
 
     global __nvmlDeviceClearEccErrorCounts
-    data["__nvmlDeviceClearEccErrorCounts"] = <intptr_t>__nvmlDeviceClearEccErrorCounts
+    data["__nvmlDeviceClearEccErrorCounts"] = <_cyb_intptr_t>__nvmlDeviceClearEccErrorCounts
 
     global __nvmlDeviceSetDriverModel
-    data["__nvmlDeviceSetDriverModel"] = <intptr_t>__nvmlDeviceSetDriverModel
+    data["__nvmlDeviceSetDriverModel"] = <_cyb_intptr_t>__nvmlDeviceSetDriverModel
 
     global __nvmlDeviceSetGpuLockedClocks
-    data["__nvmlDeviceSetGpuLockedClocks"] = <intptr_t>__nvmlDeviceSetGpuLockedClocks
+    data["__nvmlDeviceSetGpuLockedClocks"] = <_cyb_intptr_t>__nvmlDeviceSetGpuLockedClocks
 
     global __nvmlDeviceResetGpuLockedClocks
-    data["__nvmlDeviceResetGpuLockedClocks"] = <intptr_t>__nvmlDeviceResetGpuLockedClocks
+    data["__nvmlDeviceResetGpuLockedClocks"] = <_cyb_intptr_t>__nvmlDeviceResetGpuLockedClocks
 
     global __nvmlDeviceSetMemoryLockedClocks
-    data["__nvmlDeviceSetMemoryLockedClocks"] = <intptr_t>__nvmlDeviceSetMemoryLockedClocks
+    data["__nvmlDeviceSetMemoryLockedClocks"] = <_cyb_intptr_t>__nvmlDeviceSetMemoryLockedClocks
 
     global __nvmlDeviceResetMemoryLockedClocks
-    data["__nvmlDeviceResetMemoryLockedClocks"] = <intptr_t>__nvmlDeviceResetMemoryLockedClocks
+    data["__nvmlDeviceResetMemoryLockedClocks"] = <_cyb_intptr_t>__nvmlDeviceResetMemoryLockedClocks
 
     global __nvmlDeviceSetAutoBoostedClocksEnabled
-    data["__nvmlDeviceSetAutoBoostedClocksEnabled"] = <intptr_t>__nvmlDeviceSetAutoBoostedClocksEnabled
+    data["__nvmlDeviceSetAutoBoostedClocksEnabled"] = <_cyb_intptr_t>__nvmlDeviceSetAutoBoostedClocksEnabled
 
     global __nvmlDeviceSetDefaultAutoBoostedClocksEnabled
-    data["__nvmlDeviceSetDefaultAutoBoostedClocksEnabled"] = <intptr_t>__nvmlDeviceSetDefaultAutoBoostedClocksEnabled
+    data["__nvmlDeviceSetDefaultAutoBoostedClocksEnabled"] = <_cyb_intptr_t>__nvmlDeviceSetDefaultAutoBoostedClocksEnabled
 
     global __nvmlDeviceSetDefaultFanSpeed_v2
-    data["__nvmlDeviceSetDefaultFanSpeed_v2"] = <intptr_t>__nvmlDeviceSetDefaultFanSpeed_v2
+    data["__nvmlDeviceSetDefaultFanSpeed_v2"] = <_cyb_intptr_t>__nvmlDeviceSetDefaultFanSpeed_v2
 
     global __nvmlDeviceSetFanControlPolicy
-    data["__nvmlDeviceSetFanControlPolicy"] = <intptr_t>__nvmlDeviceSetFanControlPolicy
+    data["__nvmlDeviceSetFanControlPolicy"] = <_cyb_intptr_t>__nvmlDeviceSetFanControlPolicy
 
     global __nvmlDeviceSetTemperatureThreshold
-    data["__nvmlDeviceSetTemperatureThreshold"] = <intptr_t>__nvmlDeviceSetTemperatureThreshold
+    data["__nvmlDeviceSetTemperatureThreshold"] = <_cyb_intptr_t>__nvmlDeviceSetTemperatureThreshold
 
     global __nvmlDeviceSetGpuOperationMode
-    data["__nvmlDeviceSetGpuOperationMode"] = <intptr_t>__nvmlDeviceSetGpuOperationMode
+    data["__nvmlDeviceSetGpuOperationMode"] = <_cyb_intptr_t>__nvmlDeviceSetGpuOperationMode
 
     global __nvmlDeviceSetAPIRestriction
-    data["__nvmlDeviceSetAPIRestriction"] = <intptr_t>__nvmlDeviceSetAPIRestriction
+    data["__nvmlDeviceSetAPIRestriction"] = <_cyb_intptr_t>__nvmlDeviceSetAPIRestriction
 
     global __nvmlDeviceSetFanSpeed_v2
-    data["__nvmlDeviceSetFanSpeed_v2"] = <intptr_t>__nvmlDeviceSetFanSpeed_v2
+    data["__nvmlDeviceSetFanSpeed_v2"] = <_cyb_intptr_t>__nvmlDeviceSetFanSpeed_v2
 
     global __nvmlDeviceSetAccountingMode
-    data["__nvmlDeviceSetAccountingMode"] = <intptr_t>__nvmlDeviceSetAccountingMode
+    data["__nvmlDeviceSetAccountingMode"] = <_cyb_intptr_t>__nvmlDeviceSetAccountingMode
 
     global __nvmlDeviceClearAccountingPids
-    data["__nvmlDeviceClearAccountingPids"] = <intptr_t>__nvmlDeviceClearAccountingPids
+    data["__nvmlDeviceClearAccountingPids"] = <_cyb_intptr_t>__nvmlDeviceClearAccountingPids
 
     global __nvmlDeviceSetPowerManagementLimit_v2
-    data["__nvmlDeviceSetPowerManagementLimit_v2"] = <intptr_t>__nvmlDeviceSetPowerManagementLimit_v2
+    data["__nvmlDeviceSetPowerManagementLimit_v2"] = <_cyb_intptr_t>__nvmlDeviceSetPowerManagementLimit_v2
 
     global __nvmlDeviceGetNvLinkState
-    data["__nvmlDeviceGetNvLinkState"] = <intptr_t>__nvmlDeviceGetNvLinkState
+    data["__nvmlDeviceGetNvLinkState"] = <_cyb_intptr_t>__nvmlDeviceGetNvLinkState
 
     global __nvmlDeviceGetNvLinkVersion
-    data["__nvmlDeviceGetNvLinkVersion"] = <intptr_t>__nvmlDeviceGetNvLinkVersion
+    data["__nvmlDeviceGetNvLinkVersion"] = <_cyb_intptr_t>__nvmlDeviceGetNvLinkVersion
 
     global __nvmlDeviceGetNvLinkCapability
-    data["__nvmlDeviceGetNvLinkCapability"] = <intptr_t>__nvmlDeviceGetNvLinkCapability
+    data["__nvmlDeviceGetNvLinkCapability"] = <_cyb_intptr_t>__nvmlDeviceGetNvLinkCapability
 
     global __nvmlDeviceGetNvLinkRemotePciInfo_v2
-    data["__nvmlDeviceGetNvLinkRemotePciInfo_v2"] = <intptr_t>__nvmlDeviceGetNvLinkRemotePciInfo_v2
+    data["__nvmlDeviceGetNvLinkRemotePciInfo_v2"] = <_cyb_intptr_t>__nvmlDeviceGetNvLinkRemotePciInfo_v2
 
     global __nvmlDeviceGetNvLinkErrorCounter
-    data["__nvmlDeviceGetNvLinkErrorCounter"] = <intptr_t>__nvmlDeviceGetNvLinkErrorCounter
+    data["__nvmlDeviceGetNvLinkErrorCounter"] = <_cyb_intptr_t>__nvmlDeviceGetNvLinkErrorCounter
 
     global __nvmlDeviceResetNvLinkErrorCounters
-    data["__nvmlDeviceResetNvLinkErrorCounters"] = <intptr_t>__nvmlDeviceResetNvLinkErrorCounters
+    data["__nvmlDeviceResetNvLinkErrorCounters"] = <_cyb_intptr_t>__nvmlDeviceResetNvLinkErrorCounters
 
     global __nvmlDeviceGetNvLinkRemoteDeviceType
-    data["__nvmlDeviceGetNvLinkRemoteDeviceType"] = <intptr_t>__nvmlDeviceGetNvLinkRemoteDeviceType
+    data["__nvmlDeviceGetNvLinkRemoteDeviceType"] = <_cyb_intptr_t>__nvmlDeviceGetNvLinkRemoteDeviceType
 
     global __nvmlDeviceSetNvLinkDeviceLowPowerThreshold
-    data["__nvmlDeviceSetNvLinkDeviceLowPowerThreshold"] = <intptr_t>__nvmlDeviceSetNvLinkDeviceLowPowerThreshold
+    data["__nvmlDeviceSetNvLinkDeviceLowPowerThreshold"] = <_cyb_intptr_t>__nvmlDeviceSetNvLinkDeviceLowPowerThreshold
 
     global __nvmlSystemSetNvlinkBwMode
-    data["__nvmlSystemSetNvlinkBwMode"] = <intptr_t>__nvmlSystemSetNvlinkBwMode
+    data["__nvmlSystemSetNvlinkBwMode"] = <_cyb_intptr_t>__nvmlSystemSetNvlinkBwMode
 
     global __nvmlSystemGetNvlinkBwMode
-    data["__nvmlSystemGetNvlinkBwMode"] = <intptr_t>__nvmlSystemGetNvlinkBwMode
+    data["__nvmlSystemGetNvlinkBwMode"] = <_cyb_intptr_t>__nvmlSystemGetNvlinkBwMode
 
     global __nvmlDeviceGetNvlinkSupportedBwModes
-    data["__nvmlDeviceGetNvlinkSupportedBwModes"] = <intptr_t>__nvmlDeviceGetNvlinkSupportedBwModes
+    data["__nvmlDeviceGetNvlinkSupportedBwModes"] = <_cyb_intptr_t>__nvmlDeviceGetNvlinkSupportedBwModes
 
     global __nvmlDeviceGetNvlinkBwMode
-    data["__nvmlDeviceGetNvlinkBwMode"] = <intptr_t>__nvmlDeviceGetNvlinkBwMode
+    data["__nvmlDeviceGetNvlinkBwMode"] = <_cyb_intptr_t>__nvmlDeviceGetNvlinkBwMode
 
     global __nvmlDeviceSetNvlinkBwMode
-    data["__nvmlDeviceSetNvlinkBwMode"] = <intptr_t>__nvmlDeviceSetNvlinkBwMode
+    data["__nvmlDeviceSetNvlinkBwMode"] = <_cyb_intptr_t>__nvmlDeviceSetNvlinkBwMode
 
     global __nvmlEventSetCreate
-    data["__nvmlEventSetCreate"] = <intptr_t>__nvmlEventSetCreate
+    data["__nvmlEventSetCreate"] = <_cyb_intptr_t>__nvmlEventSetCreate
 
     global __nvmlDeviceRegisterEvents
-    data["__nvmlDeviceRegisterEvents"] = <intptr_t>__nvmlDeviceRegisterEvents
+    data["__nvmlDeviceRegisterEvents"] = <_cyb_intptr_t>__nvmlDeviceRegisterEvents
 
     global __nvmlDeviceGetSupportedEventTypes
-    data["__nvmlDeviceGetSupportedEventTypes"] = <intptr_t>__nvmlDeviceGetSupportedEventTypes
+    data["__nvmlDeviceGetSupportedEventTypes"] = <_cyb_intptr_t>__nvmlDeviceGetSupportedEventTypes
 
     global __nvmlEventSetWait_v2
-    data["__nvmlEventSetWait_v2"] = <intptr_t>__nvmlEventSetWait_v2
+    data["__nvmlEventSetWait_v2"] = <_cyb_intptr_t>__nvmlEventSetWait_v2
 
     global __nvmlEventSetFree
-    data["__nvmlEventSetFree"] = <intptr_t>__nvmlEventSetFree
+    data["__nvmlEventSetFree"] = <_cyb_intptr_t>__nvmlEventSetFree
 
     global __nvmlSystemEventSetCreate
-    data["__nvmlSystemEventSetCreate"] = <intptr_t>__nvmlSystemEventSetCreate
+    data["__nvmlSystemEventSetCreate"] = <_cyb_intptr_t>__nvmlSystemEventSetCreate
 
     global __nvmlSystemEventSetFree
-    data["__nvmlSystemEventSetFree"] = <intptr_t>__nvmlSystemEventSetFree
+    data["__nvmlSystemEventSetFree"] = <_cyb_intptr_t>__nvmlSystemEventSetFree
 
     global __nvmlSystemRegisterEvents
-    data["__nvmlSystemRegisterEvents"] = <intptr_t>__nvmlSystemRegisterEvents
+    data["__nvmlSystemRegisterEvents"] = <_cyb_intptr_t>__nvmlSystemRegisterEvents
 
     global __nvmlSystemEventSetWait
-    data["__nvmlSystemEventSetWait"] = <intptr_t>__nvmlSystemEventSetWait
+    data["__nvmlSystemEventSetWait"] = <_cyb_intptr_t>__nvmlSystemEventSetWait
 
     global __nvmlDeviceModifyDrainState
-    data["__nvmlDeviceModifyDrainState"] = <intptr_t>__nvmlDeviceModifyDrainState
+    data["__nvmlDeviceModifyDrainState"] = <_cyb_intptr_t>__nvmlDeviceModifyDrainState
 
     global __nvmlDeviceQueryDrainState
-    data["__nvmlDeviceQueryDrainState"] = <intptr_t>__nvmlDeviceQueryDrainState
+    data["__nvmlDeviceQueryDrainState"] = <_cyb_intptr_t>__nvmlDeviceQueryDrainState
 
     global __nvmlDeviceRemoveGpu_v2
-    data["__nvmlDeviceRemoveGpu_v2"] = <intptr_t>__nvmlDeviceRemoveGpu_v2
+    data["__nvmlDeviceRemoveGpu_v2"] = <_cyb_intptr_t>__nvmlDeviceRemoveGpu_v2
 
     global __nvmlDeviceDiscoverGpus
-    data["__nvmlDeviceDiscoverGpus"] = <intptr_t>__nvmlDeviceDiscoverGpus
+    data["__nvmlDeviceDiscoverGpus"] = <_cyb_intptr_t>__nvmlDeviceDiscoverGpus
 
     global __nvmlDeviceGetFieldValues
-    data["__nvmlDeviceGetFieldValues"] = <intptr_t>__nvmlDeviceGetFieldValues
+    data["__nvmlDeviceGetFieldValues"] = <_cyb_intptr_t>__nvmlDeviceGetFieldValues
 
     global __nvmlDeviceClearFieldValues
-    data["__nvmlDeviceClearFieldValues"] = <intptr_t>__nvmlDeviceClearFieldValues
+    data["__nvmlDeviceClearFieldValues"] = <_cyb_intptr_t>__nvmlDeviceClearFieldValues
 
     global __nvmlDeviceGetVirtualizationMode
-    data["__nvmlDeviceGetVirtualizationMode"] = <intptr_t>__nvmlDeviceGetVirtualizationMode
+    data["__nvmlDeviceGetVirtualizationMode"] = <_cyb_intptr_t>__nvmlDeviceGetVirtualizationMode
 
     global __nvmlDeviceGetHostVgpuMode
-    data["__nvmlDeviceGetHostVgpuMode"] = <intptr_t>__nvmlDeviceGetHostVgpuMode
+    data["__nvmlDeviceGetHostVgpuMode"] = <_cyb_intptr_t>__nvmlDeviceGetHostVgpuMode
 
     global __nvmlDeviceSetVirtualizationMode
-    data["__nvmlDeviceSetVirtualizationMode"] = <intptr_t>__nvmlDeviceSetVirtualizationMode
+    data["__nvmlDeviceSetVirtualizationMode"] = <_cyb_intptr_t>__nvmlDeviceSetVirtualizationMode
 
     global __nvmlDeviceGetVgpuHeterogeneousMode
-    data["__nvmlDeviceGetVgpuHeterogeneousMode"] = <intptr_t>__nvmlDeviceGetVgpuHeterogeneousMode
+    data["__nvmlDeviceGetVgpuHeterogeneousMode"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuHeterogeneousMode
 
     global __nvmlDeviceSetVgpuHeterogeneousMode
-    data["__nvmlDeviceSetVgpuHeterogeneousMode"] = <intptr_t>__nvmlDeviceSetVgpuHeterogeneousMode
+    data["__nvmlDeviceSetVgpuHeterogeneousMode"] = <_cyb_intptr_t>__nvmlDeviceSetVgpuHeterogeneousMode
 
     global __nvmlVgpuInstanceGetPlacementId
-    data["__nvmlVgpuInstanceGetPlacementId"] = <intptr_t>__nvmlVgpuInstanceGetPlacementId
+    data["__nvmlVgpuInstanceGetPlacementId"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetPlacementId
 
     global __nvmlDeviceGetVgpuTypeSupportedPlacements
-    data["__nvmlDeviceGetVgpuTypeSupportedPlacements"] = <intptr_t>__nvmlDeviceGetVgpuTypeSupportedPlacements
+    data["__nvmlDeviceGetVgpuTypeSupportedPlacements"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuTypeSupportedPlacements
 
     global __nvmlDeviceGetVgpuTypeCreatablePlacements
-    data["__nvmlDeviceGetVgpuTypeCreatablePlacements"] = <intptr_t>__nvmlDeviceGetVgpuTypeCreatablePlacements
+    data["__nvmlDeviceGetVgpuTypeCreatablePlacements"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuTypeCreatablePlacements
 
     global __nvmlVgpuTypeGetGspHeapSize
-    data["__nvmlVgpuTypeGetGspHeapSize"] = <intptr_t>__nvmlVgpuTypeGetGspHeapSize
+    data["__nvmlVgpuTypeGetGspHeapSize"] = <_cyb_intptr_t>__nvmlVgpuTypeGetGspHeapSize
 
     global __nvmlVgpuTypeGetFbReservation
-    data["__nvmlVgpuTypeGetFbReservation"] = <intptr_t>__nvmlVgpuTypeGetFbReservation
+    data["__nvmlVgpuTypeGetFbReservation"] = <_cyb_intptr_t>__nvmlVgpuTypeGetFbReservation
 
     global __nvmlVgpuInstanceGetRuntimeStateSize
-    data["__nvmlVgpuInstanceGetRuntimeStateSize"] = <intptr_t>__nvmlVgpuInstanceGetRuntimeStateSize
+    data["__nvmlVgpuInstanceGetRuntimeStateSize"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetRuntimeStateSize
 
     global __nvmlDeviceSetVgpuCapabilities
-    data["__nvmlDeviceSetVgpuCapabilities"] = <intptr_t>__nvmlDeviceSetVgpuCapabilities
+    data["__nvmlDeviceSetVgpuCapabilities"] = <_cyb_intptr_t>__nvmlDeviceSetVgpuCapabilities
 
     global __nvmlDeviceGetGridLicensableFeatures_v4
-    data["__nvmlDeviceGetGridLicensableFeatures_v4"] = <intptr_t>__nvmlDeviceGetGridLicensableFeatures_v4
+    data["__nvmlDeviceGetGridLicensableFeatures_v4"] = <_cyb_intptr_t>__nvmlDeviceGetGridLicensableFeatures_v4
 
     global __nvmlGetVgpuDriverCapabilities
-    data["__nvmlGetVgpuDriverCapabilities"] = <intptr_t>__nvmlGetVgpuDriverCapabilities
+    data["__nvmlGetVgpuDriverCapabilities"] = <_cyb_intptr_t>__nvmlGetVgpuDriverCapabilities
 
     global __nvmlDeviceGetVgpuCapabilities
-    data["__nvmlDeviceGetVgpuCapabilities"] = <intptr_t>__nvmlDeviceGetVgpuCapabilities
+    data["__nvmlDeviceGetVgpuCapabilities"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuCapabilities
 
     global __nvmlDeviceGetSupportedVgpus
-    data["__nvmlDeviceGetSupportedVgpus"] = <intptr_t>__nvmlDeviceGetSupportedVgpus
+    data["__nvmlDeviceGetSupportedVgpus"] = <_cyb_intptr_t>__nvmlDeviceGetSupportedVgpus
 
     global __nvmlDeviceGetCreatableVgpus
-    data["__nvmlDeviceGetCreatableVgpus"] = <intptr_t>__nvmlDeviceGetCreatableVgpus
+    data["__nvmlDeviceGetCreatableVgpus"] = <_cyb_intptr_t>__nvmlDeviceGetCreatableVgpus
 
     global __nvmlVgpuTypeGetClass
-    data["__nvmlVgpuTypeGetClass"] = <intptr_t>__nvmlVgpuTypeGetClass
+    data["__nvmlVgpuTypeGetClass"] = <_cyb_intptr_t>__nvmlVgpuTypeGetClass
 
     global __nvmlVgpuTypeGetName
-    data["__nvmlVgpuTypeGetName"] = <intptr_t>__nvmlVgpuTypeGetName
+    data["__nvmlVgpuTypeGetName"] = <_cyb_intptr_t>__nvmlVgpuTypeGetName
 
     global __nvmlVgpuTypeGetGpuInstanceProfileId
-    data["__nvmlVgpuTypeGetGpuInstanceProfileId"] = <intptr_t>__nvmlVgpuTypeGetGpuInstanceProfileId
+    data["__nvmlVgpuTypeGetGpuInstanceProfileId"] = <_cyb_intptr_t>__nvmlVgpuTypeGetGpuInstanceProfileId
 
     global __nvmlVgpuTypeGetDeviceID
-    data["__nvmlVgpuTypeGetDeviceID"] = <intptr_t>__nvmlVgpuTypeGetDeviceID
+    data["__nvmlVgpuTypeGetDeviceID"] = <_cyb_intptr_t>__nvmlVgpuTypeGetDeviceID
 
     global __nvmlVgpuTypeGetFramebufferSize
-    data["__nvmlVgpuTypeGetFramebufferSize"] = <intptr_t>__nvmlVgpuTypeGetFramebufferSize
+    data["__nvmlVgpuTypeGetFramebufferSize"] = <_cyb_intptr_t>__nvmlVgpuTypeGetFramebufferSize
 
     global __nvmlVgpuTypeGetNumDisplayHeads
-    data["__nvmlVgpuTypeGetNumDisplayHeads"] = <intptr_t>__nvmlVgpuTypeGetNumDisplayHeads
+    data["__nvmlVgpuTypeGetNumDisplayHeads"] = <_cyb_intptr_t>__nvmlVgpuTypeGetNumDisplayHeads
 
     global __nvmlVgpuTypeGetResolution
-    data["__nvmlVgpuTypeGetResolution"] = <intptr_t>__nvmlVgpuTypeGetResolution
+    data["__nvmlVgpuTypeGetResolution"] = <_cyb_intptr_t>__nvmlVgpuTypeGetResolution
 
     global __nvmlVgpuTypeGetLicense
-    data["__nvmlVgpuTypeGetLicense"] = <intptr_t>__nvmlVgpuTypeGetLicense
+    data["__nvmlVgpuTypeGetLicense"] = <_cyb_intptr_t>__nvmlVgpuTypeGetLicense
 
     global __nvmlVgpuTypeGetFrameRateLimit
-    data["__nvmlVgpuTypeGetFrameRateLimit"] = <intptr_t>__nvmlVgpuTypeGetFrameRateLimit
+    data["__nvmlVgpuTypeGetFrameRateLimit"] = <_cyb_intptr_t>__nvmlVgpuTypeGetFrameRateLimit
 
     global __nvmlVgpuTypeGetMaxInstances
-    data["__nvmlVgpuTypeGetMaxInstances"] = <intptr_t>__nvmlVgpuTypeGetMaxInstances
+    data["__nvmlVgpuTypeGetMaxInstances"] = <_cyb_intptr_t>__nvmlVgpuTypeGetMaxInstances
 
     global __nvmlVgpuTypeGetMaxInstancesPerVm
-    data["__nvmlVgpuTypeGetMaxInstancesPerVm"] = <intptr_t>__nvmlVgpuTypeGetMaxInstancesPerVm
+    data["__nvmlVgpuTypeGetMaxInstancesPerVm"] = <_cyb_intptr_t>__nvmlVgpuTypeGetMaxInstancesPerVm
 
     global __nvmlVgpuTypeGetBAR1Info
-    data["__nvmlVgpuTypeGetBAR1Info"] = <intptr_t>__nvmlVgpuTypeGetBAR1Info
+    data["__nvmlVgpuTypeGetBAR1Info"] = <_cyb_intptr_t>__nvmlVgpuTypeGetBAR1Info
 
     global __nvmlDeviceGetActiveVgpus
-    data["__nvmlDeviceGetActiveVgpus"] = <intptr_t>__nvmlDeviceGetActiveVgpus
+    data["__nvmlDeviceGetActiveVgpus"] = <_cyb_intptr_t>__nvmlDeviceGetActiveVgpus
 
     global __nvmlVgpuInstanceGetVmID
-    data["__nvmlVgpuInstanceGetVmID"] = <intptr_t>__nvmlVgpuInstanceGetVmID
+    data["__nvmlVgpuInstanceGetVmID"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetVmID
 
     global __nvmlVgpuInstanceGetUUID
-    data["__nvmlVgpuInstanceGetUUID"] = <intptr_t>__nvmlVgpuInstanceGetUUID
+    data["__nvmlVgpuInstanceGetUUID"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetUUID
 
     global __nvmlVgpuInstanceGetVmDriverVersion
-    data["__nvmlVgpuInstanceGetVmDriverVersion"] = <intptr_t>__nvmlVgpuInstanceGetVmDriverVersion
+    data["__nvmlVgpuInstanceGetVmDriverVersion"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetVmDriverVersion
 
     global __nvmlVgpuInstanceGetFbUsage
-    data["__nvmlVgpuInstanceGetFbUsage"] = <intptr_t>__nvmlVgpuInstanceGetFbUsage
+    data["__nvmlVgpuInstanceGetFbUsage"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetFbUsage
 
     global __nvmlVgpuInstanceGetLicenseStatus
-    data["__nvmlVgpuInstanceGetLicenseStatus"] = <intptr_t>__nvmlVgpuInstanceGetLicenseStatus
+    data["__nvmlVgpuInstanceGetLicenseStatus"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetLicenseStatus
 
     global __nvmlVgpuInstanceGetType
-    data["__nvmlVgpuInstanceGetType"] = <intptr_t>__nvmlVgpuInstanceGetType
+    data["__nvmlVgpuInstanceGetType"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetType
 
     global __nvmlVgpuInstanceGetFrameRateLimit
-    data["__nvmlVgpuInstanceGetFrameRateLimit"] = <intptr_t>__nvmlVgpuInstanceGetFrameRateLimit
+    data["__nvmlVgpuInstanceGetFrameRateLimit"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetFrameRateLimit
 
     global __nvmlVgpuInstanceGetEccMode
-    data["__nvmlVgpuInstanceGetEccMode"] = <intptr_t>__nvmlVgpuInstanceGetEccMode
+    data["__nvmlVgpuInstanceGetEccMode"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetEccMode
 
     global __nvmlVgpuInstanceGetEncoderCapacity
-    data["__nvmlVgpuInstanceGetEncoderCapacity"] = <intptr_t>__nvmlVgpuInstanceGetEncoderCapacity
+    data["__nvmlVgpuInstanceGetEncoderCapacity"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetEncoderCapacity
 
     global __nvmlVgpuInstanceSetEncoderCapacity
-    data["__nvmlVgpuInstanceSetEncoderCapacity"] = <intptr_t>__nvmlVgpuInstanceSetEncoderCapacity
+    data["__nvmlVgpuInstanceSetEncoderCapacity"] = <_cyb_intptr_t>__nvmlVgpuInstanceSetEncoderCapacity
 
     global __nvmlVgpuInstanceGetEncoderStats
-    data["__nvmlVgpuInstanceGetEncoderStats"] = <intptr_t>__nvmlVgpuInstanceGetEncoderStats
+    data["__nvmlVgpuInstanceGetEncoderStats"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetEncoderStats
 
     global __nvmlVgpuInstanceGetEncoderSessions
-    data["__nvmlVgpuInstanceGetEncoderSessions"] = <intptr_t>__nvmlVgpuInstanceGetEncoderSessions
+    data["__nvmlVgpuInstanceGetEncoderSessions"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetEncoderSessions
 
     global __nvmlVgpuInstanceGetFBCStats
-    data["__nvmlVgpuInstanceGetFBCStats"] = <intptr_t>__nvmlVgpuInstanceGetFBCStats
+    data["__nvmlVgpuInstanceGetFBCStats"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetFBCStats
 
     global __nvmlVgpuInstanceGetFBCSessions
-    data["__nvmlVgpuInstanceGetFBCSessions"] = <intptr_t>__nvmlVgpuInstanceGetFBCSessions
+    data["__nvmlVgpuInstanceGetFBCSessions"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetFBCSessions
 
     global __nvmlVgpuInstanceGetGpuInstanceId
-    data["__nvmlVgpuInstanceGetGpuInstanceId"] = <intptr_t>__nvmlVgpuInstanceGetGpuInstanceId
+    data["__nvmlVgpuInstanceGetGpuInstanceId"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetGpuInstanceId
 
     global __nvmlVgpuInstanceGetGpuPciId
-    data["__nvmlVgpuInstanceGetGpuPciId"] = <intptr_t>__nvmlVgpuInstanceGetGpuPciId
+    data["__nvmlVgpuInstanceGetGpuPciId"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetGpuPciId
 
     global __nvmlVgpuTypeGetCapabilities
-    data["__nvmlVgpuTypeGetCapabilities"] = <intptr_t>__nvmlVgpuTypeGetCapabilities
+    data["__nvmlVgpuTypeGetCapabilities"] = <_cyb_intptr_t>__nvmlVgpuTypeGetCapabilities
 
     global __nvmlVgpuInstanceGetMdevUUID
-    data["__nvmlVgpuInstanceGetMdevUUID"] = <intptr_t>__nvmlVgpuInstanceGetMdevUUID
+    data["__nvmlVgpuInstanceGetMdevUUID"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetMdevUUID
 
     global __nvmlGpuInstanceGetCreatableVgpus
-    data["__nvmlGpuInstanceGetCreatableVgpus"] = <intptr_t>__nvmlGpuInstanceGetCreatableVgpus
+    data["__nvmlGpuInstanceGetCreatableVgpus"] = <_cyb_intptr_t>__nvmlGpuInstanceGetCreatableVgpus
 
     global __nvmlVgpuTypeGetMaxInstancesPerGpuInstance
-    data["__nvmlVgpuTypeGetMaxInstancesPerGpuInstance"] = <intptr_t>__nvmlVgpuTypeGetMaxInstancesPerGpuInstance
+    data["__nvmlVgpuTypeGetMaxInstancesPerGpuInstance"] = <_cyb_intptr_t>__nvmlVgpuTypeGetMaxInstancesPerGpuInstance
 
     global __nvmlGpuInstanceGetActiveVgpus
-    data["__nvmlGpuInstanceGetActiveVgpus"] = <intptr_t>__nvmlGpuInstanceGetActiveVgpus
+    data["__nvmlGpuInstanceGetActiveVgpus"] = <_cyb_intptr_t>__nvmlGpuInstanceGetActiveVgpus
 
     global __nvmlGpuInstanceSetVgpuSchedulerState
-    data["__nvmlGpuInstanceSetVgpuSchedulerState"] = <intptr_t>__nvmlGpuInstanceSetVgpuSchedulerState
+    data["__nvmlGpuInstanceSetVgpuSchedulerState"] = <_cyb_intptr_t>__nvmlGpuInstanceSetVgpuSchedulerState
 
     global __nvmlGpuInstanceGetVgpuSchedulerState
-    data["__nvmlGpuInstanceGetVgpuSchedulerState"] = <intptr_t>__nvmlGpuInstanceGetVgpuSchedulerState
+    data["__nvmlGpuInstanceGetVgpuSchedulerState"] = <_cyb_intptr_t>__nvmlGpuInstanceGetVgpuSchedulerState
 
     global __nvmlGpuInstanceGetVgpuSchedulerLog
-    data["__nvmlGpuInstanceGetVgpuSchedulerLog"] = <intptr_t>__nvmlGpuInstanceGetVgpuSchedulerLog
+    data["__nvmlGpuInstanceGetVgpuSchedulerLog"] = <_cyb_intptr_t>__nvmlGpuInstanceGetVgpuSchedulerLog
 
     global __nvmlGpuInstanceGetVgpuTypeCreatablePlacements
-    data["__nvmlGpuInstanceGetVgpuTypeCreatablePlacements"] = <intptr_t>__nvmlGpuInstanceGetVgpuTypeCreatablePlacements
+    data["__nvmlGpuInstanceGetVgpuTypeCreatablePlacements"] = <_cyb_intptr_t>__nvmlGpuInstanceGetVgpuTypeCreatablePlacements
 
     global __nvmlGpuInstanceGetVgpuHeterogeneousMode
-    data["__nvmlGpuInstanceGetVgpuHeterogeneousMode"] = <intptr_t>__nvmlGpuInstanceGetVgpuHeterogeneousMode
+    data["__nvmlGpuInstanceGetVgpuHeterogeneousMode"] = <_cyb_intptr_t>__nvmlGpuInstanceGetVgpuHeterogeneousMode
 
     global __nvmlGpuInstanceSetVgpuHeterogeneousMode
-    data["__nvmlGpuInstanceSetVgpuHeterogeneousMode"] = <intptr_t>__nvmlGpuInstanceSetVgpuHeterogeneousMode
+    data["__nvmlGpuInstanceSetVgpuHeterogeneousMode"] = <_cyb_intptr_t>__nvmlGpuInstanceSetVgpuHeterogeneousMode
 
     global __nvmlVgpuInstanceGetMetadata
-    data["__nvmlVgpuInstanceGetMetadata"] = <intptr_t>__nvmlVgpuInstanceGetMetadata
+    data["__nvmlVgpuInstanceGetMetadata"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetMetadata
 
     global __nvmlDeviceGetVgpuMetadata
-    data["__nvmlDeviceGetVgpuMetadata"] = <intptr_t>__nvmlDeviceGetVgpuMetadata
+    data["__nvmlDeviceGetVgpuMetadata"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuMetadata
 
     global __nvmlGetVgpuCompatibility
-    data["__nvmlGetVgpuCompatibility"] = <intptr_t>__nvmlGetVgpuCompatibility
+    data["__nvmlGetVgpuCompatibility"] = <_cyb_intptr_t>__nvmlGetVgpuCompatibility
 
     global __nvmlDeviceGetPgpuMetadataString
-    data["__nvmlDeviceGetPgpuMetadataString"] = <intptr_t>__nvmlDeviceGetPgpuMetadataString
+    data["__nvmlDeviceGetPgpuMetadataString"] = <_cyb_intptr_t>__nvmlDeviceGetPgpuMetadataString
 
     global __nvmlDeviceGetVgpuSchedulerLog
-    data["__nvmlDeviceGetVgpuSchedulerLog"] = <intptr_t>__nvmlDeviceGetVgpuSchedulerLog
+    data["__nvmlDeviceGetVgpuSchedulerLog"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuSchedulerLog
 
     global __nvmlDeviceGetVgpuSchedulerState
-    data["__nvmlDeviceGetVgpuSchedulerState"] = <intptr_t>__nvmlDeviceGetVgpuSchedulerState
+    data["__nvmlDeviceGetVgpuSchedulerState"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuSchedulerState
 
     global __nvmlDeviceGetVgpuSchedulerCapabilities
-    data["__nvmlDeviceGetVgpuSchedulerCapabilities"] = <intptr_t>__nvmlDeviceGetVgpuSchedulerCapabilities
+    data["__nvmlDeviceGetVgpuSchedulerCapabilities"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuSchedulerCapabilities
 
     global __nvmlDeviceSetVgpuSchedulerState
-    data["__nvmlDeviceSetVgpuSchedulerState"] = <intptr_t>__nvmlDeviceSetVgpuSchedulerState
+    data["__nvmlDeviceSetVgpuSchedulerState"] = <_cyb_intptr_t>__nvmlDeviceSetVgpuSchedulerState
 
     global __nvmlGetVgpuVersion
-    data["__nvmlGetVgpuVersion"] = <intptr_t>__nvmlGetVgpuVersion
+    data["__nvmlGetVgpuVersion"] = <_cyb_intptr_t>__nvmlGetVgpuVersion
 
     global __nvmlSetVgpuVersion
-    data["__nvmlSetVgpuVersion"] = <intptr_t>__nvmlSetVgpuVersion
+    data["__nvmlSetVgpuVersion"] = <_cyb_intptr_t>__nvmlSetVgpuVersion
 
     global __nvmlDeviceGetVgpuUtilization
-    data["__nvmlDeviceGetVgpuUtilization"] = <intptr_t>__nvmlDeviceGetVgpuUtilization
+    data["__nvmlDeviceGetVgpuUtilization"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuUtilization
 
     global __nvmlDeviceGetVgpuInstancesUtilizationInfo
-    data["__nvmlDeviceGetVgpuInstancesUtilizationInfo"] = <intptr_t>__nvmlDeviceGetVgpuInstancesUtilizationInfo
+    data["__nvmlDeviceGetVgpuInstancesUtilizationInfo"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuInstancesUtilizationInfo
 
     global __nvmlDeviceGetVgpuProcessUtilization
-    data["__nvmlDeviceGetVgpuProcessUtilization"] = <intptr_t>__nvmlDeviceGetVgpuProcessUtilization
+    data["__nvmlDeviceGetVgpuProcessUtilization"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuProcessUtilization
 
     global __nvmlDeviceGetVgpuProcessesUtilizationInfo
-    data["__nvmlDeviceGetVgpuProcessesUtilizationInfo"] = <intptr_t>__nvmlDeviceGetVgpuProcessesUtilizationInfo
+    data["__nvmlDeviceGetVgpuProcessesUtilizationInfo"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuProcessesUtilizationInfo
 
     global __nvmlVgpuInstanceGetAccountingMode
-    data["__nvmlVgpuInstanceGetAccountingMode"] = <intptr_t>__nvmlVgpuInstanceGetAccountingMode
+    data["__nvmlVgpuInstanceGetAccountingMode"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetAccountingMode
 
     global __nvmlVgpuInstanceGetAccountingPids
-    data["__nvmlVgpuInstanceGetAccountingPids"] = <intptr_t>__nvmlVgpuInstanceGetAccountingPids
+    data["__nvmlVgpuInstanceGetAccountingPids"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetAccountingPids
 
     global __nvmlVgpuInstanceGetAccountingStats
-    data["__nvmlVgpuInstanceGetAccountingStats"] = <intptr_t>__nvmlVgpuInstanceGetAccountingStats
+    data["__nvmlVgpuInstanceGetAccountingStats"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetAccountingStats
 
     global __nvmlVgpuInstanceClearAccountingPids
-    data["__nvmlVgpuInstanceClearAccountingPids"] = <intptr_t>__nvmlVgpuInstanceClearAccountingPids
+    data["__nvmlVgpuInstanceClearAccountingPids"] = <_cyb_intptr_t>__nvmlVgpuInstanceClearAccountingPids
 
     global __nvmlVgpuInstanceGetLicenseInfo_v2
-    data["__nvmlVgpuInstanceGetLicenseInfo_v2"] = <intptr_t>__nvmlVgpuInstanceGetLicenseInfo_v2
+    data["__nvmlVgpuInstanceGetLicenseInfo_v2"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetLicenseInfo_v2
 
     global __nvmlGetExcludedDeviceCount
-    data["__nvmlGetExcludedDeviceCount"] = <intptr_t>__nvmlGetExcludedDeviceCount
+    data["__nvmlGetExcludedDeviceCount"] = <_cyb_intptr_t>__nvmlGetExcludedDeviceCount
 
     global __nvmlGetExcludedDeviceInfoByIndex
-    data["__nvmlGetExcludedDeviceInfoByIndex"] = <intptr_t>__nvmlGetExcludedDeviceInfoByIndex
+    data["__nvmlGetExcludedDeviceInfoByIndex"] = <_cyb_intptr_t>__nvmlGetExcludedDeviceInfoByIndex
 
     global __nvmlDeviceSetMigMode
-    data["__nvmlDeviceSetMigMode"] = <intptr_t>__nvmlDeviceSetMigMode
+    data["__nvmlDeviceSetMigMode"] = <_cyb_intptr_t>__nvmlDeviceSetMigMode
 
     global __nvmlDeviceGetMigMode
-    data["__nvmlDeviceGetMigMode"] = <intptr_t>__nvmlDeviceGetMigMode
+    data["__nvmlDeviceGetMigMode"] = <_cyb_intptr_t>__nvmlDeviceGetMigMode
 
     global __nvmlDeviceGetGpuInstanceProfileInfoV
-    data["__nvmlDeviceGetGpuInstanceProfileInfoV"] = <intptr_t>__nvmlDeviceGetGpuInstanceProfileInfoV
+    data["__nvmlDeviceGetGpuInstanceProfileInfoV"] = <_cyb_intptr_t>__nvmlDeviceGetGpuInstanceProfileInfoV
 
     global __nvmlDeviceGetGpuInstancePossiblePlacements_v2
-    data["__nvmlDeviceGetGpuInstancePossiblePlacements_v2"] = <intptr_t>__nvmlDeviceGetGpuInstancePossiblePlacements_v2
+    data["__nvmlDeviceGetGpuInstancePossiblePlacements_v2"] = <_cyb_intptr_t>__nvmlDeviceGetGpuInstancePossiblePlacements_v2
 
     global __nvmlDeviceGetGpuInstanceRemainingCapacity
-    data["__nvmlDeviceGetGpuInstanceRemainingCapacity"] = <intptr_t>__nvmlDeviceGetGpuInstanceRemainingCapacity
+    data["__nvmlDeviceGetGpuInstanceRemainingCapacity"] = <_cyb_intptr_t>__nvmlDeviceGetGpuInstanceRemainingCapacity
 
     global __nvmlDeviceCreateGpuInstance
-    data["__nvmlDeviceCreateGpuInstance"] = <intptr_t>__nvmlDeviceCreateGpuInstance
+    data["__nvmlDeviceCreateGpuInstance"] = <_cyb_intptr_t>__nvmlDeviceCreateGpuInstance
 
     global __nvmlDeviceCreateGpuInstanceWithPlacement
-    data["__nvmlDeviceCreateGpuInstanceWithPlacement"] = <intptr_t>__nvmlDeviceCreateGpuInstanceWithPlacement
+    data["__nvmlDeviceCreateGpuInstanceWithPlacement"] = <_cyb_intptr_t>__nvmlDeviceCreateGpuInstanceWithPlacement
 
     global __nvmlGpuInstanceDestroy
-    data["__nvmlGpuInstanceDestroy"] = <intptr_t>__nvmlGpuInstanceDestroy
+    data["__nvmlGpuInstanceDestroy"] = <_cyb_intptr_t>__nvmlGpuInstanceDestroy
 
     global __nvmlDeviceGetGpuInstances
-    data["__nvmlDeviceGetGpuInstances"] = <intptr_t>__nvmlDeviceGetGpuInstances
+    data["__nvmlDeviceGetGpuInstances"] = <_cyb_intptr_t>__nvmlDeviceGetGpuInstances
 
     global __nvmlDeviceGetGpuInstanceById
-    data["__nvmlDeviceGetGpuInstanceById"] = <intptr_t>__nvmlDeviceGetGpuInstanceById
+    data["__nvmlDeviceGetGpuInstanceById"] = <_cyb_intptr_t>__nvmlDeviceGetGpuInstanceById
 
     global __nvmlGpuInstanceGetInfo
-    data["__nvmlGpuInstanceGetInfo"] = <intptr_t>__nvmlGpuInstanceGetInfo
+    data["__nvmlGpuInstanceGetInfo"] = <_cyb_intptr_t>__nvmlGpuInstanceGetInfo
 
     global __nvmlGpuInstanceGetComputeInstanceProfileInfoV
-    data["__nvmlGpuInstanceGetComputeInstanceProfileInfoV"] = <intptr_t>__nvmlGpuInstanceGetComputeInstanceProfileInfoV
+    data["__nvmlGpuInstanceGetComputeInstanceProfileInfoV"] = <_cyb_intptr_t>__nvmlGpuInstanceGetComputeInstanceProfileInfoV
 
     global __nvmlGpuInstanceGetComputeInstanceRemainingCapacity
-    data["__nvmlGpuInstanceGetComputeInstanceRemainingCapacity"] = <intptr_t>__nvmlGpuInstanceGetComputeInstanceRemainingCapacity
+    data["__nvmlGpuInstanceGetComputeInstanceRemainingCapacity"] = <_cyb_intptr_t>__nvmlGpuInstanceGetComputeInstanceRemainingCapacity
 
     global __nvmlGpuInstanceGetComputeInstancePossiblePlacements
-    data["__nvmlGpuInstanceGetComputeInstancePossiblePlacements"] = <intptr_t>__nvmlGpuInstanceGetComputeInstancePossiblePlacements
+    data["__nvmlGpuInstanceGetComputeInstancePossiblePlacements"] = <_cyb_intptr_t>__nvmlGpuInstanceGetComputeInstancePossiblePlacements
 
     global __nvmlGpuInstanceCreateComputeInstance
-    data["__nvmlGpuInstanceCreateComputeInstance"] = <intptr_t>__nvmlGpuInstanceCreateComputeInstance
+    data["__nvmlGpuInstanceCreateComputeInstance"] = <_cyb_intptr_t>__nvmlGpuInstanceCreateComputeInstance
 
     global __nvmlGpuInstanceCreateComputeInstanceWithPlacement
-    data["__nvmlGpuInstanceCreateComputeInstanceWithPlacement"] = <intptr_t>__nvmlGpuInstanceCreateComputeInstanceWithPlacement
+    data["__nvmlGpuInstanceCreateComputeInstanceWithPlacement"] = <_cyb_intptr_t>__nvmlGpuInstanceCreateComputeInstanceWithPlacement
 
     global __nvmlComputeInstanceDestroy
-    data["__nvmlComputeInstanceDestroy"] = <intptr_t>__nvmlComputeInstanceDestroy
+    data["__nvmlComputeInstanceDestroy"] = <_cyb_intptr_t>__nvmlComputeInstanceDestroy
 
     global __nvmlGpuInstanceGetComputeInstances
-    data["__nvmlGpuInstanceGetComputeInstances"] = <intptr_t>__nvmlGpuInstanceGetComputeInstances
+    data["__nvmlGpuInstanceGetComputeInstances"] = <_cyb_intptr_t>__nvmlGpuInstanceGetComputeInstances
 
     global __nvmlGpuInstanceGetComputeInstanceById
-    data["__nvmlGpuInstanceGetComputeInstanceById"] = <intptr_t>__nvmlGpuInstanceGetComputeInstanceById
+    data["__nvmlGpuInstanceGetComputeInstanceById"] = <_cyb_intptr_t>__nvmlGpuInstanceGetComputeInstanceById
 
     global __nvmlComputeInstanceGetInfo_v2
-    data["__nvmlComputeInstanceGetInfo_v2"] = <intptr_t>__nvmlComputeInstanceGetInfo_v2
+    data["__nvmlComputeInstanceGetInfo_v2"] = <_cyb_intptr_t>__nvmlComputeInstanceGetInfo_v2
 
     global __nvmlDeviceIsMigDeviceHandle
-    data["__nvmlDeviceIsMigDeviceHandle"] = <intptr_t>__nvmlDeviceIsMigDeviceHandle
+    data["__nvmlDeviceIsMigDeviceHandle"] = <_cyb_intptr_t>__nvmlDeviceIsMigDeviceHandle
 
     global __nvmlDeviceGetGpuInstanceId
-    data["__nvmlDeviceGetGpuInstanceId"] = <intptr_t>__nvmlDeviceGetGpuInstanceId
+    data["__nvmlDeviceGetGpuInstanceId"] = <_cyb_intptr_t>__nvmlDeviceGetGpuInstanceId
 
     global __nvmlDeviceGetComputeInstanceId
-    data["__nvmlDeviceGetComputeInstanceId"] = <intptr_t>__nvmlDeviceGetComputeInstanceId
+    data["__nvmlDeviceGetComputeInstanceId"] = <_cyb_intptr_t>__nvmlDeviceGetComputeInstanceId
 
     global __nvmlDeviceGetMaxMigDeviceCount
-    data["__nvmlDeviceGetMaxMigDeviceCount"] = <intptr_t>__nvmlDeviceGetMaxMigDeviceCount
+    data["__nvmlDeviceGetMaxMigDeviceCount"] = <_cyb_intptr_t>__nvmlDeviceGetMaxMigDeviceCount
 
     global __nvmlDeviceGetMigDeviceHandleByIndex
-    data["__nvmlDeviceGetMigDeviceHandleByIndex"] = <intptr_t>__nvmlDeviceGetMigDeviceHandleByIndex
+    data["__nvmlDeviceGetMigDeviceHandleByIndex"] = <_cyb_intptr_t>__nvmlDeviceGetMigDeviceHandleByIndex
 
     global __nvmlDeviceGetDeviceHandleFromMigDeviceHandle
-    data["__nvmlDeviceGetDeviceHandleFromMigDeviceHandle"] = <intptr_t>__nvmlDeviceGetDeviceHandleFromMigDeviceHandle
+    data["__nvmlDeviceGetDeviceHandleFromMigDeviceHandle"] = <_cyb_intptr_t>__nvmlDeviceGetDeviceHandleFromMigDeviceHandle
 
     global __nvmlDeviceGetCapabilities
-    data["__nvmlDeviceGetCapabilities"] = <intptr_t>__nvmlDeviceGetCapabilities
+    data["__nvmlDeviceGetCapabilities"] = <_cyb_intptr_t>__nvmlDeviceGetCapabilities
 
     global __nvmlDevicePowerSmoothingActivatePresetProfile
-    data["__nvmlDevicePowerSmoothingActivatePresetProfile"] = <intptr_t>__nvmlDevicePowerSmoothingActivatePresetProfile
+    data["__nvmlDevicePowerSmoothingActivatePresetProfile"] = <_cyb_intptr_t>__nvmlDevicePowerSmoothingActivatePresetProfile
 
     global __nvmlDevicePowerSmoothingUpdatePresetProfileParam
-    data["__nvmlDevicePowerSmoothingUpdatePresetProfileParam"] = <intptr_t>__nvmlDevicePowerSmoothingUpdatePresetProfileParam
+    data["__nvmlDevicePowerSmoothingUpdatePresetProfileParam"] = <_cyb_intptr_t>__nvmlDevicePowerSmoothingUpdatePresetProfileParam
 
     global __nvmlDevicePowerSmoothingSetState
-    data["__nvmlDevicePowerSmoothingSetState"] = <intptr_t>__nvmlDevicePowerSmoothingSetState
+    data["__nvmlDevicePowerSmoothingSetState"] = <_cyb_intptr_t>__nvmlDevicePowerSmoothingSetState
 
     global __nvmlDeviceGetAddressingMode
-    data["__nvmlDeviceGetAddressingMode"] = <intptr_t>__nvmlDeviceGetAddressingMode
+    data["__nvmlDeviceGetAddressingMode"] = <_cyb_intptr_t>__nvmlDeviceGetAddressingMode
 
     global __nvmlDeviceGetRepairStatus
-    data["__nvmlDeviceGetRepairStatus"] = <intptr_t>__nvmlDeviceGetRepairStatus
+    data["__nvmlDeviceGetRepairStatus"] = <_cyb_intptr_t>__nvmlDeviceGetRepairStatus
 
     global __nvmlDeviceGetPowerMizerMode_v1
-    data["__nvmlDeviceGetPowerMizerMode_v1"] = <intptr_t>__nvmlDeviceGetPowerMizerMode_v1
+    data["__nvmlDeviceGetPowerMizerMode_v1"] = <_cyb_intptr_t>__nvmlDeviceGetPowerMizerMode_v1
 
     global __nvmlDeviceSetPowerMizerMode_v1
-    data["__nvmlDeviceSetPowerMizerMode_v1"] = <intptr_t>__nvmlDeviceSetPowerMizerMode_v1
+    data["__nvmlDeviceSetPowerMizerMode_v1"] = <_cyb_intptr_t>__nvmlDeviceSetPowerMizerMode_v1
 
     global __nvmlDeviceGetPdi
-    data["__nvmlDeviceGetPdi"] = <intptr_t>__nvmlDeviceGetPdi
+    data["__nvmlDeviceGetPdi"] = <_cyb_intptr_t>__nvmlDeviceGetPdi
 
     global __nvmlDeviceSetHostname_v1
-    data["__nvmlDeviceSetHostname_v1"] = <intptr_t>__nvmlDeviceSetHostname_v1
+    data["__nvmlDeviceSetHostname_v1"] = <_cyb_intptr_t>__nvmlDeviceSetHostname_v1
 
     global __nvmlDeviceGetHostname_v1
-    data["__nvmlDeviceGetHostname_v1"] = <intptr_t>__nvmlDeviceGetHostname_v1
+    data["__nvmlDeviceGetHostname_v1"] = <_cyb_intptr_t>__nvmlDeviceGetHostname_v1
 
     global __nvmlDeviceGetNvLinkInfo
-    data["__nvmlDeviceGetNvLinkInfo"] = <intptr_t>__nvmlDeviceGetNvLinkInfo
+    data["__nvmlDeviceGetNvLinkInfo"] = <_cyb_intptr_t>__nvmlDeviceGetNvLinkInfo
 
     global __nvmlDeviceReadWritePRM_v1
-    data["__nvmlDeviceReadWritePRM_v1"] = <intptr_t>__nvmlDeviceReadWritePRM_v1
+    data["__nvmlDeviceReadWritePRM_v1"] = <_cyb_intptr_t>__nvmlDeviceReadWritePRM_v1
 
     global __nvmlDeviceGetGpuInstanceProfileInfoByIdV
-    data["__nvmlDeviceGetGpuInstanceProfileInfoByIdV"] = <intptr_t>__nvmlDeviceGetGpuInstanceProfileInfoByIdV
+    data["__nvmlDeviceGetGpuInstanceProfileInfoByIdV"] = <_cyb_intptr_t>__nvmlDeviceGetGpuInstanceProfileInfoByIdV
 
     global __nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts
-    data["__nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts"] = <intptr_t>__nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts
+    data["__nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts"] = <_cyb_intptr_t>__nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts
 
     global __nvmlDeviceGetUnrepairableMemoryFlag_v1
-    data["__nvmlDeviceGetUnrepairableMemoryFlag_v1"] = <intptr_t>__nvmlDeviceGetUnrepairableMemoryFlag_v1
+    data["__nvmlDeviceGetUnrepairableMemoryFlag_v1"] = <_cyb_intptr_t>__nvmlDeviceGetUnrepairableMemoryFlag_v1
 
     global __nvmlDeviceReadPRMCounters_v1
-    data["__nvmlDeviceReadPRMCounters_v1"] = <intptr_t>__nvmlDeviceReadPRMCounters_v1
+    data["__nvmlDeviceReadPRMCounters_v1"] = <_cyb_intptr_t>__nvmlDeviceReadPRMCounters_v1
 
     global __nvmlDeviceSetRusdSettings_v1
-    data["__nvmlDeviceSetRusdSettings_v1"] = <intptr_t>__nvmlDeviceSetRusdSettings_v1
+    data["__nvmlDeviceSetRusdSettings_v1"] = <_cyb_intptr_t>__nvmlDeviceSetRusdSettings_v1
 
     global __nvmlDeviceVgpuForceGspUnload
-    data["__nvmlDeviceVgpuForceGspUnload"] = <intptr_t>__nvmlDeviceVgpuForceGspUnload
+    data["__nvmlDeviceVgpuForceGspUnload"] = <_cyb_intptr_t>__nvmlDeviceVgpuForceGspUnload
 
     global __nvmlDeviceGetVgpuSchedulerState_v2
-    data["__nvmlDeviceGetVgpuSchedulerState_v2"] = <intptr_t>__nvmlDeviceGetVgpuSchedulerState_v2
+    data["__nvmlDeviceGetVgpuSchedulerState_v2"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuSchedulerState_v2
 
     global __nvmlGpuInstanceGetVgpuSchedulerState_v2
-    data["__nvmlGpuInstanceGetVgpuSchedulerState_v2"] = <intptr_t>__nvmlGpuInstanceGetVgpuSchedulerState_v2
+    data["__nvmlGpuInstanceGetVgpuSchedulerState_v2"] = <_cyb_intptr_t>__nvmlGpuInstanceGetVgpuSchedulerState_v2
 
     global __nvmlDeviceGetVgpuSchedulerLog_v2
-    data["__nvmlDeviceGetVgpuSchedulerLog_v2"] = <intptr_t>__nvmlDeviceGetVgpuSchedulerLog_v2
+    data["__nvmlDeviceGetVgpuSchedulerLog_v2"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuSchedulerLog_v2
 
     global __nvmlGpuInstanceGetVgpuSchedulerLog_v2
-    data["__nvmlGpuInstanceGetVgpuSchedulerLog_v2"] = <intptr_t>__nvmlGpuInstanceGetVgpuSchedulerLog_v2
+    data["__nvmlGpuInstanceGetVgpuSchedulerLog_v2"] = <_cyb_intptr_t>__nvmlGpuInstanceGetVgpuSchedulerLog_v2
 
     global __nvmlDeviceSetVgpuSchedulerState_v2
-    data["__nvmlDeviceSetVgpuSchedulerState_v2"] = <intptr_t>__nvmlDeviceSetVgpuSchedulerState_v2
+    data["__nvmlDeviceSetVgpuSchedulerState_v2"] = <_cyb_intptr_t>__nvmlDeviceSetVgpuSchedulerState_v2
 
     global __nvmlGpuInstanceSetVgpuSchedulerState_v2
-    data["__nvmlGpuInstanceSetVgpuSchedulerState_v2"] = <intptr_t>__nvmlGpuInstanceSetVgpuSchedulerState_v2
-
-    func_ptrs = data
+    data["__nvmlGpuInstanceSetVgpuSchedulerState_v2"] = <_cyb_intptr_t>__nvmlGpuInstanceSetVgpuSchedulerState_v2
+    _cyb_func_ptrs = data
     return data
 
 
 cpdef _inspect_function_pointer(str name):
-    global func_ptrs
-    if func_ptrs is None:
-        func_ptrs = _inspect_function_pointers()
-    return func_ptrs[name]
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is None:
+        _cyb_func_ptrs = _inspect_function_pointers()
+    return _cyb_func_ptrs[name]
+
+
+
+
+cdef void* load_library() except* with gil:
+    cdef uintptr_t handle = load_nvidia_dynamic_lib("nvml")._handle_uint
+    return <void*>handle
 
 
 ###############################################################################

--- a/cuda_bindings/cuda/bindings/_internal/nvml_windows.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvml_windows.pyx
@@ -3,82 +3,31 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.9.1 to 13.3.0. Do not modify it directly.
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=71acdbf6d477ea00af29faeca397fad7352eec03aca08accffa76af57f2234f9
 
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=56d9b790c493aea94da4c2c52e78dea025da7c698edc614c374767038d40869c
-from libc.stdint cimport intptr_t
 
-import os
-import threading
+# <<<< PREAMBLE CONTENT >>>>
 
-from cuda.pathfinder import load_nvidia_dynamic_lib
-
-from .utils import FunctionNotFoundError, NotSupportedError
-
-from libc.stddef cimport wchar_t
-from libc.stdint cimport uintptr_t
-from cpython cimport PyUnicode_AsWideCharString, PyMem_Free
-
-# You must 'from .utils import NotSupportedError' before using this template
-
-cdef extern from "windows.h" nogil:
+cdef extern from "<windows.h>":
     ctypedef void* HMODULE
-    ctypedef void* HANDLE
-    ctypedef void* FARPROC
-    ctypedef unsigned long DWORD
-    ctypedef const wchar_t *LPCWSTR
-    ctypedef const char *LPCSTR
+    void* _cyb_GetProcAddress "GetProcAddress"(HMODULE, const char*) nogil
 
-    cdef DWORD LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800
-    cdef DWORD LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000
-    cdef DWORD LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR = 0x00000100
+from libc.stdint cimport intptr_t as _cyb_intptr_t
 
-    HMODULE _LoadLibraryExW "LoadLibraryExW"(
-        LPCWSTR lpLibFileName,
-        HANDLE hFile,
-        DWORD dwFlags
-    )
+import threading as _cyb_threading
 
-    FARPROC _GetProcAddress "GetProcAddress"(HMODULE hModule, LPCSTR lpProcName)
+cdef bint _cyb___py_nvml_init = False
+cdef dict _cyb_func_ptrs = None
+cdef object _cyb_symbol_lock = _cyb_threading.Lock()
 
-cdef inline uintptr_t LoadLibraryExW(str path, HANDLE hFile, DWORD dwFlags):
-    cdef uintptr_t result
-    cdef wchar_t* wpath = PyUnicode_AsWideCharString(path, NULL)
-    with nogil:
-        result = <uintptr_t>_LoadLibraryExW(
-            wpath,
-            hFile,
-            dwFlags
-        )
-    PyMem_Free(wpath)
-    return result
+# <<<< END OF PREAMBLE CONTENT >>>>
 
-cdef inline void *GetProcAddress(uintptr_t hModule, const char* lpProcName) nogil:
-    return _GetProcAddress(<HMODULE>hModule, lpProcName)
-
-cdef int get_cuda_version():
-    cdef int err, driver_ver = 0
-
-    # Load driver to check version
-    handle = LoadLibraryExW("nvcuda.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32)
-    if handle == 0:
-        raise NotSupportedError('CUDA driver is not found')
-    cuDriverGetVersion = GetProcAddress(handle, 'cuDriverGetVersion')
-    if cuDriverGetVersion == NULL:
-        raise RuntimeError('Did not find cuDriverGetVersion symbol in nvcuda.dll')
-    err = (<int (*)(int*) noexcept nogil>cuDriverGetVersion)(&driver_ver)
-    if err != 0:
-        raise RuntimeError(f'cuDriverGetVersion returned error code {err}')
-
-    return driver_ver
-
-
-
+from libc.stdint cimport uintptr_t
+from cuda.pathfinder import load_nvidia_dynamic_lib
+from .utils import FunctionNotFoundError, NotSupportedError
 ###############################################################################
 # Wrapper init
 ###############################################################################
-
-cdef object __symbol_lock = threading.Lock()
-cdef bint __py_nvml_init = False
 
 cdef void* __nvmlInit_v2 = NULL
 cdef void* __nvmlInitWithFlags = NULL
@@ -432,2158 +381,2152 @@ cdef void* __nvmlGpuInstanceGetVgpuSchedulerLog_v2 = NULL
 cdef void* __nvmlDeviceSetVgpuSchedulerState_v2 = NULL
 cdef void* __nvmlGpuInstanceSetVgpuSchedulerState_v2 = NULL
 
-
-cdef uintptr_t load_library() except* with gil:
-    return load_nvidia_dynamic_lib("nvml")._handle_uint
-
-
 cdef int _init_nvml() except -1 nogil:
-    global __py_nvml_init
+    global _cyb___py_nvml_init
 
-    cdef int err, driver_ver = 0
+    cdef int err
     cdef uintptr_t handle
+    with gil, _cyb_symbol_lock:
+        if _cyb___py_nvml_init: return 0
 
-    with gil, __symbol_lock:
         handle = load_library()
-
-        # Load function
         global __nvmlInit_v2
-        __nvmlInit_v2 = GetProcAddress(handle, 'nvmlInit_v2')
+        __nvmlInit_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlInit_v2')
 
         global __nvmlInitWithFlags
-        __nvmlInitWithFlags = GetProcAddress(handle, 'nvmlInitWithFlags')
+        __nvmlInitWithFlags = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlInitWithFlags')
 
         global __nvmlShutdown
-        __nvmlShutdown = GetProcAddress(handle, 'nvmlShutdown')
+        __nvmlShutdown = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlShutdown')
 
         global __nvmlErrorString
-        __nvmlErrorString = GetProcAddress(handle, 'nvmlErrorString')
+        __nvmlErrorString = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlErrorString')
 
         global __nvmlSystemGetDriverVersion
-        __nvmlSystemGetDriverVersion = GetProcAddress(handle, 'nvmlSystemGetDriverVersion')
+        __nvmlSystemGetDriverVersion = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemGetDriverVersion')
 
         global __nvmlSystemGetNVMLVersion
-        __nvmlSystemGetNVMLVersion = GetProcAddress(handle, 'nvmlSystemGetNVMLVersion')
+        __nvmlSystemGetNVMLVersion = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemGetNVMLVersion')
 
         global __nvmlSystemGetCudaDriverVersion
-        __nvmlSystemGetCudaDriverVersion = GetProcAddress(handle, 'nvmlSystemGetCudaDriverVersion')
+        __nvmlSystemGetCudaDriverVersion = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemGetCudaDriverVersion')
 
         global __nvmlSystemGetCudaDriverVersion_v2
-        __nvmlSystemGetCudaDriverVersion_v2 = GetProcAddress(handle, 'nvmlSystemGetCudaDriverVersion_v2')
+        __nvmlSystemGetCudaDriverVersion_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemGetCudaDriverVersion_v2')
 
         global __nvmlSystemGetProcessName
-        __nvmlSystemGetProcessName = GetProcAddress(handle, 'nvmlSystemGetProcessName')
+        __nvmlSystemGetProcessName = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemGetProcessName')
 
         global __nvmlSystemGetHicVersion
-        __nvmlSystemGetHicVersion = GetProcAddress(handle, 'nvmlSystemGetHicVersion')
+        __nvmlSystemGetHicVersion = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemGetHicVersion')
 
         global __nvmlSystemGetTopologyGpuSet
-        __nvmlSystemGetTopologyGpuSet = GetProcAddress(handle, 'nvmlSystemGetTopologyGpuSet')
+        __nvmlSystemGetTopologyGpuSet = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemGetTopologyGpuSet')
 
         global __nvmlSystemGetDriverBranch
-        __nvmlSystemGetDriverBranch = GetProcAddress(handle, 'nvmlSystemGetDriverBranch')
+        __nvmlSystemGetDriverBranch = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemGetDriverBranch')
 
         global __nvmlUnitGetCount
-        __nvmlUnitGetCount = GetProcAddress(handle, 'nvmlUnitGetCount')
+        __nvmlUnitGetCount = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlUnitGetCount')
 
         global __nvmlUnitGetHandleByIndex
-        __nvmlUnitGetHandleByIndex = GetProcAddress(handle, 'nvmlUnitGetHandleByIndex')
+        __nvmlUnitGetHandleByIndex = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlUnitGetHandleByIndex')
 
         global __nvmlUnitGetUnitInfo
-        __nvmlUnitGetUnitInfo = GetProcAddress(handle, 'nvmlUnitGetUnitInfo')
+        __nvmlUnitGetUnitInfo = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlUnitGetUnitInfo')
 
         global __nvmlUnitGetLedState
-        __nvmlUnitGetLedState = GetProcAddress(handle, 'nvmlUnitGetLedState')
+        __nvmlUnitGetLedState = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlUnitGetLedState')
 
         global __nvmlUnitGetPsuInfo
-        __nvmlUnitGetPsuInfo = GetProcAddress(handle, 'nvmlUnitGetPsuInfo')
+        __nvmlUnitGetPsuInfo = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlUnitGetPsuInfo')
 
         global __nvmlUnitGetTemperature
-        __nvmlUnitGetTemperature = GetProcAddress(handle, 'nvmlUnitGetTemperature')
+        __nvmlUnitGetTemperature = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlUnitGetTemperature')
 
         global __nvmlUnitGetFanSpeedInfo
-        __nvmlUnitGetFanSpeedInfo = GetProcAddress(handle, 'nvmlUnitGetFanSpeedInfo')
+        __nvmlUnitGetFanSpeedInfo = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlUnitGetFanSpeedInfo')
 
         global __nvmlUnitGetDevices
-        __nvmlUnitGetDevices = GetProcAddress(handle, 'nvmlUnitGetDevices')
+        __nvmlUnitGetDevices = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlUnitGetDevices')
 
         global __nvmlDeviceGetCount_v2
-        __nvmlDeviceGetCount_v2 = GetProcAddress(handle, 'nvmlDeviceGetCount_v2')
+        __nvmlDeviceGetCount_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetCount_v2')
 
         global __nvmlDeviceGetAttributes_v2
-        __nvmlDeviceGetAttributes_v2 = GetProcAddress(handle, 'nvmlDeviceGetAttributes_v2')
+        __nvmlDeviceGetAttributes_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetAttributes_v2')
 
         global __nvmlDeviceGetHandleByIndex_v2
-        __nvmlDeviceGetHandleByIndex_v2 = GetProcAddress(handle, 'nvmlDeviceGetHandleByIndex_v2')
+        __nvmlDeviceGetHandleByIndex_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetHandleByIndex_v2')
 
         global __nvmlDeviceGetHandleBySerial
-        __nvmlDeviceGetHandleBySerial = GetProcAddress(handle, 'nvmlDeviceGetHandleBySerial')
+        __nvmlDeviceGetHandleBySerial = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetHandleBySerial')
 
         global __nvmlDeviceGetHandleByUUID
-        __nvmlDeviceGetHandleByUUID = GetProcAddress(handle, 'nvmlDeviceGetHandleByUUID')
+        __nvmlDeviceGetHandleByUUID = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetHandleByUUID')
 
         global __nvmlDeviceGetHandleByUUIDV
-        __nvmlDeviceGetHandleByUUIDV = GetProcAddress(handle, 'nvmlDeviceGetHandleByUUIDV')
+        __nvmlDeviceGetHandleByUUIDV = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetHandleByUUIDV')
 
         global __nvmlDeviceGetHandleByPciBusId_v2
-        __nvmlDeviceGetHandleByPciBusId_v2 = GetProcAddress(handle, 'nvmlDeviceGetHandleByPciBusId_v2')
+        __nvmlDeviceGetHandleByPciBusId_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetHandleByPciBusId_v2')
 
         global __nvmlDeviceGetName
-        __nvmlDeviceGetName = GetProcAddress(handle, 'nvmlDeviceGetName')
+        __nvmlDeviceGetName = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetName')
 
         global __nvmlDeviceGetBrand
-        __nvmlDeviceGetBrand = GetProcAddress(handle, 'nvmlDeviceGetBrand')
+        __nvmlDeviceGetBrand = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetBrand')
 
         global __nvmlDeviceGetIndex
-        __nvmlDeviceGetIndex = GetProcAddress(handle, 'nvmlDeviceGetIndex')
+        __nvmlDeviceGetIndex = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetIndex')
 
         global __nvmlDeviceGetSerial
-        __nvmlDeviceGetSerial = GetProcAddress(handle, 'nvmlDeviceGetSerial')
+        __nvmlDeviceGetSerial = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetSerial')
 
         global __nvmlDeviceGetModuleId
-        __nvmlDeviceGetModuleId = GetProcAddress(handle, 'nvmlDeviceGetModuleId')
+        __nvmlDeviceGetModuleId = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetModuleId')
 
         global __nvmlDeviceGetC2cModeInfoV
-        __nvmlDeviceGetC2cModeInfoV = GetProcAddress(handle, 'nvmlDeviceGetC2cModeInfoV')
+        __nvmlDeviceGetC2cModeInfoV = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetC2cModeInfoV')
 
         global __nvmlDeviceGetMemoryAffinity
-        __nvmlDeviceGetMemoryAffinity = GetProcAddress(handle, 'nvmlDeviceGetMemoryAffinity')
+        __nvmlDeviceGetMemoryAffinity = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetMemoryAffinity')
 
         global __nvmlDeviceGetCpuAffinityWithinScope
-        __nvmlDeviceGetCpuAffinityWithinScope = GetProcAddress(handle, 'nvmlDeviceGetCpuAffinityWithinScope')
+        __nvmlDeviceGetCpuAffinityWithinScope = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetCpuAffinityWithinScope')
 
         global __nvmlDeviceGetCpuAffinity
-        __nvmlDeviceGetCpuAffinity = GetProcAddress(handle, 'nvmlDeviceGetCpuAffinity')
+        __nvmlDeviceGetCpuAffinity = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetCpuAffinity')
 
         global __nvmlDeviceSetCpuAffinity
-        __nvmlDeviceSetCpuAffinity = GetProcAddress(handle, 'nvmlDeviceSetCpuAffinity')
+        __nvmlDeviceSetCpuAffinity = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetCpuAffinity')
 
         global __nvmlDeviceClearCpuAffinity
-        __nvmlDeviceClearCpuAffinity = GetProcAddress(handle, 'nvmlDeviceClearCpuAffinity')
+        __nvmlDeviceClearCpuAffinity = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceClearCpuAffinity')
 
         global __nvmlDeviceGetNumaNodeId
-        __nvmlDeviceGetNumaNodeId = GetProcAddress(handle, 'nvmlDeviceGetNumaNodeId')
+        __nvmlDeviceGetNumaNodeId = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetNumaNodeId')
 
         global __nvmlDeviceGetTopologyCommonAncestor
-        __nvmlDeviceGetTopologyCommonAncestor = GetProcAddress(handle, 'nvmlDeviceGetTopologyCommonAncestor')
+        __nvmlDeviceGetTopologyCommonAncestor = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetTopologyCommonAncestor')
 
         global __nvmlDeviceGetTopologyNearestGpus
-        __nvmlDeviceGetTopologyNearestGpus = GetProcAddress(handle, 'nvmlDeviceGetTopologyNearestGpus')
+        __nvmlDeviceGetTopologyNearestGpus = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetTopologyNearestGpus')
 
         global __nvmlDeviceGetP2PStatus
-        __nvmlDeviceGetP2PStatus = GetProcAddress(handle, 'nvmlDeviceGetP2PStatus')
+        __nvmlDeviceGetP2PStatus = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetP2PStatus')
 
         global __nvmlDeviceGetUUID
-        __nvmlDeviceGetUUID = GetProcAddress(handle, 'nvmlDeviceGetUUID')
+        __nvmlDeviceGetUUID = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetUUID')
 
         global __nvmlDeviceGetMinorNumber
-        __nvmlDeviceGetMinorNumber = GetProcAddress(handle, 'nvmlDeviceGetMinorNumber')
+        __nvmlDeviceGetMinorNumber = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetMinorNumber')
 
         global __nvmlDeviceGetBoardPartNumber
-        __nvmlDeviceGetBoardPartNumber = GetProcAddress(handle, 'nvmlDeviceGetBoardPartNumber')
+        __nvmlDeviceGetBoardPartNumber = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetBoardPartNumber')
 
         global __nvmlDeviceGetInforomVersion
-        __nvmlDeviceGetInforomVersion = GetProcAddress(handle, 'nvmlDeviceGetInforomVersion')
+        __nvmlDeviceGetInforomVersion = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetInforomVersion')
 
         global __nvmlDeviceGetInforomImageVersion
-        __nvmlDeviceGetInforomImageVersion = GetProcAddress(handle, 'nvmlDeviceGetInforomImageVersion')
+        __nvmlDeviceGetInforomImageVersion = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetInforomImageVersion')
 
         global __nvmlDeviceGetInforomConfigurationChecksum
-        __nvmlDeviceGetInforomConfigurationChecksum = GetProcAddress(handle, 'nvmlDeviceGetInforomConfigurationChecksum')
+        __nvmlDeviceGetInforomConfigurationChecksum = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetInforomConfigurationChecksum')
 
         global __nvmlDeviceValidateInforom
-        __nvmlDeviceValidateInforom = GetProcAddress(handle, 'nvmlDeviceValidateInforom')
+        __nvmlDeviceValidateInforom = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceValidateInforom')
 
         global __nvmlDeviceGetLastBBXFlushTime
-        __nvmlDeviceGetLastBBXFlushTime = GetProcAddress(handle, 'nvmlDeviceGetLastBBXFlushTime')
+        __nvmlDeviceGetLastBBXFlushTime = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetLastBBXFlushTime')
 
         global __nvmlDeviceGetDisplayMode
-        __nvmlDeviceGetDisplayMode = GetProcAddress(handle, 'nvmlDeviceGetDisplayMode')
+        __nvmlDeviceGetDisplayMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetDisplayMode')
 
         global __nvmlDeviceGetDisplayActive
-        __nvmlDeviceGetDisplayActive = GetProcAddress(handle, 'nvmlDeviceGetDisplayActive')
+        __nvmlDeviceGetDisplayActive = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetDisplayActive')
 
         global __nvmlDeviceGetPersistenceMode
-        __nvmlDeviceGetPersistenceMode = GetProcAddress(handle, 'nvmlDeviceGetPersistenceMode')
+        __nvmlDeviceGetPersistenceMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetPersistenceMode')
 
         global __nvmlDeviceGetPciInfoExt
-        __nvmlDeviceGetPciInfoExt = GetProcAddress(handle, 'nvmlDeviceGetPciInfoExt')
+        __nvmlDeviceGetPciInfoExt = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetPciInfoExt')
 
         global __nvmlDeviceGetPciInfo_v3
-        __nvmlDeviceGetPciInfo_v3 = GetProcAddress(handle, 'nvmlDeviceGetPciInfo_v3')
+        __nvmlDeviceGetPciInfo_v3 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetPciInfo_v3')
 
         global __nvmlDeviceGetMaxPcieLinkGeneration
-        __nvmlDeviceGetMaxPcieLinkGeneration = GetProcAddress(handle, 'nvmlDeviceGetMaxPcieLinkGeneration')
+        __nvmlDeviceGetMaxPcieLinkGeneration = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetMaxPcieLinkGeneration')
 
         global __nvmlDeviceGetGpuMaxPcieLinkGeneration
-        __nvmlDeviceGetGpuMaxPcieLinkGeneration = GetProcAddress(handle, 'nvmlDeviceGetGpuMaxPcieLinkGeneration')
+        __nvmlDeviceGetGpuMaxPcieLinkGeneration = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetGpuMaxPcieLinkGeneration')
 
         global __nvmlDeviceGetMaxPcieLinkWidth
-        __nvmlDeviceGetMaxPcieLinkWidth = GetProcAddress(handle, 'nvmlDeviceGetMaxPcieLinkWidth')
+        __nvmlDeviceGetMaxPcieLinkWidth = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetMaxPcieLinkWidth')
 
         global __nvmlDeviceGetCurrPcieLinkGeneration
-        __nvmlDeviceGetCurrPcieLinkGeneration = GetProcAddress(handle, 'nvmlDeviceGetCurrPcieLinkGeneration')
+        __nvmlDeviceGetCurrPcieLinkGeneration = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetCurrPcieLinkGeneration')
 
         global __nvmlDeviceGetCurrPcieLinkWidth
-        __nvmlDeviceGetCurrPcieLinkWidth = GetProcAddress(handle, 'nvmlDeviceGetCurrPcieLinkWidth')
+        __nvmlDeviceGetCurrPcieLinkWidth = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetCurrPcieLinkWidth')
 
         global __nvmlDeviceGetPcieThroughput
-        __nvmlDeviceGetPcieThroughput = GetProcAddress(handle, 'nvmlDeviceGetPcieThroughput')
+        __nvmlDeviceGetPcieThroughput = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetPcieThroughput')
 
         global __nvmlDeviceGetPcieReplayCounter
-        __nvmlDeviceGetPcieReplayCounter = GetProcAddress(handle, 'nvmlDeviceGetPcieReplayCounter')
+        __nvmlDeviceGetPcieReplayCounter = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetPcieReplayCounter')
 
         global __nvmlDeviceGetClockInfo
-        __nvmlDeviceGetClockInfo = GetProcAddress(handle, 'nvmlDeviceGetClockInfo')
+        __nvmlDeviceGetClockInfo = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetClockInfo')
 
         global __nvmlDeviceGetMaxClockInfo
-        __nvmlDeviceGetMaxClockInfo = GetProcAddress(handle, 'nvmlDeviceGetMaxClockInfo')
+        __nvmlDeviceGetMaxClockInfo = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetMaxClockInfo')
 
         global __nvmlDeviceGetGpcClkVfOffset
-        __nvmlDeviceGetGpcClkVfOffset = GetProcAddress(handle, 'nvmlDeviceGetGpcClkVfOffset')
+        __nvmlDeviceGetGpcClkVfOffset = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetGpcClkVfOffset')
 
         global __nvmlDeviceGetClock
-        __nvmlDeviceGetClock = GetProcAddress(handle, 'nvmlDeviceGetClock')
+        __nvmlDeviceGetClock = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetClock')
 
         global __nvmlDeviceGetMaxCustomerBoostClock
-        __nvmlDeviceGetMaxCustomerBoostClock = GetProcAddress(handle, 'nvmlDeviceGetMaxCustomerBoostClock')
+        __nvmlDeviceGetMaxCustomerBoostClock = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetMaxCustomerBoostClock')
 
         global __nvmlDeviceGetSupportedMemoryClocks
-        __nvmlDeviceGetSupportedMemoryClocks = GetProcAddress(handle, 'nvmlDeviceGetSupportedMemoryClocks')
+        __nvmlDeviceGetSupportedMemoryClocks = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetSupportedMemoryClocks')
 
         global __nvmlDeviceGetSupportedGraphicsClocks
-        __nvmlDeviceGetSupportedGraphicsClocks = GetProcAddress(handle, 'nvmlDeviceGetSupportedGraphicsClocks')
+        __nvmlDeviceGetSupportedGraphicsClocks = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetSupportedGraphicsClocks')
 
         global __nvmlDeviceGetAutoBoostedClocksEnabled
-        __nvmlDeviceGetAutoBoostedClocksEnabled = GetProcAddress(handle, 'nvmlDeviceGetAutoBoostedClocksEnabled')
+        __nvmlDeviceGetAutoBoostedClocksEnabled = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetAutoBoostedClocksEnabled')
 
         global __nvmlDeviceGetFanSpeed
-        __nvmlDeviceGetFanSpeed = GetProcAddress(handle, 'nvmlDeviceGetFanSpeed')
+        __nvmlDeviceGetFanSpeed = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetFanSpeed')
 
         global __nvmlDeviceGetFanSpeed_v2
-        __nvmlDeviceGetFanSpeed_v2 = GetProcAddress(handle, 'nvmlDeviceGetFanSpeed_v2')
+        __nvmlDeviceGetFanSpeed_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetFanSpeed_v2')
 
         global __nvmlDeviceGetFanSpeedRPM
-        __nvmlDeviceGetFanSpeedRPM = GetProcAddress(handle, 'nvmlDeviceGetFanSpeedRPM')
+        __nvmlDeviceGetFanSpeedRPM = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetFanSpeedRPM')
 
         global __nvmlDeviceGetTargetFanSpeed
-        __nvmlDeviceGetTargetFanSpeed = GetProcAddress(handle, 'nvmlDeviceGetTargetFanSpeed')
+        __nvmlDeviceGetTargetFanSpeed = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetTargetFanSpeed')
 
         global __nvmlDeviceGetMinMaxFanSpeed
-        __nvmlDeviceGetMinMaxFanSpeed = GetProcAddress(handle, 'nvmlDeviceGetMinMaxFanSpeed')
+        __nvmlDeviceGetMinMaxFanSpeed = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetMinMaxFanSpeed')
 
         global __nvmlDeviceGetFanControlPolicy_v2
-        __nvmlDeviceGetFanControlPolicy_v2 = GetProcAddress(handle, 'nvmlDeviceGetFanControlPolicy_v2')
+        __nvmlDeviceGetFanControlPolicy_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetFanControlPolicy_v2')
 
         global __nvmlDeviceGetNumFans
-        __nvmlDeviceGetNumFans = GetProcAddress(handle, 'nvmlDeviceGetNumFans')
+        __nvmlDeviceGetNumFans = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetNumFans')
 
         global __nvmlDeviceGetCoolerInfo
-        __nvmlDeviceGetCoolerInfo = GetProcAddress(handle, 'nvmlDeviceGetCoolerInfo')
+        __nvmlDeviceGetCoolerInfo = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetCoolerInfo')
 
         global __nvmlDeviceGetTemperatureV
-        __nvmlDeviceGetTemperatureV = GetProcAddress(handle, 'nvmlDeviceGetTemperatureV')
+        __nvmlDeviceGetTemperatureV = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetTemperatureV')
 
         global __nvmlDeviceGetTemperatureThreshold
-        __nvmlDeviceGetTemperatureThreshold = GetProcAddress(handle, 'nvmlDeviceGetTemperatureThreshold')
+        __nvmlDeviceGetTemperatureThreshold = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetTemperatureThreshold')
 
         global __nvmlDeviceGetMarginTemperature
-        __nvmlDeviceGetMarginTemperature = GetProcAddress(handle, 'nvmlDeviceGetMarginTemperature')
+        __nvmlDeviceGetMarginTemperature = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetMarginTemperature')
 
         global __nvmlDeviceGetThermalSettings
-        __nvmlDeviceGetThermalSettings = GetProcAddress(handle, 'nvmlDeviceGetThermalSettings')
+        __nvmlDeviceGetThermalSettings = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetThermalSettings')
 
         global __nvmlDeviceGetPerformanceState
-        __nvmlDeviceGetPerformanceState = GetProcAddress(handle, 'nvmlDeviceGetPerformanceState')
+        __nvmlDeviceGetPerformanceState = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetPerformanceState')
 
         global __nvmlDeviceGetCurrentClocksEventReasons
-        __nvmlDeviceGetCurrentClocksEventReasons = GetProcAddress(handle, 'nvmlDeviceGetCurrentClocksEventReasons')
+        __nvmlDeviceGetCurrentClocksEventReasons = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetCurrentClocksEventReasons')
 
         global __nvmlDeviceGetSupportedClocksEventReasons
-        __nvmlDeviceGetSupportedClocksEventReasons = GetProcAddress(handle, 'nvmlDeviceGetSupportedClocksEventReasons')
+        __nvmlDeviceGetSupportedClocksEventReasons = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetSupportedClocksEventReasons')
 
         global __nvmlDeviceGetPowerState
-        __nvmlDeviceGetPowerState = GetProcAddress(handle, 'nvmlDeviceGetPowerState')
+        __nvmlDeviceGetPowerState = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetPowerState')
 
         global __nvmlDeviceGetDynamicPstatesInfo
-        __nvmlDeviceGetDynamicPstatesInfo = GetProcAddress(handle, 'nvmlDeviceGetDynamicPstatesInfo')
+        __nvmlDeviceGetDynamicPstatesInfo = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetDynamicPstatesInfo')
 
         global __nvmlDeviceGetMemClkVfOffset
-        __nvmlDeviceGetMemClkVfOffset = GetProcAddress(handle, 'nvmlDeviceGetMemClkVfOffset')
+        __nvmlDeviceGetMemClkVfOffset = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetMemClkVfOffset')
 
         global __nvmlDeviceGetMinMaxClockOfPState
-        __nvmlDeviceGetMinMaxClockOfPState = GetProcAddress(handle, 'nvmlDeviceGetMinMaxClockOfPState')
+        __nvmlDeviceGetMinMaxClockOfPState = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetMinMaxClockOfPState')
 
         global __nvmlDeviceGetSupportedPerformanceStates
-        __nvmlDeviceGetSupportedPerformanceStates = GetProcAddress(handle, 'nvmlDeviceGetSupportedPerformanceStates')
+        __nvmlDeviceGetSupportedPerformanceStates = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetSupportedPerformanceStates')
 
         global __nvmlDeviceGetGpcClkMinMaxVfOffset
-        __nvmlDeviceGetGpcClkMinMaxVfOffset = GetProcAddress(handle, 'nvmlDeviceGetGpcClkMinMaxVfOffset')
+        __nvmlDeviceGetGpcClkMinMaxVfOffset = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetGpcClkMinMaxVfOffset')
 
         global __nvmlDeviceGetMemClkMinMaxVfOffset
-        __nvmlDeviceGetMemClkMinMaxVfOffset = GetProcAddress(handle, 'nvmlDeviceGetMemClkMinMaxVfOffset')
+        __nvmlDeviceGetMemClkMinMaxVfOffset = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetMemClkMinMaxVfOffset')
 
         global __nvmlDeviceGetClockOffsets
-        __nvmlDeviceGetClockOffsets = GetProcAddress(handle, 'nvmlDeviceGetClockOffsets')
+        __nvmlDeviceGetClockOffsets = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetClockOffsets')
 
         global __nvmlDeviceSetClockOffsets
-        __nvmlDeviceSetClockOffsets = GetProcAddress(handle, 'nvmlDeviceSetClockOffsets')
+        __nvmlDeviceSetClockOffsets = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetClockOffsets')
 
         global __nvmlDeviceGetPerformanceModes
-        __nvmlDeviceGetPerformanceModes = GetProcAddress(handle, 'nvmlDeviceGetPerformanceModes')
+        __nvmlDeviceGetPerformanceModes = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetPerformanceModes')
 
         global __nvmlDeviceGetCurrentClockFreqs
-        __nvmlDeviceGetCurrentClockFreqs = GetProcAddress(handle, 'nvmlDeviceGetCurrentClockFreqs')
+        __nvmlDeviceGetCurrentClockFreqs = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetCurrentClockFreqs')
 
         global __nvmlDeviceGetPowerManagementLimit
-        __nvmlDeviceGetPowerManagementLimit = GetProcAddress(handle, 'nvmlDeviceGetPowerManagementLimit')
+        __nvmlDeviceGetPowerManagementLimit = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetPowerManagementLimit')
 
         global __nvmlDeviceGetPowerManagementLimitConstraints
-        __nvmlDeviceGetPowerManagementLimitConstraints = GetProcAddress(handle, 'nvmlDeviceGetPowerManagementLimitConstraints')
+        __nvmlDeviceGetPowerManagementLimitConstraints = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetPowerManagementLimitConstraints')
 
         global __nvmlDeviceGetPowerManagementDefaultLimit
-        __nvmlDeviceGetPowerManagementDefaultLimit = GetProcAddress(handle, 'nvmlDeviceGetPowerManagementDefaultLimit')
+        __nvmlDeviceGetPowerManagementDefaultLimit = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetPowerManagementDefaultLimit')
 
         global __nvmlDeviceGetPowerUsage
-        __nvmlDeviceGetPowerUsage = GetProcAddress(handle, 'nvmlDeviceGetPowerUsage')
+        __nvmlDeviceGetPowerUsage = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetPowerUsage')
 
         global __nvmlDeviceGetTotalEnergyConsumption
-        __nvmlDeviceGetTotalEnergyConsumption = GetProcAddress(handle, 'nvmlDeviceGetTotalEnergyConsumption')
+        __nvmlDeviceGetTotalEnergyConsumption = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetTotalEnergyConsumption')
 
         global __nvmlDeviceGetEnforcedPowerLimit
-        __nvmlDeviceGetEnforcedPowerLimit = GetProcAddress(handle, 'nvmlDeviceGetEnforcedPowerLimit')
+        __nvmlDeviceGetEnforcedPowerLimit = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetEnforcedPowerLimit')
 
         global __nvmlDeviceGetGpuOperationMode
-        __nvmlDeviceGetGpuOperationMode = GetProcAddress(handle, 'nvmlDeviceGetGpuOperationMode')
+        __nvmlDeviceGetGpuOperationMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetGpuOperationMode')
 
         global __nvmlDeviceGetMemoryInfo_v2
-        __nvmlDeviceGetMemoryInfo_v2 = GetProcAddress(handle, 'nvmlDeviceGetMemoryInfo_v2')
+        __nvmlDeviceGetMemoryInfo_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetMemoryInfo_v2')
 
         global __nvmlDeviceGetComputeMode
-        __nvmlDeviceGetComputeMode = GetProcAddress(handle, 'nvmlDeviceGetComputeMode')
+        __nvmlDeviceGetComputeMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetComputeMode')
 
         global __nvmlDeviceGetCudaComputeCapability
-        __nvmlDeviceGetCudaComputeCapability = GetProcAddress(handle, 'nvmlDeviceGetCudaComputeCapability')
+        __nvmlDeviceGetCudaComputeCapability = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetCudaComputeCapability')
 
         global __nvmlDeviceGetDramEncryptionMode
-        __nvmlDeviceGetDramEncryptionMode = GetProcAddress(handle, 'nvmlDeviceGetDramEncryptionMode')
+        __nvmlDeviceGetDramEncryptionMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetDramEncryptionMode')
 
         global __nvmlDeviceSetDramEncryptionMode
-        __nvmlDeviceSetDramEncryptionMode = GetProcAddress(handle, 'nvmlDeviceSetDramEncryptionMode')
+        __nvmlDeviceSetDramEncryptionMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetDramEncryptionMode')
 
         global __nvmlDeviceGetEccMode
-        __nvmlDeviceGetEccMode = GetProcAddress(handle, 'nvmlDeviceGetEccMode')
+        __nvmlDeviceGetEccMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetEccMode')
 
         global __nvmlDeviceGetDefaultEccMode
-        __nvmlDeviceGetDefaultEccMode = GetProcAddress(handle, 'nvmlDeviceGetDefaultEccMode')
+        __nvmlDeviceGetDefaultEccMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetDefaultEccMode')
 
         global __nvmlDeviceGetBoardId
-        __nvmlDeviceGetBoardId = GetProcAddress(handle, 'nvmlDeviceGetBoardId')
+        __nvmlDeviceGetBoardId = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetBoardId')
 
         global __nvmlDeviceGetMultiGpuBoard
-        __nvmlDeviceGetMultiGpuBoard = GetProcAddress(handle, 'nvmlDeviceGetMultiGpuBoard')
+        __nvmlDeviceGetMultiGpuBoard = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetMultiGpuBoard')
 
         global __nvmlDeviceGetTotalEccErrors
-        __nvmlDeviceGetTotalEccErrors = GetProcAddress(handle, 'nvmlDeviceGetTotalEccErrors')
+        __nvmlDeviceGetTotalEccErrors = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetTotalEccErrors')
 
         global __nvmlDeviceGetMemoryErrorCounter
-        __nvmlDeviceGetMemoryErrorCounter = GetProcAddress(handle, 'nvmlDeviceGetMemoryErrorCounter')
+        __nvmlDeviceGetMemoryErrorCounter = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetMemoryErrorCounter')
 
         global __nvmlDeviceGetUtilizationRates
-        __nvmlDeviceGetUtilizationRates = GetProcAddress(handle, 'nvmlDeviceGetUtilizationRates')
+        __nvmlDeviceGetUtilizationRates = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetUtilizationRates')
 
         global __nvmlDeviceGetEncoderUtilization
-        __nvmlDeviceGetEncoderUtilization = GetProcAddress(handle, 'nvmlDeviceGetEncoderUtilization')
+        __nvmlDeviceGetEncoderUtilization = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetEncoderUtilization')
 
         global __nvmlDeviceGetEncoderCapacity
-        __nvmlDeviceGetEncoderCapacity = GetProcAddress(handle, 'nvmlDeviceGetEncoderCapacity')
+        __nvmlDeviceGetEncoderCapacity = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetEncoderCapacity')
 
         global __nvmlDeviceGetEncoderStats
-        __nvmlDeviceGetEncoderStats = GetProcAddress(handle, 'nvmlDeviceGetEncoderStats')
+        __nvmlDeviceGetEncoderStats = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetEncoderStats')
 
         global __nvmlDeviceGetEncoderSessions
-        __nvmlDeviceGetEncoderSessions = GetProcAddress(handle, 'nvmlDeviceGetEncoderSessions')
+        __nvmlDeviceGetEncoderSessions = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetEncoderSessions')
 
         global __nvmlDeviceGetDecoderUtilization
-        __nvmlDeviceGetDecoderUtilization = GetProcAddress(handle, 'nvmlDeviceGetDecoderUtilization')
+        __nvmlDeviceGetDecoderUtilization = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetDecoderUtilization')
 
         global __nvmlDeviceGetJpgUtilization
-        __nvmlDeviceGetJpgUtilization = GetProcAddress(handle, 'nvmlDeviceGetJpgUtilization')
+        __nvmlDeviceGetJpgUtilization = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetJpgUtilization')
 
         global __nvmlDeviceGetOfaUtilization
-        __nvmlDeviceGetOfaUtilization = GetProcAddress(handle, 'nvmlDeviceGetOfaUtilization')
+        __nvmlDeviceGetOfaUtilization = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetOfaUtilization')
 
         global __nvmlDeviceGetFBCStats
-        __nvmlDeviceGetFBCStats = GetProcAddress(handle, 'nvmlDeviceGetFBCStats')
+        __nvmlDeviceGetFBCStats = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetFBCStats')
 
         global __nvmlDeviceGetFBCSessions
-        __nvmlDeviceGetFBCSessions = GetProcAddress(handle, 'nvmlDeviceGetFBCSessions')
+        __nvmlDeviceGetFBCSessions = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetFBCSessions')
 
         global __nvmlDeviceGetDriverModel_v2
-        __nvmlDeviceGetDriverModel_v2 = GetProcAddress(handle, 'nvmlDeviceGetDriverModel_v2')
+        __nvmlDeviceGetDriverModel_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetDriverModel_v2')
 
         global __nvmlDeviceGetVbiosVersion
-        __nvmlDeviceGetVbiosVersion = GetProcAddress(handle, 'nvmlDeviceGetVbiosVersion')
+        __nvmlDeviceGetVbiosVersion = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetVbiosVersion')
 
         global __nvmlDeviceGetBridgeChipInfo
-        __nvmlDeviceGetBridgeChipInfo = GetProcAddress(handle, 'nvmlDeviceGetBridgeChipInfo')
+        __nvmlDeviceGetBridgeChipInfo = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetBridgeChipInfo')
 
         global __nvmlDeviceGetComputeRunningProcesses_v3
-        __nvmlDeviceGetComputeRunningProcesses_v3 = GetProcAddress(handle, 'nvmlDeviceGetComputeRunningProcesses_v3')
+        __nvmlDeviceGetComputeRunningProcesses_v3 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetComputeRunningProcesses_v3')
 
         global __nvmlDeviceGetGraphicsRunningProcesses_v3
-        __nvmlDeviceGetGraphicsRunningProcesses_v3 = GetProcAddress(handle, 'nvmlDeviceGetGraphicsRunningProcesses_v3')
+        __nvmlDeviceGetGraphicsRunningProcesses_v3 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetGraphicsRunningProcesses_v3')
 
         global __nvmlDeviceGetMPSComputeRunningProcesses_v3
-        __nvmlDeviceGetMPSComputeRunningProcesses_v3 = GetProcAddress(handle, 'nvmlDeviceGetMPSComputeRunningProcesses_v3')
+        __nvmlDeviceGetMPSComputeRunningProcesses_v3 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetMPSComputeRunningProcesses_v3')
 
         global __nvmlDeviceGetRunningProcessDetailList
-        __nvmlDeviceGetRunningProcessDetailList = GetProcAddress(handle, 'nvmlDeviceGetRunningProcessDetailList')
+        __nvmlDeviceGetRunningProcessDetailList = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetRunningProcessDetailList')
 
         global __nvmlDeviceOnSameBoard
-        __nvmlDeviceOnSameBoard = GetProcAddress(handle, 'nvmlDeviceOnSameBoard')
+        __nvmlDeviceOnSameBoard = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceOnSameBoard')
 
         global __nvmlDeviceGetAPIRestriction
-        __nvmlDeviceGetAPIRestriction = GetProcAddress(handle, 'nvmlDeviceGetAPIRestriction')
+        __nvmlDeviceGetAPIRestriction = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetAPIRestriction')
 
         global __nvmlDeviceGetSamples
-        __nvmlDeviceGetSamples = GetProcAddress(handle, 'nvmlDeviceGetSamples')
+        __nvmlDeviceGetSamples = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetSamples')
 
         global __nvmlDeviceGetBAR1MemoryInfo
-        __nvmlDeviceGetBAR1MemoryInfo = GetProcAddress(handle, 'nvmlDeviceGetBAR1MemoryInfo')
+        __nvmlDeviceGetBAR1MemoryInfo = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetBAR1MemoryInfo')
 
         global __nvmlDeviceGetIrqNum
-        __nvmlDeviceGetIrqNum = GetProcAddress(handle, 'nvmlDeviceGetIrqNum')
+        __nvmlDeviceGetIrqNum = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetIrqNum')
 
         global __nvmlDeviceGetNumGpuCores
-        __nvmlDeviceGetNumGpuCores = GetProcAddress(handle, 'nvmlDeviceGetNumGpuCores')
+        __nvmlDeviceGetNumGpuCores = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetNumGpuCores')
 
         global __nvmlDeviceGetPowerSource
-        __nvmlDeviceGetPowerSource = GetProcAddress(handle, 'nvmlDeviceGetPowerSource')
+        __nvmlDeviceGetPowerSource = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetPowerSource')
 
         global __nvmlDeviceGetMemoryBusWidth
-        __nvmlDeviceGetMemoryBusWidth = GetProcAddress(handle, 'nvmlDeviceGetMemoryBusWidth')
+        __nvmlDeviceGetMemoryBusWidth = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetMemoryBusWidth')
 
         global __nvmlDeviceGetPcieLinkMaxSpeed
-        __nvmlDeviceGetPcieLinkMaxSpeed = GetProcAddress(handle, 'nvmlDeviceGetPcieLinkMaxSpeed')
+        __nvmlDeviceGetPcieLinkMaxSpeed = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetPcieLinkMaxSpeed')
 
         global __nvmlDeviceGetPcieSpeed
-        __nvmlDeviceGetPcieSpeed = GetProcAddress(handle, 'nvmlDeviceGetPcieSpeed')
+        __nvmlDeviceGetPcieSpeed = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetPcieSpeed')
 
         global __nvmlDeviceGetAdaptiveClockInfoStatus
-        __nvmlDeviceGetAdaptiveClockInfoStatus = GetProcAddress(handle, 'nvmlDeviceGetAdaptiveClockInfoStatus')
+        __nvmlDeviceGetAdaptiveClockInfoStatus = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetAdaptiveClockInfoStatus')
 
         global __nvmlDeviceGetBusType
-        __nvmlDeviceGetBusType = GetProcAddress(handle, 'nvmlDeviceGetBusType')
+        __nvmlDeviceGetBusType = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetBusType')
 
         global __nvmlDeviceGetGpuFabricInfoV
-        __nvmlDeviceGetGpuFabricInfoV = GetProcAddress(handle, 'nvmlDeviceGetGpuFabricInfoV')
+        __nvmlDeviceGetGpuFabricInfoV = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetGpuFabricInfoV')
 
         global __nvmlSystemGetConfComputeCapabilities
-        __nvmlSystemGetConfComputeCapabilities = GetProcAddress(handle, 'nvmlSystemGetConfComputeCapabilities')
+        __nvmlSystemGetConfComputeCapabilities = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemGetConfComputeCapabilities')
 
         global __nvmlSystemGetConfComputeState
-        __nvmlSystemGetConfComputeState = GetProcAddress(handle, 'nvmlSystemGetConfComputeState')
+        __nvmlSystemGetConfComputeState = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemGetConfComputeState')
 
         global __nvmlDeviceGetConfComputeMemSizeInfo
-        __nvmlDeviceGetConfComputeMemSizeInfo = GetProcAddress(handle, 'nvmlDeviceGetConfComputeMemSizeInfo')
+        __nvmlDeviceGetConfComputeMemSizeInfo = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetConfComputeMemSizeInfo')
 
         global __nvmlSystemGetConfComputeGpusReadyState
-        __nvmlSystemGetConfComputeGpusReadyState = GetProcAddress(handle, 'nvmlSystemGetConfComputeGpusReadyState')
+        __nvmlSystemGetConfComputeGpusReadyState = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemGetConfComputeGpusReadyState')
 
         global __nvmlDeviceGetConfComputeProtectedMemoryUsage
-        __nvmlDeviceGetConfComputeProtectedMemoryUsage = GetProcAddress(handle, 'nvmlDeviceGetConfComputeProtectedMemoryUsage')
+        __nvmlDeviceGetConfComputeProtectedMemoryUsage = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetConfComputeProtectedMemoryUsage')
 
         global __nvmlDeviceGetConfComputeGpuCertificate
-        __nvmlDeviceGetConfComputeGpuCertificate = GetProcAddress(handle, 'nvmlDeviceGetConfComputeGpuCertificate')
+        __nvmlDeviceGetConfComputeGpuCertificate = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetConfComputeGpuCertificate')
 
         global __nvmlDeviceGetConfComputeGpuAttestationReport
-        __nvmlDeviceGetConfComputeGpuAttestationReport = GetProcAddress(handle, 'nvmlDeviceGetConfComputeGpuAttestationReport')
+        __nvmlDeviceGetConfComputeGpuAttestationReport = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetConfComputeGpuAttestationReport')
 
         global __nvmlSystemGetConfComputeKeyRotationThresholdInfo
-        __nvmlSystemGetConfComputeKeyRotationThresholdInfo = GetProcAddress(handle, 'nvmlSystemGetConfComputeKeyRotationThresholdInfo')
+        __nvmlSystemGetConfComputeKeyRotationThresholdInfo = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemGetConfComputeKeyRotationThresholdInfo')
 
         global __nvmlDeviceSetConfComputeUnprotectedMemSize
-        __nvmlDeviceSetConfComputeUnprotectedMemSize = GetProcAddress(handle, 'nvmlDeviceSetConfComputeUnprotectedMemSize')
+        __nvmlDeviceSetConfComputeUnprotectedMemSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetConfComputeUnprotectedMemSize')
 
         global __nvmlSystemSetConfComputeGpusReadyState
-        __nvmlSystemSetConfComputeGpusReadyState = GetProcAddress(handle, 'nvmlSystemSetConfComputeGpusReadyState')
+        __nvmlSystemSetConfComputeGpusReadyState = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemSetConfComputeGpusReadyState')
 
         global __nvmlSystemSetConfComputeKeyRotationThresholdInfo
-        __nvmlSystemSetConfComputeKeyRotationThresholdInfo = GetProcAddress(handle, 'nvmlSystemSetConfComputeKeyRotationThresholdInfo')
+        __nvmlSystemSetConfComputeKeyRotationThresholdInfo = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemSetConfComputeKeyRotationThresholdInfo')
 
         global __nvmlSystemGetConfComputeSettings
-        __nvmlSystemGetConfComputeSettings = GetProcAddress(handle, 'nvmlSystemGetConfComputeSettings')
+        __nvmlSystemGetConfComputeSettings = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemGetConfComputeSettings')
 
         global __nvmlDeviceGetGspFirmwareVersion
-        __nvmlDeviceGetGspFirmwareVersion = GetProcAddress(handle, 'nvmlDeviceGetGspFirmwareVersion')
+        __nvmlDeviceGetGspFirmwareVersion = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetGspFirmwareVersion')
 
         global __nvmlDeviceGetGspFirmwareMode
-        __nvmlDeviceGetGspFirmwareMode = GetProcAddress(handle, 'nvmlDeviceGetGspFirmwareMode')
+        __nvmlDeviceGetGspFirmwareMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetGspFirmwareMode')
 
         global __nvmlDeviceGetSramEccErrorStatus
-        __nvmlDeviceGetSramEccErrorStatus = GetProcAddress(handle, 'nvmlDeviceGetSramEccErrorStatus')
+        __nvmlDeviceGetSramEccErrorStatus = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetSramEccErrorStatus')
 
         global __nvmlDeviceGetAccountingMode
-        __nvmlDeviceGetAccountingMode = GetProcAddress(handle, 'nvmlDeviceGetAccountingMode')
+        __nvmlDeviceGetAccountingMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetAccountingMode')
 
         global __nvmlDeviceGetAccountingStats
-        __nvmlDeviceGetAccountingStats = GetProcAddress(handle, 'nvmlDeviceGetAccountingStats')
+        __nvmlDeviceGetAccountingStats = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetAccountingStats')
 
         global __nvmlDeviceGetAccountingPids
-        __nvmlDeviceGetAccountingPids = GetProcAddress(handle, 'nvmlDeviceGetAccountingPids')
+        __nvmlDeviceGetAccountingPids = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetAccountingPids')
 
         global __nvmlDeviceGetAccountingBufferSize
-        __nvmlDeviceGetAccountingBufferSize = GetProcAddress(handle, 'nvmlDeviceGetAccountingBufferSize')
+        __nvmlDeviceGetAccountingBufferSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetAccountingBufferSize')
 
         global __nvmlDeviceGetRetiredPages
-        __nvmlDeviceGetRetiredPages = GetProcAddress(handle, 'nvmlDeviceGetRetiredPages')
+        __nvmlDeviceGetRetiredPages = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetRetiredPages')
 
         global __nvmlDeviceGetRetiredPages_v2
-        __nvmlDeviceGetRetiredPages_v2 = GetProcAddress(handle, 'nvmlDeviceGetRetiredPages_v2')
+        __nvmlDeviceGetRetiredPages_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetRetiredPages_v2')
 
         global __nvmlDeviceGetRetiredPagesPendingStatus
-        __nvmlDeviceGetRetiredPagesPendingStatus = GetProcAddress(handle, 'nvmlDeviceGetRetiredPagesPendingStatus')
+        __nvmlDeviceGetRetiredPagesPendingStatus = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetRetiredPagesPendingStatus')
 
         global __nvmlDeviceGetRemappedRows
-        __nvmlDeviceGetRemappedRows = GetProcAddress(handle, 'nvmlDeviceGetRemappedRows')
+        __nvmlDeviceGetRemappedRows = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetRemappedRows')
 
         global __nvmlDeviceGetRowRemapperHistogram
-        __nvmlDeviceGetRowRemapperHistogram = GetProcAddress(handle, 'nvmlDeviceGetRowRemapperHistogram')
+        __nvmlDeviceGetRowRemapperHistogram = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetRowRemapperHistogram')
 
         global __nvmlDeviceGetArchitecture
-        __nvmlDeviceGetArchitecture = GetProcAddress(handle, 'nvmlDeviceGetArchitecture')
+        __nvmlDeviceGetArchitecture = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetArchitecture')
 
         global __nvmlDeviceGetClkMonStatus
-        __nvmlDeviceGetClkMonStatus = GetProcAddress(handle, 'nvmlDeviceGetClkMonStatus')
+        __nvmlDeviceGetClkMonStatus = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetClkMonStatus')
 
         global __nvmlDeviceGetProcessUtilization
-        __nvmlDeviceGetProcessUtilization = GetProcAddress(handle, 'nvmlDeviceGetProcessUtilization')
+        __nvmlDeviceGetProcessUtilization = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetProcessUtilization')
 
         global __nvmlDeviceGetProcessesUtilizationInfo
-        __nvmlDeviceGetProcessesUtilizationInfo = GetProcAddress(handle, 'nvmlDeviceGetProcessesUtilizationInfo')
+        __nvmlDeviceGetProcessesUtilizationInfo = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetProcessesUtilizationInfo')
 
         global __nvmlDeviceGetPlatformInfo
-        __nvmlDeviceGetPlatformInfo = GetProcAddress(handle, 'nvmlDeviceGetPlatformInfo')
+        __nvmlDeviceGetPlatformInfo = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetPlatformInfo')
 
         global __nvmlUnitSetLedState
-        __nvmlUnitSetLedState = GetProcAddress(handle, 'nvmlUnitSetLedState')
+        __nvmlUnitSetLedState = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlUnitSetLedState')
 
         global __nvmlDeviceSetPersistenceMode
-        __nvmlDeviceSetPersistenceMode = GetProcAddress(handle, 'nvmlDeviceSetPersistenceMode')
+        __nvmlDeviceSetPersistenceMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetPersistenceMode')
 
         global __nvmlDeviceSetComputeMode
-        __nvmlDeviceSetComputeMode = GetProcAddress(handle, 'nvmlDeviceSetComputeMode')
+        __nvmlDeviceSetComputeMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetComputeMode')
 
         global __nvmlDeviceSetEccMode
-        __nvmlDeviceSetEccMode = GetProcAddress(handle, 'nvmlDeviceSetEccMode')
+        __nvmlDeviceSetEccMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetEccMode')
 
         global __nvmlDeviceClearEccErrorCounts
-        __nvmlDeviceClearEccErrorCounts = GetProcAddress(handle, 'nvmlDeviceClearEccErrorCounts')
+        __nvmlDeviceClearEccErrorCounts = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceClearEccErrorCounts')
 
         global __nvmlDeviceSetDriverModel
-        __nvmlDeviceSetDriverModel = GetProcAddress(handle, 'nvmlDeviceSetDriverModel')
+        __nvmlDeviceSetDriverModel = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetDriverModel')
 
         global __nvmlDeviceSetGpuLockedClocks
-        __nvmlDeviceSetGpuLockedClocks = GetProcAddress(handle, 'nvmlDeviceSetGpuLockedClocks')
+        __nvmlDeviceSetGpuLockedClocks = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetGpuLockedClocks')
 
         global __nvmlDeviceResetGpuLockedClocks
-        __nvmlDeviceResetGpuLockedClocks = GetProcAddress(handle, 'nvmlDeviceResetGpuLockedClocks')
+        __nvmlDeviceResetGpuLockedClocks = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceResetGpuLockedClocks')
 
         global __nvmlDeviceSetMemoryLockedClocks
-        __nvmlDeviceSetMemoryLockedClocks = GetProcAddress(handle, 'nvmlDeviceSetMemoryLockedClocks')
+        __nvmlDeviceSetMemoryLockedClocks = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetMemoryLockedClocks')
 
         global __nvmlDeviceResetMemoryLockedClocks
-        __nvmlDeviceResetMemoryLockedClocks = GetProcAddress(handle, 'nvmlDeviceResetMemoryLockedClocks')
+        __nvmlDeviceResetMemoryLockedClocks = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceResetMemoryLockedClocks')
 
         global __nvmlDeviceSetAutoBoostedClocksEnabled
-        __nvmlDeviceSetAutoBoostedClocksEnabled = GetProcAddress(handle, 'nvmlDeviceSetAutoBoostedClocksEnabled')
+        __nvmlDeviceSetAutoBoostedClocksEnabled = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetAutoBoostedClocksEnabled')
 
         global __nvmlDeviceSetDefaultAutoBoostedClocksEnabled
-        __nvmlDeviceSetDefaultAutoBoostedClocksEnabled = GetProcAddress(handle, 'nvmlDeviceSetDefaultAutoBoostedClocksEnabled')
+        __nvmlDeviceSetDefaultAutoBoostedClocksEnabled = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetDefaultAutoBoostedClocksEnabled')
 
         global __nvmlDeviceSetDefaultFanSpeed_v2
-        __nvmlDeviceSetDefaultFanSpeed_v2 = GetProcAddress(handle, 'nvmlDeviceSetDefaultFanSpeed_v2')
+        __nvmlDeviceSetDefaultFanSpeed_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetDefaultFanSpeed_v2')
 
         global __nvmlDeviceSetFanControlPolicy
-        __nvmlDeviceSetFanControlPolicy = GetProcAddress(handle, 'nvmlDeviceSetFanControlPolicy')
+        __nvmlDeviceSetFanControlPolicy = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetFanControlPolicy')
 
         global __nvmlDeviceSetTemperatureThreshold
-        __nvmlDeviceSetTemperatureThreshold = GetProcAddress(handle, 'nvmlDeviceSetTemperatureThreshold')
+        __nvmlDeviceSetTemperatureThreshold = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetTemperatureThreshold')
 
         global __nvmlDeviceSetGpuOperationMode
-        __nvmlDeviceSetGpuOperationMode = GetProcAddress(handle, 'nvmlDeviceSetGpuOperationMode')
+        __nvmlDeviceSetGpuOperationMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetGpuOperationMode')
 
         global __nvmlDeviceSetAPIRestriction
-        __nvmlDeviceSetAPIRestriction = GetProcAddress(handle, 'nvmlDeviceSetAPIRestriction')
+        __nvmlDeviceSetAPIRestriction = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetAPIRestriction')
 
         global __nvmlDeviceSetFanSpeed_v2
-        __nvmlDeviceSetFanSpeed_v2 = GetProcAddress(handle, 'nvmlDeviceSetFanSpeed_v2')
+        __nvmlDeviceSetFanSpeed_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetFanSpeed_v2')
 
         global __nvmlDeviceSetAccountingMode
-        __nvmlDeviceSetAccountingMode = GetProcAddress(handle, 'nvmlDeviceSetAccountingMode')
+        __nvmlDeviceSetAccountingMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetAccountingMode')
 
         global __nvmlDeviceClearAccountingPids
-        __nvmlDeviceClearAccountingPids = GetProcAddress(handle, 'nvmlDeviceClearAccountingPids')
+        __nvmlDeviceClearAccountingPids = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceClearAccountingPids')
 
         global __nvmlDeviceSetPowerManagementLimit_v2
-        __nvmlDeviceSetPowerManagementLimit_v2 = GetProcAddress(handle, 'nvmlDeviceSetPowerManagementLimit_v2')
+        __nvmlDeviceSetPowerManagementLimit_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetPowerManagementLimit_v2')
 
         global __nvmlDeviceGetNvLinkState
-        __nvmlDeviceGetNvLinkState = GetProcAddress(handle, 'nvmlDeviceGetNvLinkState')
+        __nvmlDeviceGetNvLinkState = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetNvLinkState')
 
         global __nvmlDeviceGetNvLinkVersion
-        __nvmlDeviceGetNvLinkVersion = GetProcAddress(handle, 'nvmlDeviceGetNvLinkVersion')
+        __nvmlDeviceGetNvLinkVersion = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetNvLinkVersion')
 
         global __nvmlDeviceGetNvLinkCapability
-        __nvmlDeviceGetNvLinkCapability = GetProcAddress(handle, 'nvmlDeviceGetNvLinkCapability')
+        __nvmlDeviceGetNvLinkCapability = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetNvLinkCapability')
 
         global __nvmlDeviceGetNvLinkRemotePciInfo_v2
-        __nvmlDeviceGetNvLinkRemotePciInfo_v2 = GetProcAddress(handle, 'nvmlDeviceGetNvLinkRemotePciInfo_v2')
+        __nvmlDeviceGetNvLinkRemotePciInfo_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetNvLinkRemotePciInfo_v2')
 
         global __nvmlDeviceGetNvLinkErrorCounter
-        __nvmlDeviceGetNvLinkErrorCounter = GetProcAddress(handle, 'nvmlDeviceGetNvLinkErrorCounter')
+        __nvmlDeviceGetNvLinkErrorCounter = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetNvLinkErrorCounter')
 
         global __nvmlDeviceResetNvLinkErrorCounters
-        __nvmlDeviceResetNvLinkErrorCounters = GetProcAddress(handle, 'nvmlDeviceResetNvLinkErrorCounters')
+        __nvmlDeviceResetNvLinkErrorCounters = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceResetNvLinkErrorCounters')
 
         global __nvmlDeviceGetNvLinkRemoteDeviceType
-        __nvmlDeviceGetNvLinkRemoteDeviceType = GetProcAddress(handle, 'nvmlDeviceGetNvLinkRemoteDeviceType')
+        __nvmlDeviceGetNvLinkRemoteDeviceType = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetNvLinkRemoteDeviceType')
 
         global __nvmlDeviceSetNvLinkDeviceLowPowerThreshold
-        __nvmlDeviceSetNvLinkDeviceLowPowerThreshold = GetProcAddress(handle, 'nvmlDeviceSetNvLinkDeviceLowPowerThreshold')
+        __nvmlDeviceSetNvLinkDeviceLowPowerThreshold = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetNvLinkDeviceLowPowerThreshold')
 
         global __nvmlSystemSetNvlinkBwMode
-        __nvmlSystemSetNvlinkBwMode = GetProcAddress(handle, 'nvmlSystemSetNvlinkBwMode')
+        __nvmlSystemSetNvlinkBwMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemSetNvlinkBwMode')
 
         global __nvmlSystemGetNvlinkBwMode
-        __nvmlSystemGetNvlinkBwMode = GetProcAddress(handle, 'nvmlSystemGetNvlinkBwMode')
+        __nvmlSystemGetNvlinkBwMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemGetNvlinkBwMode')
 
         global __nvmlDeviceGetNvlinkSupportedBwModes
-        __nvmlDeviceGetNvlinkSupportedBwModes = GetProcAddress(handle, 'nvmlDeviceGetNvlinkSupportedBwModes')
+        __nvmlDeviceGetNvlinkSupportedBwModes = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetNvlinkSupportedBwModes')
 
         global __nvmlDeviceGetNvlinkBwMode
-        __nvmlDeviceGetNvlinkBwMode = GetProcAddress(handle, 'nvmlDeviceGetNvlinkBwMode')
+        __nvmlDeviceGetNvlinkBwMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetNvlinkBwMode')
 
         global __nvmlDeviceSetNvlinkBwMode
-        __nvmlDeviceSetNvlinkBwMode = GetProcAddress(handle, 'nvmlDeviceSetNvlinkBwMode')
+        __nvmlDeviceSetNvlinkBwMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetNvlinkBwMode')
 
         global __nvmlEventSetCreate
-        __nvmlEventSetCreate = GetProcAddress(handle, 'nvmlEventSetCreate')
+        __nvmlEventSetCreate = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlEventSetCreate')
 
         global __nvmlDeviceRegisterEvents
-        __nvmlDeviceRegisterEvents = GetProcAddress(handle, 'nvmlDeviceRegisterEvents')
+        __nvmlDeviceRegisterEvents = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceRegisterEvents')
 
         global __nvmlDeviceGetSupportedEventTypes
-        __nvmlDeviceGetSupportedEventTypes = GetProcAddress(handle, 'nvmlDeviceGetSupportedEventTypes')
+        __nvmlDeviceGetSupportedEventTypes = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetSupportedEventTypes')
 
         global __nvmlEventSetWait_v2
-        __nvmlEventSetWait_v2 = GetProcAddress(handle, 'nvmlEventSetWait_v2')
+        __nvmlEventSetWait_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlEventSetWait_v2')
 
         global __nvmlEventSetFree
-        __nvmlEventSetFree = GetProcAddress(handle, 'nvmlEventSetFree')
+        __nvmlEventSetFree = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlEventSetFree')
 
         global __nvmlSystemEventSetCreate
-        __nvmlSystemEventSetCreate = GetProcAddress(handle, 'nvmlSystemEventSetCreate')
+        __nvmlSystemEventSetCreate = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemEventSetCreate')
 
         global __nvmlSystemEventSetFree
-        __nvmlSystemEventSetFree = GetProcAddress(handle, 'nvmlSystemEventSetFree')
+        __nvmlSystemEventSetFree = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemEventSetFree')
 
         global __nvmlSystemRegisterEvents
-        __nvmlSystemRegisterEvents = GetProcAddress(handle, 'nvmlSystemRegisterEvents')
+        __nvmlSystemRegisterEvents = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemRegisterEvents')
 
         global __nvmlSystemEventSetWait
-        __nvmlSystemEventSetWait = GetProcAddress(handle, 'nvmlSystemEventSetWait')
+        __nvmlSystemEventSetWait = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSystemEventSetWait')
 
         global __nvmlDeviceModifyDrainState
-        __nvmlDeviceModifyDrainState = GetProcAddress(handle, 'nvmlDeviceModifyDrainState')
+        __nvmlDeviceModifyDrainState = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceModifyDrainState')
 
         global __nvmlDeviceQueryDrainState
-        __nvmlDeviceQueryDrainState = GetProcAddress(handle, 'nvmlDeviceQueryDrainState')
+        __nvmlDeviceQueryDrainState = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceQueryDrainState')
 
         global __nvmlDeviceRemoveGpu_v2
-        __nvmlDeviceRemoveGpu_v2 = GetProcAddress(handle, 'nvmlDeviceRemoveGpu_v2')
+        __nvmlDeviceRemoveGpu_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceRemoveGpu_v2')
 
         global __nvmlDeviceDiscoverGpus
-        __nvmlDeviceDiscoverGpus = GetProcAddress(handle, 'nvmlDeviceDiscoverGpus')
+        __nvmlDeviceDiscoverGpus = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceDiscoverGpus')
 
         global __nvmlDeviceGetFieldValues
-        __nvmlDeviceGetFieldValues = GetProcAddress(handle, 'nvmlDeviceGetFieldValues')
+        __nvmlDeviceGetFieldValues = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetFieldValues')
 
         global __nvmlDeviceClearFieldValues
-        __nvmlDeviceClearFieldValues = GetProcAddress(handle, 'nvmlDeviceClearFieldValues')
+        __nvmlDeviceClearFieldValues = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceClearFieldValues')
 
         global __nvmlDeviceGetVirtualizationMode
-        __nvmlDeviceGetVirtualizationMode = GetProcAddress(handle, 'nvmlDeviceGetVirtualizationMode')
+        __nvmlDeviceGetVirtualizationMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetVirtualizationMode')
 
         global __nvmlDeviceGetHostVgpuMode
-        __nvmlDeviceGetHostVgpuMode = GetProcAddress(handle, 'nvmlDeviceGetHostVgpuMode')
+        __nvmlDeviceGetHostVgpuMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetHostVgpuMode')
 
         global __nvmlDeviceSetVirtualizationMode
-        __nvmlDeviceSetVirtualizationMode = GetProcAddress(handle, 'nvmlDeviceSetVirtualizationMode')
+        __nvmlDeviceSetVirtualizationMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetVirtualizationMode')
 
         global __nvmlDeviceGetVgpuHeterogeneousMode
-        __nvmlDeviceGetVgpuHeterogeneousMode = GetProcAddress(handle, 'nvmlDeviceGetVgpuHeterogeneousMode')
+        __nvmlDeviceGetVgpuHeterogeneousMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetVgpuHeterogeneousMode')
 
         global __nvmlDeviceSetVgpuHeterogeneousMode
-        __nvmlDeviceSetVgpuHeterogeneousMode = GetProcAddress(handle, 'nvmlDeviceSetVgpuHeterogeneousMode')
+        __nvmlDeviceSetVgpuHeterogeneousMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetVgpuHeterogeneousMode')
 
         global __nvmlVgpuInstanceGetPlacementId
-        __nvmlVgpuInstanceGetPlacementId = GetProcAddress(handle, 'nvmlVgpuInstanceGetPlacementId')
+        __nvmlVgpuInstanceGetPlacementId = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetPlacementId')
 
         global __nvmlDeviceGetVgpuTypeSupportedPlacements
-        __nvmlDeviceGetVgpuTypeSupportedPlacements = GetProcAddress(handle, 'nvmlDeviceGetVgpuTypeSupportedPlacements')
+        __nvmlDeviceGetVgpuTypeSupportedPlacements = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetVgpuTypeSupportedPlacements')
 
         global __nvmlDeviceGetVgpuTypeCreatablePlacements
-        __nvmlDeviceGetVgpuTypeCreatablePlacements = GetProcAddress(handle, 'nvmlDeviceGetVgpuTypeCreatablePlacements')
+        __nvmlDeviceGetVgpuTypeCreatablePlacements = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetVgpuTypeCreatablePlacements')
 
         global __nvmlVgpuTypeGetGspHeapSize
-        __nvmlVgpuTypeGetGspHeapSize = GetProcAddress(handle, 'nvmlVgpuTypeGetGspHeapSize')
+        __nvmlVgpuTypeGetGspHeapSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuTypeGetGspHeapSize')
 
         global __nvmlVgpuTypeGetFbReservation
-        __nvmlVgpuTypeGetFbReservation = GetProcAddress(handle, 'nvmlVgpuTypeGetFbReservation')
+        __nvmlVgpuTypeGetFbReservation = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuTypeGetFbReservation')
 
         global __nvmlVgpuInstanceGetRuntimeStateSize
-        __nvmlVgpuInstanceGetRuntimeStateSize = GetProcAddress(handle, 'nvmlVgpuInstanceGetRuntimeStateSize')
+        __nvmlVgpuInstanceGetRuntimeStateSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetRuntimeStateSize')
 
         global __nvmlDeviceSetVgpuCapabilities
-        __nvmlDeviceSetVgpuCapabilities = GetProcAddress(handle, 'nvmlDeviceSetVgpuCapabilities')
+        __nvmlDeviceSetVgpuCapabilities = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetVgpuCapabilities')
 
         global __nvmlDeviceGetGridLicensableFeatures_v4
-        __nvmlDeviceGetGridLicensableFeatures_v4 = GetProcAddress(handle, 'nvmlDeviceGetGridLicensableFeatures_v4')
+        __nvmlDeviceGetGridLicensableFeatures_v4 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetGridLicensableFeatures_v4')
 
         global __nvmlGetVgpuDriverCapabilities
-        __nvmlGetVgpuDriverCapabilities = GetProcAddress(handle, 'nvmlGetVgpuDriverCapabilities')
+        __nvmlGetVgpuDriverCapabilities = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGetVgpuDriverCapabilities')
 
         global __nvmlDeviceGetVgpuCapabilities
-        __nvmlDeviceGetVgpuCapabilities = GetProcAddress(handle, 'nvmlDeviceGetVgpuCapabilities')
+        __nvmlDeviceGetVgpuCapabilities = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetVgpuCapabilities')
 
         global __nvmlDeviceGetSupportedVgpus
-        __nvmlDeviceGetSupportedVgpus = GetProcAddress(handle, 'nvmlDeviceGetSupportedVgpus')
+        __nvmlDeviceGetSupportedVgpus = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetSupportedVgpus')
 
         global __nvmlDeviceGetCreatableVgpus
-        __nvmlDeviceGetCreatableVgpus = GetProcAddress(handle, 'nvmlDeviceGetCreatableVgpus')
+        __nvmlDeviceGetCreatableVgpus = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetCreatableVgpus')
 
         global __nvmlVgpuTypeGetClass
-        __nvmlVgpuTypeGetClass = GetProcAddress(handle, 'nvmlVgpuTypeGetClass')
+        __nvmlVgpuTypeGetClass = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuTypeGetClass')
 
         global __nvmlVgpuTypeGetName
-        __nvmlVgpuTypeGetName = GetProcAddress(handle, 'nvmlVgpuTypeGetName')
+        __nvmlVgpuTypeGetName = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuTypeGetName')
 
         global __nvmlVgpuTypeGetGpuInstanceProfileId
-        __nvmlVgpuTypeGetGpuInstanceProfileId = GetProcAddress(handle, 'nvmlVgpuTypeGetGpuInstanceProfileId')
+        __nvmlVgpuTypeGetGpuInstanceProfileId = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuTypeGetGpuInstanceProfileId')
 
         global __nvmlVgpuTypeGetDeviceID
-        __nvmlVgpuTypeGetDeviceID = GetProcAddress(handle, 'nvmlVgpuTypeGetDeviceID')
+        __nvmlVgpuTypeGetDeviceID = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuTypeGetDeviceID')
 
         global __nvmlVgpuTypeGetFramebufferSize
-        __nvmlVgpuTypeGetFramebufferSize = GetProcAddress(handle, 'nvmlVgpuTypeGetFramebufferSize')
+        __nvmlVgpuTypeGetFramebufferSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuTypeGetFramebufferSize')
 
         global __nvmlVgpuTypeGetNumDisplayHeads
-        __nvmlVgpuTypeGetNumDisplayHeads = GetProcAddress(handle, 'nvmlVgpuTypeGetNumDisplayHeads')
+        __nvmlVgpuTypeGetNumDisplayHeads = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuTypeGetNumDisplayHeads')
 
         global __nvmlVgpuTypeGetResolution
-        __nvmlVgpuTypeGetResolution = GetProcAddress(handle, 'nvmlVgpuTypeGetResolution')
+        __nvmlVgpuTypeGetResolution = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuTypeGetResolution')
 
         global __nvmlVgpuTypeGetLicense
-        __nvmlVgpuTypeGetLicense = GetProcAddress(handle, 'nvmlVgpuTypeGetLicense')
+        __nvmlVgpuTypeGetLicense = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuTypeGetLicense')
 
         global __nvmlVgpuTypeGetFrameRateLimit
-        __nvmlVgpuTypeGetFrameRateLimit = GetProcAddress(handle, 'nvmlVgpuTypeGetFrameRateLimit')
+        __nvmlVgpuTypeGetFrameRateLimit = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuTypeGetFrameRateLimit')
 
         global __nvmlVgpuTypeGetMaxInstances
-        __nvmlVgpuTypeGetMaxInstances = GetProcAddress(handle, 'nvmlVgpuTypeGetMaxInstances')
+        __nvmlVgpuTypeGetMaxInstances = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuTypeGetMaxInstances')
 
         global __nvmlVgpuTypeGetMaxInstancesPerVm
-        __nvmlVgpuTypeGetMaxInstancesPerVm = GetProcAddress(handle, 'nvmlVgpuTypeGetMaxInstancesPerVm')
+        __nvmlVgpuTypeGetMaxInstancesPerVm = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuTypeGetMaxInstancesPerVm')
 
         global __nvmlVgpuTypeGetBAR1Info
-        __nvmlVgpuTypeGetBAR1Info = GetProcAddress(handle, 'nvmlVgpuTypeGetBAR1Info')
+        __nvmlVgpuTypeGetBAR1Info = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuTypeGetBAR1Info')
 
         global __nvmlDeviceGetActiveVgpus
-        __nvmlDeviceGetActiveVgpus = GetProcAddress(handle, 'nvmlDeviceGetActiveVgpus')
+        __nvmlDeviceGetActiveVgpus = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetActiveVgpus')
 
         global __nvmlVgpuInstanceGetVmID
-        __nvmlVgpuInstanceGetVmID = GetProcAddress(handle, 'nvmlVgpuInstanceGetVmID')
+        __nvmlVgpuInstanceGetVmID = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetVmID')
 
         global __nvmlVgpuInstanceGetUUID
-        __nvmlVgpuInstanceGetUUID = GetProcAddress(handle, 'nvmlVgpuInstanceGetUUID')
+        __nvmlVgpuInstanceGetUUID = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetUUID')
 
         global __nvmlVgpuInstanceGetVmDriverVersion
-        __nvmlVgpuInstanceGetVmDriverVersion = GetProcAddress(handle, 'nvmlVgpuInstanceGetVmDriverVersion')
+        __nvmlVgpuInstanceGetVmDriverVersion = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetVmDriverVersion')
 
         global __nvmlVgpuInstanceGetFbUsage
-        __nvmlVgpuInstanceGetFbUsage = GetProcAddress(handle, 'nvmlVgpuInstanceGetFbUsage')
+        __nvmlVgpuInstanceGetFbUsage = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetFbUsage')
 
         global __nvmlVgpuInstanceGetLicenseStatus
-        __nvmlVgpuInstanceGetLicenseStatus = GetProcAddress(handle, 'nvmlVgpuInstanceGetLicenseStatus')
+        __nvmlVgpuInstanceGetLicenseStatus = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetLicenseStatus')
 
         global __nvmlVgpuInstanceGetType
-        __nvmlVgpuInstanceGetType = GetProcAddress(handle, 'nvmlVgpuInstanceGetType')
+        __nvmlVgpuInstanceGetType = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetType')
 
         global __nvmlVgpuInstanceGetFrameRateLimit
-        __nvmlVgpuInstanceGetFrameRateLimit = GetProcAddress(handle, 'nvmlVgpuInstanceGetFrameRateLimit')
+        __nvmlVgpuInstanceGetFrameRateLimit = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetFrameRateLimit')
 
         global __nvmlVgpuInstanceGetEccMode
-        __nvmlVgpuInstanceGetEccMode = GetProcAddress(handle, 'nvmlVgpuInstanceGetEccMode')
+        __nvmlVgpuInstanceGetEccMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetEccMode')
 
         global __nvmlVgpuInstanceGetEncoderCapacity
-        __nvmlVgpuInstanceGetEncoderCapacity = GetProcAddress(handle, 'nvmlVgpuInstanceGetEncoderCapacity')
+        __nvmlVgpuInstanceGetEncoderCapacity = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetEncoderCapacity')
 
         global __nvmlVgpuInstanceSetEncoderCapacity
-        __nvmlVgpuInstanceSetEncoderCapacity = GetProcAddress(handle, 'nvmlVgpuInstanceSetEncoderCapacity')
+        __nvmlVgpuInstanceSetEncoderCapacity = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceSetEncoderCapacity')
 
         global __nvmlVgpuInstanceGetEncoderStats
-        __nvmlVgpuInstanceGetEncoderStats = GetProcAddress(handle, 'nvmlVgpuInstanceGetEncoderStats')
+        __nvmlVgpuInstanceGetEncoderStats = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetEncoderStats')
 
         global __nvmlVgpuInstanceGetEncoderSessions
-        __nvmlVgpuInstanceGetEncoderSessions = GetProcAddress(handle, 'nvmlVgpuInstanceGetEncoderSessions')
+        __nvmlVgpuInstanceGetEncoderSessions = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetEncoderSessions')
 
         global __nvmlVgpuInstanceGetFBCStats
-        __nvmlVgpuInstanceGetFBCStats = GetProcAddress(handle, 'nvmlVgpuInstanceGetFBCStats')
+        __nvmlVgpuInstanceGetFBCStats = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetFBCStats')
 
         global __nvmlVgpuInstanceGetFBCSessions
-        __nvmlVgpuInstanceGetFBCSessions = GetProcAddress(handle, 'nvmlVgpuInstanceGetFBCSessions')
+        __nvmlVgpuInstanceGetFBCSessions = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetFBCSessions')
 
         global __nvmlVgpuInstanceGetGpuInstanceId
-        __nvmlVgpuInstanceGetGpuInstanceId = GetProcAddress(handle, 'nvmlVgpuInstanceGetGpuInstanceId')
+        __nvmlVgpuInstanceGetGpuInstanceId = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetGpuInstanceId')
 
         global __nvmlVgpuInstanceGetGpuPciId
-        __nvmlVgpuInstanceGetGpuPciId = GetProcAddress(handle, 'nvmlVgpuInstanceGetGpuPciId')
+        __nvmlVgpuInstanceGetGpuPciId = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetGpuPciId')
 
         global __nvmlVgpuTypeGetCapabilities
-        __nvmlVgpuTypeGetCapabilities = GetProcAddress(handle, 'nvmlVgpuTypeGetCapabilities')
+        __nvmlVgpuTypeGetCapabilities = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuTypeGetCapabilities')
 
         global __nvmlVgpuInstanceGetMdevUUID
-        __nvmlVgpuInstanceGetMdevUUID = GetProcAddress(handle, 'nvmlVgpuInstanceGetMdevUUID')
+        __nvmlVgpuInstanceGetMdevUUID = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetMdevUUID')
 
         global __nvmlGpuInstanceGetCreatableVgpus
-        __nvmlGpuInstanceGetCreatableVgpus = GetProcAddress(handle, 'nvmlGpuInstanceGetCreatableVgpus')
+        __nvmlGpuInstanceGetCreatableVgpus = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGpuInstanceGetCreatableVgpus')
 
         global __nvmlVgpuTypeGetMaxInstancesPerGpuInstance
-        __nvmlVgpuTypeGetMaxInstancesPerGpuInstance = GetProcAddress(handle, 'nvmlVgpuTypeGetMaxInstancesPerGpuInstance')
+        __nvmlVgpuTypeGetMaxInstancesPerGpuInstance = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuTypeGetMaxInstancesPerGpuInstance')
 
         global __nvmlGpuInstanceGetActiveVgpus
-        __nvmlGpuInstanceGetActiveVgpus = GetProcAddress(handle, 'nvmlGpuInstanceGetActiveVgpus')
+        __nvmlGpuInstanceGetActiveVgpus = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGpuInstanceGetActiveVgpus')
 
         global __nvmlGpuInstanceSetVgpuSchedulerState
-        __nvmlGpuInstanceSetVgpuSchedulerState = GetProcAddress(handle, 'nvmlGpuInstanceSetVgpuSchedulerState')
+        __nvmlGpuInstanceSetVgpuSchedulerState = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGpuInstanceSetVgpuSchedulerState')
 
         global __nvmlGpuInstanceGetVgpuSchedulerState
-        __nvmlGpuInstanceGetVgpuSchedulerState = GetProcAddress(handle, 'nvmlGpuInstanceGetVgpuSchedulerState')
+        __nvmlGpuInstanceGetVgpuSchedulerState = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGpuInstanceGetVgpuSchedulerState')
 
         global __nvmlGpuInstanceGetVgpuSchedulerLog
-        __nvmlGpuInstanceGetVgpuSchedulerLog = GetProcAddress(handle, 'nvmlGpuInstanceGetVgpuSchedulerLog')
+        __nvmlGpuInstanceGetVgpuSchedulerLog = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGpuInstanceGetVgpuSchedulerLog')
 
         global __nvmlGpuInstanceGetVgpuTypeCreatablePlacements
-        __nvmlGpuInstanceGetVgpuTypeCreatablePlacements = GetProcAddress(handle, 'nvmlGpuInstanceGetVgpuTypeCreatablePlacements')
+        __nvmlGpuInstanceGetVgpuTypeCreatablePlacements = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGpuInstanceGetVgpuTypeCreatablePlacements')
 
         global __nvmlGpuInstanceGetVgpuHeterogeneousMode
-        __nvmlGpuInstanceGetVgpuHeterogeneousMode = GetProcAddress(handle, 'nvmlGpuInstanceGetVgpuHeterogeneousMode')
+        __nvmlGpuInstanceGetVgpuHeterogeneousMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGpuInstanceGetVgpuHeterogeneousMode')
 
         global __nvmlGpuInstanceSetVgpuHeterogeneousMode
-        __nvmlGpuInstanceSetVgpuHeterogeneousMode = GetProcAddress(handle, 'nvmlGpuInstanceSetVgpuHeterogeneousMode')
+        __nvmlGpuInstanceSetVgpuHeterogeneousMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGpuInstanceSetVgpuHeterogeneousMode')
 
         global __nvmlVgpuInstanceGetMetadata
-        __nvmlVgpuInstanceGetMetadata = GetProcAddress(handle, 'nvmlVgpuInstanceGetMetadata')
+        __nvmlVgpuInstanceGetMetadata = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetMetadata')
 
         global __nvmlDeviceGetVgpuMetadata
-        __nvmlDeviceGetVgpuMetadata = GetProcAddress(handle, 'nvmlDeviceGetVgpuMetadata')
+        __nvmlDeviceGetVgpuMetadata = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetVgpuMetadata')
 
         global __nvmlGetVgpuCompatibility
-        __nvmlGetVgpuCompatibility = GetProcAddress(handle, 'nvmlGetVgpuCompatibility')
+        __nvmlGetVgpuCompatibility = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGetVgpuCompatibility')
 
         global __nvmlDeviceGetPgpuMetadataString
-        __nvmlDeviceGetPgpuMetadataString = GetProcAddress(handle, 'nvmlDeviceGetPgpuMetadataString')
+        __nvmlDeviceGetPgpuMetadataString = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetPgpuMetadataString')
 
         global __nvmlDeviceGetVgpuSchedulerLog
-        __nvmlDeviceGetVgpuSchedulerLog = GetProcAddress(handle, 'nvmlDeviceGetVgpuSchedulerLog')
+        __nvmlDeviceGetVgpuSchedulerLog = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetVgpuSchedulerLog')
 
         global __nvmlDeviceGetVgpuSchedulerState
-        __nvmlDeviceGetVgpuSchedulerState = GetProcAddress(handle, 'nvmlDeviceGetVgpuSchedulerState')
+        __nvmlDeviceGetVgpuSchedulerState = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetVgpuSchedulerState')
 
         global __nvmlDeviceGetVgpuSchedulerCapabilities
-        __nvmlDeviceGetVgpuSchedulerCapabilities = GetProcAddress(handle, 'nvmlDeviceGetVgpuSchedulerCapabilities')
+        __nvmlDeviceGetVgpuSchedulerCapabilities = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetVgpuSchedulerCapabilities')
 
         global __nvmlDeviceSetVgpuSchedulerState
-        __nvmlDeviceSetVgpuSchedulerState = GetProcAddress(handle, 'nvmlDeviceSetVgpuSchedulerState')
+        __nvmlDeviceSetVgpuSchedulerState = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetVgpuSchedulerState')
 
         global __nvmlGetVgpuVersion
-        __nvmlGetVgpuVersion = GetProcAddress(handle, 'nvmlGetVgpuVersion')
+        __nvmlGetVgpuVersion = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGetVgpuVersion')
 
         global __nvmlSetVgpuVersion
-        __nvmlSetVgpuVersion = GetProcAddress(handle, 'nvmlSetVgpuVersion')
+        __nvmlSetVgpuVersion = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlSetVgpuVersion')
 
         global __nvmlDeviceGetVgpuUtilization
-        __nvmlDeviceGetVgpuUtilization = GetProcAddress(handle, 'nvmlDeviceGetVgpuUtilization')
+        __nvmlDeviceGetVgpuUtilization = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetVgpuUtilization')
 
         global __nvmlDeviceGetVgpuInstancesUtilizationInfo
-        __nvmlDeviceGetVgpuInstancesUtilizationInfo = GetProcAddress(handle, 'nvmlDeviceGetVgpuInstancesUtilizationInfo')
+        __nvmlDeviceGetVgpuInstancesUtilizationInfo = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetVgpuInstancesUtilizationInfo')
 
         global __nvmlDeviceGetVgpuProcessUtilization
-        __nvmlDeviceGetVgpuProcessUtilization = GetProcAddress(handle, 'nvmlDeviceGetVgpuProcessUtilization')
+        __nvmlDeviceGetVgpuProcessUtilization = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetVgpuProcessUtilization')
 
         global __nvmlDeviceGetVgpuProcessesUtilizationInfo
-        __nvmlDeviceGetVgpuProcessesUtilizationInfo = GetProcAddress(handle, 'nvmlDeviceGetVgpuProcessesUtilizationInfo')
+        __nvmlDeviceGetVgpuProcessesUtilizationInfo = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetVgpuProcessesUtilizationInfo')
 
         global __nvmlVgpuInstanceGetAccountingMode
-        __nvmlVgpuInstanceGetAccountingMode = GetProcAddress(handle, 'nvmlVgpuInstanceGetAccountingMode')
+        __nvmlVgpuInstanceGetAccountingMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetAccountingMode')
 
         global __nvmlVgpuInstanceGetAccountingPids
-        __nvmlVgpuInstanceGetAccountingPids = GetProcAddress(handle, 'nvmlVgpuInstanceGetAccountingPids')
+        __nvmlVgpuInstanceGetAccountingPids = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetAccountingPids')
 
         global __nvmlVgpuInstanceGetAccountingStats
-        __nvmlVgpuInstanceGetAccountingStats = GetProcAddress(handle, 'nvmlVgpuInstanceGetAccountingStats')
+        __nvmlVgpuInstanceGetAccountingStats = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetAccountingStats')
 
         global __nvmlVgpuInstanceClearAccountingPids
-        __nvmlVgpuInstanceClearAccountingPids = GetProcAddress(handle, 'nvmlVgpuInstanceClearAccountingPids')
+        __nvmlVgpuInstanceClearAccountingPids = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceClearAccountingPids')
 
         global __nvmlVgpuInstanceGetLicenseInfo_v2
-        __nvmlVgpuInstanceGetLicenseInfo_v2 = GetProcAddress(handle, 'nvmlVgpuInstanceGetLicenseInfo_v2')
+        __nvmlVgpuInstanceGetLicenseInfo_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlVgpuInstanceGetLicenseInfo_v2')
 
         global __nvmlGetExcludedDeviceCount
-        __nvmlGetExcludedDeviceCount = GetProcAddress(handle, 'nvmlGetExcludedDeviceCount')
+        __nvmlGetExcludedDeviceCount = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGetExcludedDeviceCount')
 
         global __nvmlGetExcludedDeviceInfoByIndex
-        __nvmlGetExcludedDeviceInfoByIndex = GetProcAddress(handle, 'nvmlGetExcludedDeviceInfoByIndex')
+        __nvmlGetExcludedDeviceInfoByIndex = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGetExcludedDeviceInfoByIndex')
 
         global __nvmlDeviceSetMigMode
-        __nvmlDeviceSetMigMode = GetProcAddress(handle, 'nvmlDeviceSetMigMode')
+        __nvmlDeviceSetMigMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetMigMode')
 
         global __nvmlDeviceGetMigMode
-        __nvmlDeviceGetMigMode = GetProcAddress(handle, 'nvmlDeviceGetMigMode')
+        __nvmlDeviceGetMigMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetMigMode')
 
         global __nvmlDeviceGetGpuInstanceProfileInfoV
-        __nvmlDeviceGetGpuInstanceProfileInfoV = GetProcAddress(handle, 'nvmlDeviceGetGpuInstanceProfileInfoV')
+        __nvmlDeviceGetGpuInstanceProfileInfoV = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetGpuInstanceProfileInfoV')
 
         global __nvmlDeviceGetGpuInstancePossiblePlacements_v2
-        __nvmlDeviceGetGpuInstancePossiblePlacements_v2 = GetProcAddress(handle, 'nvmlDeviceGetGpuInstancePossiblePlacements_v2')
+        __nvmlDeviceGetGpuInstancePossiblePlacements_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetGpuInstancePossiblePlacements_v2')
 
         global __nvmlDeviceGetGpuInstanceRemainingCapacity
-        __nvmlDeviceGetGpuInstanceRemainingCapacity = GetProcAddress(handle, 'nvmlDeviceGetGpuInstanceRemainingCapacity')
+        __nvmlDeviceGetGpuInstanceRemainingCapacity = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetGpuInstanceRemainingCapacity')
 
         global __nvmlDeviceCreateGpuInstance
-        __nvmlDeviceCreateGpuInstance = GetProcAddress(handle, 'nvmlDeviceCreateGpuInstance')
+        __nvmlDeviceCreateGpuInstance = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceCreateGpuInstance')
 
         global __nvmlDeviceCreateGpuInstanceWithPlacement
-        __nvmlDeviceCreateGpuInstanceWithPlacement = GetProcAddress(handle, 'nvmlDeviceCreateGpuInstanceWithPlacement')
+        __nvmlDeviceCreateGpuInstanceWithPlacement = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceCreateGpuInstanceWithPlacement')
 
         global __nvmlGpuInstanceDestroy
-        __nvmlGpuInstanceDestroy = GetProcAddress(handle, 'nvmlGpuInstanceDestroy')
+        __nvmlGpuInstanceDestroy = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGpuInstanceDestroy')
 
         global __nvmlDeviceGetGpuInstances
-        __nvmlDeviceGetGpuInstances = GetProcAddress(handle, 'nvmlDeviceGetGpuInstances')
+        __nvmlDeviceGetGpuInstances = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetGpuInstances')
 
         global __nvmlDeviceGetGpuInstanceById
-        __nvmlDeviceGetGpuInstanceById = GetProcAddress(handle, 'nvmlDeviceGetGpuInstanceById')
+        __nvmlDeviceGetGpuInstanceById = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetGpuInstanceById')
 
         global __nvmlGpuInstanceGetInfo
-        __nvmlGpuInstanceGetInfo = GetProcAddress(handle, 'nvmlGpuInstanceGetInfo')
+        __nvmlGpuInstanceGetInfo = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGpuInstanceGetInfo')
 
         global __nvmlGpuInstanceGetComputeInstanceProfileInfoV
-        __nvmlGpuInstanceGetComputeInstanceProfileInfoV = GetProcAddress(handle, 'nvmlGpuInstanceGetComputeInstanceProfileInfoV')
+        __nvmlGpuInstanceGetComputeInstanceProfileInfoV = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGpuInstanceGetComputeInstanceProfileInfoV')
 
         global __nvmlGpuInstanceGetComputeInstanceRemainingCapacity
-        __nvmlGpuInstanceGetComputeInstanceRemainingCapacity = GetProcAddress(handle, 'nvmlGpuInstanceGetComputeInstanceRemainingCapacity')
+        __nvmlGpuInstanceGetComputeInstanceRemainingCapacity = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGpuInstanceGetComputeInstanceRemainingCapacity')
 
         global __nvmlGpuInstanceGetComputeInstancePossiblePlacements
-        __nvmlGpuInstanceGetComputeInstancePossiblePlacements = GetProcAddress(handle, 'nvmlGpuInstanceGetComputeInstancePossiblePlacements')
+        __nvmlGpuInstanceGetComputeInstancePossiblePlacements = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGpuInstanceGetComputeInstancePossiblePlacements')
 
         global __nvmlGpuInstanceCreateComputeInstance
-        __nvmlGpuInstanceCreateComputeInstance = GetProcAddress(handle, 'nvmlGpuInstanceCreateComputeInstance')
+        __nvmlGpuInstanceCreateComputeInstance = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGpuInstanceCreateComputeInstance')
 
         global __nvmlGpuInstanceCreateComputeInstanceWithPlacement
-        __nvmlGpuInstanceCreateComputeInstanceWithPlacement = GetProcAddress(handle, 'nvmlGpuInstanceCreateComputeInstanceWithPlacement')
+        __nvmlGpuInstanceCreateComputeInstanceWithPlacement = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGpuInstanceCreateComputeInstanceWithPlacement')
 
         global __nvmlComputeInstanceDestroy
-        __nvmlComputeInstanceDestroy = GetProcAddress(handle, 'nvmlComputeInstanceDestroy')
+        __nvmlComputeInstanceDestroy = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlComputeInstanceDestroy')
 
         global __nvmlGpuInstanceGetComputeInstances
-        __nvmlGpuInstanceGetComputeInstances = GetProcAddress(handle, 'nvmlGpuInstanceGetComputeInstances')
+        __nvmlGpuInstanceGetComputeInstances = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGpuInstanceGetComputeInstances')
 
         global __nvmlGpuInstanceGetComputeInstanceById
-        __nvmlGpuInstanceGetComputeInstanceById = GetProcAddress(handle, 'nvmlGpuInstanceGetComputeInstanceById')
+        __nvmlGpuInstanceGetComputeInstanceById = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGpuInstanceGetComputeInstanceById')
 
         global __nvmlComputeInstanceGetInfo_v2
-        __nvmlComputeInstanceGetInfo_v2 = GetProcAddress(handle, 'nvmlComputeInstanceGetInfo_v2')
+        __nvmlComputeInstanceGetInfo_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlComputeInstanceGetInfo_v2')
 
         global __nvmlDeviceIsMigDeviceHandle
-        __nvmlDeviceIsMigDeviceHandle = GetProcAddress(handle, 'nvmlDeviceIsMigDeviceHandle')
+        __nvmlDeviceIsMigDeviceHandle = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceIsMigDeviceHandle')
 
         global __nvmlDeviceGetGpuInstanceId
-        __nvmlDeviceGetGpuInstanceId = GetProcAddress(handle, 'nvmlDeviceGetGpuInstanceId')
+        __nvmlDeviceGetGpuInstanceId = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetGpuInstanceId')
 
         global __nvmlDeviceGetComputeInstanceId
-        __nvmlDeviceGetComputeInstanceId = GetProcAddress(handle, 'nvmlDeviceGetComputeInstanceId')
+        __nvmlDeviceGetComputeInstanceId = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetComputeInstanceId')
 
         global __nvmlDeviceGetMaxMigDeviceCount
-        __nvmlDeviceGetMaxMigDeviceCount = GetProcAddress(handle, 'nvmlDeviceGetMaxMigDeviceCount')
+        __nvmlDeviceGetMaxMigDeviceCount = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetMaxMigDeviceCount')
 
         global __nvmlDeviceGetMigDeviceHandleByIndex
-        __nvmlDeviceGetMigDeviceHandleByIndex = GetProcAddress(handle, 'nvmlDeviceGetMigDeviceHandleByIndex')
+        __nvmlDeviceGetMigDeviceHandleByIndex = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetMigDeviceHandleByIndex')
 
         global __nvmlDeviceGetDeviceHandleFromMigDeviceHandle
-        __nvmlDeviceGetDeviceHandleFromMigDeviceHandle = GetProcAddress(handle, 'nvmlDeviceGetDeviceHandleFromMigDeviceHandle')
+        __nvmlDeviceGetDeviceHandleFromMigDeviceHandle = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetDeviceHandleFromMigDeviceHandle')
 
         global __nvmlDeviceGetCapabilities
-        __nvmlDeviceGetCapabilities = GetProcAddress(handle, 'nvmlDeviceGetCapabilities')
+        __nvmlDeviceGetCapabilities = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetCapabilities')
 
         global __nvmlDevicePowerSmoothingActivatePresetProfile
-        __nvmlDevicePowerSmoothingActivatePresetProfile = GetProcAddress(handle, 'nvmlDevicePowerSmoothingActivatePresetProfile')
+        __nvmlDevicePowerSmoothingActivatePresetProfile = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDevicePowerSmoothingActivatePresetProfile')
 
         global __nvmlDevicePowerSmoothingUpdatePresetProfileParam
-        __nvmlDevicePowerSmoothingUpdatePresetProfileParam = GetProcAddress(handle, 'nvmlDevicePowerSmoothingUpdatePresetProfileParam')
+        __nvmlDevicePowerSmoothingUpdatePresetProfileParam = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDevicePowerSmoothingUpdatePresetProfileParam')
 
         global __nvmlDevicePowerSmoothingSetState
-        __nvmlDevicePowerSmoothingSetState = GetProcAddress(handle, 'nvmlDevicePowerSmoothingSetState')
+        __nvmlDevicePowerSmoothingSetState = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDevicePowerSmoothingSetState')
 
         global __nvmlDeviceGetAddressingMode
-        __nvmlDeviceGetAddressingMode = GetProcAddress(handle, 'nvmlDeviceGetAddressingMode')
+        __nvmlDeviceGetAddressingMode = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetAddressingMode')
 
         global __nvmlDeviceGetRepairStatus
-        __nvmlDeviceGetRepairStatus = GetProcAddress(handle, 'nvmlDeviceGetRepairStatus')
+        __nvmlDeviceGetRepairStatus = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetRepairStatus')
 
         global __nvmlDeviceGetPowerMizerMode_v1
-        __nvmlDeviceGetPowerMizerMode_v1 = GetProcAddress(handle, 'nvmlDeviceGetPowerMizerMode_v1')
+        __nvmlDeviceGetPowerMizerMode_v1 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetPowerMizerMode_v1')
 
         global __nvmlDeviceSetPowerMizerMode_v1
-        __nvmlDeviceSetPowerMizerMode_v1 = GetProcAddress(handle, 'nvmlDeviceSetPowerMizerMode_v1')
+        __nvmlDeviceSetPowerMizerMode_v1 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetPowerMizerMode_v1')
 
         global __nvmlDeviceGetPdi
-        __nvmlDeviceGetPdi = GetProcAddress(handle, 'nvmlDeviceGetPdi')
+        __nvmlDeviceGetPdi = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetPdi')
 
         global __nvmlDeviceSetHostname_v1
-        __nvmlDeviceSetHostname_v1 = GetProcAddress(handle, 'nvmlDeviceSetHostname_v1')
+        __nvmlDeviceSetHostname_v1 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetHostname_v1')
 
         global __nvmlDeviceGetHostname_v1
-        __nvmlDeviceGetHostname_v1 = GetProcAddress(handle, 'nvmlDeviceGetHostname_v1')
+        __nvmlDeviceGetHostname_v1 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetHostname_v1')
 
         global __nvmlDeviceGetNvLinkInfo
-        __nvmlDeviceGetNvLinkInfo = GetProcAddress(handle, 'nvmlDeviceGetNvLinkInfo')
+        __nvmlDeviceGetNvLinkInfo = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetNvLinkInfo')
 
         global __nvmlDeviceReadWritePRM_v1
-        __nvmlDeviceReadWritePRM_v1 = GetProcAddress(handle, 'nvmlDeviceReadWritePRM_v1')
+        __nvmlDeviceReadWritePRM_v1 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceReadWritePRM_v1')
 
         global __nvmlDeviceGetGpuInstanceProfileInfoByIdV
-        __nvmlDeviceGetGpuInstanceProfileInfoByIdV = GetProcAddress(handle, 'nvmlDeviceGetGpuInstanceProfileInfoByIdV')
+        __nvmlDeviceGetGpuInstanceProfileInfoByIdV = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetGpuInstanceProfileInfoByIdV')
 
         global __nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts
-        __nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts = GetProcAddress(handle, 'nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts')
+        __nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts')
 
         global __nvmlDeviceGetUnrepairableMemoryFlag_v1
-        __nvmlDeviceGetUnrepairableMemoryFlag_v1 = GetProcAddress(handle, 'nvmlDeviceGetUnrepairableMemoryFlag_v1')
+        __nvmlDeviceGetUnrepairableMemoryFlag_v1 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetUnrepairableMemoryFlag_v1')
 
         global __nvmlDeviceReadPRMCounters_v1
-        __nvmlDeviceReadPRMCounters_v1 = GetProcAddress(handle, 'nvmlDeviceReadPRMCounters_v1')
+        __nvmlDeviceReadPRMCounters_v1 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceReadPRMCounters_v1')
 
         global __nvmlDeviceSetRusdSettings_v1
-        __nvmlDeviceSetRusdSettings_v1 = GetProcAddress(handle, 'nvmlDeviceSetRusdSettings_v1')
+        __nvmlDeviceSetRusdSettings_v1 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetRusdSettings_v1')
 
         global __nvmlDeviceVgpuForceGspUnload
-        __nvmlDeviceVgpuForceGspUnload = GetProcAddress(handle, 'nvmlDeviceVgpuForceGspUnload')
+        __nvmlDeviceVgpuForceGspUnload = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceVgpuForceGspUnload')
 
         global __nvmlDeviceGetVgpuSchedulerState_v2
-        __nvmlDeviceGetVgpuSchedulerState_v2 = GetProcAddress(handle, 'nvmlDeviceGetVgpuSchedulerState_v2')
+        __nvmlDeviceGetVgpuSchedulerState_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetVgpuSchedulerState_v2')
 
         global __nvmlGpuInstanceGetVgpuSchedulerState_v2
-        __nvmlGpuInstanceGetVgpuSchedulerState_v2 = GetProcAddress(handle, 'nvmlGpuInstanceGetVgpuSchedulerState_v2')
+        __nvmlGpuInstanceGetVgpuSchedulerState_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGpuInstanceGetVgpuSchedulerState_v2')
 
         global __nvmlDeviceGetVgpuSchedulerLog_v2
-        __nvmlDeviceGetVgpuSchedulerLog_v2 = GetProcAddress(handle, 'nvmlDeviceGetVgpuSchedulerLog_v2')
+        __nvmlDeviceGetVgpuSchedulerLog_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceGetVgpuSchedulerLog_v2')
 
         global __nvmlGpuInstanceGetVgpuSchedulerLog_v2
-        __nvmlGpuInstanceGetVgpuSchedulerLog_v2 = GetProcAddress(handle, 'nvmlGpuInstanceGetVgpuSchedulerLog_v2')
+        __nvmlGpuInstanceGetVgpuSchedulerLog_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGpuInstanceGetVgpuSchedulerLog_v2')
 
         global __nvmlDeviceSetVgpuSchedulerState_v2
-        __nvmlDeviceSetVgpuSchedulerState_v2 = GetProcAddress(handle, 'nvmlDeviceSetVgpuSchedulerState_v2')
+        __nvmlDeviceSetVgpuSchedulerState_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlDeviceSetVgpuSchedulerState_v2')
 
         global __nvmlGpuInstanceSetVgpuSchedulerState_v2
-        __nvmlGpuInstanceSetVgpuSchedulerState_v2 = GetProcAddress(handle, 'nvmlGpuInstanceSetVgpuSchedulerState_v2')
+        __nvmlGpuInstanceSetVgpuSchedulerState_v2 = _cyb_GetProcAddress(<HMODULE>handle, 'nvmlGpuInstanceSetVgpuSchedulerState_v2')
 
-        __py_nvml_init = True
+        _cyb___py_nvml_init = True
         return 0
 
-
 cdef inline int _check_or_init_nvml() except -1 nogil:
-    if __py_nvml_init:
+    if _cyb___py_nvml_init:
         return 0
 
     return _init_nvml()
 
 
-cdef dict func_ptrs = None
-
-
 cpdef dict _inspect_function_pointers():
-    global func_ptrs
-    if func_ptrs is not None:
-        return func_ptrs
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is not None:
+        return _cyb_func_ptrs
 
     _check_or_init_nvml()
     cdef dict data = {}
-
     global __nvmlInit_v2
-    data["__nvmlInit_v2"] = <intptr_t>__nvmlInit_v2
+    data["__nvmlInit_v2"] = <_cyb_intptr_t>__nvmlInit_v2
 
     global __nvmlInitWithFlags
-    data["__nvmlInitWithFlags"] = <intptr_t>__nvmlInitWithFlags
+    data["__nvmlInitWithFlags"] = <_cyb_intptr_t>__nvmlInitWithFlags
 
     global __nvmlShutdown
-    data["__nvmlShutdown"] = <intptr_t>__nvmlShutdown
+    data["__nvmlShutdown"] = <_cyb_intptr_t>__nvmlShutdown
 
     global __nvmlErrorString
-    data["__nvmlErrorString"] = <intptr_t>__nvmlErrorString
+    data["__nvmlErrorString"] = <_cyb_intptr_t>__nvmlErrorString
 
     global __nvmlSystemGetDriverVersion
-    data["__nvmlSystemGetDriverVersion"] = <intptr_t>__nvmlSystemGetDriverVersion
+    data["__nvmlSystemGetDriverVersion"] = <_cyb_intptr_t>__nvmlSystemGetDriverVersion
 
     global __nvmlSystemGetNVMLVersion
-    data["__nvmlSystemGetNVMLVersion"] = <intptr_t>__nvmlSystemGetNVMLVersion
+    data["__nvmlSystemGetNVMLVersion"] = <_cyb_intptr_t>__nvmlSystemGetNVMLVersion
 
     global __nvmlSystemGetCudaDriverVersion
-    data["__nvmlSystemGetCudaDriverVersion"] = <intptr_t>__nvmlSystemGetCudaDriverVersion
+    data["__nvmlSystemGetCudaDriverVersion"] = <_cyb_intptr_t>__nvmlSystemGetCudaDriverVersion
 
     global __nvmlSystemGetCudaDriverVersion_v2
-    data["__nvmlSystemGetCudaDriverVersion_v2"] = <intptr_t>__nvmlSystemGetCudaDriverVersion_v2
+    data["__nvmlSystemGetCudaDriverVersion_v2"] = <_cyb_intptr_t>__nvmlSystemGetCudaDriverVersion_v2
 
     global __nvmlSystemGetProcessName
-    data["__nvmlSystemGetProcessName"] = <intptr_t>__nvmlSystemGetProcessName
+    data["__nvmlSystemGetProcessName"] = <_cyb_intptr_t>__nvmlSystemGetProcessName
 
     global __nvmlSystemGetHicVersion
-    data["__nvmlSystemGetHicVersion"] = <intptr_t>__nvmlSystemGetHicVersion
+    data["__nvmlSystemGetHicVersion"] = <_cyb_intptr_t>__nvmlSystemGetHicVersion
 
     global __nvmlSystemGetTopologyGpuSet
-    data["__nvmlSystemGetTopologyGpuSet"] = <intptr_t>__nvmlSystemGetTopologyGpuSet
+    data["__nvmlSystemGetTopologyGpuSet"] = <_cyb_intptr_t>__nvmlSystemGetTopologyGpuSet
 
     global __nvmlSystemGetDriverBranch
-    data["__nvmlSystemGetDriverBranch"] = <intptr_t>__nvmlSystemGetDriverBranch
+    data["__nvmlSystemGetDriverBranch"] = <_cyb_intptr_t>__nvmlSystemGetDriverBranch
 
     global __nvmlUnitGetCount
-    data["__nvmlUnitGetCount"] = <intptr_t>__nvmlUnitGetCount
+    data["__nvmlUnitGetCount"] = <_cyb_intptr_t>__nvmlUnitGetCount
 
     global __nvmlUnitGetHandleByIndex
-    data["__nvmlUnitGetHandleByIndex"] = <intptr_t>__nvmlUnitGetHandleByIndex
+    data["__nvmlUnitGetHandleByIndex"] = <_cyb_intptr_t>__nvmlUnitGetHandleByIndex
 
     global __nvmlUnitGetUnitInfo
-    data["__nvmlUnitGetUnitInfo"] = <intptr_t>__nvmlUnitGetUnitInfo
+    data["__nvmlUnitGetUnitInfo"] = <_cyb_intptr_t>__nvmlUnitGetUnitInfo
 
     global __nvmlUnitGetLedState
-    data["__nvmlUnitGetLedState"] = <intptr_t>__nvmlUnitGetLedState
+    data["__nvmlUnitGetLedState"] = <_cyb_intptr_t>__nvmlUnitGetLedState
 
     global __nvmlUnitGetPsuInfo
-    data["__nvmlUnitGetPsuInfo"] = <intptr_t>__nvmlUnitGetPsuInfo
+    data["__nvmlUnitGetPsuInfo"] = <_cyb_intptr_t>__nvmlUnitGetPsuInfo
 
     global __nvmlUnitGetTemperature
-    data["__nvmlUnitGetTemperature"] = <intptr_t>__nvmlUnitGetTemperature
+    data["__nvmlUnitGetTemperature"] = <_cyb_intptr_t>__nvmlUnitGetTemperature
 
     global __nvmlUnitGetFanSpeedInfo
-    data["__nvmlUnitGetFanSpeedInfo"] = <intptr_t>__nvmlUnitGetFanSpeedInfo
+    data["__nvmlUnitGetFanSpeedInfo"] = <_cyb_intptr_t>__nvmlUnitGetFanSpeedInfo
 
     global __nvmlUnitGetDevices
-    data["__nvmlUnitGetDevices"] = <intptr_t>__nvmlUnitGetDevices
+    data["__nvmlUnitGetDevices"] = <_cyb_intptr_t>__nvmlUnitGetDevices
 
     global __nvmlDeviceGetCount_v2
-    data["__nvmlDeviceGetCount_v2"] = <intptr_t>__nvmlDeviceGetCount_v2
+    data["__nvmlDeviceGetCount_v2"] = <_cyb_intptr_t>__nvmlDeviceGetCount_v2
 
     global __nvmlDeviceGetAttributes_v2
-    data["__nvmlDeviceGetAttributes_v2"] = <intptr_t>__nvmlDeviceGetAttributes_v2
+    data["__nvmlDeviceGetAttributes_v2"] = <_cyb_intptr_t>__nvmlDeviceGetAttributes_v2
 
     global __nvmlDeviceGetHandleByIndex_v2
-    data["__nvmlDeviceGetHandleByIndex_v2"] = <intptr_t>__nvmlDeviceGetHandleByIndex_v2
+    data["__nvmlDeviceGetHandleByIndex_v2"] = <_cyb_intptr_t>__nvmlDeviceGetHandleByIndex_v2
 
     global __nvmlDeviceGetHandleBySerial
-    data["__nvmlDeviceGetHandleBySerial"] = <intptr_t>__nvmlDeviceGetHandleBySerial
+    data["__nvmlDeviceGetHandleBySerial"] = <_cyb_intptr_t>__nvmlDeviceGetHandleBySerial
 
     global __nvmlDeviceGetHandleByUUID
-    data["__nvmlDeviceGetHandleByUUID"] = <intptr_t>__nvmlDeviceGetHandleByUUID
+    data["__nvmlDeviceGetHandleByUUID"] = <_cyb_intptr_t>__nvmlDeviceGetHandleByUUID
 
     global __nvmlDeviceGetHandleByUUIDV
-    data["__nvmlDeviceGetHandleByUUIDV"] = <intptr_t>__nvmlDeviceGetHandleByUUIDV
+    data["__nvmlDeviceGetHandleByUUIDV"] = <_cyb_intptr_t>__nvmlDeviceGetHandleByUUIDV
 
     global __nvmlDeviceGetHandleByPciBusId_v2
-    data["__nvmlDeviceGetHandleByPciBusId_v2"] = <intptr_t>__nvmlDeviceGetHandleByPciBusId_v2
+    data["__nvmlDeviceGetHandleByPciBusId_v2"] = <_cyb_intptr_t>__nvmlDeviceGetHandleByPciBusId_v2
 
     global __nvmlDeviceGetName
-    data["__nvmlDeviceGetName"] = <intptr_t>__nvmlDeviceGetName
+    data["__nvmlDeviceGetName"] = <_cyb_intptr_t>__nvmlDeviceGetName
 
     global __nvmlDeviceGetBrand
-    data["__nvmlDeviceGetBrand"] = <intptr_t>__nvmlDeviceGetBrand
+    data["__nvmlDeviceGetBrand"] = <_cyb_intptr_t>__nvmlDeviceGetBrand
 
     global __nvmlDeviceGetIndex
-    data["__nvmlDeviceGetIndex"] = <intptr_t>__nvmlDeviceGetIndex
+    data["__nvmlDeviceGetIndex"] = <_cyb_intptr_t>__nvmlDeviceGetIndex
 
     global __nvmlDeviceGetSerial
-    data["__nvmlDeviceGetSerial"] = <intptr_t>__nvmlDeviceGetSerial
+    data["__nvmlDeviceGetSerial"] = <_cyb_intptr_t>__nvmlDeviceGetSerial
 
     global __nvmlDeviceGetModuleId
-    data["__nvmlDeviceGetModuleId"] = <intptr_t>__nvmlDeviceGetModuleId
+    data["__nvmlDeviceGetModuleId"] = <_cyb_intptr_t>__nvmlDeviceGetModuleId
 
     global __nvmlDeviceGetC2cModeInfoV
-    data["__nvmlDeviceGetC2cModeInfoV"] = <intptr_t>__nvmlDeviceGetC2cModeInfoV
+    data["__nvmlDeviceGetC2cModeInfoV"] = <_cyb_intptr_t>__nvmlDeviceGetC2cModeInfoV
 
     global __nvmlDeviceGetMemoryAffinity
-    data["__nvmlDeviceGetMemoryAffinity"] = <intptr_t>__nvmlDeviceGetMemoryAffinity
+    data["__nvmlDeviceGetMemoryAffinity"] = <_cyb_intptr_t>__nvmlDeviceGetMemoryAffinity
 
     global __nvmlDeviceGetCpuAffinityWithinScope
-    data["__nvmlDeviceGetCpuAffinityWithinScope"] = <intptr_t>__nvmlDeviceGetCpuAffinityWithinScope
+    data["__nvmlDeviceGetCpuAffinityWithinScope"] = <_cyb_intptr_t>__nvmlDeviceGetCpuAffinityWithinScope
 
     global __nvmlDeviceGetCpuAffinity
-    data["__nvmlDeviceGetCpuAffinity"] = <intptr_t>__nvmlDeviceGetCpuAffinity
+    data["__nvmlDeviceGetCpuAffinity"] = <_cyb_intptr_t>__nvmlDeviceGetCpuAffinity
 
     global __nvmlDeviceSetCpuAffinity
-    data["__nvmlDeviceSetCpuAffinity"] = <intptr_t>__nvmlDeviceSetCpuAffinity
+    data["__nvmlDeviceSetCpuAffinity"] = <_cyb_intptr_t>__nvmlDeviceSetCpuAffinity
 
     global __nvmlDeviceClearCpuAffinity
-    data["__nvmlDeviceClearCpuAffinity"] = <intptr_t>__nvmlDeviceClearCpuAffinity
+    data["__nvmlDeviceClearCpuAffinity"] = <_cyb_intptr_t>__nvmlDeviceClearCpuAffinity
 
     global __nvmlDeviceGetNumaNodeId
-    data["__nvmlDeviceGetNumaNodeId"] = <intptr_t>__nvmlDeviceGetNumaNodeId
+    data["__nvmlDeviceGetNumaNodeId"] = <_cyb_intptr_t>__nvmlDeviceGetNumaNodeId
 
     global __nvmlDeviceGetTopologyCommonAncestor
-    data["__nvmlDeviceGetTopologyCommonAncestor"] = <intptr_t>__nvmlDeviceGetTopologyCommonAncestor
+    data["__nvmlDeviceGetTopologyCommonAncestor"] = <_cyb_intptr_t>__nvmlDeviceGetTopologyCommonAncestor
 
     global __nvmlDeviceGetTopologyNearestGpus
-    data["__nvmlDeviceGetTopologyNearestGpus"] = <intptr_t>__nvmlDeviceGetTopologyNearestGpus
+    data["__nvmlDeviceGetTopologyNearestGpus"] = <_cyb_intptr_t>__nvmlDeviceGetTopologyNearestGpus
 
     global __nvmlDeviceGetP2PStatus
-    data["__nvmlDeviceGetP2PStatus"] = <intptr_t>__nvmlDeviceGetP2PStatus
+    data["__nvmlDeviceGetP2PStatus"] = <_cyb_intptr_t>__nvmlDeviceGetP2PStatus
 
     global __nvmlDeviceGetUUID
-    data["__nvmlDeviceGetUUID"] = <intptr_t>__nvmlDeviceGetUUID
+    data["__nvmlDeviceGetUUID"] = <_cyb_intptr_t>__nvmlDeviceGetUUID
 
     global __nvmlDeviceGetMinorNumber
-    data["__nvmlDeviceGetMinorNumber"] = <intptr_t>__nvmlDeviceGetMinorNumber
+    data["__nvmlDeviceGetMinorNumber"] = <_cyb_intptr_t>__nvmlDeviceGetMinorNumber
 
     global __nvmlDeviceGetBoardPartNumber
-    data["__nvmlDeviceGetBoardPartNumber"] = <intptr_t>__nvmlDeviceGetBoardPartNumber
+    data["__nvmlDeviceGetBoardPartNumber"] = <_cyb_intptr_t>__nvmlDeviceGetBoardPartNumber
 
     global __nvmlDeviceGetInforomVersion
-    data["__nvmlDeviceGetInforomVersion"] = <intptr_t>__nvmlDeviceGetInforomVersion
+    data["__nvmlDeviceGetInforomVersion"] = <_cyb_intptr_t>__nvmlDeviceGetInforomVersion
 
     global __nvmlDeviceGetInforomImageVersion
-    data["__nvmlDeviceGetInforomImageVersion"] = <intptr_t>__nvmlDeviceGetInforomImageVersion
+    data["__nvmlDeviceGetInforomImageVersion"] = <_cyb_intptr_t>__nvmlDeviceGetInforomImageVersion
 
     global __nvmlDeviceGetInforomConfigurationChecksum
-    data["__nvmlDeviceGetInforomConfigurationChecksum"] = <intptr_t>__nvmlDeviceGetInforomConfigurationChecksum
+    data["__nvmlDeviceGetInforomConfigurationChecksum"] = <_cyb_intptr_t>__nvmlDeviceGetInforomConfigurationChecksum
 
     global __nvmlDeviceValidateInforom
-    data["__nvmlDeviceValidateInforom"] = <intptr_t>__nvmlDeviceValidateInforom
+    data["__nvmlDeviceValidateInforom"] = <_cyb_intptr_t>__nvmlDeviceValidateInforom
 
     global __nvmlDeviceGetLastBBXFlushTime
-    data["__nvmlDeviceGetLastBBXFlushTime"] = <intptr_t>__nvmlDeviceGetLastBBXFlushTime
+    data["__nvmlDeviceGetLastBBXFlushTime"] = <_cyb_intptr_t>__nvmlDeviceGetLastBBXFlushTime
 
     global __nvmlDeviceGetDisplayMode
-    data["__nvmlDeviceGetDisplayMode"] = <intptr_t>__nvmlDeviceGetDisplayMode
+    data["__nvmlDeviceGetDisplayMode"] = <_cyb_intptr_t>__nvmlDeviceGetDisplayMode
 
     global __nvmlDeviceGetDisplayActive
-    data["__nvmlDeviceGetDisplayActive"] = <intptr_t>__nvmlDeviceGetDisplayActive
+    data["__nvmlDeviceGetDisplayActive"] = <_cyb_intptr_t>__nvmlDeviceGetDisplayActive
 
     global __nvmlDeviceGetPersistenceMode
-    data["__nvmlDeviceGetPersistenceMode"] = <intptr_t>__nvmlDeviceGetPersistenceMode
+    data["__nvmlDeviceGetPersistenceMode"] = <_cyb_intptr_t>__nvmlDeviceGetPersistenceMode
 
     global __nvmlDeviceGetPciInfoExt
-    data["__nvmlDeviceGetPciInfoExt"] = <intptr_t>__nvmlDeviceGetPciInfoExt
+    data["__nvmlDeviceGetPciInfoExt"] = <_cyb_intptr_t>__nvmlDeviceGetPciInfoExt
 
     global __nvmlDeviceGetPciInfo_v3
-    data["__nvmlDeviceGetPciInfo_v3"] = <intptr_t>__nvmlDeviceGetPciInfo_v3
+    data["__nvmlDeviceGetPciInfo_v3"] = <_cyb_intptr_t>__nvmlDeviceGetPciInfo_v3
 
     global __nvmlDeviceGetMaxPcieLinkGeneration
-    data["__nvmlDeviceGetMaxPcieLinkGeneration"] = <intptr_t>__nvmlDeviceGetMaxPcieLinkGeneration
+    data["__nvmlDeviceGetMaxPcieLinkGeneration"] = <_cyb_intptr_t>__nvmlDeviceGetMaxPcieLinkGeneration
 
     global __nvmlDeviceGetGpuMaxPcieLinkGeneration
-    data["__nvmlDeviceGetGpuMaxPcieLinkGeneration"] = <intptr_t>__nvmlDeviceGetGpuMaxPcieLinkGeneration
+    data["__nvmlDeviceGetGpuMaxPcieLinkGeneration"] = <_cyb_intptr_t>__nvmlDeviceGetGpuMaxPcieLinkGeneration
 
     global __nvmlDeviceGetMaxPcieLinkWidth
-    data["__nvmlDeviceGetMaxPcieLinkWidth"] = <intptr_t>__nvmlDeviceGetMaxPcieLinkWidth
+    data["__nvmlDeviceGetMaxPcieLinkWidth"] = <_cyb_intptr_t>__nvmlDeviceGetMaxPcieLinkWidth
 
     global __nvmlDeviceGetCurrPcieLinkGeneration
-    data["__nvmlDeviceGetCurrPcieLinkGeneration"] = <intptr_t>__nvmlDeviceGetCurrPcieLinkGeneration
+    data["__nvmlDeviceGetCurrPcieLinkGeneration"] = <_cyb_intptr_t>__nvmlDeviceGetCurrPcieLinkGeneration
 
     global __nvmlDeviceGetCurrPcieLinkWidth
-    data["__nvmlDeviceGetCurrPcieLinkWidth"] = <intptr_t>__nvmlDeviceGetCurrPcieLinkWidth
+    data["__nvmlDeviceGetCurrPcieLinkWidth"] = <_cyb_intptr_t>__nvmlDeviceGetCurrPcieLinkWidth
 
     global __nvmlDeviceGetPcieThroughput
-    data["__nvmlDeviceGetPcieThroughput"] = <intptr_t>__nvmlDeviceGetPcieThroughput
+    data["__nvmlDeviceGetPcieThroughput"] = <_cyb_intptr_t>__nvmlDeviceGetPcieThroughput
 
     global __nvmlDeviceGetPcieReplayCounter
-    data["__nvmlDeviceGetPcieReplayCounter"] = <intptr_t>__nvmlDeviceGetPcieReplayCounter
+    data["__nvmlDeviceGetPcieReplayCounter"] = <_cyb_intptr_t>__nvmlDeviceGetPcieReplayCounter
 
     global __nvmlDeviceGetClockInfo
-    data["__nvmlDeviceGetClockInfo"] = <intptr_t>__nvmlDeviceGetClockInfo
+    data["__nvmlDeviceGetClockInfo"] = <_cyb_intptr_t>__nvmlDeviceGetClockInfo
 
     global __nvmlDeviceGetMaxClockInfo
-    data["__nvmlDeviceGetMaxClockInfo"] = <intptr_t>__nvmlDeviceGetMaxClockInfo
+    data["__nvmlDeviceGetMaxClockInfo"] = <_cyb_intptr_t>__nvmlDeviceGetMaxClockInfo
 
     global __nvmlDeviceGetGpcClkVfOffset
-    data["__nvmlDeviceGetGpcClkVfOffset"] = <intptr_t>__nvmlDeviceGetGpcClkVfOffset
+    data["__nvmlDeviceGetGpcClkVfOffset"] = <_cyb_intptr_t>__nvmlDeviceGetGpcClkVfOffset
 
     global __nvmlDeviceGetClock
-    data["__nvmlDeviceGetClock"] = <intptr_t>__nvmlDeviceGetClock
+    data["__nvmlDeviceGetClock"] = <_cyb_intptr_t>__nvmlDeviceGetClock
 
     global __nvmlDeviceGetMaxCustomerBoostClock
-    data["__nvmlDeviceGetMaxCustomerBoostClock"] = <intptr_t>__nvmlDeviceGetMaxCustomerBoostClock
+    data["__nvmlDeviceGetMaxCustomerBoostClock"] = <_cyb_intptr_t>__nvmlDeviceGetMaxCustomerBoostClock
 
     global __nvmlDeviceGetSupportedMemoryClocks
-    data["__nvmlDeviceGetSupportedMemoryClocks"] = <intptr_t>__nvmlDeviceGetSupportedMemoryClocks
+    data["__nvmlDeviceGetSupportedMemoryClocks"] = <_cyb_intptr_t>__nvmlDeviceGetSupportedMemoryClocks
 
     global __nvmlDeviceGetSupportedGraphicsClocks
-    data["__nvmlDeviceGetSupportedGraphicsClocks"] = <intptr_t>__nvmlDeviceGetSupportedGraphicsClocks
+    data["__nvmlDeviceGetSupportedGraphicsClocks"] = <_cyb_intptr_t>__nvmlDeviceGetSupportedGraphicsClocks
 
     global __nvmlDeviceGetAutoBoostedClocksEnabled
-    data["__nvmlDeviceGetAutoBoostedClocksEnabled"] = <intptr_t>__nvmlDeviceGetAutoBoostedClocksEnabled
+    data["__nvmlDeviceGetAutoBoostedClocksEnabled"] = <_cyb_intptr_t>__nvmlDeviceGetAutoBoostedClocksEnabled
 
     global __nvmlDeviceGetFanSpeed
-    data["__nvmlDeviceGetFanSpeed"] = <intptr_t>__nvmlDeviceGetFanSpeed
+    data["__nvmlDeviceGetFanSpeed"] = <_cyb_intptr_t>__nvmlDeviceGetFanSpeed
 
     global __nvmlDeviceGetFanSpeed_v2
-    data["__nvmlDeviceGetFanSpeed_v2"] = <intptr_t>__nvmlDeviceGetFanSpeed_v2
+    data["__nvmlDeviceGetFanSpeed_v2"] = <_cyb_intptr_t>__nvmlDeviceGetFanSpeed_v2
 
     global __nvmlDeviceGetFanSpeedRPM
-    data["__nvmlDeviceGetFanSpeedRPM"] = <intptr_t>__nvmlDeviceGetFanSpeedRPM
+    data["__nvmlDeviceGetFanSpeedRPM"] = <_cyb_intptr_t>__nvmlDeviceGetFanSpeedRPM
 
     global __nvmlDeviceGetTargetFanSpeed
-    data["__nvmlDeviceGetTargetFanSpeed"] = <intptr_t>__nvmlDeviceGetTargetFanSpeed
+    data["__nvmlDeviceGetTargetFanSpeed"] = <_cyb_intptr_t>__nvmlDeviceGetTargetFanSpeed
 
     global __nvmlDeviceGetMinMaxFanSpeed
-    data["__nvmlDeviceGetMinMaxFanSpeed"] = <intptr_t>__nvmlDeviceGetMinMaxFanSpeed
+    data["__nvmlDeviceGetMinMaxFanSpeed"] = <_cyb_intptr_t>__nvmlDeviceGetMinMaxFanSpeed
 
     global __nvmlDeviceGetFanControlPolicy_v2
-    data["__nvmlDeviceGetFanControlPolicy_v2"] = <intptr_t>__nvmlDeviceGetFanControlPolicy_v2
+    data["__nvmlDeviceGetFanControlPolicy_v2"] = <_cyb_intptr_t>__nvmlDeviceGetFanControlPolicy_v2
 
     global __nvmlDeviceGetNumFans
-    data["__nvmlDeviceGetNumFans"] = <intptr_t>__nvmlDeviceGetNumFans
+    data["__nvmlDeviceGetNumFans"] = <_cyb_intptr_t>__nvmlDeviceGetNumFans
 
     global __nvmlDeviceGetCoolerInfo
-    data["__nvmlDeviceGetCoolerInfo"] = <intptr_t>__nvmlDeviceGetCoolerInfo
+    data["__nvmlDeviceGetCoolerInfo"] = <_cyb_intptr_t>__nvmlDeviceGetCoolerInfo
 
     global __nvmlDeviceGetTemperatureV
-    data["__nvmlDeviceGetTemperatureV"] = <intptr_t>__nvmlDeviceGetTemperatureV
+    data["__nvmlDeviceGetTemperatureV"] = <_cyb_intptr_t>__nvmlDeviceGetTemperatureV
 
     global __nvmlDeviceGetTemperatureThreshold
-    data["__nvmlDeviceGetTemperatureThreshold"] = <intptr_t>__nvmlDeviceGetTemperatureThreshold
+    data["__nvmlDeviceGetTemperatureThreshold"] = <_cyb_intptr_t>__nvmlDeviceGetTemperatureThreshold
 
     global __nvmlDeviceGetMarginTemperature
-    data["__nvmlDeviceGetMarginTemperature"] = <intptr_t>__nvmlDeviceGetMarginTemperature
+    data["__nvmlDeviceGetMarginTemperature"] = <_cyb_intptr_t>__nvmlDeviceGetMarginTemperature
 
     global __nvmlDeviceGetThermalSettings
-    data["__nvmlDeviceGetThermalSettings"] = <intptr_t>__nvmlDeviceGetThermalSettings
+    data["__nvmlDeviceGetThermalSettings"] = <_cyb_intptr_t>__nvmlDeviceGetThermalSettings
 
     global __nvmlDeviceGetPerformanceState
-    data["__nvmlDeviceGetPerformanceState"] = <intptr_t>__nvmlDeviceGetPerformanceState
+    data["__nvmlDeviceGetPerformanceState"] = <_cyb_intptr_t>__nvmlDeviceGetPerformanceState
 
     global __nvmlDeviceGetCurrentClocksEventReasons
-    data["__nvmlDeviceGetCurrentClocksEventReasons"] = <intptr_t>__nvmlDeviceGetCurrentClocksEventReasons
+    data["__nvmlDeviceGetCurrentClocksEventReasons"] = <_cyb_intptr_t>__nvmlDeviceGetCurrentClocksEventReasons
 
     global __nvmlDeviceGetSupportedClocksEventReasons
-    data["__nvmlDeviceGetSupportedClocksEventReasons"] = <intptr_t>__nvmlDeviceGetSupportedClocksEventReasons
+    data["__nvmlDeviceGetSupportedClocksEventReasons"] = <_cyb_intptr_t>__nvmlDeviceGetSupportedClocksEventReasons
 
     global __nvmlDeviceGetPowerState
-    data["__nvmlDeviceGetPowerState"] = <intptr_t>__nvmlDeviceGetPowerState
+    data["__nvmlDeviceGetPowerState"] = <_cyb_intptr_t>__nvmlDeviceGetPowerState
 
     global __nvmlDeviceGetDynamicPstatesInfo
-    data["__nvmlDeviceGetDynamicPstatesInfo"] = <intptr_t>__nvmlDeviceGetDynamicPstatesInfo
+    data["__nvmlDeviceGetDynamicPstatesInfo"] = <_cyb_intptr_t>__nvmlDeviceGetDynamicPstatesInfo
 
     global __nvmlDeviceGetMemClkVfOffset
-    data["__nvmlDeviceGetMemClkVfOffset"] = <intptr_t>__nvmlDeviceGetMemClkVfOffset
+    data["__nvmlDeviceGetMemClkVfOffset"] = <_cyb_intptr_t>__nvmlDeviceGetMemClkVfOffset
 
     global __nvmlDeviceGetMinMaxClockOfPState
-    data["__nvmlDeviceGetMinMaxClockOfPState"] = <intptr_t>__nvmlDeviceGetMinMaxClockOfPState
+    data["__nvmlDeviceGetMinMaxClockOfPState"] = <_cyb_intptr_t>__nvmlDeviceGetMinMaxClockOfPState
 
     global __nvmlDeviceGetSupportedPerformanceStates
-    data["__nvmlDeviceGetSupportedPerformanceStates"] = <intptr_t>__nvmlDeviceGetSupportedPerformanceStates
+    data["__nvmlDeviceGetSupportedPerformanceStates"] = <_cyb_intptr_t>__nvmlDeviceGetSupportedPerformanceStates
 
     global __nvmlDeviceGetGpcClkMinMaxVfOffset
-    data["__nvmlDeviceGetGpcClkMinMaxVfOffset"] = <intptr_t>__nvmlDeviceGetGpcClkMinMaxVfOffset
+    data["__nvmlDeviceGetGpcClkMinMaxVfOffset"] = <_cyb_intptr_t>__nvmlDeviceGetGpcClkMinMaxVfOffset
 
     global __nvmlDeviceGetMemClkMinMaxVfOffset
-    data["__nvmlDeviceGetMemClkMinMaxVfOffset"] = <intptr_t>__nvmlDeviceGetMemClkMinMaxVfOffset
+    data["__nvmlDeviceGetMemClkMinMaxVfOffset"] = <_cyb_intptr_t>__nvmlDeviceGetMemClkMinMaxVfOffset
 
     global __nvmlDeviceGetClockOffsets
-    data["__nvmlDeviceGetClockOffsets"] = <intptr_t>__nvmlDeviceGetClockOffsets
+    data["__nvmlDeviceGetClockOffsets"] = <_cyb_intptr_t>__nvmlDeviceGetClockOffsets
 
     global __nvmlDeviceSetClockOffsets
-    data["__nvmlDeviceSetClockOffsets"] = <intptr_t>__nvmlDeviceSetClockOffsets
+    data["__nvmlDeviceSetClockOffsets"] = <_cyb_intptr_t>__nvmlDeviceSetClockOffsets
 
     global __nvmlDeviceGetPerformanceModes
-    data["__nvmlDeviceGetPerformanceModes"] = <intptr_t>__nvmlDeviceGetPerformanceModes
+    data["__nvmlDeviceGetPerformanceModes"] = <_cyb_intptr_t>__nvmlDeviceGetPerformanceModes
 
     global __nvmlDeviceGetCurrentClockFreqs
-    data["__nvmlDeviceGetCurrentClockFreqs"] = <intptr_t>__nvmlDeviceGetCurrentClockFreqs
+    data["__nvmlDeviceGetCurrentClockFreqs"] = <_cyb_intptr_t>__nvmlDeviceGetCurrentClockFreqs
 
     global __nvmlDeviceGetPowerManagementLimit
-    data["__nvmlDeviceGetPowerManagementLimit"] = <intptr_t>__nvmlDeviceGetPowerManagementLimit
+    data["__nvmlDeviceGetPowerManagementLimit"] = <_cyb_intptr_t>__nvmlDeviceGetPowerManagementLimit
 
     global __nvmlDeviceGetPowerManagementLimitConstraints
-    data["__nvmlDeviceGetPowerManagementLimitConstraints"] = <intptr_t>__nvmlDeviceGetPowerManagementLimitConstraints
+    data["__nvmlDeviceGetPowerManagementLimitConstraints"] = <_cyb_intptr_t>__nvmlDeviceGetPowerManagementLimitConstraints
 
     global __nvmlDeviceGetPowerManagementDefaultLimit
-    data["__nvmlDeviceGetPowerManagementDefaultLimit"] = <intptr_t>__nvmlDeviceGetPowerManagementDefaultLimit
+    data["__nvmlDeviceGetPowerManagementDefaultLimit"] = <_cyb_intptr_t>__nvmlDeviceGetPowerManagementDefaultLimit
 
     global __nvmlDeviceGetPowerUsage
-    data["__nvmlDeviceGetPowerUsage"] = <intptr_t>__nvmlDeviceGetPowerUsage
+    data["__nvmlDeviceGetPowerUsage"] = <_cyb_intptr_t>__nvmlDeviceGetPowerUsage
 
     global __nvmlDeviceGetTotalEnergyConsumption
-    data["__nvmlDeviceGetTotalEnergyConsumption"] = <intptr_t>__nvmlDeviceGetTotalEnergyConsumption
+    data["__nvmlDeviceGetTotalEnergyConsumption"] = <_cyb_intptr_t>__nvmlDeviceGetTotalEnergyConsumption
 
     global __nvmlDeviceGetEnforcedPowerLimit
-    data["__nvmlDeviceGetEnforcedPowerLimit"] = <intptr_t>__nvmlDeviceGetEnforcedPowerLimit
+    data["__nvmlDeviceGetEnforcedPowerLimit"] = <_cyb_intptr_t>__nvmlDeviceGetEnforcedPowerLimit
 
     global __nvmlDeviceGetGpuOperationMode
-    data["__nvmlDeviceGetGpuOperationMode"] = <intptr_t>__nvmlDeviceGetGpuOperationMode
+    data["__nvmlDeviceGetGpuOperationMode"] = <_cyb_intptr_t>__nvmlDeviceGetGpuOperationMode
 
     global __nvmlDeviceGetMemoryInfo_v2
-    data["__nvmlDeviceGetMemoryInfo_v2"] = <intptr_t>__nvmlDeviceGetMemoryInfo_v2
+    data["__nvmlDeviceGetMemoryInfo_v2"] = <_cyb_intptr_t>__nvmlDeviceGetMemoryInfo_v2
 
     global __nvmlDeviceGetComputeMode
-    data["__nvmlDeviceGetComputeMode"] = <intptr_t>__nvmlDeviceGetComputeMode
+    data["__nvmlDeviceGetComputeMode"] = <_cyb_intptr_t>__nvmlDeviceGetComputeMode
 
     global __nvmlDeviceGetCudaComputeCapability
-    data["__nvmlDeviceGetCudaComputeCapability"] = <intptr_t>__nvmlDeviceGetCudaComputeCapability
+    data["__nvmlDeviceGetCudaComputeCapability"] = <_cyb_intptr_t>__nvmlDeviceGetCudaComputeCapability
 
     global __nvmlDeviceGetDramEncryptionMode
-    data["__nvmlDeviceGetDramEncryptionMode"] = <intptr_t>__nvmlDeviceGetDramEncryptionMode
+    data["__nvmlDeviceGetDramEncryptionMode"] = <_cyb_intptr_t>__nvmlDeviceGetDramEncryptionMode
 
     global __nvmlDeviceSetDramEncryptionMode
-    data["__nvmlDeviceSetDramEncryptionMode"] = <intptr_t>__nvmlDeviceSetDramEncryptionMode
+    data["__nvmlDeviceSetDramEncryptionMode"] = <_cyb_intptr_t>__nvmlDeviceSetDramEncryptionMode
 
     global __nvmlDeviceGetEccMode
-    data["__nvmlDeviceGetEccMode"] = <intptr_t>__nvmlDeviceGetEccMode
+    data["__nvmlDeviceGetEccMode"] = <_cyb_intptr_t>__nvmlDeviceGetEccMode
 
     global __nvmlDeviceGetDefaultEccMode
-    data["__nvmlDeviceGetDefaultEccMode"] = <intptr_t>__nvmlDeviceGetDefaultEccMode
+    data["__nvmlDeviceGetDefaultEccMode"] = <_cyb_intptr_t>__nvmlDeviceGetDefaultEccMode
 
     global __nvmlDeviceGetBoardId
-    data["__nvmlDeviceGetBoardId"] = <intptr_t>__nvmlDeviceGetBoardId
+    data["__nvmlDeviceGetBoardId"] = <_cyb_intptr_t>__nvmlDeviceGetBoardId
 
     global __nvmlDeviceGetMultiGpuBoard
-    data["__nvmlDeviceGetMultiGpuBoard"] = <intptr_t>__nvmlDeviceGetMultiGpuBoard
+    data["__nvmlDeviceGetMultiGpuBoard"] = <_cyb_intptr_t>__nvmlDeviceGetMultiGpuBoard
 
     global __nvmlDeviceGetTotalEccErrors
-    data["__nvmlDeviceGetTotalEccErrors"] = <intptr_t>__nvmlDeviceGetTotalEccErrors
+    data["__nvmlDeviceGetTotalEccErrors"] = <_cyb_intptr_t>__nvmlDeviceGetTotalEccErrors
 
     global __nvmlDeviceGetMemoryErrorCounter
-    data["__nvmlDeviceGetMemoryErrorCounter"] = <intptr_t>__nvmlDeviceGetMemoryErrorCounter
+    data["__nvmlDeviceGetMemoryErrorCounter"] = <_cyb_intptr_t>__nvmlDeviceGetMemoryErrorCounter
 
     global __nvmlDeviceGetUtilizationRates
-    data["__nvmlDeviceGetUtilizationRates"] = <intptr_t>__nvmlDeviceGetUtilizationRates
+    data["__nvmlDeviceGetUtilizationRates"] = <_cyb_intptr_t>__nvmlDeviceGetUtilizationRates
 
     global __nvmlDeviceGetEncoderUtilization
-    data["__nvmlDeviceGetEncoderUtilization"] = <intptr_t>__nvmlDeviceGetEncoderUtilization
+    data["__nvmlDeviceGetEncoderUtilization"] = <_cyb_intptr_t>__nvmlDeviceGetEncoderUtilization
 
     global __nvmlDeviceGetEncoderCapacity
-    data["__nvmlDeviceGetEncoderCapacity"] = <intptr_t>__nvmlDeviceGetEncoderCapacity
+    data["__nvmlDeviceGetEncoderCapacity"] = <_cyb_intptr_t>__nvmlDeviceGetEncoderCapacity
 
     global __nvmlDeviceGetEncoderStats
-    data["__nvmlDeviceGetEncoderStats"] = <intptr_t>__nvmlDeviceGetEncoderStats
+    data["__nvmlDeviceGetEncoderStats"] = <_cyb_intptr_t>__nvmlDeviceGetEncoderStats
 
     global __nvmlDeviceGetEncoderSessions
-    data["__nvmlDeviceGetEncoderSessions"] = <intptr_t>__nvmlDeviceGetEncoderSessions
+    data["__nvmlDeviceGetEncoderSessions"] = <_cyb_intptr_t>__nvmlDeviceGetEncoderSessions
 
     global __nvmlDeviceGetDecoderUtilization
-    data["__nvmlDeviceGetDecoderUtilization"] = <intptr_t>__nvmlDeviceGetDecoderUtilization
+    data["__nvmlDeviceGetDecoderUtilization"] = <_cyb_intptr_t>__nvmlDeviceGetDecoderUtilization
 
     global __nvmlDeviceGetJpgUtilization
-    data["__nvmlDeviceGetJpgUtilization"] = <intptr_t>__nvmlDeviceGetJpgUtilization
+    data["__nvmlDeviceGetJpgUtilization"] = <_cyb_intptr_t>__nvmlDeviceGetJpgUtilization
 
     global __nvmlDeviceGetOfaUtilization
-    data["__nvmlDeviceGetOfaUtilization"] = <intptr_t>__nvmlDeviceGetOfaUtilization
+    data["__nvmlDeviceGetOfaUtilization"] = <_cyb_intptr_t>__nvmlDeviceGetOfaUtilization
 
     global __nvmlDeviceGetFBCStats
-    data["__nvmlDeviceGetFBCStats"] = <intptr_t>__nvmlDeviceGetFBCStats
+    data["__nvmlDeviceGetFBCStats"] = <_cyb_intptr_t>__nvmlDeviceGetFBCStats
 
     global __nvmlDeviceGetFBCSessions
-    data["__nvmlDeviceGetFBCSessions"] = <intptr_t>__nvmlDeviceGetFBCSessions
+    data["__nvmlDeviceGetFBCSessions"] = <_cyb_intptr_t>__nvmlDeviceGetFBCSessions
 
     global __nvmlDeviceGetDriverModel_v2
-    data["__nvmlDeviceGetDriverModel_v2"] = <intptr_t>__nvmlDeviceGetDriverModel_v2
+    data["__nvmlDeviceGetDriverModel_v2"] = <_cyb_intptr_t>__nvmlDeviceGetDriverModel_v2
 
     global __nvmlDeviceGetVbiosVersion
-    data["__nvmlDeviceGetVbiosVersion"] = <intptr_t>__nvmlDeviceGetVbiosVersion
+    data["__nvmlDeviceGetVbiosVersion"] = <_cyb_intptr_t>__nvmlDeviceGetVbiosVersion
 
     global __nvmlDeviceGetBridgeChipInfo
-    data["__nvmlDeviceGetBridgeChipInfo"] = <intptr_t>__nvmlDeviceGetBridgeChipInfo
+    data["__nvmlDeviceGetBridgeChipInfo"] = <_cyb_intptr_t>__nvmlDeviceGetBridgeChipInfo
 
     global __nvmlDeviceGetComputeRunningProcesses_v3
-    data["__nvmlDeviceGetComputeRunningProcesses_v3"] = <intptr_t>__nvmlDeviceGetComputeRunningProcesses_v3
+    data["__nvmlDeviceGetComputeRunningProcesses_v3"] = <_cyb_intptr_t>__nvmlDeviceGetComputeRunningProcesses_v3
 
     global __nvmlDeviceGetGraphicsRunningProcesses_v3
-    data["__nvmlDeviceGetGraphicsRunningProcesses_v3"] = <intptr_t>__nvmlDeviceGetGraphicsRunningProcesses_v3
+    data["__nvmlDeviceGetGraphicsRunningProcesses_v3"] = <_cyb_intptr_t>__nvmlDeviceGetGraphicsRunningProcesses_v3
 
     global __nvmlDeviceGetMPSComputeRunningProcesses_v3
-    data["__nvmlDeviceGetMPSComputeRunningProcesses_v3"] = <intptr_t>__nvmlDeviceGetMPSComputeRunningProcesses_v3
+    data["__nvmlDeviceGetMPSComputeRunningProcesses_v3"] = <_cyb_intptr_t>__nvmlDeviceGetMPSComputeRunningProcesses_v3
 
     global __nvmlDeviceGetRunningProcessDetailList
-    data["__nvmlDeviceGetRunningProcessDetailList"] = <intptr_t>__nvmlDeviceGetRunningProcessDetailList
+    data["__nvmlDeviceGetRunningProcessDetailList"] = <_cyb_intptr_t>__nvmlDeviceGetRunningProcessDetailList
 
     global __nvmlDeviceOnSameBoard
-    data["__nvmlDeviceOnSameBoard"] = <intptr_t>__nvmlDeviceOnSameBoard
+    data["__nvmlDeviceOnSameBoard"] = <_cyb_intptr_t>__nvmlDeviceOnSameBoard
 
     global __nvmlDeviceGetAPIRestriction
-    data["__nvmlDeviceGetAPIRestriction"] = <intptr_t>__nvmlDeviceGetAPIRestriction
+    data["__nvmlDeviceGetAPIRestriction"] = <_cyb_intptr_t>__nvmlDeviceGetAPIRestriction
 
     global __nvmlDeviceGetSamples
-    data["__nvmlDeviceGetSamples"] = <intptr_t>__nvmlDeviceGetSamples
+    data["__nvmlDeviceGetSamples"] = <_cyb_intptr_t>__nvmlDeviceGetSamples
 
     global __nvmlDeviceGetBAR1MemoryInfo
-    data["__nvmlDeviceGetBAR1MemoryInfo"] = <intptr_t>__nvmlDeviceGetBAR1MemoryInfo
+    data["__nvmlDeviceGetBAR1MemoryInfo"] = <_cyb_intptr_t>__nvmlDeviceGetBAR1MemoryInfo
 
     global __nvmlDeviceGetIrqNum
-    data["__nvmlDeviceGetIrqNum"] = <intptr_t>__nvmlDeviceGetIrqNum
+    data["__nvmlDeviceGetIrqNum"] = <_cyb_intptr_t>__nvmlDeviceGetIrqNum
 
     global __nvmlDeviceGetNumGpuCores
-    data["__nvmlDeviceGetNumGpuCores"] = <intptr_t>__nvmlDeviceGetNumGpuCores
+    data["__nvmlDeviceGetNumGpuCores"] = <_cyb_intptr_t>__nvmlDeviceGetNumGpuCores
 
     global __nvmlDeviceGetPowerSource
-    data["__nvmlDeviceGetPowerSource"] = <intptr_t>__nvmlDeviceGetPowerSource
+    data["__nvmlDeviceGetPowerSource"] = <_cyb_intptr_t>__nvmlDeviceGetPowerSource
 
     global __nvmlDeviceGetMemoryBusWidth
-    data["__nvmlDeviceGetMemoryBusWidth"] = <intptr_t>__nvmlDeviceGetMemoryBusWidth
+    data["__nvmlDeviceGetMemoryBusWidth"] = <_cyb_intptr_t>__nvmlDeviceGetMemoryBusWidth
 
     global __nvmlDeviceGetPcieLinkMaxSpeed
-    data["__nvmlDeviceGetPcieLinkMaxSpeed"] = <intptr_t>__nvmlDeviceGetPcieLinkMaxSpeed
+    data["__nvmlDeviceGetPcieLinkMaxSpeed"] = <_cyb_intptr_t>__nvmlDeviceGetPcieLinkMaxSpeed
 
     global __nvmlDeviceGetPcieSpeed
-    data["__nvmlDeviceGetPcieSpeed"] = <intptr_t>__nvmlDeviceGetPcieSpeed
+    data["__nvmlDeviceGetPcieSpeed"] = <_cyb_intptr_t>__nvmlDeviceGetPcieSpeed
 
     global __nvmlDeviceGetAdaptiveClockInfoStatus
-    data["__nvmlDeviceGetAdaptiveClockInfoStatus"] = <intptr_t>__nvmlDeviceGetAdaptiveClockInfoStatus
+    data["__nvmlDeviceGetAdaptiveClockInfoStatus"] = <_cyb_intptr_t>__nvmlDeviceGetAdaptiveClockInfoStatus
 
     global __nvmlDeviceGetBusType
-    data["__nvmlDeviceGetBusType"] = <intptr_t>__nvmlDeviceGetBusType
+    data["__nvmlDeviceGetBusType"] = <_cyb_intptr_t>__nvmlDeviceGetBusType
 
     global __nvmlDeviceGetGpuFabricInfoV
-    data["__nvmlDeviceGetGpuFabricInfoV"] = <intptr_t>__nvmlDeviceGetGpuFabricInfoV
+    data["__nvmlDeviceGetGpuFabricInfoV"] = <_cyb_intptr_t>__nvmlDeviceGetGpuFabricInfoV
 
     global __nvmlSystemGetConfComputeCapabilities
-    data["__nvmlSystemGetConfComputeCapabilities"] = <intptr_t>__nvmlSystemGetConfComputeCapabilities
+    data["__nvmlSystemGetConfComputeCapabilities"] = <_cyb_intptr_t>__nvmlSystemGetConfComputeCapabilities
 
     global __nvmlSystemGetConfComputeState
-    data["__nvmlSystemGetConfComputeState"] = <intptr_t>__nvmlSystemGetConfComputeState
+    data["__nvmlSystemGetConfComputeState"] = <_cyb_intptr_t>__nvmlSystemGetConfComputeState
 
     global __nvmlDeviceGetConfComputeMemSizeInfo
-    data["__nvmlDeviceGetConfComputeMemSizeInfo"] = <intptr_t>__nvmlDeviceGetConfComputeMemSizeInfo
+    data["__nvmlDeviceGetConfComputeMemSizeInfo"] = <_cyb_intptr_t>__nvmlDeviceGetConfComputeMemSizeInfo
 
     global __nvmlSystemGetConfComputeGpusReadyState
-    data["__nvmlSystemGetConfComputeGpusReadyState"] = <intptr_t>__nvmlSystemGetConfComputeGpusReadyState
+    data["__nvmlSystemGetConfComputeGpusReadyState"] = <_cyb_intptr_t>__nvmlSystemGetConfComputeGpusReadyState
 
     global __nvmlDeviceGetConfComputeProtectedMemoryUsage
-    data["__nvmlDeviceGetConfComputeProtectedMemoryUsage"] = <intptr_t>__nvmlDeviceGetConfComputeProtectedMemoryUsage
+    data["__nvmlDeviceGetConfComputeProtectedMemoryUsage"] = <_cyb_intptr_t>__nvmlDeviceGetConfComputeProtectedMemoryUsage
 
     global __nvmlDeviceGetConfComputeGpuCertificate
-    data["__nvmlDeviceGetConfComputeGpuCertificate"] = <intptr_t>__nvmlDeviceGetConfComputeGpuCertificate
+    data["__nvmlDeviceGetConfComputeGpuCertificate"] = <_cyb_intptr_t>__nvmlDeviceGetConfComputeGpuCertificate
 
     global __nvmlDeviceGetConfComputeGpuAttestationReport
-    data["__nvmlDeviceGetConfComputeGpuAttestationReport"] = <intptr_t>__nvmlDeviceGetConfComputeGpuAttestationReport
+    data["__nvmlDeviceGetConfComputeGpuAttestationReport"] = <_cyb_intptr_t>__nvmlDeviceGetConfComputeGpuAttestationReport
 
     global __nvmlSystemGetConfComputeKeyRotationThresholdInfo
-    data["__nvmlSystemGetConfComputeKeyRotationThresholdInfo"] = <intptr_t>__nvmlSystemGetConfComputeKeyRotationThresholdInfo
+    data["__nvmlSystemGetConfComputeKeyRotationThresholdInfo"] = <_cyb_intptr_t>__nvmlSystemGetConfComputeKeyRotationThresholdInfo
 
     global __nvmlDeviceSetConfComputeUnprotectedMemSize
-    data["__nvmlDeviceSetConfComputeUnprotectedMemSize"] = <intptr_t>__nvmlDeviceSetConfComputeUnprotectedMemSize
+    data["__nvmlDeviceSetConfComputeUnprotectedMemSize"] = <_cyb_intptr_t>__nvmlDeviceSetConfComputeUnprotectedMemSize
 
     global __nvmlSystemSetConfComputeGpusReadyState
-    data["__nvmlSystemSetConfComputeGpusReadyState"] = <intptr_t>__nvmlSystemSetConfComputeGpusReadyState
+    data["__nvmlSystemSetConfComputeGpusReadyState"] = <_cyb_intptr_t>__nvmlSystemSetConfComputeGpusReadyState
 
     global __nvmlSystemSetConfComputeKeyRotationThresholdInfo
-    data["__nvmlSystemSetConfComputeKeyRotationThresholdInfo"] = <intptr_t>__nvmlSystemSetConfComputeKeyRotationThresholdInfo
+    data["__nvmlSystemSetConfComputeKeyRotationThresholdInfo"] = <_cyb_intptr_t>__nvmlSystemSetConfComputeKeyRotationThresholdInfo
 
     global __nvmlSystemGetConfComputeSettings
-    data["__nvmlSystemGetConfComputeSettings"] = <intptr_t>__nvmlSystemGetConfComputeSettings
+    data["__nvmlSystemGetConfComputeSettings"] = <_cyb_intptr_t>__nvmlSystemGetConfComputeSettings
 
     global __nvmlDeviceGetGspFirmwareVersion
-    data["__nvmlDeviceGetGspFirmwareVersion"] = <intptr_t>__nvmlDeviceGetGspFirmwareVersion
+    data["__nvmlDeviceGetGspFirmwareVersion"] = <_cyb_intptr_t>__nvmlDeviceGetGspFirmwareVersion
 
     global __nvmlDeviceGetGspFirmwareMode
-    data["__nvmlDeviceGetGspFirmwareMode"] = <intptr_t>__nvmlDeviceGetGspFirmwareMode
+    data["__nvmlDeviceGetGspFirmwareMode"] = <_cyb_intptr_t>__nvmlDeviceGetGspFirmwareMode
 
     global __nvmlDeviceGetSramEccErrorStatus
-    data["__nvmlDeviceGetSramEccErrorStatus"] = <intptr_t>__nvmlDeviceGetSramEccErrorStatus
+    data["__nvmlDeviceGetSramEccErrorStatus"] = <_cyb_intptr_t>__nvmlDeviceGetSramEccErrorStatus
 
     global __nvmlDeviceGetAccountingMode
-    data["__nvmlDeviceGetAccountingMode"] = <intptr_t>__nvmlDeviceGetAccountingMode
+    data["__nvmlDeviceGetAccountingMode"] = <_cyb_intptr_t>__nvmlDeviceGetAccountingMode
 
     global __nvmlDeviceGetAccountingStats
-    data["__nvmlDeviceGetAccountingStats"] = <intptr_t>__nvmlDeviceGetAccountingStats
+    data["__nvmlDeviceGetAccountingStats"] = <_cyb_intptr_t>__nvmlDeviceGetAccountingStats
 
     global __nvmlDeviceGetAccountingPids
-    data["__nvmlDeviceGetAccountingPids"] = <intptr_t>__nvmlDeviceGetAccountingPids
+    data["__nvmlDeviceGetAccountingPids"] = <_cyb_intptr_t>__nvmlDeviceGetAccountingPids
 
     global __nvmlDeviceGetAccountingBufferSize
-    data["__nvmlDeviceGetAccountingBufferSize"] = <intptr_t>__nvmlDeviceGetAccountingBufferSize
+    data["__nvmlDeviceGetAccountingBufferSize"] = <_cyb_intptr_t>__nvmlDeviceGetAccountingBufferSize
 
     global __nvmlDeviceGetRetiredPages
-    data["__nvmlDeviceGetRetiredPages"] = <intptr_t>__nvmlDeviceGetRetiredPages
+    data["__nvmlDeviceGetRetiredPages"] = <_cyb_intptr_t>__nvmlDeviceGetRetiredPages
 
     global __nvmlDeviceGetRetiredPages_v2
-    data["__nvmlDeviceGetRetiredPages_v2"] = <intptr_t>__nvmlDeviceGetRetiredPages_v2
+    data["__nvmlDeviceGetRetiredPages_v2"] = <_cyb_intptr_t>__nvmlDeviceGetRetiredPages_v2
 
     global __nvmlDeviceGetRetiredPagesPendingStatus
-    data["__nvmlDeviceGetRetiredPagesPendingStatus"] = <intptr_t>__nvmlDeviceGetRetiredPagesPendingStatus
+    data["__nvmlDeviceGetRetiredPagesPendingStatus"] = <_cyb_intptr_t>__nvmlDeviceGetRetiredPagesPendingStatus
 
     global __nvmlDeviceGetRemappedRows
-    data["__nvmlDeviceGetRemappedRows"] = <intptr_t>__nvmlDeviceGetRemappedRows
+    data["__nvmlDeviceGetRemappedRows"] = <_cyb_intptr_t>__nvmlDeviceGetRemappedRows
 
     global __nvmlDeviceGetRowRemapperHistogram
-    data["__nvmlDeviceGetRowRemapperHistogram"] = <intptr_t>__nvmlDeviceGetRowRemapperHistogram
+    data["__nvmlDeviceGetRowRemapperHistogram"] = <_cyb_intptr_t>__nvmlDeviceGetRowRemapperHistogram
 
     global __nvmlDeviceGetArchitecture
-    data["__nvmlDeviceGetArchitecture"] = <intptr_t>__nvmlDeviceGetArchitecture
+    data["__nvmlDeviceGetArchitecture"] = <_cyb_intptr_t>__nvmlDeviceGetArchitecture
 
     global __nvmlDeviceGetClkMonStatus
-    data["__nvmlDeviceGetClkMonStatus"] = <intptr_t>__nvmlDeviceGetClkMonStatus
+    data["__nvmlDeviceGetClkMonStatus"] = <_cyb_intptr_t>__nvmlDeviceGetClkMonStatus
 
     global __nvmlDeviceGetProcessUtilization
-    data["__nvmlDeviceGetProcessUtilization"] = <intptr_t>__nvmlDeviceGetProcessUtilization
+    data["__nvmlDeviceGetProcessUtilization"] = <_cyb_intptr_t>__nvmlDeviceGetProcessUtilization
 
     global __nvmlDeviceGetProcessesUtilizationInfo
-    data["__nvmlDeviceGetProcessesUtilizationInfo"] = <intptr_t>__nvmlDeviceGetProcessesUtilizationInfo
+    data["__nvmlDeviceGetProcessesUtilizationInfo"] = <_cyb_intptr_t>__nvmlDeviceGetProcessesUtilizationInfo
 
     global __nvmlDeviceGetPlatformInfo
-    data["__nvmlDeviceGetPlatformInfo"] = <intptr_t>__nvmlDeviceGetPlatformInfo
+    data["__nvmlDeviceGetPlatformInfo"] = <_cyb_intptr_t>__nvmlDeviceGetPlatformInfo
 
     global __nvmlUnitSetLedState
-    data["__nvmlUnitSetLedState"] = <intptr_t>__nvmlUnitSetLedState
+    data["__nvmlUnitSetLedState"] = <_cyb_intptr_t>__nvmlUnitSetLedState
 
     global __nvmlDeviceSetPersistenceMode
-    data["__nvmlDeviceSetPersistenceMode"] = <intptr_t>__nvmlDeviceSetPersistenceMode
+    data["__nvmlDeviceSetPersistenceMode"] = <_cyb_intptr_t>__nvmlDeviceSetPersistenceMode
 
     global __nvmlDeviceSetComputeMode
-    data["__nvmlDeviceSetComputeMode"] = <intptr_t>__nvmlDeviceSetComputeMode
+    data["__nvmlDeviceSetComputeMode"] = <_cyb_intptr_t>__nvmlDeviceSetComputeMode
 
     global __nvmlDeviceSetEccMode
-    data["__nvmlDeviceSetEccMode"] = <intptr_t>__nvmlDeviceSetEccMode
+    data["__nvmlDeviceSetEccMode"] = <_cyb_intptr_t>__nvmlDeviceSetEccMode
 
     global __nvmlDeviceClearEccErrorCounts
-    data["__nvmlDeviceClearEccErrorCounts"] = <intptr_t>__nvmlDeviceClearEccErrorCounts
+    data["__nvmlDeviceClearEccErrorCounts"] = <_cyb_intptr_t>__nvmlDeviceClearEccErrorCounts
 
     global __nvmlDeviceSetDriverModel
-    data["__nvmlDeviceSetDriverModel"] = <intptr_t>__nvmlDeviceSetDriverModel
+    data["__nvmlDeviceSetDriverModel"] = <_cyb_intptr_t>__nvmlDeviceSetDriverModel
 
     global __nvmlDeviceSetGpuLockedClocks
-    data["__nvmlDeviceSetGpuLockedClocks"] = <intptr_t>__nvmlDeviceSetGpuLockedClocks
+    data["__nvmlDeviceSetGpuLockedClocks"] = <_cyb_intptr_t>__nvmlDeviceSetGpuLockedClocks
 
     global __nvmlDeviceResetGpuLockedClocks
-    data["__nvmlDeviceResetGpuLockedClocks"] = <intptr_t>__nvmlDeviceResetGpuLockedClocks
+    data["__nvmlDeviceResetGpuLockedClocks"] = <_cyb_intptr_t>__nvmlDeviceResetGpuLockedClocks
 
     global __nvmlDeviceSetMemoryLockedClocks
-    data["__nvmlDeviceSetMemoryLockedClocks"] = <intptr_t>__nvmlDeviceSetMemoryLockedClocks
+    data["__nvmlDeviceSetMemoryLockedClocks"] = <_cyb_intptr_t>__nvmlDeviceSetMemoryLockedClocks
 
     global __nvmlDeviceResetMemoryLockedClocks
-    data["__nvmlDeviceResetMemoryLockedClocks"] = <intptr_t>__nvmlDeviceResetMemoryLockedClocks
+    data["__nvmlDeviceResetMemoryLockedClocks"] = <_cyb_intptr_t>__nvmlDeviceResetMemoryLockedClocks
 
     global __nvmlDeviceSetAutoBoostedClocksEnabled
-    data["__nvmlDeviceSetAutoBoostedClocksEnabled"] = <intptr_t>__nvmlDeviceSetAutoBoostedClocksEnabled
+    data["__nvmlDeviceSetAutoBoostedClocksEnabled"] = <_cyb_intptr_t>__nvmlDeviceSetAutoBoostedClocksEnabled
 
     global __nvmlDeviceSetDefaultAutoBoostedClocksEnabled
-    data["__nvmlDeviceSetDefaultAutoBoostedClocksEnabled"] = <intptr_t>__nvmlDeviceSetDefaultAutoBoostedClocksEnabled
+    data["__nvmlDeviceSetDefaultAutoBoostedClocksEnabled"] = <_cyb_intptr_t>__nvmlDeviceSetDefaultAutoBoostedClocksEnabled
 
     global __nvmlDeviceSetDefaultFanSpeed_v2
-    data["__nvmlDeviceSetDefaultFanSpeed_v2"] = <intptr_t>__nvmlDeviceSetDefaultFanSpeed_v2
+    data["__nvmlDeviceSetDefaultFanSpeed_v2"] = <_cyb_intptr_t>__nvmlDeviceSetDefaultFanSpeed_v2
 
     global __nvmlDeviceSetFanControlPolicy
-    data["__nvmlDeviceSetFanControlPolicy"] = <intptr_t>__nvmlDeviceSetFanControlPolicy
+    data["__nvmlDeviceSetFanControlPolicy"] = <_cyb_intptr_t>__nvmlDeviceSetFanControlPolicy
 
     global __nvmlDeviceSetTemperatureThreshold
-    data["__nvmlDeviceSetTemperatureThreshold"] = <intptr_t>__nvmlDeviceSetTemperatureThreshold
+    data["__nvmlDeviceSetTemperatureThreshold"] = <_cyb_intptr_t>__nvmlDeviceSetTemperatureThreshold
 
     global __nvmlDeviceSetGpuOperationMode
-    data["__nvmlDeviceSetGpuOperationMode"] = <intptr_t>__nvmlDeviceSetGpuOperationMode
+    data["__nvmlDeviceSetGpuOperationMode"] = <_cyb_intptr_t>__nvmlDeviceSetGpuOperationMode
 
     global __nvmlDeviceSetAPIRestriction
-    data["__nvmlDeviceSetAPIRestriction"] = <intptr_t>__nvmlDeviceSetAPIRestriction
+    data["__nvmlDeviceSetAPIRestriction"] = <_cyb_intptr_t>__nvmlDeviceSetAPIRestriction
 
     global __nvmlDeviceSetFanSpeed_v2
-    data["__nvmlDeviceSetFanSpeed_v2"] = <intptr_t>__nvmlDeviceSetFanSpeed_v2
+    data["__nvmlDeviceSetFanSpeed_v2"] = <_cyb_intptr_t>__nvmlDeviceSetFanSpeed_v2
 
     global __nvmlDeviceSetAccountingMode
-    data["__nvmlDeviceSetAccountingMode"] = <intptr_t>__nvmlDeviceSetAccountingMode
+    data["__nvmlDeviceSetAccountingMode"] = <_cyb_intptr_t>__nvmlDeviceSetAccountingMode
 
     global __nvmlDeviceClearAccountingPids
-    data["__nvmlDeviceClearAccountingPids"] = <intptr_t>__nvmlDeviceClearAccountingPids
+    data["__nvmlDeviceClearAccountingPids"] = <_cyb_intptr_t>__nvmlDeviceClearAccountingPids
 
     global __nvmlDeviceSetPowerManagementLimit_v2
-    data["__nvmlDeviceSetPowerManagementLimit_v2"] = <intptr_t>__nvmlDeviceSetPowerManagementLimit_v2
+    data["__nvmlDeviceSetPowerManagementLimit_v2"] = <_cyb_intptr_t>__nvmlDeviceSetPowerManagementLimit_v2
 
     global __nvmlDeviceGetNvLinkState
-    data["__nvmlDeviceGetNvLinkState"] = <intptr_t>__nvmlDeviceGetNvLinkState
+    data["__nvmlDeviceGetNvLinkState"] = <_cyb_intptr_t>__nvmlDeviceGetNvLinkState
 
     global __nvmlDeviceGetNvLinkVersion
-    data["__nvmlDeviceGetNvLinkVersion"] = <intptr_t>__nvmlDeviceGetNvLinkVersion
+    data["__nvmlDeviceGetNvLinkVersion"] = <_cyb_intptr_t>__nvmlDeviceGetNvLinkVersion
 
     global __nvmlDeviceGetNvLinkCapability
-    data["__nvmlDeviceGetNvLinkCapability"] = <intptr_t>__nvmlDeviceGetNvLinkCapability
+    data["__nvmlDeviceGetNvLinkCapability"] = <_cyb_intptr_t>__nvmlDeviceGetNvLinkCapability
 
     global __nvmlDeviceGetNvLinkRemotePciInfo_v2
-    data["__nvmlDeviceGetNvLinkRemotePciInfo_v2"] = <intptr_t>__nvmlDeviceGetNvLinkRemotePciInfo_v2
+    data["__nvmlDeviceGetNvLinkRemotePciInfo_v2"] = <_cyb_intptr_t>__nvmlDeviceGetNvLinkRemotePciInfo_v2
 
     global __nvmlDeviceGetNvLinkErrorCounter
-    data["__nvmlDeviceGetNvLinkErrorCounter"] = <intptr_t>__nvmlDeviceGetNvLinkErrorCounter
+    data["__nvmlDeviceGetNvLinkErrorCounter"] = <_cyb_intptr_t>__nvmlDeviceGetNvLinkErrorCounter
 
     global __nvmlDeviceResetNvLinkErrorCounters
-    data["__nvmlDeviceResetNvLinkErrorCounters"] = <intptr_t>__nvmlDeviceResetNvLinkErrorCounters
+    data["__nvmlDeviceResetNvLinkErrorCounters"] = <_cyb_intptr_t>__nvmlDeviceResetNvLinkErrorCounters
 
     global __nvmlDeviceGetNvLinkRemoteDeviceType
-    data["__nvmlDeviceGetNvLinkRemoteDeviceType"] = <intptr_t>__nvmlDeviceGetNvLinkRemoteDeviceType
+    data["__nvmlDeviceGetNvLinkRemoteDeviceType"] = <_cyb_intptr_t>__nvmlDeviceGetNvLinkRemoteDeviceType
 
     global __nvmlDeviceSetNvLinkDeviceLowPowerThreshold
-    data["__nvmlDeviceSetNvLinkDeviceLowPowerThreshold"] = <intptr_t>__nvmlDeviceSetNvLinkDeviceLowPowerThreshold
+    data["__nvmlDeviceSetNvLinkDeviceLowPowerThreshold"] = <_cyb_intptr_t>__nvmlDeviceSetNvLinkDeviceLowPowerThreshold
 
     global __nvmlSystemSetNvlinkBwMode
-    data["__nvmlSystemSetNvlinkBwMode"] = <intptr_t>__nvmlSystemSetNvlinkBwMode
+    data["__nvmlSystemSetNvlinkBwMode"] = <_cyb_intptr_t>__nvmlSystemSetNvlinkBwMode
 
     global __nvmlSystemGetNvlinkBwMode
-    data["__nvmlSystemGetNvlinkBwMode"] = <intptr_t>__nvmlSystemGetNvlinkBwMode
+    data["__nvmlSystemGetNvlinkBwMode"] = <_cyb_intptr_t>__nvmlSystemGetNvlinkBwMode
 
     global __nvmlDeviceGetNvlinkSupportedBwModes
-    data["__nvmlDeviceGetNvlinkSupportedBwModes"] = <intptr_t>__nvmlDeviceGetNvlinkSupportedBwModes
+    data["__nvmlDeviceGetNvlinkSupportedBwModes"] = <_cyb_intptr_t>__nvmlDeviceGetNvlinkSupportedBwModes
 
     global __nvmlDeviceGetNvlinkBwMode
-    data["__nvmlDeviceGetNvlinkBwMode"] = <intptr_t>__nvmlDeviceGetNvlinkBwMode
+    data["__nvmlDeviceGetNvlinkBwMode"] = <_cyb_intptr_t>__nvmlDeviceGetNvlinkBwMode
 
     global __nvmlDeviceSetNvlinkBwMode
-    data["__nvmlDeviceSetNvlinkBwMode"] = <intptr_t>__nvmlDeviceSetNvlinkBwMode
+    data["__nvmlDeviceSetNvlinkBwMode"] = <_cyb_intptr_t>__nvmlDeviceSetNvlinkBwMode
 
     global __nvmlEventSetCreate
-    data["__nvmlEventSetCreate"] = <intptr_t>__nvmlEventSetCreate
+    data["__nvmlEventSetCreate"] = <_cyb_intptr_t>__nvmlEventSetCreate
 
     global __nvmlDeviceRegisterEvents
-    data["__nvmlDeviceRegisterEvents"] = <intptr_t>__nvmlDeviceRegisterEvents
+    data["__nvmlDeviceRegisterEvents"] = <_cyb_intptr_t>__nvmlDeviceRegisterEvents
 
     global __nvmlDeviceGetSupportedEventTypes
-    data["__nvmlDeviceGetSupportedEventTypes"] = <intptr_t>__nvmlDeviceGetSupportedEventTypes
+    data["__nvmlDeviceGetSupportedEventTypes"] = <_cyb_intptr_t>__nvmlDeviceGetSupportedEventTypes
 
     global __nvmlEventSetWait_v2
-    data["__nvmlEventSetWait_v2"] = <intptr_t>__nvmlEventSetWait_v2
+    data["__nvmlEventSetWait_v2"] = <_cyb_intptr_t>__nvmlEventSetWait_v2
 
     global __nvmlEventSetFree
-    data["__nvmlEventSetFree"] = <intptr_t>__nvmlEventSetFree
+    data["__nvmlEventSetFree"] = <_cyb_intptr_t>__nvmlEventSetFree
 
     global __nvmlSystemEventSetCreate
-    data["__nvmlSystemEventSetCreate"] = <intptr_t>__nvmlSystemEventSetCreate
+    data["__nvmlSystemEventSetCreate"] = <_cyb_intptr_t>__nvmlSystemEventSetCreate
 
     global __nvmlSystemEventSetFree
-    data["__nvmlSystemEventSetFree"] = <intptr_t>__nvmlSystemEventSetFree
+    data["__nvmlSystemEventSetFree"] = <_cyb_intptr_t>__nvmlSystemEventSetFree
 
     global __nvmlSystemRegisterEvents
-    data["__nvmlSystemRegisterEvents"] = <intptr_t>__nvmlSystemRegisterEvents
+    data["__nvmlSystemRegisterEvents"] = <_cyb_intptr_t>__nvmlSystemRegisterEvents
 
     global __nvmlSystemEventSetWait
-    data["__nvmlSystemEventSetWait"] = <intptr_t>__nvmlSystemEventSetWait
+    data["__nvmlSystemEventSetWait"] = <_cyb_intptr_t>__nvmlSystemEventSetWait
 
     global __nvmlDeviceModifyDrainState
-    data["__nvmlDeviceModifyDrainState"] = <intptr_t>__nvmlDeviceModifyDrainState
+    data["__nvmlDeviceModifyDrainState"] = <_cyb_intptr_t>__nvmlDeviceModifyDrainState
 
     global __nvmlDeviceQueryDrainState
-    data["__nvmlDeviceQueryDrainState"] = <intptr_t>__nvmlDeviceQueryDrainState
+    data["__nvmlDeviceQueryDrainState"] = <_cyb_intptr_t>__nvmlDeviceQueryDrainState
 
     global __nvmlDeviceRemoveGpu_v2
-    data["__nvmlDeviceRemoveGpu_v2"] = <intptr_t>__nvmlDeviceRemoveGpu_v2
+    data["__nvmlDeviceRemoveGpu_v2"] = <_cyb_intptr_t>__nvmlDeviceRemoveGpu_v2
 
     global __nvmlDeviceDiscoverGpus
-    data["__nvmlDeviceDiscoverGpus"] = <intptr_t>__nvmlDeviceDiscoverGpus
+    data["__nvmlDeviceDiscoverGpus"] = <_cyb_intptr_t>__nvmlDeviceDiscoverGpus
 
     global __nvmlDeviceGetFieldValues
-    data["__nvmlDeviceGetFieldValues"] = <intptr_t>__nvmlDeviceGetFieldValues
+    data["__nvmlDeviceGetFieldValues"] = <_cyb_intptr_t>__nvmlDeviceGetFieldValues
 
     global __nvmlDeviceClearFieldValues
-    data["__nvmlDeviceClearFieldValues"] = <intptr_t>__nvmlDeviceClearFieldValues
+    data["__nvmlDeviceClearFieldValues"] = <_cyb_intptr_t>__nvmlDeviceClearFieldValues
 
     global __nvmlDeviceGetVirtualizationMode
-    data["__nvmlDeviceGetVirtualizationMode"] = <intptr_t>__nvmlDeviceGetVirtualizationMode
+    data["__nvmlDeviceGetVirtualizationMode"] = <_cyb_intptr_t>__nvmlDeviceGetVirtualizationMode
 
     global __nvmlDeviceGetHostVgpuMode
-    data["__nvmlDeviceGetHostVgpuMode"] = <intptr_t>__nvmlDeviceGetHostVgpuMode
+    data["__nvmlDeviceGetHostVgpuMode"] = <_cyb_intptr_t>__nvmlDeviceGetHostVgpuMode
 
     global __nvmlDeviceSetVirtualizationMode
-    data["__nvmlDeviceSetVirtualizationMode"] = <intptr_t>__nvmlDeviceSetVirtualizationMode
+    data["__nvmlDeviceSetVirtualizationMode"] = <_cyb_intptr_t>__nvmlDeviceSetVirtualizationMode
 
     global __nvmlDeviceGetVgpuHeterogeneousMode
-    data["__nvmlDeviceGetVgpuHeterogeneousMode"] = <intptr_t>__nvmlDeviceGetVgpuHeterogeneousMode
+    data["__nvmlDeviceGetVgpuHeterogeneousMode"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuHeterogeneousMode
 
     global __nvmlDeviceSetVgpuHeterogeneousMode
-    data["__nvmlDeviceSetVgpuHeterogeneousMode"] = <intptr_t>__nvmlDeviceSetVgpuHeterogeneousMode
+    data["__nvmlDeviceSetVgpuHeterogeneousMode"] = <_cyb_intptr_t>__nvmlDeviceSetVgpuHeterogeneousMode
 
     global __nvmlVgpuInstanceGetPlacementId
-    data["__nvmlVgpuInstanceGetPlacementId"] = <intptr_t>__nvmlVgpuInstanceGetPlacementId
+    data["__nvmlVgpuInstanceGetPlacementId"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetPlacementId
 
     global __nvmlDeviceGetVgpuTypeSupportedPlacements
-    data["__nvmlDeviceGetVgpuTypeSupportedPlacements"] = <intptr_t>__nvmlDeviceGetVgpuTypeSupportedPlacements
+    data["__nvmlDeviceGetVgpuTypeSupportedPlacements"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuTypeSupportedPlacements
 
     global __nvmlDeviceGetVgpuTypeCreatablePlacements
-    data["__nvmlDeviceGetVgpuTypeCreatablePlacements"] = <intptr_t>__nvmlDeviceGetVgpuTypeCreatablePlacements
+    data["__nvmlDeviceGetVgpuTypeCreatablePlacements"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuTypeCreatablePlacements
 
     global __nvmlVgpuTypeGetGspHeapSize
-    data["__nvmlVgpuTypeGetGspHeapSize"] = <intptr_t>__nvmlVgpuTypeGetGspHeapSize
+    data["__nvmlVgpuTypeGetGspHeapSize"] = <_cyb_intptr_t>__nvmlVgpuTypeGetGspHeapSize
 
     global __nvmlVgpuTypeGetFbReservation
-    data["__nvmlVgpuTypeGetFbReservation"] = <intptr_t>__nvmlVgpuTypeGetFbReservation
+    data["__nvmlVgpuTypeGetFbReservation"] = <_cyb_intptr_t>__nvmlVgpuTypeGetFbReservation
 
     global __nvmlVgpuInstanceGetRuntimeStateSize
-    data["__nvmlVgpuInstanceGetRuntimeStateSize"] = <intptr_t>__nvmlVgpuInstanceGetRuntimeStateSize
+    data["__nvmlVgpuInstanceGetRuntimeStateSize"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetRuntimeStateSize
 
     global __nvmlDeviceSetVgpuCapabilities
-    data["__nvmlDeviceSetVgpuCapabilities"] = <intptr_t>__nvmlDeviceSetVgpuCapabilities
+    data["__nvmlDeviceSetVgpuCapabilities"] = <_cyb_intptr_t>__nvmlDeviceSetVgpuCapabilities
 
     global __nvmlDeviceGetGridLicensableFeatures_v4
-    data["__nvmlDeviceGetGridLicensableFeatures_v4"] = <intptr_t>__nvmlDeviceGetGridLicensableFeatures_v4
+    data["__nvmlDeviceGetGridLicensableFeatures_v4"] = <_cyb_intptr_t>__nvmlDeviceGetGridLicensableFeatures_v4
 
     global __nvmlGetVgpuDriverCapabilities
-    data["__nvmlGetVgpuDriverCapabilities"] = <intptr_t>__nvmlGetVgpuDriverCapabilities
+    data["__nvmlGetVgpuDriverCapabilities"] = <_cyb_intptr_t>__nvmlGetVgpuDriverCapabilities
 
     global __nvmlDeviceGetVgpuCapabilities
-    data["__nvmlDeviceGetVgpuCapabilities"] = <intptr_t>__nvmlDeviceGetVgpuCapabilities
+    data["__nvmlDeviceGetVgpuCapabilities"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuCapabilities
 
     global __nvmlDeviceGetSupportedVgpus
-    data["__nvmlDeviceGetSupportedVgpus"] = <intptr_t>__nvmlDeviceGetSupportedVgpus
+    data["__nvmlDeviceGetSupportedVgpus"] = <_cyb_intptr_t>__nvmlDeviceGetSupportedVgpus
 
     global __nvmlDeviceGetCreatableVgpus
-    data["__nvmlDeviceGetCreatableVgpus"] = <intptr_t>__nvmlDeviceGetCreatableVgpus
+    data["__nvmlDeviceGetCreatableVgpus"] = <_cyb_intptr_t>__nvmlDeviceGetCreatableVgpus
 
     global __nvmlVgpuTypeGetClass
-    data["__nvmlVgpuTypeGetClass"] = <intptr_t>__nvmlVgpuTypeGetClass
+    data["__nvmlVgpuTypeGetClass"] = <_cyb_intptr_t>__nvmlVgpuTypeGetClass
 
     global __nvmlVgpuTypeGetName
-    data["__nvmlVgpuTypeGetName"] = <intptr_t>__nvmlVgpuTypeGetName
+    data["__nvmlVgpuTypeGetName"] = <_cyb_intptr_t>__nvmlVgpuTypeGetName
 
     global __nvmlVgpuTypeGetGpuInstanceProfileId
-    data["__nvmlVgpuTypeGetGpuInstanceProfileId"] = <intptr_t>__nvmlVgpuTypeGetGpuInstanceProfileId
+    data["__nvmlVgpuTypeGetGpuInstanceProfileId"] = <_cyb_intptr_t>__nvmlVgpuTypeGetGpuInstanceProfileId
 
     global __nvmlVgpuTypeGetDeviceID
-    data["__nvmlVgpuTypeGetDeviceID"] = <intptr_t>__nvmlVgpuTypeGetDeviceID
+    data["__nvmlVgpuTypeGetDeviceID"] = <_cyb_intptr_t>__nvmlVgpuTypeGetDeviceID
 
     global __nvmlVgpuTypeGetFramebufferSize
-    data["__nvmlVgpuTypeGetFramebufferSize"] = <intptr_t>__nvmlVgpuTypeGetFramebufferSize
+    data["__nvmlVgpuTypeGetFramebufferSize"] = <_cyb_intptr_t>__nvmlVgpuTypeGetFramebufferSize
 
     global __nvmlVgpuTypeGetNumDisplayHeads
-    data["__nvmlVgpuTypeGetNumDisplayHeads"] = <intptr_t>__nvmlVgpuTypeGetNumDisplayHeads
+    data["__nvmlVgpuTypeGetNumDisplayHeads"] = <_cyb_intptr_t>__nvmlVgpuTypeGetNumDisplayHeads
 
     global __nvmlVgpuTypeGetResolution
-    data["__nvmlVgpuTypeGetResolution"] = <intptr_t>__nvmlVgpuTypeGetResolution
+    data["__nvmlVgpuTypeGetResolution"] = <_cyb_intptr_t>__nvmlVgpuTypeGetResolution
 
     global __nvmlVgpuTypeGetLicense
-    data["__nvmlVgpuTypeGetLicense"] = <intptr_t>__nvmlVgpuTypeGetLicense
+    data["__nvmlVgpuTypeGetLicense"] = <_cyb_intptr_t>__nvmlVgpuTypeGetLicense
 
     global __nvmlVgpuTypeGetFrameRateLimit
-    data["__nvmlVgpuTypeGetFrameRateLimit"] = <intptr_t>__nvmlVgpuTypeGetFrameRateLimit
+    data["__nvmlVgpuTypeGetFrameRateLimit"] = <_cyb_intptr_t>__nvmlVgpuTypeGetFrameRateLimit
 
     global __nvmlVgpuTypeGetMaxInstances
-    data["__nvmlVgpuTypeGetMaxInstances"] = <intptr_t>__nvmlVgpuTypeGetMaxInstances
+    data["__nvmlVgpuTypeGetMaxInstances"] = <_cyb_intptr_t>__nvmlVgpuTypeGetMaxInstances
 
     global __nvmlVgpuTypeGetMaxInstancesPerVm
-    data["__nvmlVgpuTypeGetMaxInstancesPerVm"] = <intptr_t>__nvmlVgpuTypeGetMaxInstancesPerVm
+    data["__nvmlVgpuTypeGetMaxInstancesPerVm"] = <_cyb_intptr_t>__nvmlVgpuTypeGetMaxInstancesPerVm
 
     global __nvmlVgpuTypeGetBAR1Info
-    data["__nvmlVgpuTypeGetBAR1Info"] = <intptr_t>__nvmlVgpuTypeGetBAR1Info
+    data["__nvmlVgpuTypeGetBAR1Info"] = <_cyb_intptr_t>__nvmlVgpuTypeGetBAR1Info
 
     global __nvmlDeviceGetActiveVgpus
-    data["__nvmlDeviceGetActiveVgpus"] = <intptr_t>__nvmlDeviceGetActiveVgpus
+    data["__nvmlDeviceGetActiveVgpus"] = <_cyb_intptr_t>__nvmlDeviceGetActiveVgpus
 
     global __nvmlVgpuInstanceGetVmID
-    data["__nvmlVgpuInstanceGetVmID"] = <intptr_t>__nvmlVgpuInstanceGetVmID
+    data["__nvmlVgpuInstanceGetVmID"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetVmID
 
     global __nvmlVgpuInstanceGetUUID
-    data["__nvmlVgpuInstanceGetUUID"] = <intptr_t>__nvmlVgpuInstanceGetUUID
+    data["__nvmlVgpuInstanceGetUUID"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetUUID
 
     global __nvmlVgpuInstanceGetVmDriverVersion
-    data["__nvmlVgpuInstanceGetVmDriverVersion"] = <intptr_t>__nvmlVgpuInstanceGetVmDriverVersion
+    data["__nvmlVgpuInstanceGetVmDriverVersion"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetVmDriverVersion
 
     global __nvmlVgpuInstanceGetFbUsage
-    data["__nvmlVgpuInstanceGetFbUsage"] = <intptr_t>__nvmlVgpuInstanceGetFbUsage
+    data["__nvmlVgpuInstanceGetFbUsage"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetFbUsage
 
     global __nvmlVgpuInstanceGetLicenseStatus
-    data["__nvmlVgpuInstanceGetLicenseStatus"] = <intptr_t>__nvmlVgpuInstanceGetLicenseStatus
+    data["__nvmlVgpuInstanceGetLicenseStatus"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetLicenseStatus
 
     global __nvmlVgpuInstanceGetType
-    data["__nvmlVgpuInstanceGetType"] = <intptr_t>__nvmlVgpuInstanceGetType
+    data["__nvmlVgpuInstanceGetType"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetType
 
     global __nvmlVgpuInstanceGetFrameRateLimit
-    data["__nvmlVgpuInstanceGetFrameRateLimit"] = <intptr_t>__nvmlVgpuInstanceGetFrameRateLimit
+    data["__nvmlVgpuInstanceGetFrameRateLimit"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetFrameRateLimit
 
     global __nvmlVgpuInstanceGetEccMode
-    data["__nvmlVgpuInstanceGetEccMode"] = <intptr_t>__nvmlVgpuInstanceGetEccMode
+    data["__nvmlVgpuInstanceGetEccMode"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetEccMode
 
     global __nvmlVgpuInstanceGetEncoderCapacity
-    data["__nvmlVgpuInstanceGetEncoderCapacity"] = <intptr_t>__nvmlVgpuInstanceGetEncoderCapacity
+    data["__nvmlVgpuInstanceGetEncoderCapacity"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetEncoderCapacity
 
     global __nvmlVgpuInstanceSetEncoderCapacity
-    data["__nvmlVgpuInstanceSetEncoderCapacity"] = <intptr_t>__nvmlVgpuInstanceSetEncoderCapacity
+    data["__nvmlVgpuInstanceSetEncoderCapacity"] = <_cyb_intptr_t>__nvmlVgpuInstanceSetEncoderCapacity
 
     global __nvmlVgpuInstanceGetEncoderStats
-    data["__nvmlVgpuInstanceGetEncoderStats"] = <intptr_t>__nvmlVgpuInstanceGetEncoderStats
+    data["__nvmlVgpuInstanceGetEncoderStats"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetEncoderStats
 
     global __nvmlVgpuInstanceGetEncoderSessions
-    data["__nvmlVgpuInstanceGetEncoderSessions"] = <intptr_t>__nvmlVgpuInstanceGetEncoderSessions
+    data["__nvmlVgpuInstanceGetEncoderSessions"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetEncoderSessions
 
     global __nvmlVgpuInstanceGetFBCStats
-    data["__nvmlVgpuInstanceGetFBCStats"] = <intptr_t>__nvmlVgpuInstanceGetFBCStats
+    data["__nvmlVgpuInstanceGetFBCStats"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetFBCStats
 
     global __nvmlVgpuInstanceGetFBCSessions
-    data["__nvmlVgpuInstanceGetFBCSessions"] = <intptr_t>__nvmlVgpuInstanceGetFBCSessions
+    data["__nvmlVgpuInstanceGetFBCSessions"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetFBCSessions
 
     global __nvmlVgpuInstanceGetGpuInstanceId
-    data["__nvmlVgpuInstanceGetGpuInstanceId"] = <intptr_t>__nvmlVgpuInstanceGetGpuInstanceId
+    data["__nvmlVgpuInstanceGetGpuInstanceId"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetGpuInstanceId
 
     global __nvmlVgpuInstanceGetGpuPciId
-    data["__nvmlVgpuInstanceGetGpuPciId"] = <intptr_t>__nvmlVgpuInstanceGetGpuPciId
+    data["__nvmlVgpuInstanceGetGpuPciId"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetGpuPciId
 
     global __nvmlVgpuTypeGetCapabilities
-    data["__nvmlVgpuTypeGetCapabilities"] = <intptr_t>__nvmlVgpuTypeGetCapabilities
+    data["__nvmlVgpuTypeGetCapabilities"] = <_cyb_intptr_t>__nvmlVgpuTypeGetCapabilities
 
     global __nvmlVgpuInstanceGetMdevUUID
-    data["__nvmlVgpuInstanceGetMdevUUID"] = <intptr_t>__nvmlVgpuInstanceGetMdevUUID
+    data["__nvmlVgpuInstanceGetMdevUUID"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetMdevUUID
 
     global __nvmlGpuInstanceGetCreatableVgpus
-    data["__nvmlGpuInstanceGetCreatableVgpus"] = <intptr_t>__nvmlGpuInstanceGetCreatableVgpus
+    data["__nvmlGpuInstanceGetCreatableVgpus"] = <_cyb_intptr_t>__nvmlGpuInstanceGetCreatableVgpus
 
     global __nvmlVgpuTypeGetMaxInstancesPerGpuInstance
-    data["__nvmlVgpuTypeGetMaxInstancesPerGpuInstance"] = <intptr_t>__nvmlVgpuTypeGetMaxInstancesPerGpuInstance
+    data["__nvmlVgpuTypeGetMaxInstancesPerGpuInstance"] = <_cyb_intptr_t>__nvmlVgpuTypeGetMaxInstancesPerGpuInstance
 
     global __nvmlGpuInstanceGetActiveVgpus
-    data["__nvmlGpuInstanceGetActiveVgpus"] = <intptr_t>__nvmlGpuInstanceGetActiveVgpus
+    data["__nvmlGpuInstanceGetActiveVgpus"] = <_cyb_intptr_t>__nvmlGpuInstanceGetActiveVgpus
 
     global __nvmlGpuInstanceSetVgpuSchedulerState
-    data["__nvmlGpuInstanceSetVgpuSchedulerState"] = <intptr_t>__nvmlGpuInstanceSetVgpuSchedulerState
+    data["__nvmlGpuInstanceSetVgpuSchedulerState"] = <_cyb_intptr_t>__nvmlGpuInstanceSetVgpuSchedulerState
 
     global __nvmlGpuInstanceGetVgpuSchedulerState
-    data["__nvmlGpuInstanceGetVgpuSchedulerState"] = <intptr_t>__nvmlGpuInstanceGetVgpuSchedulerState
+    data["__nvmlGpuInstanceGetVgpuSchedulerState"] = <_cyb_intptr_t>__nvmlGpuInstanceGetVgpuSchedulerState
 
     global __nvmlGpuInstanceGetVgpuSchedulerLog
-    data["__nvmlGpuInstanceGetVgpuSchedulerLog"] = <intptr_t>__nvmlGpuInstanceGetVgpuSchedulerLog
+    data["__nvmlGpuInstanceGetVgpuSchedulerLog"] = <_cyb_intptr_t>__nvmlGpuInstanceGetVgpuSchedulerLog
 
     global __nvmlGpuInstanceGetVgpuTypeCreatablePlacements
-    data["__nvmlGpuInstanceGetVgpuTypeCreatablePlacements"] = <intptr_t>__nvmlGpuInstanceGetVgpuTypeCreatablePlacements
+    data["__nvmlGpuInstanceGetVgpuTypeCreatablePlacements"] = <_cyb_intptr_t>__nvmlGpuInstanceGetVgpuTypeCreatablePlacements
 
     global __nvmlGpuInstanceGetVgpuHeterogeneousMode
-    data["__nvmlGpuInstanceGetVgpuHeterogeneousMode"] = <intptr_t>__nvmlGpuInstanceGetVgpuHeterogeneousMode
+    data["__nvmlGpuInstanceGetVgpuHeterogeneousMode"] = <_cyb_intptr_t>__nvmlGpuInstanceGetVgpuHeterogeneousMode
 
     global __nvmlGpuInstanceSetVgpuHeterogeneousMode
-    data["__nvmlGpuInstanceSetVgpuHeterogeneousMode"] = <intptr_t>__nvmlGpuInstanceSetVgpuHeterogeneousMode
+    data["__nvmlGpuInstanceSetVgpuHeterogeneousMode"] = <_cyb_intptr_t>__nvmlGpuInstanceSetVgpuHeterogeneousMode
 
     global __nvmlVgpuInstanceGetMetadata
-    data["__nvmlVgpuInstanceGetMetadata"] = <intptr_t>__nvmlVgpuInstanceGetMetadata
+    data["__nvmlVgpuInstanceGetMetadata"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetMetadata
 
     global __nvmlDeviceGetVgpuMetadata
-    data["__nvmlDeviceGetVgpuMetadata"] = <intptr_t>__nvmlDeviceGetVgpuMetadata
+    data["__nvmlDeviceGetVgpuMetadata"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuMetadata
 
     global __nvmlGetVgpuCompatibility
-    data["__nvmlGetVgpuCompatibility"] = <intptr_t>__nvmlGetVgpuCompatibility
+    data["__nvmlGetVgpuCompatibility"] = <_cyb_intptr_t>__nvmlGetVgpuCompatibility
 
     global __nvmlDeviceGetPgpuMetadataString
-    data["__nvmlDeviceGetPgpuMetadataString"] = <intptr_t>__nvmlDeviceGetPgpuMetadataString
+    data["__nvmlDeviceGetPgpuMetadataString"] = <_cyb_intptr_t>__nvmlDeviceGetPgpuMetadataString
 
     global __nvmlDeviceGetVgpuSchedulerLog
-    data["__nvmlDeviceGetVgpuSchedulerLog"] = <intptr_t>__nvmlDeviceGetVgpuSchedulerLog
+    data["__nvmlDeviceGetVgpuSchedulerLog"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuSchedulerLog
 
     global __nvmlDeviceGetVgpuSchedulerState
-    data["__nvmlDeviceGetVgpuSchedulerState"] = <intptr_t>__nvmlDeviceGetVgpuSchedulerState
+    data["__nvmlDeviceGetVgpuSchedulerState"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuSchedulerState
 
     global __nvmlDeviceGetVgpuSchedulerCapabilities
-    data["__nvmlDeviceGetVgpuSchedulerCapabilities"] = <intptr_t>__nvmlDeviceGetVgpuSchedulerCapabilities
+    data["__nvmlDeviceGetVgpuSchedulerCapabilities"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuSchedulerCapabilities
 
     global __nvmlDeviceSetVgpuSchedulerState
-    data["__nvmlDeviceSetVgpuSchedulerState"] = <intptr_t>__nvmlDeviceSetVgpuSchedulerState
+    data["__nvmlDeviceSetVgpuSchedulerState"] = <_cyb_intptr_t>__nvmlDeviceSetVgpuSchedulerState
 
     global __nvmlGetVgpuVersion
-    data["__nvmlGetVgpuVersion"] = <intptr_t>__nvmlGetVgpuVersion
+    data["__nvmlGetVgpuVersion"] = <_cyb_intptr_t>__nvmlGetVgpuVersion
 
     global __nvmlSetVgpuVersion
-    data["__nvmlSetVgpuVersion"] = <intptr_t>__nvmlSetVgpuVersion
+    data["__nvmlSetVgpuVersion"] = <_cyb_intptr_t>__nvmlSetVgpuVersion
 
     global __nvmlDeviceGetVgpuUtilization
-    data["__nvmlDeviceGetVgpuUtilization"] = <intptr_t>__nvmlDeviceGetVgpuUtilization
+    data["__nvmlDeviceGetVgpuUtilization"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuUtilization
 
     global __nvmlDeviceGetVgpuInstancesUtilizationInfo
-    data["__nvmlDeviceGetVgpuInstancesUtilizationInfo"] = <intptr_t>__nvmlDeviceGetVgpuInstancesUtilizationInfo
+    data["__nvmlDeviceGetVgpuInstancesUtilizationInfo"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuInstancesUtilizationInfo
 
     global __nvmlDeviceGetVgpuProcessUtilization
-    data["__nvmlDeviceGetVgpuProcessUtilization"] = <intptr_t>__nvmlDeviceGetVgpuProcessUtilization
+    data["__nvmlDeviceGetVgpuProcessUtilization"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuProcessUtilization
 
     global __nvmlDeviceGetVgpuProcessesUtilizationInfo
-    data["__nvmlDeviceGetVgpuProcessesUtilizationInfo"] = <intptr_t>__nvmlDeviceGetVgpuProcessesUtilizationInfo
+    data["__nvmlDeviceGetVgpuProcessesUtilizationInfo"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuProcessesUtilizationInfo
 
     global __nvmlVgpuInstanceGetAccountingMode
-    data["__nvmlVgpuInstanceGetAccountingMode"] = <intptr_t>__nvmlVgpuInstanceGetAccountingMode
+    data["__nvmlVgpuInstanceGetAccountingMode"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetAccountingMode
 
     global __nvmlVgpuInstanceGetAccountingPids
-    data["__nvmlVgpuInstanceGetAccountingPids"] = <intptr_t>__nvmlVgpuInstanceGetAccountingPids
+    data["__nvmlVgpuInstanceGetAccountingPids"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetAccountingPids
 
     global __nvmlVgpuInstanceGetAccountingStats
-    data["__nvmlVgpuInstanceGetAccountingStats"] = <intptr_t>__nvmlVgpuInstanceGetAccountingStats
+    data["__nvmlVgpuInstanceGetAccountingStats"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetAccountingStats
 
     global __nvmlVgpuInstanceClearAccountingPids
-    data["__nvmlVgpuInstanceClearAccountingPids"] = <intptr_t>__nvmlVgpuInstanceClearAccountingPids
+    data["__nvmlVgpuInstanceClearAccountingPids"] = <_cyb_intptr_t>__nvmlVgpuInstanceClearAccountingPids
 
     global __nvmlVgpuInstanceGetLicenseInfo_v2
-    data["__nvmlVgpuInstanceGetLicenseInfo_v2"] = <intptr_t>__nvmlVgpuInstanceGetLicenseInfo_v2
+    data["__nvmlVgpuInstanceGetLicenseInfo_v2"] = <_cyb_intptr_t>__nvmlVgpuInstanceGetLicenseInfo_v2
 
     global __nvmlGetExcludedDeviceCount
-    data["__nvmlGetExcludedDeviceCount"] = <intptr_t>__nvmlGetExcludedDeviceCount
+    data["__nvmlGetExcludedDeviceCount"] = <_cyb_intptr_t>__nvmlGetExcludedDeviceCount
 
     global __nvmlGetExcludedDeviceInfoByIndex
-    data["__nvmlGetExcludedDeviceInfoByIndex"] = <intptr_t>__nvmlGetExcludedDeviceInfoByIndex
+    data["__nvmlGetExcludedDeviceInfoByIndex"] = <_cyb_intptr_t>__nvmlGetExcludedDeviceInfoByIndex
 
     global __nvmlDeviceSetMigMode
-    data["__nvmlDeviceSetMigMode"] = <intptr_t>__nvmlDeviceSetMigMode
+    data["__nvmlDeviceSetMigMode"] = <_cyb_intptr_t>__nvmlDeviceSetMigMode
 
     global __nvmlDeviceGetMigMode
-    data["__nvmlDeviceGetMigMode"] = <intptr_t>__nvmlDeviceGetMigMode
+    data["__nvmlDeviceGetMigMode"] = <_cyb_intptr_t>__nvmlDeviceGetMigMode
 
     global __nvmlDeviceGetGpuInstanceProfileInfoV
-    data["__nvmlDeviceGetGpuInstanceProfileInfoV"] = <intptr_t>__nvmlDeviceGetGpuInstanceProfileInfoV
+    data["__nvmlDeviceGetGpuInstanceProfileInfoV"] = <_cyb_intptr_t>__nvmlDeviceGetGpuInstanceProfileInfoV
 
     global __nvmlDeviceGetGpuInstancePossiblePlacements_v2
-    data["__nvmlDeviceGetGpuInstancePossiblePlacements_v2"] = <intptr_t>__nvmlDeviceGetGpuInstancePossiblePlacements_v2
+    data["__nvmlDeviceGetGpuInstancePossiblePlacements_v2"] = <_cyb_intptr_t>__nvmlDeviceGetGpuInstancePossiblePlacements_v2
 
     global __nvmlDeviceGetGpuInstanceRemainingCapacity
-    data["__nvmlDeviceGetGpuInstanceRemainingCapacity"] = <intptr_t>__nvmlDeviceGetGpuInstanceRemainingCapacity
+    data["__nvmlDeviceGetGpuInstanceRemainingCapacity"] = <_cyb_intptr_t>__nvmlDeviceGetGpuInstanceRemainingCapacity
 
     global __nvmlDeviceCreateGpuInstance
-    data["__nvmlDeviceCreateGpuInstance"] = <intptr_t>__nvmlDeviceCreateGpuInstance
+    data["__nvmlDeviceCreateGpuInstance"] = <_cyb_intptr_t>__nvmlDeviceCreateGpuInstance
 
     global __nvmlDeviceCreateGpuInstanceWithPlacement
-    data["__nvmlDeviceCreateGpuInstanceWithPlacement"] = <intptr_t>__nvmlDeviceCreateGpuInstanceWithPlacement
+    data["__nvmlDeviceCreateGpuInstanceWithPlacement"] = <_cyb_intptr_t>__nvmlDeviceCreateGpuInstanceWithPlacement
 
     global __nvmlGpuInstanceDestroy
-    data["__nvmlGpuInstanceDestroy"] = <intptr_t>__nvmlGpuInstanceDestroy
+    data["__nvmlGpuInstanceDestroy"] = <_cyb_intptr_t>__nvmlGpuInstanceDestroy
 
     global __nvmlDeviceGetGpuInstances
-    data["__nvmlDeviceGetGpuInstances"] = <intptr_t>__nvmlDeviceGetGpuInstances
+    data["__nvmlDeviceGetGpuInstances"] = <_cyb_intptr_t>__nvmlDeviceGetGpuInstances
 
     global __nvmlDeviceGetGpuInstanceById
-    data["__nvmlDeviceGetGpuInstanceById"] = <intptr_t>__nvmlDeviceGetGpuInstanceById
+    data["__nvmlDeviceGetGpuInstanceById"] = <_cyb_intptr_t>__nvmlDeviceGetGpuInstanceById
 
     global __nvmlGpuInstanceGetInfo
-    data["__nvmlGpuInstanceGetInfo"] = <intptr_t>__nvmlGpuInstanceGetInfo
+    data["__nvmlGpuInstanceGetInfo"] = <_cyb_intptr_t>__nvmlGpuInstanceGetInfo
 
     global __nvmlGpuInstanceGetComputeInstanceProfileInfoV
-    data["__nvmlGpuInstanceGetComputeInstanceProfileInfoV"] = <intptr_t>__nvmlGpuInstanceGetComputeInstanceProfileInfoV
+    data["__nvmlGpuInstanceGetComputeInstanceProfileInfoV"] = <_cyb_intptr_t>__nvmlGpuInstanceGetComputeInstanceProfileInfoV
 
     global __nvmlGpuInstanceGetComputeInstanceRemainingCapacity
-    data["__nvmlGpuInstanceGetComputeInstanceRemainingCapacity"] = <intptr_t>__nvmlGpuInstanceGetComputeInstanceRemainingCapacity
+    data["__nvmlGpuInstanceGetComputeInstanceRemainingCapacity"] = <_cyb_intptr_t>__nvmlGpuInstanceGetComputeInstanceRemainingCapacity
 
     global __nvmlGpuInstanceGetComputeInstancePossiblePlacements
-    data["__nvmlGpuInstanceGetComputeInstancePossiblePlacements"] = <intptr_t>__nvmlGpuInstanceGetComputeInstancePossiblePlacements
+    data["__nvmlGpuInstanceGetComputeInstancePossiblePlacements"] = <_cyb_intptr_t>__nvmlGpuInstanceGetComputeInstancePossiblePlacements
 
     global __nvmlGpuInstanceCreateComputeInstance
-    data["__nvmlGpuInstanceCreateComputeInstance"] = <intptr_t>__nvmlGpuInstanceCreateComputeInstance
+    data["__nvmlGpuInstanceCreateComputeInstance"] = <_cyb_intptr_t>__nvmlGpuInstanceCreateComputeInstance
 
     global __nvmlGpuInstanceCreateComputeInstanceWithPlacement
-    data["__nvmlGpuInstanceCreateComputeInstanceWithPlacement"] = <intptr_t>__nvmlGpuInstanceCreateComputeInstanceWithPlacement
+    data["__nvmlGpuInstanceCreateComputeInstanceWithPlacement"] = <_cyb_intptr_t>__nvmlGpuInstanceCreateComputeInstanceWithPlacement
 
     global __nvmlComputeInstanceDestroy
-    data["__nvmlComputeInstanceDestroy"] = <intptr_t>__nvmlComputeInstanceDestroy
+    data["__nvmlComputeInstanceDestroy"] = <_cyb_intptr_t>__nvmlComputeInstanceDestroy
 
     global __nvmlGpuInstanceGetComputeInstances
-    data["__nvmlGpuInstanceGetComputeInstances"] = <intptr_t>__nvmlGpuInstanceGetComputeInstances
+    data["__nvmlGpuInstanceGetComputeInstances"] = <_cyb_intptr_t>__nvmlGpuInstanceGetComputeInstances
 
     global __nvmlGpuInstanceGetComputeInstanceById
-    data["__nvmlGpuInstanceGetComputeInstanceById"] = <intptr_t>__nvmlGpuInstanceGetComputeInstanceById
+    data["__nvmlGpuInstanceGetComputeInstanceById"] = <_cyb_intptr_t>__nvmlGpuInstanceGetComputeInstanceById
 
     global __nvmlComputeInstanceGetInfo_v2
-    data["__nvmlComputeInstanceGetInfo_v2"] = <intptr_t>__nvmlComputeInstanceGetInfo_v2
+    data["__nvmlComputeInstanceGetInfo_v2"] = <_cyb_intptr_t>__nvmlComputeInstanceGetInfo_v2
 
     global __nvmlDeviceIsMigDeviceHandle
-    data["__nvmlDeviceIsMigDeviceHandle"] = <intptr_t>__nvmlDeviceIsMigDeviceHandle
+    data["__nvmlDeviceIsMigDeviceHandle"] = <_cyb_intptr_t>__nvmlDeviceIsMigDeviceHandle
 
     global __nvmlDeviceGetGpuInstanceId
-    data["__nvmlDeviceGetGpuInstanceId"] = <intptr_t>__nvmlDeviceGetGpuInstanceId
+    data["__nvmlDeviceGetGpuInstanceId"] = <_cyb_intptr_t>__nvmlDeviceGetGpuInstanceId
 
     global __nvmlDeviceGetComputeInstanceId
-    data["__nvmlDeviceGetComputeInstanceId"] = <intptr_t>__nvmlDeviceGetComputeInstanceId
+    data["__nvmlDeviceGetComputeInstanceId"] = <_cyb_intptr_t>__nvmlDeviceGetComputeInstanceId
 
     global __nvmlDeviceGetMaxMigDeviceCount
-    data["__nvmlDeviceGetMaxMigDeviceCount"] = <intptr_t>__nvmlDeviceGetMaxMigDeviceCount
+    data["__nvmlDeviceGetMaxMigDeviceCount"] = <_cyb_intptr_t>__nvmlDeviceGetMaxMigDeviceCount
 
     global __nvmlDeviceGetMigDeviceHandleByIndex
-    data["__nvmlDeviceGetMigDeviceHandleByIndex"] = <intptr_t>__nvmlDeviceGetMigDeviceHandleByIndex
+    data["__nvmlDeviceGetMigDeviceHandleByIndex"] = <_cyb_intptr_t>__nvmlDeviceGetMigDeviceHandleByIndex
 
     global __nvmlDeviceGetDeviceHandleFromMigDeviceHandle
-    data["__nvmlDeviceGetDeviceHandleFromMigDeviceHandle"] = <intptr_t>__nvmlDeviceGetDeviceHandleFromMigDeviceHandle
+    data["__nvmlDeviceGetDeviceHandleFromMigDeviceHandle"] = <_cyb_intptr_t>__nvmlDeviceGetDeviceHandleFromMigDeviceHandle
 
     global __nvmlDeviceGetCapabilities
-    data["__nvmlDeviceGetCapabilities"] = <intptr_t>__nvmlDeviceGetCapabilities
+    data["__nvmlDeviceGetCapabilities"] = <_cyb_intptr_t>__nvmlDeviceGetCapabilities
 
     global __nvmlDevicePowerSmoothingActivatePresetProfile
-    data["__nvmlDevicePowerSmoothingActivatePresetProfile"] = <intptr_t>__nvmlDevicePowerSmoothingActivatePresetProfile
+    data["__nvmlDevicePowerSmoothingActivatePresetProfile"] = <_cyb_intptr_t>__nvmlDevicePowerSmoothingActivatePresetProfile
 
     global __nvmlDevicePowerSmoothingUpdatePresetProfileParam
-    data["__nvmlDevicePowerSmoothingUpdatePresetProfileParam"] = <intptr_t>__nvmlDevicePowerSmoothingUpdatePresetProfileParam
+    data["__nvmlDevicePowerSmoothingUpdatePresetProfileParam"] = <_cyb_intptr_t>__nvmlDevicePowerSmoothingUpdatePresetProfileParam
 
     global __nvmlDevicePowerSmoothingSetState
-    data["__nvmlDevicePowerSmoothingSetState"] = <intptr_t>__nvmlDevicePowerSmoothingSetState
+    data["__nvmlDevicePowerSmoothingSetState"] = <_cyb_intptr_t>__nvmlDevicePowerSmoothingSetState
 
     global __nvmlDeviceGetAddressingMode
-    data["__nvmlDeviceGetAddressingMode"] = <intptr_t>__nvmlDeviceGetAddressingMode
+    data["__nvmlDeviceGetAddressingMode"] = <_cyb_intptr_t>__nvmlDeviceGetAddressingMode
 
     global __nvmlDeviceGetRepairStatus
-    data["__nvmlDeviceGetRepairStatus"] = <intptr_t>__nvmlDeviceGetRepairStatus
+    data["__nvmlDeviceGetRepairStatus"] = <_cyb_intptr_t>__nvmlDeviceGetRepairStatus
 
     global __nvmlDeviceGetPowerMizerMode_v1
-    data["__nvmlDeviceGetPowerMizerMode_v1"] = <intptr_t>__nvmlDeviceGetPowerMizerMode_v1
+    data["__nvmlDeviceGetPowerMizerMode_v1"] = <_cyb_intptr_t>__nvmlDeviceGetPowerMizerMode_v1
 
     global __nvmlDeviceSetPowerMizerMode_v1
-    data["__nvmlDeviceSetPowerMizerMode_v1"] = <intptr_t>__nvmlDeviceSetPowerMizerMode_v1
+    data["__nvmlDeviceSetPowerMizerMode_v1"] = <_cyb_intptr_t>__nvmlDeviceSetPowerMizerMode_v1
 
     global __nvmlDeviceGetPdi
-    data["__nvmlDeviceGetPdi"] = <intptr_t>__nvmlDeviceGetPdi
+    data["__nvmlDeviceGetPdi"] = <_cyb_intptr_t>__nvmlDeviceGetPdi
 
     global __nvmlDeviceSetHostname_v1
-    data["__nvmlDeviceSetHostname_v1"] = <intptr_t>__nvmlDeviceSetHostname_v1
+    data["__nvmlDeviceSetHostname_v1"] = <_cyb_intptr_t>__nvmlDeviceSetHostname_v1
 
     global __nvmlDeviceGetHostname_v1
-    data["__nvmlDeviceGetHostname_v1"] = <intptr_t>__nvmlDeviceGetHostname_v1
+    data["__nvmlDeviceGetHostname_v1"] = <_cyb_intptr_t>__nvmlDeviceGetHostname_v1
 
     global __nvmlDeviceGetNvLinkInfo
-    data["__nvmlDeviceGetNvLinkInfo"] = <intptr_t>__nvmlDeviceGetNvLinkInfo
+    data["__nvmlDeviceGetNvLinkInfo"] = <_cyb_intptr_t>__nvmlDeviceGetNvLinkInfo
 
     global __nvmlDeviceReadWritePRM_v1
-    data["__nvmlDeviceReadWritePRM_v1"] = <intptr_t>__nvmlDeviceReadWritePRM_v1
+    data["__nvmlDeviceReadWritePRM_v1"] = <_cyb_intptr_t>__nvmlDeviceReadWritePRM_v1
 
     global __nvmlDeviceGetGpuInstanceProfileInfoByIdV
-    data["__nvmlDeviceGetGpuInstanceProfileInfoByIdV"] = <intptr_t>__nvmlDeviceGetGpuInstanceProfileInfoByIdV
+    data["__nvmlDeviceGetGpuInstanceProfileInfoByIdV"] = <_cyb_intptr_t>__nvmlDeviceGetGpuInstanceProfileInfoByIdV
 
     global __nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts
-    data["__nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts"] = <intptr_t>__nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts
+    data["__nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts"] = <_cyb_intptr_t>__nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts
 
     global __nvmlDeviceGetUnrepairableMemoryFlag_v1
-    data["__nvmlDeviceGetUnrepairableMemoryFlag_v1"] = <intptr_t>__nvmlDeviceGetUnrepairableMemoryFlag_v1
+    data["__nvmlDeviceGetUnrepairableMemoryFlag_v1"] = <_cyb_intptr_t>__nvmlDeviceGetUnrepairableMemoryFlag_v1
 
     global __nvmlDeviceReadPRMCounters_v1
-    data["__nvmlDeviceReadPRMCounters_v1"] = <intptr_t>__nvmlDeviceReadPRMCounters_v1
+    data["__nvmlDeviceReadPRMCounters_v1"] = <_cyb_intptr_t>__nvmlDeviceReadPRMCounters_v1
 
     global __nvmlDeviceSetRusdSettings_v1
-    data["__nvmlDeviceSetRusdSettings_v1"] = <intptr_t>__nvmlDeviceSetRusdSettings_v1
+    data["__nvmlDeviceSetRusdSettings_v1"] = <_cyb_intptr_t>__nvmlDeviceSetRusdSettings_v1
 
     global __nvmlDeviceVgpuForceGspUnload
-    data["__nvmlDeviceVgpuForceGspUnload"] = <intptr_t>__nvmlDeviceVgpuForceGspUnload
+    data["__nvmlDeviceVgpuForceGspUnload"] = <_cyb_intptr_t>__nvmlDeviceVgpuForceGspUnload
 
     global __nvmlDeviceGetVgpuSchedulerState_v2
-    data["__nvmlDeviceGetVgpuSchedulerState_v2"] = <intptr_t>__nvmlDeviceGetVgpuSchedulerState_v2
+    data["__nvmlDeviceGetVgpuSchedulerState_v2"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuSchedulerState_v2
 
     global __nvmlGpuInstanceGetVgpuSchedulerState_v2
-    data["__nvmlGpuInstanceGetVgpuSchedulerState_v2"] = <intptr_t>__nvmlGpuInstanceGetVgpuSchedulerState_v2
+    data["__nvmlGpuInstanceGetVgpuSchedulerState_v2"] = <_cyb_intptr_t>__nvmlGpuInstanceGetVgpuSchedulerState_v2
 
     global __nvmlDeviceGetVgpuSchedulerLog_v2
-    data["__nvmlDeviceGetVgpuSchedulerLog_v2"] = <intptr_t>__nvmlDeviceGetVgpuSchedulerLog_v2
+    data["__nvmlDeviceGetVgpuSchedulerLog_v2"] = <_cyb_intptr_t>__nvmlDeviceGetVgpuSchedulerLog_v2
 
     global __nvmlGpuInstanceGetVgpuSchedulerLog_v2
-    data["__nvmlGpuInstanceGetVgpuSchedulerLog_v2"] = <intptr_t>__nvmlGpuInstanceGetVgpuSchedulerLog_v2
+    data["__nvmlGpuInstanceGetVgpuSchedulerLog_v2"] = <_cyb_intptr_t>__nvmlGpuInstanceGetVgpuSchedulerLog_v2
 
     global __nvmlDeviceSetVgpuSchedulerState_v2
-    data["__nvmlDeviceSetVgpuSchedulerState_v2"] = <intptr_t>__nvmlDeviceSetVgpuSchedulerState_v2
+    data["__nvmlDeviceSetVgpuSchedulerState_v2"] = <_cyb_intptr_t>__nvmlDeviceSetVgpuSchedulerState_v2
 
     global __nvmlGpuInstanceSetVgpuSchedulerState_v2
-    data["__nvmlGpuInstanceSetVgpuSchedulerState_v2"] = <intptr_t>__nvmlGpuInstanceSetVgpuSchedulerState_v2
-
-    func_ptrs = data
+    data["__nvmlGpuInstanceSetVgpuSchedulerState_v2"] = <_cyb_intptr_t>__nvmlGpuInstanceSetVgpuSchedulerState_v2
+    _cyb_func_ptrs = data
     return data
 
 
 cpdef _inspect_function_pointer(str name):
-    global func_ptrs
-    if func_ptrs is None:
-        func_ptrs = _inspect_function_pointers()
-    return func_ptrs[name]
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is None:
+        _cyb_func_ptrs = _inspect_function_pointers()
+    return _cyb_func_ptrs[name]
+
+
+
+
+cdef uintptr_t load_library() except* with gil:
+    return load_nvidia_dynamic_lib("nvml")._handle_uint
 
 
 ###############################################################################

--- a/cuda_bindings/cuda/bindings/_internal/nvrtc_linux.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvrtc_linux.pyx
@@ -3,62 +3,34 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.9.0 to 13.3.0. Do not modify it directly.
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=0ca6f301335e0e0a3b70c6fddc4f54b7930b547f18e05f0ede5a9e0f437c79f8
 
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=6e54cb56384256b65cc962fbb478f7fac87523f222a141785b66881d8f554c64
-from libc.stdint cimport intptr_t, uintptr_t
 
-import threading
+# <<<< PREAMBLE CONTENT >>>>
+
+cdef extern from "<dlfcn.h>":
+    void* _cyb_dlsym "dlsym"(void*, const char*) nogil
+    const void * _cyb_RTLD_DEFAULT "RTLD_DEFAULT"
+
+from libc.stdint cimport intptr_t as _cyb_intptr_t
+
+import threading as _cyb_threading
+
+cdef bint _cyb___py_nvrtc_init = False
+cdef dict _cyb_func_ptrs = None
+cdef object _cyb_symbol_lock = _cyb_threading.Lock()
+
+# <<<< END OF PREAMBLE CONTENT >>>>
+
+from libc.stdint cimport uintptr_t
+
 from .utils import FunctionNotFoundError, NotSupportedError
-
 from cuda.pathfinder import load_nvidia_dynamic_lib
-
-
-###############################################################################
-# Extern
-###############################################################################
-
-# You must 'from .utils import NotSupportedError' before using this template
-
-cdef extern from "<dlfcn.h>" nogil:
-    void* dlopen(const char*, int)
-    char* dlerror()
-    void* dlsym(void*, const char*)
-    int dlclose(void*)
-
-    enum:
-        RTLD_LAZY
-        RTLD_NOW
-        RTLD_GLOBAL
-        RTLD_LOCAL
-
-    const void* RTLD_DEFAULT 'RTLD_DEFAULT'
-
-cdef int get_cuda_version():
-    cdef void* handle = NULL
-    cdef int err, driver_ver = 0
-
-    # Load driver to check version
-    handle = dlopen('libcuda.so.1', RTLD_NOW | RTLD_GLOBAL)
-    if handle == NULL:
-        err_msg = dlerror()
-        raise NotSupportedError(f'CUDA driver is not found ({err_msg.decode()})')
-    cuDriverGetVersion = dlsym(handle, "cuDriverGetVersion")
-    if cuDriverGetVersion == NULL:
-        raise RuntimeError('Did not find cuDriverGetVersion symbol in libcuda.so.1')
-    err = (<int (*)(int*) noexcept nogil>cuDriverGetVersion)(&driver_ver)
-    if err != 0:
-        raise RuntimeError(f'cuDriverGetVersion returned error code {err}')
-
-    return driver_ver
-
 
 
 ###############################################################################
 # Wrapper init
 ###############################################################################
-
-cdef object __symbol_lock = threading.Lock()
-cdef bint __py_nvrtc_init = False
 
 cdef void* __nvrtcGetErrorString = NULL
 cdef void* __nvrtcVersion = NULL
@@ -90,343 +62,334 @@ cdef void* __nvrtcInstallBundledHeaders = NULL
 cdef void* __nvrtcGetBundledHeadersInfo = NULL
 cdef void* __nvrtcRemoveBundledHeaders = NULL
 
-
-cdef void* load_library() except* with gil:
-    cdef uintptr_t handle = load_nvidia_dynamic_lib("nvrtc")._handle_uint
-    return <void*>handle
-
-
 cdef int _init_nvrtc() except -1 nogil:
-    global __py_nvrtc_init
-
+    global _cyb___py_nvrtc_init
     cdef void* handle = NULL
+    with gil, _cyb_symbol_lock:
+        if _cyb___py_nvrtc_init: return 0
 
-    with gil, __symbol_lock:
-        # Recheck the flag after obtaining the locks
-        if __py_nvrtc_init:
-            return 0
-
-        # Load function
         global __nvrtcGetErrorString
-        __nvrtcGetErrorString = dlsym(RTLD_DEFAULT, 'nvrtcGetErrorString')
+        __nvrtcGetErrorString = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcGetErrorString')
         if __nvrtcGetErrorString == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcGetErrorString = dlsym(handle, 'nvrtcGetErrorString')
+            __nvrtcGetErrorString = _cyb_dlsym(handle, 'nvrtcGetErrorString')
 
         global __nvrtcVersion
-        __nvrtcVersion = dlsym(RTLD_DEFAULT, 'nvrtcVersion')
+        __nvrtcVersion = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcVersion')
         if __nvrtcVersion == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcVersion = dlsym(handle, 'nvrtcVersion')
+            __nvrtcVersion = _cyb_dlsym(handle, 'nvrtcVersion')
 
         global __nvrtcGetNumSupportedArchs
-        __nvrtcGetNumSupportedArchs = dlsym(RTLD_DEFAULT, 'nvrtcGetNumSupportedArchs')
+        __nvrtcGetNumSupportedArchs = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcGetNumSupportedArchs')
         if __nvrtcGetNumSupportedArchs == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcGetNumSupportedArchs = dlsym(handle, 'nvrtcGetNumSupportedArchs')
+            __nvrtcGetNumSupportedArchs = _cyb_dlsym(handle, 'nvrtcGetNumSupportedArchs')
 
         global __nvrtcGetSupportedArchs
-        __nvrtcGetSupportedArchs = dlsym(RTLD_DEFAULT, 'nvrtcGetSupportedArchs')
+        __nvrtcGetSupportedArchs = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcGetSupportedArchs')
         if __nvrtcGetSupportedArchs == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcGetSupportedArchs = dlsym(handle, 'nvrtcGetSupportedArchs')
+            __nvrtcGetSupportedArchs = _cyb_dlsym(handle, 'nvrtcGetSupportedArchs')
 
         global __nvrtcCreateProgram
-        __nvrtcCreateProgram = dlsym(RTLD_DEFAULT, 'nvrtcCreateProgram')
+        __nvrtcCreateProgram = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcCreateProgram')
         if __nvrtcCreateProgram == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcCreateProgram = dlsym(handle, 'nvrtcCreateProgram')
+            __nvrtcCreateProgram = _cyb_dlsym(handle, 'nvrtcCreateProgram')
 
         global __nvrtcDestroyProgram
-        __nvrtcDestroyProgram = dlsym(RTLD_DEFAULT, 'nvrtcDestroyProgram')
+        __nvrtcDestroyProgram = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcDestroyProgram')
         if __nvrtcDestroyProgram == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcDestroyProgram = dlsym(handle, 'nvrtcDestroyProgram')
+            __nvrtcDestroyProgram = _cyb_dlsym(handle, 'nvrtcDestroyProgram')
 
         global __nvrtcCompileProgram
-        __nvrtcCompileProgram = dlsym(RTLD_DEFAULT, 'nvrtcCompileProgram')
+        __nvrtcCompileProgram = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcCompileProgram')
         if __nvrtcCompileProgram == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcCompileProgram = dlsym(handle, 'nvrtcCompileProgram')
+            __nvrtcCompileProgram = _cyb_dlsym(handle, 'nvrtcCompileProgram')
 
         global __nvrtcGetPTXSize
-        __nvrtcGetPTXSize = dlsym(RTLD_DEFAULT, 'nvrtcGetPTXSize')
+        __nvrtcGetPTXSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcGetPTXSize')
         if __nvrtcGetPTXSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcGetPTXSize = dlsym(handle, 'nvrtcGetPTXSize')
+            __nvrtcGetPTXSize = _cyb_dlsym(handle, 'nvrtcGetPTXSize')
 
         global __nvrtcGetPTX
-        __nvrtcGetPTX = dlsym(RTLD_DEFAULT, 'nvrtcGetPTX')
+        __nvrtcGetPTX = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcGetPTX')
         if __nvrtcGetPTX == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcGetPTX = dlsym(handle, 'nvrtcGetPTX')
+            __nvrtcGetPTX = _cyb_dlsym(handle, 'nvrtcGetPTX')
 
         global __nvrtcGetCUBINSize
-        __nvrtcGetCUBINSize = dlsym(RTLD_DEFAULT, 'nvrtcGetCUBINSize')
+        __nvrtcGetCUBINSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcGetCUBINSize')
         if __nvrtcGetCUBINSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcGetCUBINSize = dlsym(handle, 'nvrtcGetCUBINSize')
+            __nvrtcGetCUBINSize = _cyb_dlsym(handle, 'nvrtcGetCUBINSize')
 
         global __nvrtcGetCUBIN
-        __nvrtcGetCUBIN = dlsym(RTLD_DEFAULT, 'nvrtcGetCUBIN')
+        __nvrtcGetCUBIN = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcGetCUBIN')
         if __nvrtcGetCUBIN == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcGetCUBIN = dlsym(handle, 'nvrtcGetCUBIN')
+            __nvrtcGetCUBIN = _cyb_dlsym(handle, 'nvrtcGetCUBIN')
 
         global __nvrtcGetLTOIRSize
-        __nvrtcGetLTOIRSize = dlsym(RTLD_DEFAULT, 'nvrtcGetLTOIRSize')
+        __nvrtcGetLTOIRSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcGetLTOIRSize')
         if __nvrtcGetLTOIRSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcGetLTOIRSize = dlsym(handle, 'nvrtcGetLTOIRSize')
+            __nvrtcGetLTOIRSize = _cyb_dlsym(handle, 'nvrtcGetLTOIRSize')
 
         global __nvrtcGetLTOIR
-        __nvrtcGetLTOIR = dlsym(RTLD_DEFAULT, 'nvrtcGetLTOIR')
+        __nvrtcGetLTOIR = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcGetLTOIR')
         if __nvrtcGetLTOIR == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcGetLTOIR = dlsym(handle, 'nvrtcGetLTOIR')
+            __nvrtcGetLTOIR = _cyb_dlsym(handle, 'nvrtcGetLTOIR')
 
         global __nvrtcGetOptiXIRSize
-        __nvrtcGetOptiXIRSize = dlsym(RTLD_DEFAULT, 'nvrtcGetOptiXIRSize')
+        __nvrtcGetOptiXIRSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcGetOptiXIRSize')
         if __nvrtcGetOptiXIRSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcGetOptiXIRSize = dlsym(handle, 'nvrtcGetOptiXIRSize')
+            __nvrtcGetOptiXIRSize = _cyb_dlsym(handle, 'nvrtcGetOptiXIRSize')
 
         global __nvrtcGetOptiXIR
-        __nvrtcGetOptiXIR = dlsym(RTLD_DEFAULT, 'nvrtcGetOptiXIR')
+        __nvrtcGetOptiXIR = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcGetOptiXIR')
         if __nvrtcGetOptiXIR == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcGetOptiXIR = dlsym(handle, 'nvrtcGetOptiXIR')
+            __nvrtcGetOptiXIR = _cyb_dlsym(handle, 'nvrtcGetOptiXIR')
 
         global __nvrtcGetProgramLogSize
-        __nvrtcGetProgramLogSize = dlsym(RTLD_DEFAULT, 'nvrtcGetProgramLogSize')
+        __nvrtcGetProgramLogSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcGetProgramLogSize')
         if __nvrtcGetProgramLogSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcGetProgramLogSize = dlsym(handle, 'nvrtcGetProgramLogSize')
+            __nvrtcGetProgramLogSize = _cyb_dlsym(handle, 'nvrtcGetProgramLogSize')
 
         global __nvrtcGetProgramLog
-        __nvrtcGetProgramLog = dlsym(RTLD_DEFAULT, 'nvrtcGetProgramLog')
+        __nvrtcGetProgramLog = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcGetProgramLog')
         if __nvrtcGetProgramLog == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcGetProgramLog = dlsym(handle, 'nvrtcGetProgramLog')
+            __nvrtcGetProgramLog = _cyb_dlsym(handle, 'nvrtcGetProgramLog')
 
         global __nvrtcAddNameExpression
-        __nvrtcAddNameExpression = dlsym(RTLD_DEFAULT, 'nvrtcAddNameExpression')
+        __nvrtcAddNameExpression = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcAddNameExpression')
         if __nvrtcAddNameExpression == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcAddNameExpression = dlsym(handle, 'nvrtcAddNameExpression')
+            __nvrtcAddNameExpression = _cyb_dlsym(handle, 'nvrtcAddNameExpression')
 
         global __nvrtcGetLoweredName
-        __nvrtcGetLoweredName = dlsym(RTLD_DEFAULT, 'nvrtcGetLoweredName')
+        __nvrtcGetLoweredName = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcGetLoweredName')
         if __nvrtcGetLoweredName == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcGetLoweredName = dlsym(handle, 'nvrtcGetLoweredName')
+            __nvrtcGetLoweredName = _cyb_dlsym(handle, 'nvrtcGetLoweredName')
 
         global __nvrtcGetPCHHeapSize
-        __nvrtcGetPCHHeapSize = dlsym(RTLD_DEFAULT, 'nvrtcGetPCHHeapSize')
+        __nvrtcGetPCHHeapSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcGetPCHHeapSize')
         if __nvrtcGetPCHHeapSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcGetPCHHeapSize = dlsym(handle, 'nvrtcGetPCHHeapSize')
+            __nvrtcGetPCHHeapSize = _cyb_dlsym(handle, 'nvrtcGetPCHHeapSize')
 
         global __nvrtcSetPCHHeapSize
-        __nvrtcSetPCHHeapSize = dlsym(RTLD_DEFAULT, 'nvrtcSetPCHHeapSize')
+        __nvrtcSetPCHHeapSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcSetPCHHeapSize')
         if __nvrtcSetPCHHeapSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcSetPCHHeapSize = dlsym(handle, 'nvrtcSetPCHHeapSize')
+            __nvrtcSetPCHHeapSize = _cyb_dlsym(handle, 'nvrtcSetPCHHeapSize')
 
         global __nvrtcGetPCHCreateStatus
-        __nvrtcGetPCHCreateStatus = dlsym(RTLD_DEFAULT, 'nvrtcGetPCHCreateStatus')
+        __nvrtcGetPCHCreateStatus = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcGetPCHCreateStatus')
         if __nvrtcGetPCHCreateStatus == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcGetPCHCreateStatus = dlsym(handle, 'nvrtcGetPCHCreateStatus')
+            __nvrtcGetPCHCreateStatus = _cyb_dlsym(handle, 'nvrtcGetPCHCreateStatus')
 
         global __nvrtcGetPCHHeapSizeRequired
-        __nvrtcGetPCHHeapSizeRequired = dlsym(RTLD_DEFAULT, 'nvrtcGetPCHHeapSizeRequired')
+        __nvrtcGetPCHHeapSizeRequired = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcGetPCHHeapSizeRequired')
         if __nvrtcGetPCHHeapSizeRequired == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcGetPCHHeapSizeRequired = dlsym(handle, 'nvrtcGetPCHHeapSizeRequired')
+            __nvrtcGetPCHHeapSizeRequired = _cyb_dlsym(handle, 'nvrtcGetPCHHeapSizeRequired')
 
         global __nvrtcSetFlowCallback
-        __nvrtcSetFlowCallback = dlsym(RTLD_DEFAULT, 'nvrtcSetFlowCallback')
+        __nvrtcSetFlowCallback = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcSetFlowCallback')
         if __nvrtcSetFlowCallback == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcSetFlowCallback = dlsym(handle, 'nvrtcSetFlowCallback')
+            __nvrtcSetFlowCallback = _cyb_dlsym(handle, 'nvrtcSetFlowCallback')
 
         global __nvrtcGetTileIRSize
-        __nvrtcGetTileIRSize = dlsym(RTLD_DEFAULT, 'nvrtcGetTileIRSize')
+        __nvrtcGetTileIRSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcGetTileIRSize')
         if __nvrtcGetTileIRSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcGetTileIRSize = dlsym(handle, 'nvrtcGetTileIRSize')
+            __nvrtcGetTileIRSize = _cyb_dlsym(handle, 'nvrtcGetTileIRSize')
 
         global __nvrtcGetTileIR
-        __nvrtcGetTileIR = dlsym(RTLD_DEFAULT, 'nvrtcGetTileIR')
+        __nvrtcGetTileIR = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcGetTileIR')
         if __nvrtcGetTileIR == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcGetTileIR = dlsym(handle, 'nvrtcGetTileIR')
+            __nvrtcGetTileIR = _cyb_dlsym(handle, 'nvrtcGetTileIR')
 
         global __nvrtcInstallBundledHeaders
-        __nvrtcInstallBundledHeaders = dlsym(RTLD_DEFAULT, 'nvrtcInstallBundledHeaders')
+        __nvrtcInstallBundledHeaders = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcInstallBundledHeaders')
         if __nvrtcInstallBundledHeaders == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcInstallBundledHeaders = dlsym(handle, 'nvrtcInstallBundledHeaders')
+            __nvrtcInstallBundledHeaders = _cyb_dlsym(handle, 'nvrtcInstallBundledHeaders')
 
         global __nvrtcGetBundledHeadersInfo
-        __nvrtcGetBundledHeadersInfo = dlsym(RTLD_DEFAULT, 'nvrtcGetBundledHeadersInfo')
+        __nvrtcGetBundledHeadersInfo = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcGetBundledHeadersInfo')
         if __nvrtcGetBundledHeadersInfo == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcGetBundledHeadersInfo = dlsym(handle, 'nvrtcGetBundledHeadersInfo')
+            __nvrtcGetBundledHeadersInfo = _cyb_dlsym(handle, 'nvrtcGetBundledHeadersInfo')
 
         global __nvrtcRemoveBundledHeaders
-        __nvrtcRemoveBundledHeaders = dlsym(RTLD_DEFAULT, 'nvrtcRemoveBundledHeaders')
+        __nvrtcRemoveBundledHeaders = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvrtcRemoveBundledHeaders')
         if __nvrtcRemoveBundledHeaders == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvrtcRemoveBundledHeaders = dlsym(handle, 'nvrtcRemoveBundledHeaders')
+            __nvrtcRemoveBundledHeaders = _cyb_dlsym(handle, 'nvrtcRemoveBundledHeaders')
 
-        __py_nvrtc_init = True
+        _cyb___py_nvrtc_init = True
         return 0
 
-
 cdef inline int _check_or_init_nvrtc() except -1 nogil:
-    if __py_nvrtc_init:
+    if _cyb___py_nvrtc_init:
         return 0
 
     return _init_nvrtc()
 
-cdef dict func_ptrs = None
-
 
 cpdef dict _inspect_function_pointers():
-    global func_ptrs
-    if func_ptrs is not None:
-        return func_ptrs
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is not None:
+        return _cyb_func_ptrs
 
     _check_or_init_nvrtc()
     cdef dict data = {}
-
     global __nvrtcGetErrorString
-    data["__nvrtcGetErrorString"] = <intptr_t>__nvrtcGetErrorString
+    data["__nvrtcGetErrorString"] = <_cyb_intptr_t>__nvrtcGetErrorString
 
     global __nvrtcVersion
-    data["__nvrtcVersion"] = <intptr_t>__nvrtcVersion
+    data["__nvrtcVersion"] = <_cyb_intptr_t>__nvrtcVersion
 
     global __nvrtcGetNumSupportedArchs
-    data["__nvrtcGetNumSupportedArchs"] = <intptr_t>__nvrtcGetNumSupportedArchs
+    data["__nvrtcGetNumSupportedArchs"] = <_cyb_intptr_t>__nvrtcGetNumSupportedArchs
 
     global __nvrtcGetSupportedArchs
-    data["__nvrtcGetSupportedArchs"] = <intptr_t>__nvrtcGetSupportedArchs
+    data["__nvrtcGetSupportedArchs"] = <_cyb_intptr_t>__nvrtcGetSupportedArchs
 
     global __nvrtcCreateProgram
-    data["__nvrtcCreateProgram"] = <intptr_t>__nvrtcCreateProgram
+    data["__nvrtcCreateProgram"] = <_cyb_intptr_t>__nvrtcCreateProgram
 
     global __nvrtcDestroyProgram
-    data["__nvrtcDestroyProgram"] = <intptr_t>__nvrtcDestroyProgram
+    data["__nvrtcDestroyProgram"] = <_cyb_intptr_t>__nvrtcDestroyProgram
 
     global __nvrtcCompileProgram
-    data["__nvrtcCompileProgram"] = <intptr_t>__nvrtcCompileProgram
+    data["__nvrtcCompileProgram"] = <_cyb_intptr_t>__nvrtcCompileProgram
 
     global __nvrtcGetPTXSize
-    data["__nvrtcGetPTXSize"] = <intptr_t>__nvrtcGetPTXSize
+    data["__nvrtcGetPTXSize"] = <_cyb_intptr_t>__nvrtcGetPTXSize
 
     global __nvrtcGetPTX
-    data["__nvrtcGetPTX"] = <intptr_t>__nvrtcGetPTX
+    data["__nvrtcGetPTX"] = <_cyb_intptr_t>__nvrtcGetPTX
 
     global __nvrtcGetCUBINSize
-    data["__nvrtcGetCUBINSize"] = <intptr_t>__nvrtcGetCUBINSize
+    data["__nvrtcGetCUBINSize"] = <_cyb_intptr_t>__nvrtcGetCUBINSize
 
     global __nvrtcGetCUBIN
-    data["__nvrtcGetCUBIN"] = <intptr_t>__nvrtcGetCUBIN
+    data["__nvrtcGetCUBIN"] = <_cyb_intptr_t>__nvrtcGetCUBIN
 
     global __nvrtcGetLTOIRSize
-    data["__nvrtcGetLTOIRSize"] = <intptr_t>__nvrtcGetLTOIRSize
+    data["__nvrtcGetLTOIRSize"] = <_cyb_intptr_t>__nvrtcGetLTOIRSize
 
     global __nvrtcGetLTOIR
-    data["__nvrtcGetLTOIR"] = <intptr_t>__nvrtcGetLTOIR
+    data["__nvrtcGetLTOIR"] = <_cyb_intptr_t>__nvrtcGetLTOIR
 
     global __nvrtcGetOptiXIRSize
-    data["__nvrtcGetOptiXIRSize"] = <intptr_t>__nvrtcGetOptiXIRSize
+    data["__nvrtcGetOptiXIRSize"] = <_cyb_intptr_t>__nvrtcGetOptiXIRSize
 
     global __nvrtcGetOptiXIR
-    data["__nvrtcGetOptiXIR"] = <intptr_t>__nvrtcGetOptiXIR
+    data["__nvrtcGetOptiXIR"] = <_cyb_intptr_t>__nvrtcGetOptiXIR
 
     global __nvrtcGetProgramLogSize
-    data["__nvrtcGetProgramLogSize"] = <intptr_t>__nvrtcGetProgramLogSize
+    data["__nvrtcGetProgramLogSize"] = <_cyb_intptr_t>__nvrtcGetProgramLogSize
 
     global __nvrtcGetProgramLog
-    data["__nvrtcGetProgramLog"] = <intptr_t>__nvrtcGetProgramLog
+    data["__nvrtcGetProgramLog"] = <_cyb_intptr_t>__nvrtcGetProgramLog
 
     global __nvrtcAddNameExpression
-    data["__nvrtcAddNameExpression"] = <intptr_t>__nvrtcAddNameExpression
+    data["__nvrtcAddNameExpression"] = <_cyb_intptr_t>__nvrtcAddNameExpression
 
     global __nvrtcGetLoweredName
-    data["__nvrtcGetLoweredName"] = <intptr_t>__nvrtcGetLoweredName
+    data["__nvrtcGetLoweredName"] = <_cyb_intptr_t>__nvrtcGetLoweredName
 
     global __nvrtcGetPCHHeapSize
-    data["__nvrtcGetPCHHeapSize"] = <intptr_t>__nvrtcGetPCHHeapSize
+    data["__nvrtcGetPCHHeapSize"] = <_cyb_intptr_t>__nvrtcGetPCHHeapSize
 
     global __nvrtcSetPCHHeapSize
-    data["__nvrtcSetPCHHeapSize"] = <intptr_t>__nvrtcSetPCHHeapSize
+    data["__nvrtcSetPCHHeapSize"] = <_cyb_intptr_t>__nvrtcSetPCHHeapSize
 
     global __nvrtcGetPCHCreateStatus
-    data["__nvrtcGetPCHCreateStatus"] = <intptr_t>__nvrtcGetPCHCreateStatus
+    data["__nvrtcGetPCHCreateStatus"] = <_cyb_intptr_t>__nvrtcGetPCHCreateStatus
 
     global __nvrtcGetPCHHeapSizeRequired
-    data["__nvrtcGetPCHHeapSizeRequired"] = <intptr_t>__nvrtcGetPCHHeapSizeRequired
+    data["__nvrtcGetPCHHeapSizeRequired"] = <_cyb_intptr_t>__nvrtcGetPCHHeapSizeRequired
 
     global __nvrtcSetFlowCallback
-    data["__nvrtcSetFlowCallback"] = <intptr_t>__nvrtcSetFlowCallback
+    data["__nvrtcSetFlowCallback"] = <_cyb_intptr_t>__nvrtcSetFlowCallback
 
     global __nvrtcGetTileIRSize
-    data["__nvrtcGetTileIRSize"] = <intptr_t>__nvrtcGetTileIRSize
+    data["__nvrtcGetTileIRSize"] = <_cyb_intptr_t>__nvrtcGetTileIRSize
 
     global __nvrtcGetTileIR
-    data["__nvrtcGetTileIR"] = <intptr_t>__nvrtcGetTileIR
+    data["__nvrtcGetTileIR"] = <_cyb_intptr_t>__nvrtcGetTileIR
 
     global __nvrtcInstallBundledHeaders
-    data["__nvrtcInstallBundledHeaders"] = <intptr_t>__nvrtcInstallBundledHeaders
+    data["__nvrtcInstallBundledHeaders"] = <_cyb_intptr_t>__nvrtcInstallBundledHeaders
 
     global __nvrtcGetBundledHeadersInfo
-    data["__nvrtcGetBundledHeadersInfo"] = <intptr_t>__nvrtcGetBundledHeadersInfo
+    data["__nvrtcGetBundledHeadersInfo"] = <_cyb_intptr_t>__nvrtcGetBundledHeadersInfo
 
     global __nvrtcRemoveBundledHeaders
-    data["__nvrtcRemoveBundledHeaders"] = <intptr_t>__nvrtcRemoveBundledHeaders
-
-    func_ptrs = data
+    data["__nvrtcRemoveBundledHeaders"] = <_cyb_intptr_t>__nvrtcRemoveBundledHeaders
+    _cyb_func_ptrs = data
     return data
 
 
 cpdef _inspect_function_pointer(str name):
-    global func_ptrs
-    if func_ptrs is None:
-        func_ptrs = _inspect_function_pointers()
-    return func_ptrs[name]
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is None:
+        _cyb_func_ptrs = _inspect_function_pointers()
+    return _cyb_func_ptrs[name]
+
+
+
+
+cdef void* load_library() except* with gil:
+    cdef uintptr_t handle = load_nvidia_dynamic_lib("nvrtc")._handle_uint
+    return <void*>handle
 
 
 ###############################################################################

--- a/cuda_bindings/cuda/bindings/_internal/nvrtc_windows.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvrtc_windows.pyx
@@ -3,80 +3,31 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.9.0 to 13.3.0. Do not modify it directly.
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=fb8577d2b93fb2a36b8f02f62b920524ff9c191b2f4d8203ee3105820bc6f28c
 
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=7e496ceaaaf75ed29455bb670e3b3af9ab7d4ba1ea155a129088c04aab9b3c16
-from libc.stdint cimport intptr_t
 
-import threading
-from .utils import FunctionNotFoundError, NotSupportedError
+# <<<< PREAMBLE CONTENT >>>>
 
-from cuda.pathfinder import load_nvidia_dynamic_lib
-
-from libc.stddef cimport wchar_t
-from libc.stdint cimport uintptr_t
-from cpython cimport PyUnicode_AsWideCharString, PyMem_Free
-
-# You must 'from .utils import NotSupportedError' before using this template
-
-cdef extern from "windows.h" nogil:
+cdef extern from "<windows.h>":
     ctypedef void* HMODULE
-    ctypedef void* HANDLE
-    ctypedef void* FARPROC
-    ctypedef unsigned long DWORD
-    ctypedef const wchar_t *LPCWSTR
-    ctypedef const char *LPCSTR
+    void* _cyb_GetProcAddress "GetProcAddress"(HMODULE, const char*) nogil
 
-    cdef DWORD LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800
-    cdef DWORD LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000
-    cdef DWORD LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR = 0x00000100
+from libc.stdint cimport intptr_t as _cyb_intptr_t
 
-    HMODULE _LoadLibraryExW "LoadLibraryExW"(
-        LPCWSTR lpLibFileName,
-        HANDLE hFile,
-        DWORD dwFlags
-    )
+import threading as _cyb_threading
 
-    FARPROC _GetProcAddress "GetProcAddress"(HMODULE hModule, LPCSTR lpProcName)
+cdef bint _cyb___py_nvrtc_init = False
+cdef dict _cyb_func_ptrs = None
+cdef object _cyb_symbol_lock = _cyb_threading.Lock()
 
-cdef inline uintptr_t LoadLibraryExW(str path, HANDLE hFile, DWORD dwFlags):
-    cdef uintptr_t result
-    cdef wchar_t* wpath = PyUnicode_AsWideCharString(path, NULL)
-    with nogil:
-        result = <uintptr_t>_LoadLibraryExW(
-            wpath,
-            hFile,
-            dwFlags
-        )
-    PyMem_Free(wpath)
-    return result
+# <<<< END OF PREAMBLE CONTENT >>>>
 
-cdef inline void *GetProcAddress(uintptr_t hModule, const char* lpProcName) nogil:
-    return _GetProcAddress(<HMODULE>hModule, lpProcName)
-
-cdef int get_cuda_version():
-    cdef int err, driver_ver = 0
-
-    # Load driver to check version
-    handle = LoadLibraryExW("nvcuda.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32)
-    if handle == 0:
-        raise NotSupportedError('CUDA driver is not found')
-    cuDriverGetVersion = GetProcAddress(handle, 'cuDriverGetVersion')
-    if cuDriverGetVersion == NULL:
-        raise RuntimeError('Did not find cuDriverGetVersion symbol in nvcuda.dll')
-    err = (<int (*)(int*) noexcept nogil>cuDriverGetVersion)(&driver_ver)
-    if err != 0:
-        raise RuntimeError(f'cuDriverGetVersion returned error code {err}')
-
-    return driver_ver
-
-
-
+from libc.stdint cimport uintptr_t
+from cuda.pathfinder import load_nvidia_dynamic_lib
+from .utils import FunctionNotFoundError, NotSupportedError
 ###############################################################################
 # Wrapper init
 ###############################################################################
-
-cdef object __symbol_lock = threading.Lock()
-cdef bint __py_nvrtc_init = False
 
 cdef void* __nvrtcGetErrorString = NULL
 cdef void* __nvrtcVersion = NULL
@@ -108,223 +59,220 @@ cdef void* __nvrtcInstallBundledHeaders = NULL
 cdef void* __nvrtcGetBundledHeadersInfo = NULL
 cdef void* __nvrtcRemoveBundledHeaders = NULL
 
-
 cdef int _init_nvrtc() except -1 nogil:
-    global __py_nvrtc_init
+    global _cyb___py_nvrtc_init
 
-    with gil, __symbol_lock:
-        # Recheck the flag after obtaining the locks
-        if __py_nvrtc_init:
-            return 0
+    cdef int err
+    cdef uintptr_t handle
+    with gil, _cyb_symbol_lock:
+        if _cyb___py_nvrtc_init: return 0
 
-        # Load library
-        handle = load_nvidia_dynamic_lib("nvrtc")._handle_uint
-
-        # Load function
+        handle = load_library()
         global __nvrtcGetErrorString
-        __nvrtcGetErrorString = GetProcAddress(handle, 'nvrtcGetErrorString')
+        __nvrtcGetErrorString = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcGetErrorString')
 
         global __nvrtcVersion
-        __nvrtcVersion = GetProcAddress(handle, 'nvrtcVersion')
+        __nvrtcVersion = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcVersion')
 
         global __nvrtcGetNumSupportedArchs
-        __nvrtcGetNumSupportedArchs = GetProcAddress(handle, 'nvrtcGetNumSupportedArchs')
+        __nvrtcGetNumSupportedArchs = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcGetNumSupportedArchs')
 
         global __nvrtcGetSupportedArchs
-        __nvrtcGetSupportedArchs = GetProcAddress(handle, 'nvrtcGetSupportedArchs')
+        __nvrtcGetSupportedArchs = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcGetSupportedArchs')
 
         global __nvrtcCreateProgram
-        __nvrtcCreateProgram = GetProcAddress(handle, 'nvrtcCreateProgram')
+        __nvrtcCreateProgram = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcCreateProgram')
 
         global __nvrtcDestroyProgram
-        __nvrtcDestroyProgram = GetProcAddress(handle, 'nvrtcDestroyProgram')
+        __nvrtcDestroyProgram = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcDestroyProgram')
 
         global __nvrtcCompileProgram
-        __nvrtcCompileProgram = GetProcAddress(handle, 'nvrtcCompileProgram')
+        __nvrtcCompileProgram = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcCompileProgram')
 
         global __nvrtcGetPTXSize
-        __nvrtcGetPTXSize = GetProcAddress(handle, 'nvrtcGetPTXSize')
+        __nvrtcGetPTXSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcGetPTXSize')
 
         global __nvrtcGetPTX
-        __nvrtcGetPTX = GetProcAddress(handle, 'nvrtcGetPTX')
+        __nvrtcGetPTX = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcGetPTX')
 
         global __nvrtcGetCUBINSize
-        __nvrtcGetCUBINSize = GetProcAddress(handle, 'nvrtcGetCUBINSize')
+        __nvrtcGetCUBINSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcGetCUBINSize')
 
         global __nvrtcGetCUBIN
-        __nvrtcGetCUBIN = GetProcAddress(handle, 'nvrtcGetCUBIN')
+        __nvrtcGetCUBIN = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcGetCUBIN')
 
         global __nvrtcGetLTOIRSize
-        __nvrtcGetLTOIRSize = GetProcAddress(handle, 'nvrtcGetLTOIRSize')
+        __nvrtcGetLTOIRSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcGetLTOIRSize')
 
         global __nvrtcGetLTOIR
-        __nvrtcGetLTOIR = GetProcAddress(handle, 'nvrtcGetLTOIR')
+        __nvrtcGetLTOIR = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcGetLTOIR')
 
         global __nvrtcGetOptiXIRSize
-        __nvrtcGetOptiXIRSize = GetProcAddress(handle, 'nvrtcGetOptiXIRSize')
+        __nvrtcGetOptiXIRSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcGetOptiXIRSize')
 
         global __nvrtcGetOptiXIR
-        __nvrtcGetOptiXIR = GetProcAddress(handle, 'nvrtcGetOptiXIR')
+        __nvrtcGetOptiXIR = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcGetOptiXIR')
 
         global __nvrtcGetProgramLogSize
-        __nvrtcGetProgramLogSize = GetProcAddress(handle, 'nvrtcGetProgramLogSize')
+        __nvrtcGetProgramLogSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcGetProgramLogSize')
 
         global __nvrtcGetProgramLog
-        __nvrtcGetProgramLog = GetProcAddress(handle, 'nvrtcGetProgramLog')
+        __nvrtcGetProgramLog = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcGetProgramLog')
 
         global __nvrtcAddNameExpression
-        __nvrtcAddNameExpression = GetProcAddress(handle, 'nvrtcAddNameExpression')
+        __nvrtcAddNameExpression = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcAddNameExpression')
 
         global __nvrtcGetLoweredName
-        __nvrtcGetLoweredName = GetProcAddress(handle, 'nvrtcGetLoweredName')
+        __nvrtcGetLoweredName = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcGetLoweredName')
 
         global __nvrtcGetPCHHeapSize
-        __nvrtcGetPCHHeapSize = GetProcAddress(handle, 'nvrtcGetPCHHeapSize')
+        __nvrtcGetPCHHeapSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcGetPCHHeapSize')
 
         global __nvrtcSetPCHHeapSize
-        __nvrtcSetPCHHeapSize = GetProcAddress(handle, 'nvrtcSetPCHHeapSize')
+        __nvrtcSetPCHHeapSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcSetPCHHeapSize')
 
         global __nvrtcGetPCHCreateStatus
-        __nvrtcGetPCHCreateStatus = GetProcAddress(handle, 'nvrtcGetPCHCreateStatus')
+        __nvrtcGetPCHCreateStatus = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcGetPCHCreateStatus')
 
         global __nvrtcGetPCHHeapSizeRequired
-        __nvrtcGetPCHHeapSizeRequired = GetProcAddress(handle, 'nvrtcGetPCHHeapSizeRequired')
+        __nvrtcGetPCHHeapSizeRequired = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcGetPCHHeapSizeRequired')
 
         global __nvrtcSetFlowCallback
-        __nvrtcSetFlowCallback = GetProcAddress(handle, 'nvrtcSetFlowCallback')
+        __nvrtcSetFlowCallback = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcSetFlowCallback')
 
         global __nvrtcGetTileIRSize
-        __nvrtcGetTileIRSize = GetProcAddress(handle, 'nvrtcGetTileIRSize')
+        __nvrtcGetTileIRSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcGetTileIRSize')
 
         global __nvrtcGetTileIR
-        __nvrtcGetTileIR = GetProcAddress(handle, 'nvrtcGetTileIR')
+        __nvrtcGetTileIR = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcGetTileIR')
 
         global __nvrtcInstallBundledHeaders
-        __nvrtcInstallBundledHeaders = GetProcAddress(handle, 'nvrtcInstallBundledHeaders')
+        __nvrtcInstallBundledHeaders = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcInstallBundledHeaders')
 
         global __nvrtcGetBundledHeadersInfo
-        __nvrtcGetBundledHeadersInfo = GetProcAddress(handle, 'nvrtcGetBundledHeadersInfo')
+        __nvrtcGetBundledHeadersInfo = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcGetBundledHeadersInfo')
 
         global __nvrtcRemoveBundledHeaders
-        __nvrtcRemoveBundledHeaders = GetProcAddress(handle, 'nvrtcRemoveBundledHeaders')
+        __nvrtcRemoveBundledHeaders = _cyb_GetProcAddress(<HMODULE>handle, 'nvrtcRemoveBundledHeaders')
 
-        __py_nvrtc_init = True
+        _cyb___py_nvrtc_init = True
         return 0
 
-
 cdef inline int _check_or_init_nvrtc() except -1 nogil:
-    if __py_nvrtc_init:
+    if _cyb___py_nvrtc_init:
         return 0
 
     return _init_nvrtc()
 
-cdef dict func_ptrs = None
-
 
 cpdef dict _inspect_function_pointers():
-    global func_ptrs
-    if func_ptrs is not None:
-        return func_ptrs
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is not None:
+        return _cyb_func_ptrs
 
     _check_or_init_nvrtc()
     cdef dict data = {}
-
     global __nvrtcGetErrorString
-    data["__nvrtcGetErrorString"] = <intptr_t>__nvrtcGetErrorString
+    data["__nvrtcGetErrorString"] = <_cyb_intptr_t>__nvrtcGetErrorString
 
     global __nvrtcVersion
-    data["__nvrtcVersion"] = <intptr_t>__nvrtcVersion
+    data["__nvrtcVersion"] = <_cyb_intptr_t>__nvrtcVersion
 
     global __nvrtcGetNumSupportedArchs
-    data["__nvrtcGetNumSupportedArchs"] = <intptr_t>__nvrtcGetNumSupportedArchs
+    data["__nvrtcGetNumSupportedArchs"] = <_cyb_intptr_t>__nvrtcGetNumSupportedArchs
 
     global __nvrtcGetSupportedArchs
-    data["__nvrtcGetSupportedArchs"] = <intptr_t>__nvrtcGetSupportedArchs
+    data["__nvrtcGetSupportedArchs"] = <_cyb_intptr_t>__nvrtcGetSupportedArchs
 
     global __nvrtcCreateProgram
-    data["__nvrtcCreateProgram"] = <intptr_t>__nvrtcCreateProgram
+    data["__nvrtcCreateProgram"] = <_cyb_intptr_t>__nvrtcCreateProgram
 
     global __nvrtcDestroyProgram
-    data["__nvrtcDestroyProgram"] = <intptr_t>__nvrtcDestroyProgram
+    data["__nvrtcDestroyProgram"] = <_cyb_intptr_t>__nvrtcDestroyProgram
 
     global __nvrtcCompileProgram
-    data["__nvrtcCompileProgram"] = <intptr_t>__nvrtcCompileProgram
+    data["__nvrtcCompileProgram"] = <_cyb_intptr_t>__nvrtcCompileProgram
 
     global __nvrtcGetPTXSize
-    data["__nvrtcGetPTXSize"] = <intptr_t>__nvrtcGetPTXSize
+    data["__nvrtcGetPTXSize"] = <_cyb_intptr_t>__nvrtcGetPTXSize
 
     global __nvrtcGetPTX
-    data["__nvrtcGetPTX"] = <intptr_t>__nvrtcGetPTX
+    data["__nvrtcGetPTX"] = <_cyb_intptr_t>__nvrtcGetPTX
 
     global __nvrtcGetCUBINSize
-    data["__nvrtcGetCUBINSize"] = <intptr_t>__nvrtcGetCUBINSize
+    data["__nvrtcGetCUBINSize"] = <_cyb_intptr_t>__nvrtcGetCUBINSize
 
     global __nvrtcGetCUBIN
-    data["__nvrtcGetCUBIN"] = <intptr_t>__nvrtcGetCUBIN
+    data["__nvrtcGetCUBIN"] = <_cyb_intptr_t>__nvrtcGetCUBIN
 
     global __nvrtcGetLTOIRSize
-    data["__nvrtcGetLTOIRSize"] = <intptr_t>__nvrtcGetLTOIRSize
+    data["__nvrtcGetLTOIRSize"] = <_cyb_intptr_t>__nvrtcGetLTOIRSize
 
     global __nvrtcGetLTOIR
-    data["__nvrtcGetLTOIR"] = <intptr_t>__nvrtcGetLTOIR
+    data["__nvrtcGetLTOIR"] = <_cyb_intptr_t>__nvrtcGetLTOIR
 
     global __nvrtcGetOptiXIRSize
-    data["__nvrtcGetOptiXIRSize"] = <intptr_t>__nvrtcGetOptiXIRSize
+    data["__nvrtcGetOptiXIRSize"] = <_cyb_intptr_t>__nvrtcGetOptiXIRSize
 
     global __nvrtcGetOptiXIR
-    data["__nvrtcGetOptiXIR"] = <intptr_t>__nvrtcGetOptiXIR
+    data["__nvrtcGetOptiXIR"] = <_cyb_intptr_t>__nvrtcGetOptiXIR
 
     global __nvrtcGetProgramLogSize
-    data["__nvrtcGetProgramLogSize"] = <intptr_t>__nvrtcGetProgramLogSize
+    data["__nvrtcGetProgramLogSize"] = <_cyb_intptr_t>__nvrtcGetProgramLogSize
 
     global __nvrtcGetProgramLog
-    data["__nvrtcGetProgramLog"] = <intptr_t>__nvrtcGetProgramLog
+    data["__nvrtcGetProgramLog"] = <_cyb_intptr_t>__nvrtcGetProgramLog
 
     global __nvrtcAddNameExpression
-    data["__nvrtcAddNameExpression"] = <intptr_t>__nvrtcAddNameExpression
+    data["__nvrtcAddNameExpression"] = <_cyb_intptr_t>__nvrtcAddNameExpression
 
     global __nvrtcGetLoweredName
-    data["__nvrtcGetLoweredName"] = <intptr_t>__nvrtcGetLoweredName
+    data["__nvrtcGetLoweredName"] = <_cyb_intptr_t>__nvrtcGetLoweredName
 
     global __nvrtcGetPCHHeapSize
-    data["__nvrtcGetPCHHeapSize"] = <intptr_t>__nvrtcGetPCHHeapSize
+    data["__nvrtcGetPCHHeapSize"] = <_cyb_intptr_t>__nvrtcGetPCHHeapSize
 
     global __nvrtcSetPCHHeapSize
-    data["__nvrtcSetPCHHeapSize"] = <intptr_t>__nvrtcSetPCHHeapSize
+    data["__nvrtcSetPCHHeapSize"] = <_cyb_intptr_t>__nvrtcSetPCHHeapSize
 
     global __nvrtcGetPCHCreateStatus
-    data["__nvrtcGetPCHCreateStatus"] = <intptr_t>__nvrtcGetPCHCreateStatus
+    data["__nvrtcGetPCHCreateStatus"] = <_cyb_intptr_t>__nvrtcGetPCHCreateStatus
 
     global __nvrtcGetPCHHeapSizeRequired
-    data["__nvrtcGetPCHHeapSizeRequired"] = <intptr_t>__nvrtcGetPCHHeapSizeRequired
+    data["__nvrtcGetPCHHeapSizeRequired"] = <_cyb_intptr_t>__nvrtcGetPCHHeapSizeRequired
 
     global __nvrtcSetFlowCallback
-    data["__nvrtcSetFlowCallback"] = <intptr_t>__nvrtcSetFlowCallback
+    data["__nvrtcSetFlowCallback"] = <_cyb_intptr_t>__nvrtcSetFlowCallback
 
     global __nvrtcGetTileIRSize
-    data["__nvrtcGetTileIRSize"] = <intptr_t>__nvrtcGetTileIRSize
+    data["__nvrtcGetTileIRSize"] = <_cyb_intptr_t>__nvrtcGetTileIRSize
 
     global __nvrtcGetTileIR
-    data["__nvrtcGetTileIR"] = <intptr_t>__nvrtcGetTileIR
+    data["__nvrtcGetTileIR"] = <_cyb_intptr_t>__nvrtcGetTileIR
 
     global __nvrtcInstallBundledHeaders
-    data["__nvrtcInstallBundledHeaders"] = <intptr_t>__nvrtcInstallBundledHeaders
+    data["__nvrtcInstallBundledHeaders"] = <_cyb_intptr_t>__nvrtcInstallBundledHeaders
 
     global __nvrtcGetBundledHeadersInfo
-    data["__nvrtcGetBundledHeadersInfo"] = <intptr_t>__nvrtcGetBundledHeadersInfo
+    data["__nvrtcGetBundledHeadersInfo"] = <_cyb_intptr_t>__nvrtcGetBundledHeadersInfo
 
     global __nvrtcRemoveBundledHeaders
-    data["__nvrtcRemoveBundledHeaders"] = <intptr_t>__nvrtcRemoveBundledHeaders
-
-    func_ptrs = data
+    data["__nvrtcRemoveBundledHeaders"] = <_cyb_intptr_t>__nvrtcRemoveBundledHeaders
+    _cyb_func_ptrs = data
     return data
 
 
 cpdef _inspect_function_pointer(str name):
-    global func_ptrs
-    if func_ptrs is None:
-        func_ptrs = _inspect_function_pointers()
-    return func_ptrs[name]
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is None:
+        _cyb_func_ptrs = _inspect_function_pointers()
+    return _cyb_func_ptrs[name]
+
+
+
+
+cdef uintptr_t load_library() except* with gil:
+    return load_nvidia_dynamic_lib("nvrtc")._handle_uint
 
 
 ###############################################################################

--- a/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx
@@ -3,62 +3,34 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.0.1 to 13.3.0. Do not modify it directly.
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=786a789c534d0bdda803be738a4f76f2db47bf188708dac946b41aec6c6aa4a4
 
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=3c31adc68b8220439ea196a56ea63cf670aff0f85c0a67c8f554e1af4d07f456
-from libc.stdint cimport intptr_t, uintptr_t
 
-import threading
+# <<<< PREAMBLE CONTENT >>>>
+
+cdef extern from "<dlfcn.h>":
+    void* _cyb_dlsym "dlsym"(void*, const char*) nogil
+    const void * _cyb_RTLD_DEFAULT "RTLD_DEFAULT"
+
+from libc.stdint cimport intptr_t as _cyb_intptr_t
+
+import threading as _cyb_threading
+
+cdef bint _cyb___py_nvvm_init = False
+cdef dict _cyb_func_ptrs = None
+cdef object _cyb_symbol_lock = _cyb_threading.Lock()
+
+# <<<< END OF PREAMBLE CONTENT >>>>
+
+from libc.stdint cimport uintptr_t
+
 from .utils import FunctionNotFoundError, NotSupportedError
-
 from cuda.pathfinder import load_nvidia_dynamic_lib
-
-
-###############################################################################
-# Extern
-###############################################################################
-
-# You must 'from .utils import NotSupportedError' before using this template
-
-cdef extern from "<dlfcn.h>" nogil:
-    void* dlopen(const char*, int)
-    char* dlerror()
-    void* dlsym(void*, const char*)
-    int dlclose(void*)
-
-    enum:
-        RTLD_LAZY
-        RTLD_NOW
-        RTLD_GLOBAL
-        RTLD_LOCAL
-
-    const void* RTLD_DEFAULT 'RTLD_DEFAULT'
-
-cdef int get_cuda_version():
-    cdef void* handle = NULL
-    cdef int err, driver_ver = 0
-
-    # Load driver to check version
-    handle = dlopen('libcuda.so.1', RTLD_NOW | RTLD_GLOBAL)
-    if handle == NULL:
-        err_msg = dlerror()
-        raise NotSupportedError(f'CUDA driver is not found ({err_msg.decode()})')
-    cuDriverGetVersion = dlsym(handle, "cuDriverGetVersion")
-    if cuDriverGetVersion == NULL:
-        raise RuntimeError('Did not find cuDriverGetVersion symbol in libcuda.so.1')
-    err = (<int (*)(int*) noexcept nogil>cuDriverGetVersion)(&driver_ver)
-    if err != 0:
-        raise RuntimeError(f'cuDriverGetVersion returned error code {err}')
-
-    return driver_ver
-
 
 
 ###############################################################################
 # Wrapper init
 ###############################################################################
-
-cdef object __symbol_lock = threading.Lock()
-cdef bint __py_nvvm_init = False
 
 cdef void* __nvvmGetErrorString = NULL
 cdef void* __nvvmVersion = NULL
@@ -75,194 +47,184 @@ cdef void* __nvvmGetProgramLogSize = NULL
 cdef void* __nvvmGetProgramLog = NULL
 cdef void* __nvvmLLVMVersion = NULL
 
-
-cdef void* load_library() except* with gil:
-    cdef uintptr_t handle = load_nvidia_dynamic_lib("nvvm")._handle_uint
-    return <void*>handle
-
-
 cdef int _init_nvvm() except -1 nogil:
-    global __py_nvvm_init
-
+    global _cyb___py_nvvm_init
     cdef void* handle = NULL
+    with gil, _cyb_symbol_lock:
+        if _cyb___py_nvvm_init: return 0
 
-    with gil, __symbol_lock:
-        # Recheck the flag after obtaining the locks
-        if __py_nvvm_init:
-            return 0
-
-        # Load function
         global __nvvmGetErrorString
-        __nvvmGetErrorString = dlsym(RTLD_DEFAULT, 'nvvmGetErrorString')
+        __nvvmGetErrorString = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvvmGetErrorString')
         if __nvvmGetErrorString == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvvmGetErrorString = dlsym(handle, 'nvvmGetErrorString')
+            __nvvmGetErrorString = _cyb_dlsym(handle, 'nvvmGetErrorString')
 
         global __nvvmVersion
-        __nvvmVersion = dlsym(RTLD_DEFAULT, 'nvvmVersion')
+        __nvvmVersion = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvvmVersion')
         if __nvvmVersion == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvvmVersion = dlsym(handle, 'nvvmVersion')
+            __nvvmVersion = _cyb_dlsym(handle, 'nvvmVersion')
 
         global __nvvmIRVersion
-        __nvvmIRVersion = dlsym(RTLD_DEFAULT, 'nvvmIRVersion')
+        __nvvmIRVersion = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvvmIRVersion')
         if __nvvmIRVersion == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvvmIRVersion = dlsym(handle, 'nvvmIRVersion')
+            __nvvmIRVersion = _cyb_dlsym(handle, 'nvvmIRVersion')
 
         global __nvvmCreateProgram
-        __nvvmCreateProgram = dlsym(RTLD_DEFAULT, 'nvvmCreateProgram')
+        __nvvmCreateProgram = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvvmCreateProgram')
         if __nvvmCreateProgram == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvvmCreateProgram = dlsym(handle, 'nvvmCreateProgram')
+            __nvvmCreateProgram = _cyb_dlsym(handle, 'nvvmCreateProgram')
 
         global __nvvmDestroyProgram
-        __nvvmDestroyProgram = dlsym(RTLD_DEFAULT, 'nvvmDestroyProgram')
+        __nvvmDestroyProgram = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvvmDestroyProgram')
         if __nvvmDestroyProgram == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvvmDestroyProgram = dlsym(handle, 'nvvmDestroyProgram')
+            __nvvmDestroyProgram = _cyb_dlsym(handle, 'nvvmDestroyProgram')
 
         global __nvvmAddModuleToProgram
-        __nvvmAddModuleToProgram = dlsym(RTLD_DEFAULT, 'nvvmAddModuleToProgram')
+        __nvvmAddModuleToProgram = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvvmAddModuleToProgram')
         if __nvvmAddModuleToProgram == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvvmAddModuleToProgram = dlsym(handle, 'nvvmAddModuleToProgram')
+            __nvvmAddModuleToProgram = _cyb_dlsym(handle, 'nvvmAddModuleToProgram')
 
         global __nvvmLazyAddModuleToProgram
-        __nvvmLazyAddModuleToProgram = dlsym(RTLD_DEFAULT, 'nvvmLazyAddModuleToProgram')
+        __nvvmLazyAddModuleToProgram = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvvmLazyAddModuleToProgram')
         if __nvvmLazyAddModuleToProgram == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvvmLazyAddModuleToProgram = dlsym(handle, 'nvvmLazyAddModuleToProgram')
+            __nvvmLazyAddModuleToProgram = _cyb_dlsym(handle, 'nvvmLazyAddModuleToProgram')
 
         global __nvvmCompileProgram
-        __nvvmCompileProgram = dlsym(RTLD_DEFAULT, 'nvvmCompileProgram')
+        __nvvmCompileProgram = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvvmCompileProgram')
         if __nvvmCompileProgram == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvvmCompileProgram = dlsym(handle, 'nvvmCompileProgram')
+            __nvvmCompileProgram = _cyb_dlsym(handle, 'nvvmCompileProgram')
 
         global __nvvmVerifyProgram
-        __nvvmVerifyProgram = dlsym(RTLD_DEFAULT, 'nvvmVerifyProgram')
+        __nvvmVerifyProgram = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvvmVerifyProgram')
         if __nvvmVerifyProgram == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvvmVerifyProgram = dlsym(handle, 'nvvmVerifyProgram')
+            __nvvmVerifyProgram = _cyb_dlsym(handle, 'nvvmVerifyProgram')
 
         global __nvvmGetCompiledResultSize
-        __nvvmGetCompiledResultSize = dlsym(RTLD_DEFAULT, 'nvvmGetCompiledResultSize')
+        __nvvmGetCompiledResultSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvvmGetCompiledResultSize')
         if __nvvmGetCompiledResultSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvvmGetCompiledResultSize = dlsym(handle, 'nvvmGetCompiledResultSize')
+            __nvvmGetCompiledResultSize = _cyb_dlsym(handle, 'nvvmGetCompiledResultSize')
 
         global __nvvmGetCompiledResult
-        __nvvmGetCompiledResult = dlsym(RTLD_DEFAULT, 'nvvmGetCompiledResult')
+        __nvvmGetCompiledResult = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvvmGetCompiledResult')
         if __nvvmGetCompiledResult == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvvmGetCompiledResult = dlsym(handle, 'nvvmGetCompiledResult')
+            __nvvmGetCompiledResult = _cyb_dlsym(handle, 'nvvmGetCompiledResult')
 
         global __nvvmGetProgramLogSize
-        __nvvmGetProgramLogSize = dlsym(RTLD_DEFAULT, 'nvvmGetProgramLogSize')
+        __nvvmGetProgramLogSize = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvvmGetProgramLogSize')
         if __nvvmGetProgramLogSize == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvvmGetProgramLogSize = dlsym(handle, 'nvvmGetProgramLogSize')
+            __nvvmGetProgramLogSize = _cyb_dlsym(handle, 'nvvmGetProgramLogSize')
 
         global __nvvmGetProgramLog
-        __nvvmGetProgramLog = dlsym(RTLD_DEFAULT, 'nvvmGetProgramLog')
+        __nvvmGetProgramLog = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvvmGetProgramLog')
         if __nvvmGetProgramLog == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvvmGetProgramLog = dlsym(handle, 'nvvmGetProgramLog')
+            __nvvmGetProgramLog = _cyb_dlsym(handle, 'nvvmGetProgramLog')
 
         global __nvvmLLVMVersion
-        __nvvmLLVMVersion = dlsym(RTLD_DEFAULT, 'nvvmLLVMVersion')
+        __nvvmLLVMVersion = _cyb_dlsym(_cyb_RTLD_DEFAULT, 'nvvmLLVMVersion')
         if __nvvmLLVMVersion == NULL:
             if handle == NULL:
                 handle = load_library()
-            __nvvmLLVMVersion = dlsym(handle, 'nvvmLLVMVersion')
+            __nvvmLLVMVersion = _cyb_dlsym(handle, 'nvvmLLVMVersion')
 
-        __py_nvvm_init = True
+        _cyb___py_nvvm_init = True
         return 0
 
-
 cdef inline int _check_or_init_nvvm() except -1 nogil:
-    if __py_nvvm_init:
+    if _cyb___py_nvvm_init:
         return 0
 
     return _init_nvvm()
 
 
-cdef dict func_ptrs = None
-
-
 cpdef dict _inspect_function_pointers():
-    global func_ptrs
-    if func_ptrs is not None:
-        return func_ptrs
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is not None:
+        return _cyb_func_ptrs
 
     _check_or_init_nvvm()
     cdef dict data = {}
-
     global __nvvmGetErrorString
-    data["__nvvmGetErrorString"] = <intptr_t>__nvvmGetErrorString
+    data["__nvvmGetErrorString"] = <_cyb_intptr_t>__nvvmGetErrorString
 
     global __nvvmVersion
-    data["__nvvmVersion"] = <intptr_t>__nvvmVersion
+    data["__nvvmVersion"] = <_cyb_intptr_t>__nvvmVersion
 
     global __nvvmIRVersion
-    data["__nvvmIRVersion"] = <intptr_t>__nvvmIRVersion
+    data["__nvvmIRVersion"] = <_cyb_intptr_t>__nvvmIRVersion
 
     global __nvvmCreateProgram
-    data["__nvvmCreateProgram"] = <intptr_t>__nvvmCreateProgram
+    data["__nvvmCreateProgram"] = <_cyb_intptr_t>__nvvmCreateProgram
 
     global __nvvmDestroyProgram
-    data["__nvvmDestroyProgram"] = <intptr_t>__nvvmDestroyProgram
+    data["__nvvmDestroyProgram"] = <_cyb_intptr_t>__nvvmDestroyProgram
 
     global __nvvmAddModuleToProgram
-    data["__nvvmAddModuleToProgram"] = <intptr_t>__nvvmAddModuleToProgram
+    data["__nvvmAddModuleToProgram"] = <_cyb_intptr_t>__nvvmAddModuleToProgram
 
     global __nvvmLazyAddModuleToProgram
-    data["__nvvmLazyAddModuleToProgram"] = <intptr_t>__nvvmLazyAddModuleToProgram
+    data["__nvvmLazyAddModuleToProgram"] = <_cyb_intptr_t>__nvvmLazyAddModuleToProgram
 
     global __nvvmCompileProgram
-    data["__nvvmCompileProgram"] = <intptr_t>__nvvmCompileProgram
+    data["__nvvmCompileProgram"] = <_cyb_intptr_t>__nvvmCompileProgram
 
     global __nvvmVerifyProgram
-    data["__nvvmVerifyProgram"] = <intptr_t>__nvvmVerifyProgram
+    data["__nvvmVerifyProgram"] = <_cyb_intptr_t>__nvvmVerifyProgram
 
     global __nvvmGetCompiledResultSize
-    data["__nvvmGetCompiledResultSize"] = <intptr_t>__nvvmGetCompiledResultSize
+    data["__nvvmGetCompiledResultSize"] = <_cyb_intptr_t>__nvvmGetCompiledResultSize
 
     global __nvvmGetCompiledResult
-    data["__nvvmGetCompiledResult"] = <intptr_t>__nvvmGetCompiledResult
+    data["__nvvmGetCompiledResult"] = <_cyb_intptr_t>__nvvmGetCompiledResult
 
     global __nvvmGetProgramLogSize
-    data["__nvvmGetProgramLogSize"] = <intptr_t>__nvvmGetProgramLogSize
+    data["__nvvmGetProgramLogSize"] = <_cyb_intptr_t>__nvvmGetProgramLogSize
 
     global __nvvmGetProgramLog
-    data["__nvvmGetProgramLog"] = <intptr_t>__nvvmGetProgramLog
+    data["__nvvmGetProgramLog"] = <_cyb_intptr_t>__nvvmGetProgramLog
 
     global __nvvmLLVMVersion
-    data["__nvvmLLVMVersion"] = <intptr_t>__nvvmLLVMVersion
-
-    func_ptrs = data
+    data["__nvvmLLVMVersion"] = <_cyb_intptr_t>__nvvmLLVMVersion
+    _cyb_func_ptrs = data
     return data
 
 
 cpdef _inspect_function_pointer(str name):
-    global func_ptrs
-    if func_ptrs is None:
-        func_ptrs = _inspect_function_pointers()
-    return func_ptrs[name]
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is None:
+        _cyb_func_ptrs = _inspect_function_pointers()
+    return _cyb_func_ptrs[name]
+
+
+
+
+cdef void* load_library() except* with gil:
+    cdef uintptr_t handle = load_nvidia_dynamic_lib("nvvm")._handle_uint
+    return <void*>handle
 
 
 ###############################################################################

--- a/cuda_bindings/cuda/bindings/_internal/nvvm_windows.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/nvvm_windows.pyx
@@ -3,80 +3,31 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.0.1 to 13.3.0. Do not modify it directly.
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=cd105988425e21a30e32255acbc5654de835d0c09b5dd1c4598b09146fa590c5
 
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=49ccc5908d39ebb526fee704591480550b5f780c05f14366531360e3ec2ac17a
-from libc.stdint cimport intptr_t
 
-import threading
-from .utils import FunctionNotFoundError, NotSupportedError
+# <<<< PREAMBLE CONTENT >>>>
 
-from cuda.pathfinder import load_nvidia_dynamic_lib
-
-from libc.stddef cimport wchar_t
-from libc.stdint cimport uintptr_t
-from cpython cimport PyUnicode_AsWideCharString, PyMem_Free
-
-# You must 'from .utils import NotSupportedError' before using this template
-
-cdef extern from "windows.h" nogil:
+cdef extern from "<windows.h>":
     ctypedef void* HMODULE
-    ctypedef void* HANDLE
-    ctypedef void* FARPROC
-    ctypedef unsigned long DWORD
-    ctypedef const wchar_t *LPCWSTR
-    ctypedef const char *LPCSTR
+    void* _cyb_GetProcAddress "GetProcAddress"(HMODULE, const char*) nogil
 
-    cdef DWORD LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800
-    cdef DWORD LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000
-    cdef DWORD LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR = 0x00000100
+from libc.stdint cimport intptr_t as _cyb_intptr_t
 
-    HMODULE _LoadLibraryExW "LoadLibraryExW"(
-        LPCWSTR lpLibFileName,
-        HANDLE hFile,
-        DWORD dwFlags
-    )
+import threading as _cyb_threading
 
-    FARPROC _GetProcAddress "GetProcAddress"(HMODULE hModule, LPCSTR lpProcName)
+cdef bint _cyb___py_nvvm_init = False
+cdef dict _cyb_func_ptrs = None
+cdef object _cyb_symbol_lock = _cyb_threading.Lock()
 
-cdef inline uintptr_t LoadLibraryExW(str path, HANDLE hFile, DWORD dwFlags):
-    cdef uintptr_t result
-    cdef wchar_t* wpath = PyUnicode_AsWideCharString(path, NULL)
-    with nogil:
-        result = <uintptr_t>_LoadLibraryExW(
-            wpath,
-            hFile,
-            dwFlags
-        )
-    PyMem_Free(wpath)
-    return result
+# <<<< END OF PREAMBLE CONTENT >>>>
 
-cdef inline void *GetProcAddress(uintptr_t hModule, const char* lpProcName) nogil:
-    return _GetProcAddress(<HMODULE>hModule, lpProcName)
-
-cdef int get_cuda_version():
-    cdef int err, driver_ver = 0
-
-    # Load driver to check version
-    handle = LoadLibraryExW("nvcuda.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32)
-    if handle == 0:
-        raise NotSupportedError('CUDA driver is not found')
-    cuDriverGetVersion = GetProcAddress(handle, 'cuDriverGetVersion')
-    if cuDriverGetVersion == NULL:
-        raise RuntimeError('Did not find cuDriverGetVersion symbol in nvcuda.dll')
-    err = (<int (*)(int*) noexcept nogil>cuDriverGetVersion)(&driver_ver)
-    if err != 0:
-        raise RuntimeError(f'cuDriverGetVersion returned error code {err}')
-
-    return driver_ver
-
-
-
+from libc.stdint cimport uintptr_t
+from cuda.pathfinder import load_nvidia_dynamic_lib
+from .utils import FunctionNotFoundError, NotSupportedError
 ###############################################################################
 # Wrapper init
 ###############################################################################
-
-cdef object __symbol_lock = threading.Lock()
-cdef bint __py_nvvm_init = False
 
 cdef void* __nvvmGetErrorString = NULL
 cdef void* __nvvmVersion = NULL
@@ -93,134 +44,130 @@ cdef void* __nvvmGetProgramLogSize = NULL
 cdef void* __nvvmGetProgramLog = NULL
 cdef void* __nvvmLLVMVersion = NULL
 
-
 cdef int _init_nvvm() except -1 nogil:
-    global __py_nvvm_init
+    global _cyb___py_nvvm_init
 
-    with gil, __symbol_lock:
-        # Recheck the flag after obtaining the locks
-        if __py_nvvm_init:
-            return 0
+    cdef int err
+    cdef uintptr_t handle
+    with gil, _cyb_symbol_lock:
+        if _cyb___py_nvvm_init: return 0
 
-        # Load library
-        handle = load_nvidia_dynamic_lib("nvvm")._handle_uint
-
-        # Load function
+        handle = load_library()
         global __nvvmGetErrorString
-        __nvvmGetErrorString = GetProcAddress(handle, 'nvvmGetErrorString')
+        __nvvmGetErrorString = _cyb_GetProcAddress(<HMODULE>handle, 'nvvmGetErrorString')
 
         global __nvvmVersion
-        __nvvmVersion = GetProcAddress(handle, 'nvvmVersion')
+        __nvvmVersion = _cyb_GetProcAddress(<HMODULE>handle, 'nvvmVersion')
 
         global __nvvmIRVersion
-        __nvvmIRVersion = GetProcAddress(handle, 'nvvmIRVersion')
+        __nvvmIRVersion = _cyb_GetProcAddress(<HMODULE>handle, 'nvvmIRVersion')
 
         global __nvvmCreateProgram
-        __nvvmCreateProgram = GetProcAddress(handle, 'nvvmCreateProgram')
+        __nvvmCreateProgram = _cyb_GetProcAddress(<HMODULE>handle, 'nvvmCreateProgram')
 
         global __nvvmDestroyProgram
-        __nvvmDestroyProgram = GetProcAddress(handle, 'nvvmDestroyProgram')
+        __nvvmDestroyProgram = _cyb_GetProcAddress(<HMODULE>handle, 'nvvmDestroyProgram')
 
         global __nvvmAddModuleToProgram
-        __nvvmAddModuleToProgram = GetProcAddress(handle, 'nvvmAddModuleToProgram')
+        __nvvmAddModuleToProgram = _cyb_GetProcAddress(<HMODULE>handle, 'nvvmAddModuleToProgram')
 
         global __nvvmLazyAddModuleToProgram
-        __nvvmLazyAddModuleToProgram = GetProcAddress(handle, 'nvvmLazyAddModuleToProgram')
+        __nvvmLazyAddModuleToProgram = _cyb_GetProcAddress(<HMODULE>handle, 'nvvmLazyAddModuleToProgram')
 
         global __nvvmCompileProgram
-        __nvvmCompileProgram = GetProcAddress(handle, 'nvvmCompileProgram')
+        __nvvmCompileProgram = _cyb_GetProcAddress(<HMODULE>handle, 'nvvmCompileProgram')
 
         global __nvvmVerifyProgram
-        __nvvmVerifyProgram = GetProcAddress(handle, 'nvvmVerifyProgram')
+        __nvvmVerifyProgram = _cyb_GetProcAddress(<HMODULE>handle, 'nvvmVerifyProgram')
 
         global __nvvmGetCompiledResultSize
-        __nvvmGetCompiledResultSize = GetProcAddress(handle, 'nvvmGetCompiledResultSize')
+        __nvvmGetCompiledResultSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvvmGetCompiledResultSize')
 
         global __nvvmGetCompiledResult
-        __nvvmGetCompiledResult = GetProcAddress(handle, 'nvvmGetCompiledResult')
+        __nvvmGetCompiledResult = _cyb_GetProcAddress(<HMODULE>handle, 'nvvmGetCompiledResult')
 
         global __nvvmGetProgramLogSize
-        __nvvmGetProgramLogSize = GetProcAddress(handle, 'nvvmGetProgramLogSize')
+        __nvvmGetProgramLogSize = _cyb_GetProcAddress(<HMODULE>handle, 'nvvmGetProgramLogSize')
 
         global __nvvmGetProgramLog
-        __nvvmGetProgramLog = GetProcAddress(handle, 'nvvmGetProgramLog')
+        __nvvmGetProgramLog = _cyb_GetProcAddress(<HMODULE>handle, 'nvvmGetProgramLog')
 
         global __nvvmLLVMVersion
-        __nvvmLLVMVersion = GetProcAddress(handle, 'nvvmLLVMVersion')
+        __nvvmLLVMVersion = _cyb_GetProcAddress(<HMODULE>handle, 'nvvmLLVMVersion')
 
-        __py_nvvm_init = True
+        _cyb___py_nvvm_init = True
         return 0
 
-
 cdef inline int _check_or_init_nvvm() except -1 nogil:
-    if __py_nvvm_init:
+    if _cyb___py_nvvm_init:
         return 0
 
     return _init_nvvm()
 
 
-cdef dict func_ptrs = None
-
-
 cpdef dict _inspect_function_pointers():
-    global func_ptrs
-    if func_ptrs is not None:
-        return func_ptrs
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is not None:
+        return _cyb_func_ptrs
 
     _check_or_init_nvvm()
     cdef dict data = {}
-
     global __nvvmGetErrorString
-    data["__nvvmGetErrorString"] = <intptr_t>__nvvmGetErrorString
+    data["__nvvmGetErrorString"] = <_cyb_intptr_t>__nvvmGetErrorString
 
     global __nvvmVersion
-    data["__nvvmVersion"] = <intptr_t>__nvvmVersion
+    data["__nvvmVersion"] = <_cyb_intptr_t>__nvvmVersion
 
     global __nvvmIRVersion
-    data["__nvvmIRVersion"] = <intptr_t>__nvvmIRVersion
+    data["__nvvmIRVersion"] = <_cyb_intptr_t>__nvvmIRVersion
 
     global __nvvmCreateProgram
-    data["__nvvmCreateProgram"] = <intptr_t>__nvvmCreateProgram
+    data["__nvvmCreateProgram"] = <_cyb_intptr_t>__nvvmCreateProgram
 
     global __nvvmDestroyProgram
-    data["__nvvmDestroyProgram"] = <intptr_t>__nvvmDestroyProgram
+    data["__nvvmDestroyProgram"] = <_cyb_intptr_t>__nvvmDestroyProgram
 
     global __nvvmAddModuleToProgram
-    data["__nvvmAddModuleToProgram"] = <intptr_t>__nvvmAddModuleToProgram
+    data["__nvvmAddModuleToProgram"] = <_cyb_intptr_t>__nvvmAddModuleToProgram
 
     global __nvvmLazyAddModuleToProgram
-    data["__nvvmLazyAddModuleToProgram"] = <intptr_t>__nvvmLazyAddModuleToProgram
+    data["__nvvmLazyAddModuleToProgram"] = <_cyb_intptr_t>__nvvmLazyAddModuleToProgram
 
     global __nvvmCompileProgram
-    data["__nvvmCompileProgram"] = <intptr_t>__nvvmCompileProgram
+    data["__nvvmCompileProgram"] = <_cyb_intptr_t>__nvvmCompileProgram
 
     global __nvvmVerifyProgram
-    data["__nvvmVerifyProgram"] = <intptr_t>__nvvmVerifyProgram
+    data["__nvvmVerifyProgram"] = <_cyb_intptr_t>__nvvmVerifyProgram
 
     global __nvvmGetCompiledResultSize
-    data["__nvvmGetCompiledResultSize"] = <intptr_t>__nvvmGetCompiledResultSize
+    data["__nvvmGetCompiledResultSize"] = <_cyb_intptr_t>__nvvmGetCompiledResultSize
 
     global __nvvmGetCompiledResult
-    data["__nvvmGetCompiledResult"] = <intptr_t>__nvvmGetCompiledResult
+    data["__nvvmGetCompiledResult"] = <_cyb_intptr_t>__nvvmGetCompiledResult
 
     global __nvvmGetProgramLogSize
-    data["__nvvmGetProgramLogSize"] = <intptr_t>__nvvmGetProgramLogSize
+    data["__nvvmGetProgramLogSize"] = <_cyb_intptr_t>__nvvmGetProgramLogSize
 
     global __nvvmGetProgramLog
-    data["__nvvmGetProgramLog"] = <intptr_t>__nvvmGetProgramLog
+    data["__nvvmGetProgramLog"] = <_cyb_intptr_t>__nvvmGetProgramLog
 
     global __nvvmLLVMVersion
-    data["__nvvmLLVMVersion"] = <intptr_t>__nvvmLLVMVersion
-
-    func_ptrs = data
+    data["__nvvmLLVMVersion"] = <_cyb_intptr_t>__nvvmLLVMVersion
+    _cyb_func_ptrs = data
     return data
 
 
 cpdef _inspect_function_pointer(str name):
-    global func_ptrs
-    if func_ptrs is None:
-        func_ptrs = _inspect_function_pointers()
-    return func_ptrs[name]
+    global _cyb_func_ptrs
+    if _cyb_func_ptrs is None:
+        _cyb_func_ptrs = _inspect_function_pointers()
+    return _cyb_func_ptrs[name]
+
+
+
+
+cdef uintptr_t load_library() except* with gil:
+    return load_nvidia_dynamic_lib("nvvm")._handle_uint
 
 
 ###############################################################################

--- a/cuda_bindings/cuda/bindings/cudla.pyx
+++ b/cuda_bindings/cuda/bindings/cudla.pyx
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=6e7ac86c22e602c08df8250f3b50c135945378aa8ae4ddb4e10174fd979c4aa5
+
+# This code was automatically generated across versions from 1.5.0 to 13.3.0. Do not modify it directly.
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=3ee237ed16e651bae93e2bc6d4d63dcf99b309ad7a74cb3e2bd5b9e540e714f4
+
 
 # <<<< PREAMBLE CONTENT >>>>
 
@@ -16,7 +19,9 @@ from libc.string cimport (
     memcmp as _cyb_memcmp,
     memcpy as _cyb_memcpy,
 )
+
 from enum import IntEnum as _cyb_IntEnum
+
 import numpy as _numpy
 
 cdef _cyb___getbuffer(object self, _cyb_cpython.Py_buffer *buffer, void *ptr, int size, bint readonly):
@@ -57,10 +62,8 @@ cdef _cyb_from_data(data, dtype_name, expected_dtype, lowpp_type):
         raise ValueError(f"data array must be of dtype {dtype_name}")
     return lowpp_type.from_ptr(data.ctypes.data, not data.flags.writeable, data)
 
+
 # <<<< END OF PREAMBLE CONTENT >>>>
-
-
-# This code was automatically generated across versions from 1.5.0 to 13.3.0. Do not modify it directly.
 
 cimport cython  # NOQA
 from libc.stdint cimport intptr_t, uintptr_t
@@ -1767,7 +1770,10 @@ cpdef mem_unregister(intptr_t dev_handle, intptr_t dev_ptr):
 
 
 cpdef int get_last_error(intptr_t dev_handle) except? 0:
-    return <int>cudlaGetLastError(<const DevHandle>dev_handle)
+    cdef int ret
+    with nogil:
+        ret = <int>cudlaGetLastError(<const DevHandle>dev_handle)
+    return ret
 
 
 cpdef destroy_device(intptr_t dev_handle):

--- a/cuda_bindings/cuda/bindings/cufile.pyx
+++ b/cuda_bindings/cuda/bindings/cufile.pyx
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.9.1 to 13.3.0. Do not modify it directly.
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=359f9b42f4f97b9a74570e1f7d20eb6f5faae2df194a6161f4d5a9512c3ffbe3
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=4567ca64d02631fc8d6ed11af8164d72c86b4686c105fd733d186e6c92512749
+
 
 # <<<< PREAMBLE CONTENT >>>>
 
@@ -20,7 +21,9 @@ from libc.string cimport (
     memcmp as _cyb_memcmp,
     memcpy as _cyb_memcpy,
 )
+
 from cuda.bindings._internal._fast_enum import FastEnum as _cyb_FastEnum
+
 import numpy as _numpy
 
 cdef _cyb___getbuffer(object self, _cyb_cpython.Py_buffer *buffer, void *ptr, int size, bint readonly):
@@ -61,8 +64,8 @@ cdef _cyb_from_data(data, dtype_name, expected_dtype, lowpp_type):
         raise ValueError(f"data array must be of dtype {dtype_name}")
     return lowpp_type.from_ptr(data.ctypes.data, not data.flags.writeable, data)
 
-# <<<< END OF PREAMBLE CONTENT >>>>
 
+# <<<< END OF PREAMBLE CONTENT >>>>
 
 cimport cython  # NOQA
 from libc cimport errno
@@ -2895,7 +2898,8 @@ cpdef void handle_deregister(intptr_t fh) except*:
 
     .. seealso:: `cuFileHandleDeregister`
     """
-    cuFileHandleDeregister(<Handle>fh)
+    with nogil:
+        cuFileHandleDeregister(<Handle>fh)
 
 
 cpdef buf_register(intptr_t buf_ptr_base, size_t length, int flags):
@@ -3039,7 +3043,8 @@ cpdef batch_io_cancel(intptr_t batch_idp):
 
 
 cpdef void batch_io_destroy(intptr_t batch_idp) except*:
-    cuFileBatchIODestroy(<BatchHandle>batch_idp)
+    with nogil:
+        cuFileBatchIODestroy(<BatchHandle>batch_idp)
 
 
 cpdef read_async(intptr_t fh, intptr_t buf_ptr_base, intptr_t size_p, intptr_t file_offset_p, intptr_t buf_ptr_offset_p, intptr_t bytes_read_p, intptr_t stream):

--- a/cuda_bindings/cuda/bindings/cycufile.pyx
+++ b/cuda_bindings/cuda/bindings/cycufile.pyx
@@ -3,8 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.9.1 to 13.3.0. Do not modify it directly.
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=a68ff13250f4b5131f4b4adf8a37a4283b27749e8429b5f6e57bfc68bf656b00
 
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=74f1f9c9443af66fdadbfeeb01e5c15c2d8f1b9b0b20eafa2a279583bcf7df00
+
+# <<<< PREAMBLE CONTENT >>>>
+
+cimport cython as _cyb_cython
+
+
+# <<<< END OF PREAMBLE CONTENT >>>>
+
 from ._internal cimport cufile as _cufile
 
 import cython
@@ -17,7 +25,7 @@ cdef CUfileError_t cuFileHandleRegister(CUfileHandle_t* fh, CUfileDescr_t* descr
     return _cufile._cuFileHandleRegister(fh, descr)
 
 
-@cython.show_performance_hints(False)
+@_cyb_cython.show_performance_hints(False)
 cdef void cuFileHandleDeregister(CUfileHandle_t fh) except* nogil:
     _cufile._cuFileHandleDeregister(fh)
 
@@ -90,7 +98,7 @@ cdef CUfileError_t cuFileBatchIOCancel(CUfileBatchHandle_t batch_idp) except?<CU
     return _cufile._cuFileBatchIOCancel(batch_idp)
 
 
-@cython.show_performance_hints(False)
+@_cyb_cython.show_performance_hints(False)
 cdef void cuFileBatchIODestroy(CUfileBatchHandle_t batch_idp) except* nogil:
     _cufile._cuFileBatchIODestroy(batch_idp)
 

--- a/cuda_bindings/cuda/bindings/nvfatbin.pyx
+++ b/cuda_bindings/cuda/bindings/nvfatbin.pyx
@@ -3,14 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.4.1 to 13.3.0. Do not modify it directly.
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=d5a4eb978220598892471233ffd8b7caa8cee7b6b0c27d2d9c458f1d91979f8b
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=22dd0937e8e243f48b06a24f0c1819e09360d102541b621dfe1cdeaa55c2154c
+
 
 # <<<< PREAMBLE CONTENT >>>>
 
 from cuda.bindings._internal._fast_enum import FastEnum as _cyb_FastEnum
 
-# <<<< END OF PREAMBLE CONTENT >>>>
 
+# <<<< END OF PREAMBLE CONTENT >>>>
 
 cimport cython  # NOQA
 

--- a/cuda_bindings/cuda/bindings/nvjitlink.pyx
+++ b/cuda_bindings/cuda/bindings/nvjitlink.pyx
@@ -3,14 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.0.1 to 13.3.0. Do not modify it directly.
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=18cc1af125a513c3867c6f2bd8e97f4b0b2d2e58565a8980223a419ae5f23b74
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=85275f1596953f034c156776f8fe4f6e518dbb89ffedda994d8e78bfd9284246
+
 
 # <<<< PREAMBLE CONTENT >>>>
 
 from cuda.bindings._internal._fast_enum import FastEnum as _cyb_FastEnum
 
-# <<<< END OF PREAMBLE CONTENT >>>>
 
+# <<<< END OF PREAMBLE CONTENT >>>>
 
 cimport cython  # NOQA
 

--- a/cuda_bindings/cuda/bindings/nvml.pyx
+++ b/cuda_bindings/cuda/bindings/nvml.pyx
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.9.1 to 13.3.0. Do not modify it directly.
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=fc7f9f6085964bcb1695f1a7ab9f9a8f1497bac9656947cb19c257533342fbfb
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=e47a16bd9956de14a991ded5d1aef667cdd26a141e27db5b2015b91be6918d3c
 
 
 # <<<< PREAMBLE CONTENT >>>>
@@ -840,7 +840,7 @@ class GpmMetricId(_cyb_FastEnum):
     GPM_METRIC_HMMA_TENSOR_UTIL = (NVML_GPM_METRIC_HMMA_TENSOR_UTIL, "Percentage of time the GPU's SMs were doing HMMA tensor operations. 0.0 - 100.0.")
     GPM_METRIC_DMMA_TENSOR_UTIL = (NVML_GPM_METRIC_DMMA_TENSOR_UTIL, "Percentage of time the GPU's SMs were doing DMMA tensor operations. 0.0 - 100.0.")
     GPM_METRIC_IMMA_TENSOR_UTIL = (NVML_GPM_METRIC_IMMA_TENSOR_UTIL, "Percentage of time the GPU's SMs were doing IMMA tensor operations. 0.0 - 100.0.")
-    GPM_METRIC_DRAM_BW_UTIL = (NVML_GPM_METRIC_DRAM_BW_UTIL, 'Percentage of DRAM bw used vs theoretical maximum. `0.0 - 100.0 */`.')
+    GPM_METRIC_DRAM_BW_UTIL = (NVML_GPM_METRIC_DRAM_BW_UTIL, 'Percentage of DRAM bw used vs theoretical maximum. 0.0 - 100.0 *\u200d/.')
     GPM_METRIC_FP64_UTIL = (NVML_GPM_METRIC_FP64_UTIL, "Percentage of time the GPU's SMs were doing non-tensor FP64 math. 0.0 - 100.0.")
     GPM_METRIC_FP32_UTIL = (NVML_GPM_METRIC_FP32_UTIL, "Percentage of time the GPU's SMs were doing non-tensor FP32 math. 0.0 - 100.0.")
     GPM_METRIC_FP16_UTIL = (NVML_GPM_METRIC_FP16_UTIL, "Percentage of time the GPU's SMs were doing non-tensor FP16 math. 0.0 - 100.0.")
@@ -25091,7 +25091,7 @@ cpdef int device_get_virtualization_mode(intptr_t device) except? -1:
         device (intptr_t): Identifier of the target device.
 
     Returns:
-        int: Reference to virtualization mode. One of ``NVML_GPU_VIRTUALIZATION_?``.
+        int: Reference to virtualization mode. One of NVML_GPU_VIRTUALIZATION_?.
 
     .. seealso:: `nvmlDeviceGetVirtualizationMode`
     """
@@ -25125,7 +25125,7 @@ cpdef device_set_virtualization_mode(intptr_t device, int virtual_mode):
 
     Args:
         device (intptr_t): Identifier of the target device.
-        virtual_mode (GpuVirtualizationMode): virtualization mode. One of ``NVML_GPU_VIRTUALIZATION_?``.
+        virtual_mode (GpuVirtualizationMode): virtualization mode. One of NVML_GPU_VIRTUALIZATION_?.
 
     .. seealso:: `nvmlDeviceSetVirtualizationMode`
     """

--- a/cuda_bindings/cuda/bindings/nvml.pyx
+++ b/cuda_bindings/cuda/bindings/nvml.pyx
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.9.1 to 13.3.0. Do not modify it directly.
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=52642c2c289dbd93191f019468630c0c7935bf99bc15c9c7c0de3797a109e8b0
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=fc7f9f6085964bcb1695f1a7ab9f9a8f1497bac9656947cb19c257533342fbfb
+
 
 # <<<< PREAMBLE CONTENT >>>>
 
@@ -20,7 +21,9 @@ from libc.string cimport (
     memcmp as _cyb_memcmp,
     memcpy as _cyb_memcpy,
 )
+
 from cuda.bindings._internal._fast_enum import FastEnum as _cyb_FastEnum
+
 import numpy as _numpy
 
 cdef _cyb___getbuffer(object self, _cyb_cpython.Py_buffer *buffer, void *ptr, int size, bint readonly):
@@ -61,8 +64,8 @@ cdef _cyb_from_data(data, dtype_name, expected_dtype, lowpp_type):
         raise ValueError(f"data array must be of dtype {dtype_name}")
     return lowpp_type.from_ptr(data.ctypes.data, not data.flags.writeable, data)
 
-# <<<< END OF PREAMBLE CONTENT >>>>
 
+# <<<< END OF PREAMBLE CONTENT >>>>
 
 cimport cython  # NOQA
 from cython cimport view
@@ -837,7 +840,7 @@ class GpmMetricId(_cyb_FastEnum):
     GPM_METRIC_HMMA_TENSOR_UTIL = (NVML_GPM_METRIC_HMMA_TENSOR_UTIL, "Percentage of time the GPU's SMs were doing HMMA tensor operations. 0.0 - 100.0.")
     GPM_METRIC_DMMA_TENSOR_UTIL = (NVML_GPM_METRIC_DMMA_TENSOR_UTIL, "Percentage of time the GPU's SMs were doing DMMA tensor operations. 0.0 - 100.0.")
     GPM_METRIC_IMMA_TENSOR_UTIL = (NVML_GPM_METRIC_IMMA_TENSOR_UTIL, "Percentage of time the GPU's SMs were doing IMMA tensor operations. 0.0 - 100.0.")
-    GPM_METRIC_DRAM_BW_UTIL = (NVML_GPM_METRIC_DRAM_BW_UTIL, 'Percentage of DRAM bw used vs theoretical maximum. 0.0 - 100.0 *\u200d/.')
+    GPM_METRIC_DRAM_BW_UTIL = (NVML_GPM_METRIC_DRAM_BW_UTIL, 'Percentage of DRAM bw used vs theoretical maximum. `0.0 - 100.0 */`.')
     GPM_METRIC_FP64_UTIL = (NVML_GPM_METRIC_FP64_UTIL, "Percentage of time the GPU's SMs were doing non-tensor FP64 math. 0.0 - 100.0.")
     GPM_METRIC_FP32_UTIL = (NVML_GPM_METRIC_FP32_UTIL, "Percentage of time the GPU's SMs were doing non-tensor FP32 math. 0.0 - 100.0.")
     GPM_METRIC_FP16_UTIL = (NVML_GPM_METRIC_FP16_UTIL, "Percentage of time the GPU's SMs were doing non-tensor FP16 math. 0.0 - 100.0.")
@@ -21629,8 +21632,11 @@ cpdef str error_string(int result):
 
     .. seealso:: `nvmlErrorString`
     """
+    cdef const char *_output_cstr_
     cdef bytes _output_
-    _output_ = nvmlErrorString(<_Return>result)
+    with nogil:
+        _output_cstr_ = nvmlErrorString(<_Return>result)
+    _output_ = _output_cstr_
     return _output_.decode()
 
 
@@ -25085,7 +25091,7 @@ cpdef int device_get_virtualization_mode(intptr_t device) except? -1:
         device (intptr_t): Identifier of the target device.
 
     Returns:
-        int: Reference to virtualization mode. One of NVML_GPU_VIRTUALIZATION_?.
+        int: Reference to virtualization mode. One of ``NVML_GPU_VIRTUALIZATION_?``.
 
     .. seealso:: `nvmlDeviceGetVirtualizationMode`
     """
@@ -25119,7 +25125,7 @@ cpdef device_set_virtualization_mode(intptr_t device, int virtual_mode):
 
     Args:
         device (intptr_t): Identifier of the target device.
-        virtual_mode (GpuVirtualizationMode): virtualization mode. One of NVML_GPU_VIRTUALIZATION_?.
+        virtual_mode (GpuVirtualizationMode): virtualization mode. One of ``NVML_GPU_VIRTUALIZATION_?``.
 
     .. seealso:: `nvmlDeviceSetVirtualizationMode`
     """

--- a/cuda_bindings/cuda/bindings/nvvm.pyx
+++ b/cuda_bindings/cuda/bindings/nvvm.pyx
@@ -3,14 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.0.1 to 13.3.0. Do not modify it directly.
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=663773bbe4ae03ad1e170d44b06d5a924b5e4a3a0bd901c2f276976b82943bcb
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=82dc56ccc695031faa515d1971c9841131d5aadc60c6d6e6cc223580fc544d16
+
 
 # <<<< PREAMBLE CONTENT >>>>
 
 from cuda.bindings._internal._fast_enum import FastEnum as _cyb_FastEnum
 
-# <<<< END OF PREAMBLE CONTENT >>>>
 
+# <<<< END OF PREAMBLE CONTENT >>>>
 
 cimport cython  # NOQA
 
@@ -91,8 +92,11 @@ cpdef str get_error_string(int result):
 
     .. seealso:: `nvvmGetErrorString`
     """
+    cdef const char *_output_cstr_
     cdef bytes _output_
-    _output_ = nvvmGetErrorString(<_Result>result)
+    with nogil:
+        _output_cstr_ = nvvmGetErrorString(<_Result>result)
+    _output_ = _output_cstr_
     return _output_.decode()
 
 


### PR DESCRIPTION
This brings in a few recent changes in the generator:

- Generating platform-specific files, rather than using templates
- Dropping the gil for all API calls (now for functions returning `char *`)
- Not including version information in `fast_enum.py`