### PR TITLE
Use Python 3.15b2 for now until cibuildwheel is updated

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -338,8 +338,11 @@ jobs:
         id: setup-python2
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
-          python-version: ${{ matrix.python-version }}
-          # TODO: remove allow-prereleases once 3.15 is officially supported
+          # TODO: Pin beta.2 precisely until cibuildwheel catches up (b4 broke ABI for Cython);
+          # this precise pin requires the explicit `freethreaded`.
+          # When 3.15 is officially supported we can also remove the `allow-prereleases` override.
+          python-version: ${{ startsWith(matrix.python-version, '3.15') && '3.15.0-beta.2' || matrix.python-version }}
+          freethreaded: ${{ endsWith(matrix.python-version, 't') }}
           allow-prereleases: ${{ startsWith(matrix.python-version, '3.15') }}
 
       - name: verify free-threaded build

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -296,8 +296,11 @@ jobs:
       - name: Set up Python ${{ matrix.PY_VER }}
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
-          python-version: ${{ matrix.PY_VER }}
-          # TODO: remove allow-prereleases once 3.15 is officially supported
+          # TODO: Pin beta.2 precisely until cibuildwheel catches up (b4 broke ABI for Cython)
+          # this precise pin requires the explicit `freethreaded`.
+          # When 3.15 is officially supported we can also remove the `allow-prereleases` override.
+          python-version: ${{ startsWith(matrix.PY_VER, '3.15') && '3.15.0-beta.2' || matrix.PY_VER }}
+          freethreaded: ${{ endsWith(matrix.PY_VER, 't') }}
           allow-prereleases: ${{ startsWith(matrix.PY_VER, '3.15') }}
         env:
           # we use self-hosted runners on which setup-python behaves weirdly (Python include can't be found)...

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -276,7 +276,12 @@ jobs:
       - name: Set up Python ${{ matrix.PY_VER }}
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
-          python-version: ${{ matrix.PY_VER }}
+          # TODO: Pin beta.2 precisely until cibuildwheel catches up (b4 broke ABI for Cython)
+          # this precise pin requires the explicit `freethreaded`.
+          # When 3.15 is officially supported we can also remove the `allow-prereleases` override.
+          python-version: ${{ startsWith(matrix.PY_VER, '3.15') && '3.15.0-beta.2' || matrix.PY_VER }}
+          freethreaded: ${{ endsWith(matrix.PY_VER, 't') }}
+          allow-prereleases: ${{ startsWith(matrix.PY_VER, '3.15') }}
 
       - name: Verify LongPathsEnabled
         run: |

--- a/ci/test-matrix.yml
+++ b/ci/test-matrix.yml
@@ -128,6 +128,8 @@ windows:
     - { ARCH: 'amd64', PY_VER: '3.14t', CUDA_VER: '12.9.1', LOCAL_CTK: '1', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest',  DRIVER_MODE: 'TCC' }
     - { ARCH: 'amd64', PY_VER: '3.14t', CUDA_VER: '13.0.2', LOCAL_CTK: '0', GPU: 'a100',       GPU_COUNT: '1', DRIVER: 'latest',  DRIVER_MODE: 'MCDM' }
     - { ARCH: 'amd64', PY_VER: '3.14t', CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'a100',       GPU_COUNT: '1', DRIVER: 'latest',  DRIVER_MODE: 'MCDM' }
+    - { ARCH: 'amd64', PY_VER: '3.15',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest',  DRIVER_MODE: 'MCDM' }
+    - { ARCH: 'amd64', PY_VER: '3.15t', CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest',  DRIVER_MODE: 'MCDM' }
     # special runners
     - { ARCH: 'amd64', PY_VER: '3.14',  CUDA_VER: '13.3.0', LOCAL_CTK: '1', GPU: 't4',         GPU_COUNT: '2', DRIVER: 'latest',  DRIVER_MODE: 'TCC' }
     - { ARCH: 'amd64', PY_VER: '3.14',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'h100',       GPU_COUNT: '2', DRIVER: 'latest',  DRIVER_MODE: 'MCDM' }

--- a/ci/test-matrix.yml
+++ b/ci/test-matrix.yml
@@ -128,8 +128,6 @@ windows:
     - { ARCH: 'amd64', PY_VER: '3.14t', CUDA_VER: '12.9.1', LOCAL_CTK: '1', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest',  DRIVER_MODE: 'TCC' }
     - { ARCH: 'amd64', PY_VER: '3.14t', CUDA_VER: '13.0.2', LOCAL_CTK: '0', GPU: 'a100',       GPU_COUNT: '1', DRIVER: 'latest',  DRIVER_MODE: 'MCDM' }
     - { ARCH: 'amd64', PY_VER: '3.14t', CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'a100',       GPU_COUNT: '1', DRIVER: 'latest',  DRIVER_MODE: 'MCDM' }
-    - { ARCH: 'amd64', PY_VER: '3.15',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest',  DRIVER_MODE: 'MCDM' }
-    - { ARCH: 'amd64', PY_VER: '3.15t', CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'l4',         GPU_COUNT: '1', DRIVER: 'latest',  DRIVER_MODE: 'MCDM' }
     # special runners
     - { ARCH: 'amd64', PY_VER: '3.14',  CUDA_VER: '13.3.0', LOCAL_CTK: '1', GPU: 't4',         GPU_COUNT: '2', DRIVER: 'latest',  DRIVER_MODE: 'TCC' }
     - { ARCH: 'amd64', PY_VER: '3.14',  CUDA_VER: '13.3.0', LOCAL_CTK: '0', GPU: 'h100',       GPU_COUNT: '2', DRIVER: 'latest',  DRIVER_MODE: 'MCDM' }


### PR DESCRIPTION
There actually *was* an ABI change in the thread_state struct (adding a field) and Cython grabs `current_exception` from it directly breaking Cython builds running on 3.15b4 but build prior to it.

There is no fix other than building with 3.15b4 but since cibuildwheel is still on b2 the only "fix" is to pin to b2 for now (b3 would work as well to be fair).

This *will* of course segfault again as soon as cibuildwheel is bumped to b4+ and then we can remove the precise `b2` versioning for setup-python.

I am trying to re-activate the windows 3.15 builds, IIRC they were failing and skipped, so lets see.

Closes gh-2171