### PR TITLE
fix(cuda.core): surface real CUDA error in Device.set_current()

### DIFF
--- a/cuda_core/cuda/core/_device.pyx
+++ b/cuda_core/cuda/core/_device.pyx
@@ -1289,7 +1289,10 @@ class Device:
             # use primary ctx
             h_context = get_primary_context(self._device_id)
             if h_context.get() == NULL:
-                raise ValueError("Cannot set NULL context as current")
+                HANDLE_RETURN(get_last_error())
+                raise RuntimeError(
+                    f"Failed to retain the primary context for device {self._device_id}"
+                )
             with nogil:
                 HANDLE_RETURN(cydriver.cuCtxSetCurrent(as_cu(h_context)))
             self._has_inited = True


### PR DESCRIPTION
closes #2460

Device.set_current() raised a misleading ValueError ("Cannot set NULL
context as current") when cuDevicePrimaryCtxRetain failed, discarding
the actual driver error code and leaving the thread-local error state
polluted.

Replace with HANDLE_RETURN(get_last_error()) to raise CUDAError with
the real driver status, matching the established pattern used elsewhere.

Manually verified by patching get_primary_context to return a failure;
a regression test is not practical because the failure requires
exclusive compute mode (unavailable on WDDM) or hardware error states
that cannot be simulated from Python.