### PR TITLE
Fix #2198: Announce that support for Python 3.10 is going away

### DIFF
--- a/cuda_bindings/docs/source/release/13.4.0-notes.rst
+++ b/cuda_bindings/docs/source/release/13.4.0-notes.rst
@@ -1,0 +1,21 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+.. module:: cuda.bindings
+
+``cuda-bindings`` 13.4.0 Release notes
+======================================
+
+Deprecation Notices
+-------------------
+
+* This is the last release that officially supports Python 3.10. Python 3.10
+  reaches end of life in October 2026 per the `CPython support cycle
+  <https://devguide.python.org/versions/>`_. Support will be dropped in
+  ``cuda-bindings`` 13.5.
+
+Known issues
+------------
+
+* Updating from older versions (v12.6.2.post1 and below) via ``pip install -U cuda-python`` might not work. Please do a clean re-installation by uninstalling ``pip uninstall -y cuda-python`` followed by installing ``pip install cuda-python``.
+* ``nvml.system_get_process_name`` on WSL can return incorrect values.  To work around this, set the locale to "C" before calling ``nvml.device_get_compute_running_processes_v3`` (which sets the process names) and before calling ``nvml.system_get_process_name``. ``cuda_core`` does this automatically, but users of the raw NVML API will need to do this manually.

--- a/cuda_bindings/docs/source/release/13.4.0-notes.rst
+++ b/cuda_bindings/docs/source/release/13.4.0-notes.rst
@@ -9,10 +9,9 @@
 Deprecation Notices
 -------------------
 
-* This is the last release that officially supports Python 3.10. Python 3.10
-  reaches end of life in October 2026 per the `CPython support cycle
-  <https://devguide.python.org/versions/>`_. Support will be dropped in
-  ``cuda-bindings`` 13.5.
+* Support for using ``cuda-bindings`` with Python 3.10 is deprecated and will be
+  removed in a future version.  Python 3.10 reaches end of life in October 2026
+  per the `CPython support cycle <https://devguide.python.org/versions/>`_.
 
 Known issues
 ------------

--- a/cuda_core/docs/source/release/1.2.0-notes.rst
+++ b/cuda_core/docs/source/release/1.2.0-notes.rst
@@ -9,7 +9,6 @@
 Deprecation Notices
 -------------------
 
-* This is the last release that officially supports Python 3.10. Python 3.10
-  reaches end of life in October 2026 per the `CPython support cycle
-  <https://devguide.python.org/versions/>`_. Support will be dropped in
-  ``cuda.core`` 1.3.0.
+* Support for using ``cuda-core`` with Python 3.10 is deprecated and will be
+  removed in a future version.  Python 3.10 reaches end of life in October 2026
+  per the `CPython support cycle <https://devguide.python.org/versions/>`_.

--- a/cuda_core/docs/source/release/1.2.0-notes.rst
+++ b/cuda_core/docs/source/release/1.2.0-notes.rst
@@ -1,0 +1,15 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+.. currentmodule:: cuda.core
+
+``cuda.core`` 1.2.0 Release Notes
+==================================
+
+Deprecation Notices
+-------------------
+
+* This is the last release that officially supports Python 3.10. Python 3.10
+  reaches end of life in October 2026 per the `CPython support cycle
+  <https://devguide.python.org/versions/>`_. Support will be dropped in
+  ``cuda.core`` 1.3.0.

--- a/cuda_python/docs/source/release/13.4.0-notes.rst
+++ b/cuda_python/docs/source/release/13.4.0-notes.rst
@@ -7,10 +7,9 @@ CUDA Python 13.4.0 Release notes
 Deprecation Notices
 -------------------
 
-* This is the last release that officially supports Python 3.10. Python 3.10
-  reaches end of life in October 2026 per the `CPython support cycle
-  <https://devguide.python.org/versions/>`_. Support will be dropped in
-  CUDA Python 13.5.
+* Support for using ``cuda-python`` with Python 3.10 is deprecated and will be
+  removed in a future version.  Python 3.10 reaches end of life in October 2026
+  per the `CPython support cycle <https://devguide.python.org/versions/>`_.
 
 Known issues
 ------------

--- a/cuda_python/docs/source/release/13.4.0-notes.rst
+++ b/cuda_python/docs/source/release/13.4.0-notes.rst
@@ -1,0 +1,18 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+CUDA Python 13.4.0 Release notes
+=================================
+
+Deprecation Notices
+-------------------
+
+* This is the last release that officially supports Python 3.10. Python 3.10
+  reaches end of life in October 2026 per the `CPython support cycle
+  <https://devguide.python.org/versions/>`_. Support will be dropped in
+  CUDA Python 13.5.
+
+Known issues
+------------
+
+* Updating from older versions (v12.6.2.post1 and below) via ``pip install -U cuda-python`` might not work. Please do a clean re-installation by uninstalling ``pip uninstall -y cuda-python`` followed by installing ``pip install cuda-python``.


### PR DESCRIPTION
Announce that support for Python 3.10 is going away.