### PR TITLE
Check for release notes on the tagged commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,8 @@ jobs:
     steps:
       - name: Checkout Source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ inputs.git-tag }}
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0


### PR DESCRIPTION
In the release workflow, the release notes are looked for on `main`.  This breaks when releasing from a branch -- `main` may not have that branches release notes.

This fixes the check to look for release notes in the right place.