### PR TITLE
[doc-only] cuda.core: initialize context in graph shutdown test

### DIFF
--- a/cuda_core/tests/graph/test_graph_definition_lifetime.py
+++ b/cuda_core/tests/graph/test_graph_definition_lifetime.py
@@ -443,7 +443,8 @@ def test_pending_cleanup_is_safe_during_python_shutdown(init_cuda, tmp_path):
             def __call__(self):
                 pass
 
-        Device()
+        device = Device()
+        device.set_current()
         graph = GraphDefinition()
         graph.callback(Callback())
         """


### PR DESCRIPTION
## Summary

- Establish a current CUDA context in the isolated graph-shutdown probe.
- Ensure the test reaches the interpreter-shutdown cleanup behavior it is
  intended to exercise.

## Root Cause

`test_pending_cleanup_is_safe_during_python_shutdown`, added in #2371, runs
its probe in a fresh Python subprocess. The parent test's `init_cuda` fixture
does not provide a CUDA context to that subprocess. Constructing `Device()`
initializes CUDA, but does not make the device context current, so adding the
host callback node can fail with `CUDA_ERROR_INVALID_VALUE` before the shutdown
behavior is tested.

Explicitly call `device.set_current()` before constructing the graph.

## Testing

- Focused graph-shutdown test passed.
- Full CUDA 13.4 Linux test run passed.
- Full CUDA 13.4 Windows test run passed.
- `pre-commit run --all-files` passed.
