### PR TITLE
chore: cython warnings as errors in cuda.core

### DIFF
--- a/cuda_bindings/build_hooks.py
+++ b/cuda_bindings/build_hooks.py
@@ -131,6 +131,7 @@ def _build_cuda_bindings(debug=False):
     that metadata queries do not require a CUDA toolkit installation.
     """
     from Cython.Build import cythonize
+    from Cython.Compiler import Options as _CythonOptions
 
     global _extensions
 
@@ -224,6 +225,7 @@ def _build_cuda_bindings(debug=False):
         )
 
     # Cythonize
+    _CythonOptions.warning_errors = True
     cython_directives = {"language_level": 3, "embedsignature": True, "binding": True, "freethreading_compatible": True}
     if compile_for_coverage:
         cython_directives["linetrace"] = True

--- a/cuda_bindings/build_hooks.py
+++ b/cuda_bindings/build_hooks.py
@@ -131,7 +131,6 @@ def _build_cuda_bindings(debug=False):
     that metadata queries do not require a CUDA toolkit installation.
     """
     from Cython.Build import cythonize
-    from Cython.Compiler import Options as _CythonOptions
 
     global _extensions
 
@@ -225,7 +224,6 @@ def _build_cuda_bindings(debug=False):
         )
 
     # Cythonize
-    _CythonOptions.warning_errors = True
     cython_directives = {"language_level": 3, "embedsignature": True, "binding": True, "freethreading_compatible": True}
     if compile_for_coverage:
         cython_directives["linetrace"] = True

--- a/cuda_core/build_hooks.py
+++ b/cuda_core/build_hooks.py
@@ -17,6 +17,7 @@ import zipfile
 from pathlib import Path
 
 from Cython.Build import cythonize
+from Cython.Compiler import Options as _CythonOptions
 from setuptools import Extension
 from setuptools import build_meta as _build_meta
 
@@ -212,6 +213,7 @@ def _build_cuda_core(debug=False):
     nthreads = int(os.environ.get("CUDA_PYTHON_PARALLEL_LEVEL", os.cpu_count() // 2))
     compile_time_env = {"CUDA_CORE_BUILD_MAJOR": int(_determine_cuda_major_version())}
     compiler_directives = {"embedsignature": True, "warn.deprecated.IF": False, "freethreading_compatible": True}
+    _CythonOptions.warning_errors = True
     if COMPILE_FOR_COVERAGE:
         compiler_directives["linetrace"] = True
     _extensions = cythonize(

--- a/cuda_core/cuda/core/_memory/_memory_pool.pyx
+++ b/cuda_core/cuda/core/_memory/_memory_pool.pyx
@@ -282,11 +282,11 @@ cdef int MP_init_current_pool(
             HANDLE_RETURN(cydriver.cuMemGetMemPool(&pool, &loc, alloc_type))
         self._h_pool = create_mempool_handle_ref(pool)
         self._mempool_owned = False
+        return 0
     ELSE:
         raise RuntimeError(
             "Getting the current memory pool requires CUDA 13.0 or later"
         )
-    return 0
 
 
 cdef int MP_raise_release_threshold(_MemPool self) except? -1:

--- a/cuda_core/cuda/core/graph/_graph_node.pyx
+++ b/cuda_core/cuda/core/graph/_graph_node.pyx
@@ -999,7 +999,7 @@ cdef inline MemcpyNode GN_memcpy(
     params.srcMemoryType = c_src_type
     params.dstMemoryType = c_dst_type
     if c_src_type == cydriver.CU_MEMORYTYPE_HOST:
-        params.srcHost = <const void*><uintptr_t>c_src
+        params.srcHost = <void*><uintptr_t>c_src
     else:
         params.srcDevice = c_src
     if c_dst_type == cydriver.CU_MEMORYTYPE_HOST:

--- a/cuda_core/cuda/core/system/_device.pyi
+++ b/cuda_core/cuda/core/system/_device.pyi
@@ -1036,7 +1036,7 @@ class ProcessInfo:
     Information about running compute processes on the GPU.
     """
 
-    def __init__(self, device: 'Device', process_info: nvml.ProcessInfo):
+    def __init__(self, device: Device, process_info: nvml.ProcessInfo):
         ...
 
     @property

--- a/cuda_core/cuda/core/system/_device.pyx
+++ b/cuda_core/cuda/core/system/_device.pyx
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from libc.stdint cimport intptr_t, uint64_t
 from libc.math cimport ceil
 

--- a/cuda_core/cuda/core/system/_process.pxi
+++ b/cuda_core/cuda/core/system/_process.pxi
@@ -7,7 +7,7 @@ class ProcessInfo:
     """
     Information about running compute processes on the GPU.
     """
-    def __init__(self, device: "Device", process_info: nvml.ProcessInfo):
+    def __init__(self, device: object, process_info: nvml.ProcessInfo):
         self._device = device
         self._process_info = process_info
 

--- a/cuda_core/cuda/core/system/_process.pxi
+++ b/cuda_core/cuda/core/system/_process.pxi
@@ -7,7 +7,7 @@ class ProcessInfo:
     """
     Information about running compute processes on the GPU.
     """
-    def __init__(self, device: object, process_info: nvml.ProcessInfo):
+    def __init__(self, device: Device, process_info: nvml.ProcessInfo):
         self._device = device
         self._process_info = process_info
 


### PR DESCRIPTION
This change follows up on [review feedback](https://github.com/NVIDIA/cuda-python/pull/2434#pullrequestreview-4800625822) in an earlier PR. The suggestion was to treat cython warnings as errors.
