### PR TITLE
13.4 prerelease: Fix release automation issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -518,12 +518,7 @@ jobs:
           check_result "ci-vars"        "success" "${{ needs.ci-vars.result }}"
           check_result "should-skip"    "success" "${{ needs.should-skip.result }}"
           check_result "detect-changes" "success" "${{ needs.detect-changes.result }}"
-          # doc build is non-blocking: failures are visible but don't gate merges
-          doc_result="${{ needs.doc.result }}"
-          if [[ "$doc_result" != "success" && "$doc_result" != "failure" ]]; then
-            echo "::error::doc did not match expected result (got '$doc_result', expected 'success' or 'failure')"
-            status="failed"
-          fi
+          check_result "doc"            "success" "${{ needs.doc.result }}"
 
           # [doc-only] skips all builds and tests. Windows preview wheel builds
           # run, but GPU tests remain skipped until suitable runners are available.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,8 @@ jobs:
     steps:
       - name: Checkout Source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ inputs.git-tag }}
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0

--- a/cuda_bindings/cuda/bindings/nvml.pyx
+++ b/cuda_bindings/cuda/bindings/nvml.pyx
@@ -4,7 +4,7 @@
 #
 # This code was automatically generated across versions from 12.9.1 to 13.4.0. Do not modify it directly.
 # !!! WARNING: THIS FILE CONTAINS PRERELEASE APIs !!!
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=1e395a10038778dd6f706137392c0bdf3ca8298e806338fda6f4557dd3ddf550
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=e6637452fb185e3d30ab3d126d11f1f4de18b77785d64948b4ee580f4ddf03fe
 
 
 # <<<< PREAMBLE CONTENT >>>>
@@ -24667,7 +24667,7 @@ cdef class GpuFabricInfo_v4:
 
     @property
     def num_cliques(self):
-        """int: Number of valid entries in `cliques`[]."""
+        """int: Number of valid entries in cliques[]."""
         return self._ptr[0].numCliques
 
     @num_cliques.setter
@@ -31777,7 +31777,7 @@ cpdef int device_get_virtualization_mode(intptr_t device) except? -1:
 
     Returns:
         int: Reference to virtualization mode. One of
-            NVML_GPU_VIRTUALIZATION_?.
+            ``NVML_GPU_VIRTUALIZATION_?``.
 
     .. seealso:: `nvmlDeviceGetVirtualizationMode`
     """
@@ -31812,7 +31812,7 @@ cpdef device_set_virtualization_mode(intptr_t device, int virtual_mode):
     Args:
         device (intptr_t): Identifier of the target device.
         virtual_mode (GpuVirtualizationMode): virtualization mode. One
-            of NVML_GPU_VIRTUALIZATION_?.
+            of ``NVML_GPU_VIRTUALIZATION_?``.
 
     .. seealso:: `nvmlDeviceSetVirtualizationMode`
     """

--- a/cuda_bindings/docs/source/module/driver.rst
+++ b/cuda_bindings/docs/source/module/driver.rst
@@ -1,8 +1,10 @@
 .. SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
+.. This code was automatically generated with version 13.4.0. Do not modify it directly.
+
 .. !!! WARNING: THIS FILE CONTAINS PRERELEASE APIs !!!
-.. CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=ea05ceca543606364bee4723cab7db84783c502707e837a5bba39dba9ed996f7
+.. CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=d177af98becf52d0965c6bcaf352b66e8382b394bfaae3356ee54668bbc57d4d
 ------
 driver
 ------

--- a/cuda_bindings/docs/source/module/driver.rst
+++ b/cuda_bindings/docs/source/module/driver.rst
@@ -2,7 +2,7 @@
 .. SPDX-License-Identifier: Apache-2.0
 
 .. !!! WARNING: THIS FILE CONTAINS PRERELEASE APIs !!!
-.. CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=97724cda94bae86a54d6cf1205fbed172482bf03a3231089ab976da3c0b7299d
+.. CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=ea05ceca543606364bee4723cab7db84783c502707e837a5bba39dba9ed996f7
 ------
 driver
 ------
