### PR TITLE
Add identity preserving pattern to critical_sections

### DIFF
--- a/cuda_core/cuda/core/_linker.pyx
+++ b/cuda_core/cuda/core/_linker.pyx
@@ -701,8 +701,8 @@ def _decide_nvjitlink_or_driver() -> bool:
         )
 
     warn(warn_txt, stacklevel=2, category=RuntimeWarning)
-    _use_nvjitlink_backend = False
     _driver = driver
+    _use_nvjitlink_backend = False
     return True
 
 

--- a/cuda_core/cuda/core/_memory/_buffer.pyx
+++ b/cuda_core/cuda/core/_memory/_buffer.pyx
@@ -272,8 +272,11 @@ cdef class Buffer:
     @cython.critical_section
     def ipc_descriptor(self) -> IPCBufferDescriptor:
         """Descriptor for sharing this buffer with other processes."""
+        cdef object ipc_data
         if self._ipc_data is None:
-            self._ipc_data = IPCDataForBuffer(_ipc.Buffer_get_ipc_descriptor(self), False)
+            ipc_data = IPCDataForBuffer(_ipc.Buffer_get_ipc_descriptor(self), False)
+            if self._ipc_data is None:
+                self._ipc_data = ipc_data
         return self._ipc_data.ipc_descriptor
 
     def close(self, stream: Stream | GraphBuilder | None = None) -> None:

--- a/cuda_core/cuda/core/_memory/_memory_pool.pyx
+++ b/cuda_core/cuda/core/_memory/_memory_pool.pyx
@@ -183,8 +183,11 @@ cdef class _MemPool(MemoryResource):
     @cython.critical_section
     def attributes(self) -> _MemPoolAttributes:
         """Memory pool attributes."""
+        cdef _MemPoolAttributes attributes
         if self._attributes is None:
-            self._attributes = _MemPoolAttributes._init(self._h_pool)
+            attributes = _MemPoolAttributes._init(self._h_pool)
+            if self._attributes is None:
+                self._attributes = attributes
         return self._attributes
 
     @property

--- a/cuda_core/cuda/core/_memoryview.pyx
+++ b/cuda_core/cuda/core/_memoryview.pyx
@@ -544,13 +544,16 @@ cdef class StridedMemoryView:
 
     @cython.critical_section
     cdef inline _StridedLayout get_layout(self):
+        cdef _StridedLayout layout
         if self._layout is None:
             if self.dl_tensor:
-                self._layout = layout_from_dlpack(self.dl_tensor)
+                layout = layout_from_dlpack(self.dl_tensor)
             elif self.metadata is not None:
-                self._layout = layout_from_cai(self.metadata)
+                layout = layout_from_cai(self.metadata)
             else:
                 raise ValueError("Cannot infer layout from the exporting object")
+            if self._layout is None:
+                self._layout = layout
         return self._layout
 
     @cython.critical_section
