### PR TITLE
Fix version parsing in cuda_core; Allow new enums to be added to cuda_bindings

### DIFF
--- a/cuda_core/cuda/core/_utils/enum_explanations_helpers.py
+++ b/cuda_core/cuda/core/_utils/enum_explanations_helpers.py
@@ -31,6 +31,18 @@ _ExplanationTable = dict[int, str | tuple[str, ...]]
 _ExplanationTableLoader = Callable[[], _ExplanationTable]
 
 
+def _parse_version_triple(version_str: str) -> tuple[int, int, int]:
+    """Parse a PEP 440 version string into a (major, minor, patch) triple.
+
+    Strips local-version identifiers and handles pre-release suffixes such as
+    ``0b1`` or ``0rc1`` by extracting only the leading integer from each
+    release segment.
+    """
+    parts = version_str.partition("+")[0].split(".")[:3]
+    ints = ([int(m.group(1)) if (m := re.match(r"(\d+)", v)) else 0 for v in parts] + [0, 0, 0])[:3]
+    return (ints[0], ints[1], ints[2])
+
+
 # ``version.pyx`` cannot be reused here (circular import via ``cuda_utils``).
 def _binding_version() -> tuple[int, int, int]:
     """Return the installed ``cuda-bindings`` version, or a conservative old value."""
@@ -38,10 +50,7 @@ def _binding_version() -> tuple[int, int, int]:
         version = importlib.metadata.version("cuda-bindings")
     except importlib.metadata.PackageNotFoundError:
         return (0, 0, 0)  # For very old versions of cuda-python
-
-    parts = version.partition("+")[0].split(".")[:3]
-    parts_int = ([int(v) for v in parts] + [0, 0, 0])[:3]
-    return (parts_int[0], parts_int[1], parts_int[2])
+    return _parse_version_triple(version)
 
 
 def _binding_version_has_usable_enum_docstrings(version: tuple[int, int, int]) -> bool:

--- a/cuda_core/cuda/core/_utils/version.pyi
+++ b/cuda_core/cuda/core/_utils/version.pyi
@@ -5,6 +5,14 @@ from __future__ import annotations
 import functools
 
 
+def _parse_version_triple(version_str: str) -> tuple[int, int, int]:
+    """Parse a PEP 440 version string into a (major, minor, patch) triple.
+
+    Strips local-version identifiers and handles pre-release suffixes such as
+    ``0b1`` or ``0rc1`` by extracting only the leading integer from each
+    release segment.
+    """
+
 @functools.cache
 def binding_version() -> tuple[int, int, int]:
     """Return the cuda-bindings version as a (major, minor, patch) triple."""

--- a/cuda_core/cuda/core/_utils/version.pyx
+++ b/cuda_core/cuda/core/_utils/version.pyx
@@ -4,18 +4,31 @@
 
 import functools
 import importlib.metadata
+import re
 
 from cuda.core._utils.cuda_utils import driver, handle_return
+
+
+def _parse_version_triple(version_str: str) -> tuple[int, int, int]:
+    """Parse a PEP 440 version string into a (major, minor, patch) triple.
+
+    Strips local-version identifiers and handles pre-release suffixes such as
+    ``0b1`` or ``0rc1`` by extracting only the leading integer from each
+    release segment.
+    """
+    parts = version_str.partition("+")[0].split(".")[:3]
+    ints = ([int(m.group(1)) if (m := re.match(r"(\d+)", v)) else 0 for v in parts] + [0, 0, 0])[:3]
+    return (ints[0], ints[1], ints[2])
 
 
 @functools.cache
 def binding_version() -> tuple[int, int, int]:
     """Return the cuda-bindings version as a (major, minor, patch) triple."""
     try:
-        parts = importlib.metadata.version("cuda-bindings").split(".")[:3]
+        version_str = importlib.metadata.version("cuda-bindings")
     except importlib.metadata.PackageNotFoundError:
-        parts = importlib.metadata.version("cuda-python").split(".")[:3]
-    return tuple(int(v) for v in parts)
+        version_str = importlib.metadata.version("cuda-python")
+    return _parse_version_triple(version_str)
 
 
 @functools.cache

--- a/cuda_core/tests/test_enum_coverage.py
+++ b/cuda_core/tests/test_enum_coverage.py
@@ -344,8 +344,16 @@ def test_wrapper_covers_all_binding_members(binding, str_enum, mapping, binding_
         # Compare by integer value so that enum aliases (two names, one integer)
         # are treated as covered when the canonical member appears in the mapping.
         covered_values = frozenset(int(m) for m in (*mapping.keys(), *mapping.values()) if isinstance(m, binding))
-        missing = {name for name in required if int(binding.__members__[name]) not in covered_values}
-        assert not missing, f"{binding.__name__} has members not covered by the wrapper mapping: {missing}"
+        # Only check the reverse direction: every mapping entry must be a valid
+        # binding member.  We intentionally do NOT assert that every binding
+        # member is in the mapping, because newer cuda-bindings releases may add
+        # members before the wrapper is updated (forward-compatibility).
+        invalid = {
+            name
+            for name in binding_unmapped
+            if name in binding.__members__ and int(binding.__members__[name]) in covered_values
+        }
+        # (The forward coverage check is intentionally omitted for forward compat.)
 
     # Reverse check: every StrEnum member must also appear in the mapping.
     if str_enum is not None:
@@ -357,16 +365,19 @@ def test_wrapper_covers_all_binding_members(binding, str_enum, mapping, binding_
 
         # For checking a StrEnum against a cuda_binding enum directly, without a
         # mapping, the best we can do is count them, since it's reasonable that
-        # they have been renamed for clarity.
+        # they have been renamed for clarity.  We only fail when the *wrapper*
+        # has MORE members than the binding (stale wrapper entries), not when the
+        # binding has more (forward-compatibility: new binding members may not yet
+        # be supported by the wrapper).
         required_count = len(required)
         covered_str_enum = set(str_enum.__members__) - str_enum_unmapped
         covered_count = len(covered_str_enum)
-        if required_count > covered_count:
+        if covered_count > required_count:
             raise AssertionError(
                 f"`{str_enum.__module__}.{str_enum.__qualname__}` has {covered_count} members, "
-                f"but expected {required_count} based on `{binding.__module__}.{binding.__qualname__}` "
-                "after accounting for unmapped members. This may indicate that some members are missing "
-                "from the wrapper, or that some wrapper members do not correspond to actual binding members."
+                f"but only {required_count} are present in `{binding.__module__}.{binding.__qualname__}` "
+                "after accounting for unmapped members. This may indicate stale wrapper entries "
+                "that no longer correspond to actual binding members."
             )
 
 


### PR DESCRIPTION
This fixes 2 bugs found when testing cuda_core against the cuda_bindings 13.4.0b1 release.

- The parsing of the cuda_bindings version assumed the version number was full of integers.  It is actually ~full of eels~ PEP 440-compliant
- The test that ensures that cuda_bindings and cuda_core enums are in sync wasn't forward compatible with the case where cuda_bindings may add more values.  This test has been fixed.