### PR TITLE
chore: refactor pyx files for readability

### DIFF
--- a/cuda_bindings/tests/cython/test_ccudart.pyx
+++ b/cuda_bindings/tests/cython/test_ccudart.pyx
@@ -59,11 +59,8 @@ cdef extern from *:
 
 def test_ccudart_interoperable():
     # struct
-    cdef dim3 oldDim, newDim
-    oldDim.x = 1
-    oldDim.y = 2
-    oldDim.z = 3
-    newDim = copy_and_append_dim3(oldDim)
+    cdef dim3 oldDim = [1, 2, 3]
+    cdef dim3 newDim = copy_and_append_dim3(oldDim)
     assert oldDim.x + 1 == newDim.x
     assert oldDim.y + 1 == newDim.y
     assert oldDim.z + 1 == newDim.z

--- a/cuda_core/cuda/core/_device.pyx
+++ b/cuda_core/cuda/core/_device.pyx
@@ -1316,7 +1316,6 @@ class Device:
         cdef object res
         cdef SMResource sm_res
         cdef WorkqueueResource wq_res
-        cdef GreenCtxHandle h_green
 
         if options is None:
             raise ValueError(
@@ -1348,7 +1347,7 @@ class Device:
             else:
                 raise TypeError(f"Unsupported context resource type: {type(res)}")
 
-        h_green = create_green_ctx_handle(
+        cdef GreenCtxHandle h_green = create_green_ctx_handle(
             c_resources.data(),
             <unsigned int>(c_resources.size()),
             <cydriver.CUdevice>(self._device_id),

--- a/cuda_core/cuda/core/_device_resources.pyx
+++ b/cuda_core/cuda/core/_device_resources.pyx
@@ -250,7 +250,6 @@ cdef object _resolve_split_by_count_request(SMResourceOptions options):
     cdef list counts = _broadcast_field(options.count, n_groups)
     cdef object first = counts[0]
     cdef object value
-    cdef unsigned int min_count
 
     if options.coscheduled_sm_count is not None:
         raise RuntimeError(
@@ -270,7 +269,7 @@ cdef object _resolve_split_by_count_request(SMResourceOptions options):
                 "use CUDA 13.1 or newer for per-group counts"
             )
 
-    min_count = _to_sm_count(first)
+    cdef unsigned int min_count = _to_sm_count(first)
     return n_groups, min_count
 
 

--- a/cuda_core/cuda/core/_dlpack.pyx
+++ b/cuda_core/cuda/core/_dlpack.pyx
@@ -115,10 +115,8 @@ cdef inline int setup_dl_tensor_device(DLTensor* dl_tensor, object buf) except -
 
 
 cdef inline int setup_dl_tensor_dtype(DLTensor* dl_tensor) except -1 nogil:
-    cdef DLDataType* dtype = &dl_tensor.dtype
-    dtype.code = <uint8_t>kDLInt
-    dtype.lanes = <uint16_t>1
-    dtype.bits = <uint8_t>8
+    dl_tensor.dtype = DLDataType(
+        code=<uint8_t>kDLInt, bits=<uint8_t>8, lanes=<uint16_t>1)
     return 0
 
 

--- a/cuda_core/cuda/core/_graphics.pyx
+++ b/cuda_core/cuda/core/_graphics.pyx
@@ -209,10 +209,9 @@ cdef class GraphicsResource:
         return self
 
     def _get_mapped_buffer(self) -> object:
-        cdef Buffer buf
         if self._mapped_buffer is None:
             return None
-        buf = <Buffer>self._mapped_buffer
+        cdef Buffer buf = <Buffer>self._mapped_buffer
         if not buf._h_ptr:
             self._mapped_buffer = None
             return None
@@ -250,20 +249,16 @@ cdef class GraphicsResource:
         CUDAError
             If the mapping fails.
         """
-        cdef Stream s_obj
-        cdef cydriver.CUgraphicsResource raw
-        cdef cydriver.CUstream cy_stream
         cdef cydriver.CUdeviceptr dev_ptr = 0
         cdef size_t size = 0
-        cdef Buffer buf
         if not self._handle:
             raise RuntimeError("GraphicsResource has been closed")
         if self._get_mapped_buffer() is not None:
             raise RuntimeError("GraphicsResource is already mapped")
 
-        s_obj = Stream_accept(stream)
-        raw = as_cu(self._handle)
-        cy_stream = as_cu(s_obj._h_stream)
+        cdef Stream s_obj = Stream_accept(stream)
+        cdef cydriver.CUgraphicsResource raw = as_cu(self._handle)
+        cdef cydriver.CUstream cy_stream = as_cu(s_obj._h_stream)
         with nogil:
             HANDLE_RETURN(
                 cydriver.cuGraphicsMapResources(1, &raw, cy_stream)
@@ -271,7 +266,7 @@ cdef class GraphicsResource:
             HANDLE_RETURN(
                 cydriver.cuGraphicsResourceGetMappedPointer(&dev_ptr, &size, raw)
             )
-        buf = Buffer_from_deviceptr_handle(
+        cdef Buffer buf = Buffer_from_deviceptr_handle(
             deviceptr_create_mapped_graphics(dev_ptr, self._handle, s_obj._h_stream),
             size,
             None,
@@ -299,14 +294,12 @@ cdef class GraphicsResource:
         CUDAError
             If the unmapping fails.
         """
-        cdef object buf_obj
-        cdef Buffer buf
         if not self._handle:
             raise RuntimeError("GraphicsResource has been closed")
-        buf_obj = self._get_mapped_buffer()
+        cdef object buf_obj = self._get_mapped_buffer()
         if buf_obj is None:
             raise RuntimeError("GraphicsResource is not mapped")
-        buf = <Buffer>buf_obj
+        cdef Buffer buf = <Buffer>buf_obj
         buf.close(stream=stream)
         self._mapped_buffer = None
 
@@ -332,11 +325,10 @@ cdef class GraphicsResource:
             Optional override for the stream used to close the currently
             mapped buffer, if one exists.
         """
-        cdef object buf_obj
         cdef Buffer buf
         if not self._handle:
             return
-        buf_obj = self._get_mapped_buffer()
+        cdef object buf_obj = self._get_mapped_buffer()
         if buf_obj is not None:
             buf = <Buffer>buf_obj
             buf.close(stream=stream)

--- a/cuda_core/cuda/core/_linker.pyx
+++ b/cuda_core/cuda/core/_linker.pyx
@@ -544,11 +544,10 @@ cdef inline void Linker_add_code_object(Linker self, object object_code) except 
     cdef cydriver.CUjitInputType c_drv_input_type
     cdef const char* c_data_ptr
     cdef size_t c_data_size
-    cdef const char* c_name_ptr
     cdef const char* c_file_ptr
 
     name_bytes = f"{object_code.name}".encode()
-    c_name_ptr = <const char*>name_bytes
+    cdef const char* c_name_ptr = <const char*>name_bytes
 
     input_types = _nvjitlink_input_types if self._use_nvjitlink else _driver_input_types
     py_input_type = input_types.get(object_code.code_type)

--- a/cuda_core/cuda/core/_memory/_buffer.pyx
+++ b/cuda_core/cuda/core/_memory/_buffer.pyx
@@ -422,8 +422,7 @@ cdef class Buffer:
             if not isinstance(max_version, tuple) or len(max_version) != 2:
                 raise BufferError(f"Expected max_version tuple[int, int], got {max_version}")
             versioned = max_version >= (1, 0)
-        capsule = make_py_capsule(self, versioned)
-        return capsule
+        return make_py_capsule(self, versioned)
 
     def __dlpack_device__(self) -> tuple[int, int]:
         return classify_dl_device(self)

--- a/cuda_core/cuda/core/_memory/_device_memory_resource.pyx
+++ b/cuda_core/cuda/core/_memory/_device_memory_resource.pyx
@@ -321,10 +321,10 @@ cpdef str DMR_mempool_get_access(DeviceMemoryResource dmr, int device_id):
 
     cdef int dev_id = Device(device_id).device_id
     cdef cydriver.CUmemAccess_flags flags
-    cdef cydriver.CUmemLocation location
-
-    location.type = cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
-    location.id = dev_id
+    cdef cydriver.CUmemLocation location = cydriver.CUmemLocation(
+        type=cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE,
+        id=dev_id,
+    )
 
     with nogil:
         HANDLE_RETURN(cydriver.cuMemPoolGetAccess(&flags, as_cu(dmr._h_pool), &location))

--- a/cuda_core/cuda/core/_memory/_managed_memory_ops.pyx
+++ b/cuda_core/cuda/core/_memory/_managed_memory_ops.pyx
@@ -80,7 +80,6 @@ cdef tuple _coerce_batch_buffers(object buffers, str what):
 
 
 cdef tuple _broadcast_locations(object location, Py_ssize_t n, bint allow_none, str what):
-    cdef object coerced
     if isinstance(location, Sequence):
         if len(location) != n:
             raise ValueError(
@@ -88,28 +87,30 @@ cdef tuple _broadcast_locations(object location, Py_ssize_t n, bint allow_none, 
                 f"targets length {n}"
             )
         return tuple(_coerce_location(loc, allow_none=allow_none) for loc in location)
-    coerced = _coerce_location(location, allow_none=allow_none)
+    cdef object coerced = _coerce_location(location, allow_none=allow_none)
     return tuple([coerced] * n)
 
 
 IF CUDA_CORE_BUILD_MAJOR >= 13:
     # Convert a _LocSpec dataclass to a cydriver.CUmemLocation struct.
     cdef inline cydriver.CUmemLocation _to_cumemlocation(object loc):
-        cdef cydriver.CUmemLocation out
         cdef str kind = loc.kind
         if kind == "device":
-            out.type = cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
-            out.id = <int>loc.id
+            return cydriver.CUmemLocation(
+                type=cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE,
+                id=<int>loc.id)
         elif kind == "host":
-            out.type = cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_HOST
-            out.id = 0
+            return cydriver.CUmemLocation(
+                type=cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_HOST,
+                id=0)
         elif kind == "host_numa":
-            out.type = cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_HOST_NUMA
-            out.id = <int>loc.id
+            return cydriver.CUmemLocation(
+                type=cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_HOST_NUMA,
+                id=<int>loc.id)
         else:  # host_numa_current
-            out.type = cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_HOST_NUMA_CURRENT
-            out.id = 0
-        return out
+            return cydriver.CUmemLocation(
+                type=cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_HOST_NUMA_CURRENT,
+                id=0)
 ELSE:
     # CUDA 12 cuMemPrefetchAsync takes a device ordinal (-1 = host).
     cdef inline int _to_legacy_device(object loc) except? -2:
@@ -223,8 +224,9 @@ cdef void _do_single_advise(Buffer buf, object advice_value, object loc, bint al
             # Driver ignores location for read_mostly / unset_preferred_location
             # advice values but still validates the CUmemLocation; pass a
             # host placeholder.
-            cu_loc.type = cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_HOST
-            cu_loc.id = 0
+            cu_loc = cydriver.CUmemLocation(
+                type=cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_HOST,
+                id=0)
         else:
             cu_loc = _to_cumemlocation(loc)
         with nogil:

--- a/cuda_core/cuda/core/_memory/_memory_pool.pyx
+++ b/cuda_core/cuda/core/_memory/_memory_pool.pyx
@@ -275,10 +275,9 @@ cdef int MP_init_current_pool(
     Requires CUDA 13+.
     """
     IF CUDA_CORE_BUILD_MAJOR >= 13:
-        cdef cydriver.CUmemLocation loc
         cdef cydriver.CUmemoryPool pool
-        loc.id = loc_id
-        loc.type = loc_type
+        cdef cydriver.CUmemLocation loc = cydriver.CUmemLocation(
+            type=loc_type, id=loc_id)
         with nogil:
             HANDLE_RETURN(cydriver.cuMemGetMemPool(&pool, &loc, alloc_type))
         self._h_pool = create_mempool_handle_ref(pool)

--- a/cuda_core/cuda/core/_memory/_peer_access_utils.pyx
+++ b/cuda_core/cuda/core/_memory/_peer_access_utils.pyx
@@ -92,7 +92,7 @@ cdef inline tuple _query_peer_access_ids(DeviceMemoryResource mr):
     cdef cydriver.CUmemLocation location
     cdef cydriver.CUmemoryPool h_pool = as_cu(mr._h_pool)
     cdef vector[int] peers
-    cdef size_t i, n
+    cdef size_t i
 
     location.type = cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
 
@@ -106,17 +106,17 @@ cdef inline tuple _query_peer_access_ids(DeviceMemoryResource mr):
             if flags == cydriver.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE:
                 peers.push_back(dev_id)
 
-    n = peers.size()
+    cdef size_t n = peers.size()
     return tuple(peers[i] for i in range(n))
 
 
 cdef inline bint _peer_access_includes(DeviceMemoryResource mr, int dev_id):
     """Return True if peer access from ``dev_id`` is currently granted."""
     cdef cydriver.CUmemAccess_flags flags
-    cdef cydriver.CUmemLocation location
-
-    location.type = cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
-    location.id = dev_id
+    cdef cydriver.CUmemLocation location = cydriver.CUmemLocation(
+        type=cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE,
+        id=dev_id,
+    )
     with nogil:
         HANDLE_RETURN(cydriver.cuMemPoolGetAccess(&flags, as_cu(mr._h_pool), &location))
     return flags == cydriver.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE

--- a/cuda_core/cuda/core/_stream.pyx
+++ b/cuda_core/cuda/core/_stream.pyx
@@ -125,7 +125,6 @@ cdef class Stream:
         cdef StreamHandle h_stream
         cdef cydriver.CUstream borrowed
         cdef ContextHandle h_context
-        cdef Stream self
 
         # Extract context handle if provided
         if ctx is not None:
@@ -185,7 +184,7 @@ cdef class Stream:
                 )
             else:
                 HANDLE_RETURN(res_code)
-        self = Stream._from_handle(cls, h_stream)
+        cdef Stream self = Stream._from_handle(cls, h_stream)
         self._nonblocking = int(nonblocking)
         self._priority = prio
         if device_id is not None:

--- a/cuda_core/cuda/core/_tensor_bridge.pyx
+++ b/cuda_core/cuda/core/_tensor_bridge.pyx
@@ -361,9 +361,7 @@ def view_as_torch_tensor(
     cdef int32_t dtype_code
     cdef int32_t device_type, device_index
     cdef StridedMemoryView buf
-    cdef int itemsize
     cdef intptr_t _stream_ptr_int
-    cdef _StridedLayout layout
 
     # Note: we intentionally skip PyTorch's Python-level __dlpack__ guards
     # (requires_grad, is_conj, is_neg, non-strided layout, wrong-device)
@@ -436,8 +434,8 @@ def view_as_torch_tensor(
 
     # Build _StridedLayout.  init_from_ptr copies shape/strides so we are
     # safe even though they are borrowed pointers.
-    itemsize = _get_aoti_itemsize(dtype_code)
-    layout = _StridedLayout.__new__(_StridedLayout)
+    cdef int itemsize = _get_aoti_itemsize(dtype_code)
+    cdef _StridedLayout layout = _StridedLayout.__new__(_StridedLayout)
     layout.init_from_ptr(
         <int>ndim,
         sizes_ptr,

--- a/cuda_core/cuda/core/_tensor_map.pyx
+++ b/cuda_core/cuda/core/_tensor_map.pyx
@@ -485,7 +485,6 @@ cdef class TensorMapDescriptor:
     cdef int _check_context_compat(self) except -1:
         cdef cydriver.CUcontext current_ctx
         cdef cydriver.CUdevice current_dev
-        cdef int current_dev_id
         if self._context == 0 and self._device_id < 0:
             return 0
         with nogil:
@@ -497,7 +496,7 @@ cdef class TensorMapDescriptor:
                 "TensorMapDescriptor was created in a different CUDA context")
         with nogil:
             HANDLE_RETURN(cydriver.cuCtxGetDevice(&current_dev))
-        current_dev_id = <int>current_dev
+        cdef int current_dev_id = <int>current_dev
         if self._device_id >= 0 and current_dev_id != self._device_id:
             raise RuntimeError(
                 f"TensorMapDescriptor belongs to device {self._device_id}, "

--- a/cuda_core/cuda/core/graph/_graph_builder.pyx
+++ b/cuda_core/cuda/core/graph/_graph_builder.pyx
@@ -162,7 +162,6 @@ class GraphCompleteOptions:
 
 
 def _instantiate_graph(h_graph, options: GraphCompleteOptions | None = None) -> Graph:
-    cdef cydriver.CUgraphExec c_exec
     params = driver.CUDA_GRAPH_INSTANTIATE_PARAMS()
     if options:
         flags = 0
@@ -201,7 +200,7 @@ def _instantiate_graph(h_graph, options: GraphCompleteOptions | None = None) -> 
     elif params.result_out != driver.CUgraphInstantiateResult.CUDA_GRAPH_INSTANTIATE_SUCCESS:
         raise RuntimeError(f"Graph instantiation failed with unexpected error code: {params.result_out}")
 
-    c_exec = <cydriver.CUgraphExec><intptr_t>int(py_exec)
+    cdef cydriver.CUgraphExec c_exec = <cydriver.CUgraphExec><intptr_t>int(py_exec)
     return Graph._init(c_exec)
 
 

--- a/cuda_core/cuda/core/graph/_graph_node.pyx
+++ b/cuda_core/cuda/core/graph/_graph_node.pyx
@@ -163,13 +163,11 @@ cdef class GraphNode:
         already-destroyed node (no-op).
         """
         cdef cydriver.CUgraphNode node = as_cu(self._h_node)
-        cdef GraphHandle h_graph
-        cdef cydriver.CUresult cleanup_status
         cdef PreparedAttachment prepared
         if node == NULL:
             return
 
-        h_graph = graph_node_get_graph(self._h_node)
+        cdef GraphHandle h_graph = graph_node_get_graph(self._h_node)
         # Allocate the cleanup transaction before asking CUDA to destroy the
         # node. A failed CUDA call leaves metadata and wrappers unchanged.
         HANDLE_RETURN(graph_prepare_attachment(
@@ -178,7 +176,7 @@ cdef class GraphNode:
             HANDLE_RETURN(cydriver.cuGraphDestroyNode(node))
 
         # Publish attachment removal before invalidating graph and node aliases.
-        cleanup_status = graph_commit_attachment(prepared, node)
+        cdef cydriver.CUresult cleanup_status = graph_commit_attachment(prepared, node)
         invalidate_child_graph_state(h_graph, node)
         _node_registry.pop(<uintptr_t>self._h_node.get(), None)
         invalidate_graph_node(self._h_node)
@@ -360,8 +358,8 @@ cdef class GraphNode:
         cdef cydriver.CUdeviceptr c_dst
         cdef unsigned int val
         cdef unsigned int elem_size
-        cdef OpaqueHandle dst_attachment_owner
-        dst_attachment_owner = _resolve_memcpy_operand(dst, dst_owner, "dst", &c_dst)
+        cdef OpaqueHandle dst_attachment_owner = _resolve_memcpy_operand(
+            dst, dst_owner, "dst", &c_dst)
         val, elem_size = _parse_fill_value(value)
         return GN_memset(
             self, c_dst, dst_attachment_owner,
@@ -423,9 +421,10 @@ cdef class GraphNode:
         """
         cdef cydriver.CUdeviceptr c_dst
         cdef cydriver.CUdeviceptr c_src
-        cdef OpaqueHandle dst_attachment_owner, src_attachment_owner
-        dst_attachment_owner = _resolve_memcpy_operand(dst, dst_owner, "dst", &c_dst)
-        src_attachment_owner = _resolve_memcpy_operand(src, src_owner, "src", &c_src)
+        cdef OpaqueHandle dst_attachment_owner = _resolve_memcpy_operand(
+            dst, dst_owner, "dst", &c_dst)
+        cdef OpaqueHandle src_attachment_owner = _resolve_memcpy_operand(
+            src, src_owner, "src", &c_src)
         return GN_memcpy(
             self, c_dst, dst_attachment_owner,
             c_src, src_attachment_owner, size)
@@ -713,35 +712,36 @@ cdef inline GraphNode GN_create_impl(GraphNodeHandle h_node):
 
 
 cdef inline KernelNode GN_launch(GraphNode self, LaunchConfig conf, Kernel ker, ParamHolder ker_args):
-    cdef cydriver.CUDA_KERNEL_NODE_PARAMS node_params
     cdef cydriver.CUgraphNode new_node = NULL
     cdef GraphHandle h_graph = graph_node_get_graph(self._h_node)
     cdef cydriver.CUgraphNode pred_node = as_cu(self._h_node)
     cdef cydriver.CUgraphNode* deps = NULL
     cdef size_t num_deps = 0
-    cdef OpaqueHandle kernel_owner, args_owner
+    cdef OpaqueHandle args_owner
     cdef PreparedAttachment prepared
 
     if pred_node != NULL:
         deps = &pred_node
         num_deps = 1
 
-    node_params.kern = as_cu(ker._h_kernel)
-    node_params.func = <cydriver.CUfunction>NULL
-    node_params.gridDimX = conf.grid[0]
-    node_params.gridDimY = conf.grid[1]
-    node_params.gridDimZ = conf.grid[2]
-    node_params.blockDimX = conf.block[0]
-    node_params.blockDimY = conf.block[1]
-    node_params.blockDimZ = conf.block[2]
-    node_params.sharedMemBytes = conf.shmem_size
-    node_params.kernelParams = <void**><uintptr_t>(ker_args.ptr)
-    node_params.extra = NULL
-    node_params.ctx = <cydriver.CUcontext>NULL
+    cdef cydriver.CUDA_KERNEL_NODE_PARAMS node_params = cydriver.CUDA_KERNEL_NODE_PARAMS(
+        kern=as_cu(ker._h_kernel),
+        func=<cydriver.CUfunction>NULL,
+        gridDimX=conf.grid[0],
+        gridDimY=conf.grid[1],
+        gridDimZ=conf.grid[2],
+        blockDimX=conf.block[0],
+        blockDimY=conf.block[1],
+        blockDimZ=conf.block[2],
+        sharedMemBytes=conf.shmem_size,
+        kernelParams=<void**><uintptr_t>(ker_args.ptr),
+        extra=NULL,
+        ctx=<cydriver.CUcontext>NULL,
+    )
 
     # Keep the kernel and argument objects alive because CUDA copies argument
     # values but does not retain the resources they reference.
-    kernel_owner = ker._h_kernel
+    cdef OpaqueHandle kernel_owner = ker._h_kernel
     kernel_args = ker_args.kernel_args
     if kernel_args is not None:
         args_owner = make_opaque_py(kernel_args)
@@ -881,10 +881,11 @@ cdef inline FreeNode GN_free(GraphNode self, cydriver.CUdeviceptr c_dptr):
 
 cdef inline OpaqueHandle _buffer_attachment_owner(Buffer buf, str label):
     """Copy a Buffer's device-pointer handle into an attachment owner."""
-    cdef OpaqueHandle attachment_owner
     if not buf._h_ptr:
         raise ValueError(f"{label} Buffer has no active allocation")
-    attachment_owner = buf._h_ptr
+    # The local is required: Cython permits the DevicePtrHandle -> OpaqueHandle
+    # conversion on assignment, but not directly in a return statement.
+    cdef OpaqueHandle attachment_owner = buf._h_ptr
     return attachment_owner
 
 
@@ -928,7 +929,6 @@ cdef inline MemsetNode GN_memset(
         GraphNode self, cydriver.CUdeviceptr c_dst, OpaqueHandle dst_owner,
         unsigned int val, unsigned int elem_size,
         size_t width, size_t height, size_t pitch):
-    cdef cydriver.CUDA_MEMSET_NODE_PARAMS memset_params
     cdef cydriver.CUgraphNode new_node = NULL
     cdef GraphHandle h_graph = graph_node_get_graph(self._h_node)
     cdef cydriver.CUgraphNode pred_node = as_cu(self._h_node)
@@ -944,13 +944,14 @@ cdef inline MemsetNode GN_memset(
     with nogil:
         HANDLE_RETURN(cydriver.cuCtxGetCurrent(&ctx))
 
-    c_memset(&memset_params, 0, sizeof(memset_params))
-    memset_params.dst = c_dst
-    memset_params.value = val
-    memset_params.elementSize = elem_size
-    memset_params.width = width
-    memset_params.height = height
-    memset_params.pitch = pitch
+    cdef cydriver.CUDA_MEMSET_NODE_PARAMS memset_params = cydriver.CUDA_MEMSET_NODE_PARAMS(
+        dst=c_dst,
+        pitch=pitch,
+        value=val,
+        elementSize=elem_size,
+        width=width,
+        height=height,
+    )
 
     if dst_owner:
         HANDLE_RETURN(graph_prepare_attachment(
@@ -1081,14 +1082,13 @@ cdef inline EventRecordNode GN_record_event(GraphNode self, Event ev):
     cdef cydriver.CUgraphNode pred_node = as_cu(self._h_node)
     cdef cydriver.CUgraphNode* deps = NULL
     cdef size_t num_deps = 0
-    cdef OpaqueHandle owner
     cdef PreparedAttachment prepared
 
     if pred_node != NULL:
         deps = &pred_node
         num_deps = 1
 
-    owner = ev._h_event
+    cdef OpaqueHandle owner = ev._h_event
     HANDLE_RETURN(graph_prepare_attachment(
         h_graph, owner, OpaqueHandle(), &prepared))
 
@@ -1108,14 +1108,13 @@ cdef inline EventWaitNode GN_wait_event(GraphNode self, Event ev):
     cdef cydriver.CUgraphNode pred_node = as_cu(self._h_node)
     cdef cydriver.CUgraphNode* deps = NULL
     cdef size_t num_deps = 0
-    cdef OpaqueHandle owner
     cdef PreparedAttachment prepared
 
     if pred_node != NULL:
         deps = &pred_node
         num_deps = 1
 
-    owner = ev._h_event
+    cdef OpaqueHandle owner = ev._h_event
     HANDLE_RETURN(graph_prepare_attachment(
         h_graph, owner, OpaqueHandle(), &prepared))
 

--- a/cuda_core/cuda/core/texture/_array.pyx
+++ b/cuda_core/cuda/core/texture/_array.pyx
@@ -522,7 +522,6 @@ def _create_opaque_array(options):
     shape_t = opts.shape
 
     cdef cydriver.CUarray_format c_format = <cydriver.CUarray_format>_ARRAYFORMAT_TO_CU[opts.format]
-    cdef cydriver.CUDA_ARRAY3D_DESCRIPTOR desc3d
     cdef int rank = len(shape_t)
     cdef unsigned int flags = (
         cydriver.CUDA_ARRAY3D_SURFACE_LDST if opts.is_surface_load_store else 0
@@ -530,13 +529,14 @@ def _create_opaque_array(options):
 
     # cuArray3DCreate handles 1D/2D/3D uniformly (Height/Depth 0 sentinels),
     # so a single descriptor + create_array_handle covers every shape.
-    memset(&desc3d, 0, sizeof(desc3d))
-    desc3d.Width = <size_t>shape_t[0]
-    desc3d.Height = <size_t>(shape_t[1] if rank >= 2 else 0)
-    desc3d.Depth = <size_t>(shape_t[2] if rank >= 3 else 0)
-    desc3d.Format = c_format
-    desc3d.NumChannels = <unsigned int>opts.num_channels
-    desc3d.Flags = flags
+    cdef cydriver.CUDA_ARRAY3D_DESCRIPTOR desc3d = cydriver.CUDA_ARRAY3D_DESCRIPTOR(
+        Width=<size_t>shape_t[0],
+        Height=<size_t>(shape_t[1] if rank >= 2 else 0),
+        Depth=<size_t>(shape_t[2] if rank >= 3 else 0),
+        Format=c_format,
+        NumChannels=<unsigned int>opts.num_channels,
+        Flags=flags,
+    )
 
     cdef OpaqueArrayHandle h = create_array_handle(desc3d)
     if not h:

--- a/cuda_core/cuda/core/texture/_mipmapped_array.pyx
+++ b/cuda_core/cuda/core/texture/_mipmapped_array.pyx
@@ -4,8 +4,6 @@
 
 from __future__ import annotations
 
-from libc.string cimport memset
-
 from cuda.bindings cimport cydriver
 from cuda.core.texture._array cimport _array_from_handle
 from cuda.core.texture._array import (
@@ -201,7 +199,6 @@ def _create_mipmapped_array(options):
     shape_t = opts.shape
 
     cdef cydriver.CUarray_format c_format = <cydriver.CUarray_format>_ARRAYFORMAT_TO_CU[opts.format]
-    cdef cydriver.CUDA_ARRAY3D_DESCRIPTOR desc3d
     cdef int rank = len(shape_t)
     cdef unsigned int flags = (
         cydriver.CUDA_ARRAY3D_SURFACE_LDST if opts.is_surface_load_store else 0
@@ -210,13 +207,14 @@ def _create_mipmapped_array(options):
 
     # Mipmap creation uses the 3D descriptor regardless of rank; lower-rank
     # shapes use Height=0/Depth=0 sentinels, matching cuArray3DCreate.
-    memset(&desc3d, 0, sizeof(desc3d))
-    desc3d.Width = <size_t>shape_t[0]
-    desc3d.Height = <size_t>(shape_t[1] if rank >= 2 else 0)
-    desc3d.Depth = <size_t>(shape_t[2] if rank >= 3 else 0)
-    desc3d.Format = c_format
-    desc3d.NumChannels = <unsigned int>opts.num_channels
-    desc3d.Flags = flags
+    cdef cydriver.CUDA_ARRAY3D_DESCRIPTOR desc3d = cydriver.CUDA_ARRAY3D_DESCRIPTOR(
+        Width=<size_t>shape_t[0],
+        Height=<size_t>(shape_t[1] if rank >= 2 else 0),
+        Depth=<size_t>(shape_t[2] if rank >= 3 else 0),
+        Format=c_format,
+        NumChannels=<unsigned int>opts.num_channels,
+        Flags=flags,
+    )
 
     cdef MipmappedArrayHandle h = create_mipmapped_array_handle(desc3d, c_levels)
     if not h:


### PR DESCRIPTION
Refactor: tidy cdef declarations and struct init in .pyx files

Declare cdef locals at their point of initialization rather than at the
top of the function, and replace field-by-field struct setup with
Cython's struct-initializer syntax.

Only complete initializers are converted. Cython does not zero-fill
omitted members, so a partial initializer would leave them holding stack
garbage; sites that depend on a preceding memset are left unchanged.
Where every member is now supplied, the redundant memset is dropped.

No behavior change.