@@ -6611,10 +6611,6 @@ Data types used by CUDA driver
 
     CUDA API version number
 
-.. autoattribute:: cuda.bindings.driver.CU_UUID_HAS_BEEN_DEFINED
-
-    CUDA UUID types
-
 .. autoattribute:: cuda.bindings.driver.CU_IPC_HANDLE_SIZE
 
     CUDA IPC handle size
@@ -6645,7 +6641,6 @@ Data types used by CUDA driver
 
 .. autoattribute:: cuda.bindings.driver.CU_COMPUTE_ACCELERATED_TARGET_BASE
 .. autoattribute:: cuda.bindings.driver.CU_COMPUTE_FAMILY_TARGET_BASE
-.. autoattribute:: cuda.bindings.driver.CUDA_CB
 .. autoattribute:: cuda.bindings.driver.CU_GRAPH_COND_ASSIGN_DEFAULT
 
     Conditional node handle flags Default value is applied when graph is launched.
@@ -8194,7 +8189,6 @@ Green context restrictions apply to memory copy operations only when the copy is
 .. autoclass:: cuda.bindings.driver.CUdevWorkqueueConfigResource
 .. autoclass:: cuda.bindings.driver.CUdevWorkqueueResource
 .. autoclass:: cuda.bindings.driver.CU_DEV_SM_RESOURCE_GROUP_PARAMS
-.. autofunction:: cuda.bindings.driver._CONCAT_OUTER
 .. autofunction:: cuda.bindings.driver.cuGreenCtxCreate
 .. autofunction:: cuda.bindings.driver.cuGreenCtxDestroy
 .. autofunction:: cuda.bindings.driver.cuCtxFromGreenCtx
@@ -8210,10 +8204,6 @@ Green context restrictions apply to memory copy operations only when the copy is
 .. autofunction:: cuda.bindings.driver.cuGreenCtxStreamCreate
 .. autofunction:: cuda.bindings.driver.cuGreenCtxGetId
 .. autofunction:: cuda.bindings.driver.cuStreamGetDevResource
-.. autoattribute:: cuda.bindings.driver.RESOURCE_ABI_VERSION
-.. autoattribute:: cuda.bindings.driver.RESOURCE_ABI_BYTES
-.. autoattribute:: cuda.bindings.driver._CONCAT_INNER
-.. autoattribute:: cuda.bindings.driver._CONCAT_OUTER
 
 Error Log Management Functions
 ------------------------------

--- a/cuda_bindings/docs/source/module/nvrtc.rst
+++ b/cuda_bindings/docs/source/module/nvrtc.rst
@@ -1,8 +1,10 @@
 .. SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
+.. This code was automatically generated with version 13.4.0. Do not modify it directly.
+
 .. !!! WARNING: THIS FILE CONTAINS PRERELEASE APIs !!!
-.. CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=fee6293eae318e5fe3f5cf200d625a833f48885f5cbaf2d6ae3c596d9312f670
+.. CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=e81ae93eee7b54340488dc4be19f2767d6c7316292571214623473e1d8452da7
 -----
 nvrtc
 -----

--- a/cuda_bindings/docs/source/module/runtime.rst
+++ b/cuda_bindings/docs/source/module/runtime.rst
@@ -2,7 +2,7 @@
 .. SPDX-License-Identifier: Apache-2.0
 
 .. !!! WARNING: THIS FILE CONTAINS PRERELEASE APIs !!!
-.. CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=aeabf4d9caf54446607e921c2143746c4bdc69ab464e319ee0091fdce702280f
+.. CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=b2e152b7f88e4586d38b2fe9692dba22ce9eff2fc1186a152c681481bcf3f9f9
 -------
 runtime
 -------
@@ -5397,14 +5397,9 @@ Data types used by CUDA Runtime
 
     Indicates that the layered sparse CUDA array or CUDA mipmapped array has a single mip tail region for all layers
 