@@ -560,24 +563,31 @@ cdef class StridedMemoryView:
         If the SMV was created from a Buffer, it will return the same Buffer instance.
         Otherwise, it will create a new instance with owner set to the exporting object.
         """
+        cdef object buffer
         if self._buffer is None:
             if isinstance(self.exporting_obj, Buffer):
-                self._buffer = self.exporting_obj
+                buffer = self.exporting_obj
             else:
-                self._buffer = Buffer.from_handle(self.ptr, 0, owner=self.exporting_obj)
+                buffer = Buffer.from_handle(self.ptr, 0, owner=self.exporting_obj)
+            if self._buffer is None:
+                self._buffer = buffer
         return self._buffer
 
     @cython.critical_section
     cdef inline object get_dtype(self):
+        cdef object dtype
         if self._dtype is None:
+            dtype = None
             if self.dl_tensor != NULL:
-                self._dtype = dtype_dlpack_to_numpy(&self.dl_tensor.dtype)
+                dtype = dtype_dlpack_to_numpy(&self.dl_tensor.dtype)
             elif isinstance(self.metadata, int):
                 # AOTI dtype code stored by the torch tensor bridge
-                self._dtype = _get_tensor_bridge().resolve_aoti_dtype(
+                dtype = _get_tensor_bridge().resolve_aoti_dtype(
                     self.metadata)
             elif self.metadata is not None:
-                self._dtype = _typestr2dtype(self.metadata["typestr"])
+                dtype = _typestr2dtype(self.metadata["typestr"])
+            if self._dtype is None:
+                self._dtype = dtype
         return self._dtype
 
 

--- a/cuda_core/cuda/core/_module.pxd
+++ b/cuda_core/cuda/core/_module.pxd
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from libcpp.mutex cimport py_safe_once_flag
+
 from cuda.bindings cimport cydriver
 from cuda.core._resource_handles cimport LibraryHandle, KernelHandle
 
@@ -32,6 +34,7 @@ cdef class ObjectCode:
         object _module      # bytes/str source
         dict _sym_map
         str _name
+        py_safe_once_flag _load_once
         object __weakref__
 
     cdef int _lazy_load_module(self) except -1

--- a/cuda_core/cuda/core/_module.pyx
+++ b/cuda_core/cuda/core/_module.pyx
@@ -7,6 +7,7 @@ from __future__ import annotations
 cimport cython
 from libc.stddef cimport size_t
 from libc.stdint cimport intptr_t
+from libcpp.mutex cimport py_safe_call_once
 
 from collections import namedtuple
 from os import fsencode, fspath, PathLike
@@ -590,6 +591,31 @@ CodeTypeT = bytes | bytearray | str
 
 cdef tuple _supported_code_type = tuple(ObjectCodeFormatType.__members__.values())
 
+
+cdef void _lazy_load_module_once(void *self_v) except *:
+    # Call-once helper for the lazy module loading, we want to avoid unloading
+    # a module in case of threads racing, so use `call_once`.
+    cdef ObjectCode self = <ObjectCode>self_v
+    cdef LibraryHandle h_library
+    cdef bytes path_bytes
+    module = self._module
+    if isinstance(module, str):
+        path_bytes = module.encode()
+        h_library = create_library_handle_from_file(<const char*>path_bytes)
+    elif isinstance(module, (bytes, bytearray)):
+        h_library = create_library_handle_from_data(<const void*><char*>module)
+    elif isinstance(module, PathLike):
+        path_bytes = fsencode(module)
+        h_library = create_library_handle_from_file(<const char*>path_bytes)
+    else:
+        assert_type_str_or_bytes_like(module)
+        raise_code_path_meant_to_be_unreachable()
+        return
+    if not h_library:
+        HANDLE_RETURN(get_last_error())
+    self._h_library = h_library
+
+
 cdef class ObjectCode:
     """Represent a compiled program to be loaded onto the device.
 
@@ -752,30 +778,8 @@ cdef class ObjectCode:
 
     # TODO: do we want to unload in a finalizer? Probably not..
 
-    @cython.critical_section
     cdef int _lazy_load_module(self) except -1:
-        cdef LibraryHandle _h_library
-        if self._h_library:
-            return 0
-        module = self._module
-        cdef bytes path_bytes
-        if isinstance(module, str):
-            path_bytes = module.encode()
-            _h_library = create_library_handle_from_file(<const char*>path_bytes)
-        elif isinstance(module, (bytes, bytearray)):
-            _h_library = create_library_handle_from_data(<const void*><char*>module)
-        elif isinstance(module, PathLike):
-            path_bytes = fsencode(module)
-            _h_library = create_library_handle_from_file(<const char*>path_bytes)
-        else:
-            assert_type_str_or_bytes_like(module)
-            raise_code_path_meant_to_be_unreachable()
-            return -1
-        if not _h_library:
-            HANDLE_RETURN(get_last_error())
-
-        if not self._h_library:
-            self._h_library = _h_library
+        py_safe_call_once(self._load_once, _lazy_load_module_once, <void *>self)
         return 0
 
     def get_kernel(self, name: str | bytes) -> Kernel:

--- a/cuda_core/cuda/core/_module.pyx
+++ b/cuda_core/cuda/core/_module.pyx
@@ -459,8 +459,11 @@ cdef class Kernel:
     @cython.critical_section
     def attributes(self) -> KernelAttributes:
         """Get the read-only attributes of this kernel."""
+        cdef KernelAttributes attributes
         if self._attributes is None:
-            self._attributes = KernelAttributes._init(self._h_kernel)
+            attributes = KernelAttributes._init(self._h_kernel)
+            if self._attributes is None:
+                self._attributes = attributes
         return self._attributes
 
     cdef tuple _get_arguments_info(self, bint param_info=False):
@@ -507,8 +510,11 @@ cdef class Kernel:
     @cython.critical_section
     def occupancy(self) -> KernelOccupancy:
         """Get the occupancy information for launching this kernel."""
+        cdef KernelOccupancy occupancy
         if self._occupancy is None:
-            self._occupancy = KernelOccupancy._init(self._h_kernel)
+            occupancy = KernelOccupancy._init(self._h_kernel)
+            if self._occupancy is None:
+                self._occupancy = occupancy
         return self._occupancy
 
     @property
@@ -748,24 +754,28 @@ cdef class ObjectCode:
 
     @cython.critical_section
     cdef int _lazy_load_module(self) except -1:
+        cdef LibraryHandle _h_library
         if self._h_library:
             return 0
         module = self._module
         cdef bytes path_bytes
         if isinstance(module, str):
             path_bytes = module.encode()
-            self._h_library = create_library_handle_from_file(<const char*>path_bytes)
+            _h_library = create_library_handle_from_file(<const char*>path_bytes)
         elif isinstance(module, (bytes, bytearray)):
-            self._h_library = create_library_handle_from_data(<const void*><char*>module)
+            _h_library = create_library_handle_from_data(<const void*><char*>module)
         elif isinstance(module, PathLike):
             path_bytes = fsencode(module)
-            self._h_library = create_library_handle_from_file(<const char*>path_bytes)
+            _h_library = create_library_handle_from_file(<const char*>path_bytes)
         else:
             assert_type_str_or_bytes_like(module)
             raise_code_path_meant_to_be_unreachable()
             return -1
-        if not self._h_library:
+        if not _h_library:
             HANDLE_RETURN(get_last_error())
+
+        if not self._h_library:
+            self._h_library = _h_library
         return 0
 
     def get_kernel(self, name: str | bytes) -> Kernel:

--- a/cuda_core/cuda/core/_program.pyx
+++ b/cuda_core/cuda/core/_program.pyx
@@ -649,12 +649,10 @@ def _get_nvvm_module() -> object:
     """Get the NVVM module, importing it lazily with availability checks."""
     global _nvvm_module, _nvvm_import_attempted
 
-    if _nvvm_import_attempted:
-        if _nvvm_module is None:
-            raise RuntimeError("NVVM module is not available (previous import attempt failed)")
+    if _nvvm_module is not None:
         return _nvvm_module
-
-    _nvvm_import_attempted = True
+    if _nvvm_import_attempted:
+        raise RuntimeError("NVVM module is not available (previous import attempt failed)")
 
     try:
         version = binding_version()
@@ -678,7 +676,9 @@ def _get_nvvm_module() -> object:
 
     except RuntimeError:
         _nvvm_module = None
+        _nvvm_import_attempted = True
         raise
+
 
 def _find_libdevice_path() -> object:
     """Find libdevice*.bc for NVVM compilation using cuda.pathfinder."""


### PR DESCRIPTION
Split from gh-2194 just to shrink it a bit.

These commits are straight-forward and an attempt to guarantee identity results (not a single creation of the internal object). One of these ran into an issue in the tests.  It probably doesn't matter for most, but it also doesn't hurt.

To explain what is going on: Critical sections are like the GIL.  When we call arbitrary Python code they can be _suspended_ (they definitely will be suspended in `with nogil:`, i.e. when the Python thread-state is detached!).

So, the callbacks can run in multiple threads, but after that we double-check and `if self.attr is None: self.attr = obj` is all pure C code, so only one thread can hold the critical section lock for that chunk of code.