### PR TITLE
fix(ci): avoid pipefail in ci.yaml shell code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,9 +257,9 @@ jobs:
           # --paginate fetches all pages; jq outputs one name per line per page;
           # head -1 takes the first (newest) match since GitHub returns tags
           # newest-first. Fails hard if no cuda-core-v* tag is found.
-          tag="$(gh api "repos/$GITHUB_REPOSITORY/tags" --paginate \
-            --jq '.[] | select(.name | startswith("cuda-core-v")) | .name' \
-            | head -1)"
+          mapfile -t _tags < <(gh api "repos/$GITHUB_REPOSITORY/tags" --paginate \
+            --jq '.[] | select(.name | startswith("cuda-core-v")) | .name' || true)
+          tag="${_tags[0]:-}"
           if [[ -z "${tag}" ]]; then
             echo "::error::No cuda-core-v* tag found in the repository." >&2
             exit 1


### PR DESCRIPTION
Issue: ci failures like [this](https://github.com/NVIDIA/cuda-python/actions/runs/30581324426/job/91023469937?pr=2458) 

The CI failure is a classic **SIGPIPE + `pipefail`** interaction.

The original code pipes `gh api --paginate` into `head -1`. Under `bash -o pipefail`
(set by the shell option in the step), when `head -1` reads one line and exits, it
closes the pipe. `gh api` then receives SIGPIPE (exit 141), and `pipefail` propagates
that non-zero exit code through the command substitution, causing the step to fail
under `set -e`.

The fix avoids this by:

1. Collecting all output into an array via `mapfile` (no pipe to break).
2. Using `|| true` to suppress any transient `gh api` exit code from the process substitution.
3. Taking the first element with `${_tags[0]:-}` instead of `head -1`.