-.. autoattribute:: cuda.bindings.runtime.CUDART_CB
 .. autoattribute:: cuda.bindings.runtime.cudaMemPoolCreateUsageHwDecompress
 
     This flag, if set, indicates that the memory will be used as a buffer for hardware accelerated decompression.
-
-.. autoattribute:: cuda.bindings.runtime.CU_UUID_HAS_BEEN_DEFINED
-
-    CUDA UUID types
 
 .. autoattribute:: cuda.bindings.runtime.CUDA_IPC_HANDLE_SIZE
 
@@ -5430,7 +5425,6 @@ Data types used by CUDA Runtime
 
     When /p flags of :py:obj:`~.cudaDeviceGetNvSciSyncAttributes` is set to this, it indicates that application need waiter specific NvSciSyncAttr to be filled by :py:obj:`~.cudaDeviceGetNvSciSyncAttributes`.
 
-.. autoattribute:: cuda.bindings.runtime.RESOURCE_ABI_BYTES
 .. autoattribute:: cuda.bindings.runtime.cudaGraphKernelNodePortDefault
 
     This port activates when the kernel has finished executing.
@@ -5443,14 +5437,11 @@ Data types used by CUDA Runtime
 
     This port activates when all blocks of the kernel have begun execution. See also :py:obj:`~.cudaLaunchAttributeLaunchCompletionEvent`.
 
-.. autoattribute:: cuda.bindings.runtime.cudaStreamAttrID
 .. autoattribute:: cuda.bindings.runtime.cudaStreamAttributeAccessPolicyWindow
 .. autoattribute:: cuda.bindings.runtime.cudaStreamAttributeSynchronizationPolicy
 .. autoattribute:: cuda.bindings.runtime.cudaStreamAttributeMemSyncDomainMap
 .. autoattribute:: cuda.bindings.runtime.cudaStreamAttributeMemSyncDomain
 .. autoattribute:: cuda.bindings.runtime.cudaStreamAttributePriority
-.. autoattribute:: cuda.bindings.runtime.cudaStreamAttrValue
-.. autoattribute:: cuda.bindings.runtime.cudaKernelNodeAttrID
 .. autoattribute:: cuda.bindings.runtime.cudaKernelNodeAttributeAccessPolicyWindow
 .. autoattribute:: cuda.bindings.runtime.cudaKernelNodeAttributeCooperative
 .. autoattribute:: cuda.bindings.runtime.cudaKernelNodeAttributePriority
@@ -5461,7 +5452,6 @@ Data types used by CUDA Runtime
 .. autoattribute:: cuda.bindings.runtime.cudaKernelNodeAttributePreferredSharedMemoryCarveout
 .. autoattribute:: cuda.bindings.runtime.cudaKernelNodeAttributeDeviceUpdatableKernelNode
 .. autoattribute:: cuda.bindings.runtime.cudaKernelNodeAttributeNvlinkUtilCentricScheduling
-.. autoattribute:: cuda.bindings.runtime.cudaKernelNodeAttrValue
 .. autoattribute:: cuda.bindings.runtime.cudaSurfaceType1D
 .. autoattribute:: cuda.bindings.runtime.cudaSurfaceType2D
 .. autoattribute:: cuda.bindings.runtime.cudaSurfaceType3D

--- a/cuda_bindings/docs/source/module/runtime.rst
+++ b/cuda_bindings/docs/source/module/runtime.rst
@@ -1,8 +1,10 @@
 .. SPDX-FileCopyrightText: Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
+.. This code was automatically generated with version 13.4.0. Do not modify it directly.
+
 .. !!! WARNING: THIS FILE CONTAINS PRERELEASE APIs !!!
-.. CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=b2e152b7f88e4586d38b2fe9692dba22ce9eff2fc1186a152c681481bcf3f9f9
+.. CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=1db68a52c789dfc40b5b9e8f58768e090e2668500bed69cf25d90013bdfaef43
 -------
 runtime
 -------

--- a/cuda_bindings/docs/source/release/13.4.0b1-notes.rst
+++ b/cuda_bindings/docs/source/release/13.4.0b1-notes.rst
@@ -1,0 +1,28 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+.. module:: cuda.bindings
+
+``cuda-bindings`` 13.4.0 Release notes
+======================================
+
+Deprecation Notices
+-------------------
+
+* Support for using ``cuda-bindings`` with Python 3.10 is deprecated and will be
+  removed in a future version.  Python 3.10 reaches end of life in October 2026
+  per the `CPython support cycle <https://devguide.python.org/versions/>`_.
+
+Prerelease feature
+------------------
+
+A new version of the ``nvrtc`` API is available as ``cuda.bindings._v2.nvrtc``.  The
+primary improvements are: (1) raising exceptions rather than returning error
+codes, (2) uses PEP8-compliant naming, and (3) more performance.  This API is
+still experimental and subject to change.
+
+Known issues
+------------
+
+* Updating from older versions (v12.6.2.post1 and below) via ``pip install -U cuda-python`` might not work. Please do a clean re-installation by uninstalling ``pip uninstall -y cuda-python`` followed by installing ``pip install cuda-python``.
+* ``nvml.system_get_process_name`` on WSL can return incorrect values.  To work around this, set the locale to "C" before calling ``nvml.device_get_compute_running_processes_v3`` (which sets the process names) and before calling ``nvml.system_get_process_name``. ``cuda_core`` does this automatically, but users of the raw NVML API will need to do this manually.

--- a/cuda_bindings/docs/source/release/13.4.0b1-notes.rst
+++ b/cuda_bindings/docs/source/release/13.4.0b1-notes.rst
@@ -6,6 +6,52 @@
 ``cuda-bindings`` 13.4.0 Release notes
 ======================================
 
+New APIs
+--------
+
+New APIs from CUDA Toolkit 13.4 are now available in ``cuda-bindings``.
+
+New driver API functions:
+
+* :func:`driver.cuDeviceGetFabricClusterUuid`
+* :func:`driver.cuDeviceGetCliqueCount`
+* :func:`driver.cuDeviceGetCliqueInfo`
+* :func:`driver.cuMemGetLocationInfo`
+* :func:`driver.cuGraphAddNode_v3`
+* :func:`driver.cuGraphNodeSetParams_v2`
+* :func:`driver.cuCheckpointOperationComplete`
+
+New runtime API functions:
+
+* :func:`runtime.cudaMemGetLocationInfo`
+
+New cuFile API functions:
+
+* :func:`cufile.readv`
+* :func:`cufile.writev`
+
+New NVML API functions:
+
+* :func:`nvml.system_get_cper_v1`
+* :func:`nvml.device_get_bbx_time_data_v1`
+* :func:`nvml.device_get_accounting_stats_v2`
+* :func:`nvml.device_get_remapped_rows_v2`
+* :func:`nvml.device_set_adaptive_tgp_mode_v1`
+* :func:`nvml.device_get_adaptive_tgp_mode_info_v1`
+* :func:`nvml.device_set_memory_limits_v1`
+* :func:`nvml.device_get_memory_limits_v1`
+* :func:`nvml.device_get_gpu_fabric_info_v4`
+* :func:`nvml.device_perf_metrics_get_samples_v1`
+* :func:`nvml.device_set_nvlink_bw_mode_async_v1`
+* :func:`nvml.device_get_nv_link_telemetry_samples_v1`
+* :func:`nvml.event_set_register_gpu_operational_events_v1`
+* :func:`nvml.event_set_wait_v3`
+* :func:`nvml.event_set_get_context_count_v1`
+* :func:`nvml.event_set_get_context_info_v1`
+* :func:`nvml.event_set_get_gpu_operational_event_context_legacy_xid_v1`
+* :func:`nvml.device_get_bank_remapper_status_v1`
+* :func:`nvml.event_set_get_context_data_v1`
+
 Deprecation Notices
 -------------------
 


### PR DESCRIPTION
The `Release` workflow failed for the 13.4.0b1 tag because:

- It was missing release notes exactly as 13.4.0b1 (not 13.4.0)
- The docs build fail because the docs include references to empty macros from the headers that are not defined in the code