### PR TITLE
cuda.core: Add conditional retry when default mempool reservation fails with OOM

### DIFF
--- a/cuda_core/cuda/core/_cpp/resource_handles.cpp
+++ b/cuda_core/cuda/core/_cpp/resource_handles.cpp
@@ -34,6 +34,7 @@ namespace cuda_core {
 decltype(&cuDevicePrimaryCtxRetain) p_cuDevicePrimaryCtxRetain = nullptr;
 decltype(&cuDevicePrimaryCtxRelease) p_cuDevicePrimaryCtxRelease = nullptr;
 decltype(&cuCtxGetCurrent) p_cuCtxGetCurrent = nullptr;
+decltype(&cuCtxSynchronize) p_cuCtxSynchronize = nullptr;
 decltype(&cuGreenCtxCreate) p_cuGreenCtxCreate = nullptr;
 decltype(&cuGreenCtxDestroy) p_cuGreenCtxDestroy = nullptr;
 decltype(&cuCtxFromGreenCtx) p_cuCtxFromGreenCtx = nullptr;
@@ -888,6 +889,24 @@ MemoryPoolHandle create_mempool_handle_ref(CUmemoryPool pool) {
 MemoryPoolHandle get_device_mempool(int device_id) {
     GILReleaseGuard gil;
     CUmemoryPool pool;
+    if (CUDA_SUCCESS == (err = p_cuDeviceGetMemPool(&pool, device_id))) {
+        return create_mempool_handle_ref(pool);
+    }
+    if (err != CUDA_ERROR_OUT_OF_MEMORY) {
+        return {};
+    }
+
+    // A pool's virtual address reservation is only returned once the pool is
+    // torn down, and teardown waits on the stream-ordered frees of its
+    // outstanding allocations. A pool still awaiting those frees holds address
+    // space that is recoverable but not yet recovered, which is enough to fail
+    // this lookup wherever address space is scarce. Drain outstanding work once
+    // and retry before reporting exhaustion.
+    if (CUDA_SUCCESS != p_cuCtxSynchronize()) {
+        // Report why the pool is unavailable, not why the drain failed.
+        err = CUDA_ERROR_OUT_OF_MEMORY;
+        return {};
+    }
     if (CUDA_SUCCESS != (err = p_cuDeviceGetMemPool(&pool, device_id))) {
         return {};
     }

--- a/cuda_core/cuda/core/_cpp/resource_handles.hpp
+++ b/cuda_core/cuda/core/_cpp/resource_handles.hpp
@@ -67,6 +67,7 @@ void clear_last_error() noexcept;
 extern decltype(&cuDevicePrimaryCtxRetain) p_cuDevicePrimaryCtxRetain;
 extern decltype(&cuDevicePrimaryCtxRelease) p_cuDevicePrimaryCtxRelease;
 extern decltype(&cuCtxGetCurrent) p_cuCtxGetCurrent;
+extern decltype(&cuCtxSynchronize) p_cuCtxSynchronize;
 extern decltype(&cuGreenCtxCreate) p_cuGreenCtxCreate;
 extern decltype(&cuGreenCtxDestroy) p_cuGreenCtxDestroy;
 extern decltype(&cuCtxFromGreenCtx) p_cuCtxFromGreenCtx;

--- a/cuda_core/cuda/core/_resource_handles.pyx
+++ b/cuda_core/cuda/core/_resource_handles.pyx
@@ -281,6 +281,7 @@ cdef extern from "_cpp/resource_handles.hpp" namespace "cuda_core":
     void* p_cuDevicePrimaryCtxRetain "reinterpret_cast<void*&>(cuda_core::p_cuDevicePrimaryCtxRetain)"
     void* p_cuDevicePrimaryCtxRelease "reinterpret_cast<void*&>(cuda_core::p_cuDevicePrimaryCtxRelease)"
     void* p_cuCtxGetCurrent "reinterpret_cast<void*&>(cuda_core::p_cuCtxGetCurrent)"
+    void* p_cuCtxSynchronize "reinterpret_cast<void*&>(cuda_core::p_cuCtxSynchronize)"
     void* p_cuGreenCtxCreate "reinterpret_cast<void*&>(cuda_core::p_cuGreenCtxCreate)"
     void* p_cuGreenCtxDestroy "reinterpret_cast<void*&>(cuda_core::p_cuGreenCtxDestroy)"
     void* p_cuCtxFromGreenCtx "reinterpret_cast<void*&>(cuda_core::p_cuCtxFromGreenCtx)"
@@ -383,6 +384,7 @@ cdef void* _get_optional_driver_fn(str name):
 
 cdef void _init_driver_fn_pointers() noexcept:
     global p_cuDevicePrimaryCtxRetain, p_cuDevicePrimaryCtxRelease, p_cuCtxGetCurrent
+    global p_cuCtxSynchronize
     global p_cuGreenCtxCreate, p_cuGreenCtxDestroy, p_cuCtxFromGreenCtx
     global p_cuDevResourceGenerateDesc, p_cuGreenCtxStreamCreate
     global p_cuStreamCreateWithPriority, p_cuStreamDestroy
@@ -410,6 +412,7 @@ cdef void _init_driver_fn_pointers() noexcept:
     p_cuDevicePrimaryCtxRetain = _get_driver_fn("cuDevicePrimaryCtxRetain")
     p_cuDevicePrimaryCtxRelease = _get_driver_fn("cuDevicePrimaryCtxRelease")
     p_cuCtxGetCurrent = _get_driver_fn("cuCtxGetCurrent")
+    p_cuCtxSynchronize = _get_driver_fn("cuCtxSynchronize")
     p_cuGreenCtxCreate = _get_optional_driver_fn("cuGreenCtxCreate")
     p_cuGreenCtxDestroy = _get_optional_driver_fn("cuGreenCtxDestroy")
     p_cuCtxFromGreenCtx = _get_optional_driver_fn("cuCtxFromGreenCtx")

--- a/cuda_core/tests/test_mempool_oom_retry.py
+++ b/cuda_core/tests/test_mempool_oom_retry.py
@@ -3,10 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Regression test for the deferred-release retry in ``get_device_mempool``.
 
-Issue #2381: the driver reserves virtual address space per memory pool -- on
-Windows MCDM roughly 2x device memory against a 40-bit (1 TiB) cap -- so pools
-that are awaiting teardown can starve the *default* pool's reservation. cuda.core
-then reports ``CUDA_ERROR_OUT_OF_MEMORY`` on a device with ample free memory.
+Issue #2381: each memory pool reserves virtual address space scaling with device
+memory, and the per-process budget is bounded (notably ~1 TB on Windows MCDM), so
+pools awaiting teardown can starve the *default* pool's reservation. cuda.core then
+reports ``CUDA_ERROR_OUT_OF_MEMORY`` on a device with ample free memory.
 
 A pool's address space comes back only once the pool is destroyed, and
 ``cuMemPoolDestroy`` waits on the stream-ordered frees of the pool's outstanding
@@ -22,6 +22,8 @@ fail, so a process that has already touched it could never reproduce the failure
 from __future__ import annotations
 
 import multiprocessing as _mp
+import queue
+import traceback
 
 import pytest
 from helpers.child_processes import child_timeout_sec, kill_subprocesses
@@ -39,14 +41,17 @@ NO_EXHAUSTION = "no-exhaustion"
 NOT_DEFERRED = "not-deferred"
 RECOVERED = "recovered"
 NOT_RECOVERED = "not-recovered"
+UNSUPPORTED = "unsupported"
+CRASHED = "crashed"
+TIMED_OUT = "timed-out"
 
 
-def _worker_deferred_release(result_queue):
+def _run_deferred_release():
     """Drive a default-pool lookup into deferred-release failure, then retry it.
 
-    Reports one of the module-level outcome strings so the parent can tell a
-    genuine regression apart from a machine whose address space is too large to
-    exhaust.
+    Returns an ``(outcome, detail)`` pair using the module-level outcome strings,
+    so the parent can tell a genuine regression apart from a machine that cannot
+    run this at all.
     """
     import gc
     import time
@@ -57,14 +62,17 @@ def _worker_deferred_release(result_queue):
     from cuda.core import Device, DeviceMemoryResource, DeviceMemoryResourceOptions
     from cuda.core._utils.cuda_utils import CUDAError
 
+    device = Device(0)
+    device.set_current()
+    if not device.properties.memory_pools_supported:
+        return UNSUPPORTED, "Device does not support mempool operations"
+
+    err, dev = driver.cuDeviceGet(0)
+    assert err == driver.CUresult.CUDA_SUCCESS, err
+
     def default_pool_available():
         err, _pool = driver.cuDeviceGetMemPool(dev)
         return err == driver.CUresult.CUDA_SUCCESS
-
-    device = Device(0)
-    device.set_current()
-    err, dev = driver.cuDeviceGet(0)
-    assert err == driver.CUresult.CUDA_SUCCESS, err
 
     # Build everything before the address space is gone; afterwards even kernel
     # compilation could fail for unrelated reasons.
@@ -74,25 +82,34 @@ def _worker_deferred_release(result_queue):
 
     pools = []
     buffers = []
+    # Stop well inside the parent's timeout. An address space too large to
+    # exhaust -- WSL, for one -- would otherwise grind through thousands of pool
+    # creations until the parent gave up, failing the run instead of skipping it.
+    deadline = time.monotonic() + child_timeout_sec() / 2
 
     def reserve_until_oom(pool_bytes):
         options = DeviceMemoryResourceOptions(max_size=pool_bytes)
         for _ in range(MAX_POOLS_PER_PASS):
+            if time.monotonic() > deadline:
+                return
             try:
                 mr = DeviceMemoryResource(device, options=options)
+                # An empty pool is torn down immediately, which is the one case
+                # that cannot defer anything, so hold an allocation to force
+                # teardown to wait. Exhaustion frequently surfaces here rather
+                # than at construction, so both must share this guard -- an
+                # unguarded allocate kills the whole child process.
+                buffer = mr.allocate(1024, stream=dealloc_stream)
             except (CUDAError, RuntimeError):
                 return
-            # An empty pool is torn down immediately, which is the one case that
-            # cannot defer anything. Hold an allocation so teardown must wait.
-            buffers.append(mr.allocate(1024, stream=dealloc_stream))
             pools.append(mr)
+            buffers.append(buffer)
 
     reserve_until_oom(POOL_BYTES_COARSE)
     reserve_until_oom(POOL_BYTES_FINE)
 
     if default_pool_available():
-        result_queue.put((NO_EXHAUSTION, len(pools)))
-        return
+        return NO_EXHAUSTION, f"{len(pools)} pools reserved, default pool still available"
 
     # Stall the deallocation stream behind a slow kernel on another stream, so
     # the frees below cannot retire until the context is drained.
@@ -105,8 +122,7 @@ def _worker_deferred_release(result_queue):
 
     if default_pool_available():
         # Release outran us; there was no deferred window to recover from.
-        result_queue.put((NOT_DEFERRED, len(pools)))
-        return
+        return NOT_DEFERRED, None
 
     # The raw lookup just failed, so anything the retried lookup achieves below
     # is attributable to the retry itself -- no cross-build comparison needed.
@@ -116,9 +132,20 @@ def _worker_deferred_release(result_queue):
     try:
         DeviceMemoryResource(device)
     except (CUDAError, RuntimeError) as exc:
-        result_queue.put((NOT_RECOVERED, repr(exc)))
-        return
-    result_queue.put((RECOVERED, time.perf_counter() - started))
+        return NOT_RECOVERED, repr(exc)
+    return RECOVERED, time.perf_counter() - started
+
+
+def _worker_deferred_release(result_queue):
+    """Always report an outcome, so a crash surfaces as a diagnosis.
+
+    Without this the parent would block until its timeout and raise a bare
+    ``queue.Empty``, hiding whatever actually went wrong in the child.
+    """
+    try:
+        result_queue.put(_run_deferred_release())
+    except BaseException:
+        result_queue.put((CRASHED, traceback.format_exc()))
 
 
 @pytest.mark.agent_authored(model="claude-opus-5")
@@ -130,16 +157,22 @@ def test_default_mempool_lookup_recovers_from_deferred_release():
     proc.start()
     try:
         outcome, detail = result_queue.get(timeout=child_timeout_sec())
+    except queue.Empty:
+        outcome, detail = TIMED_OUT, f"child produced no result within {child_timeout_sec()}s"
     finally:
         proc.join(timeout=child_timeout_sec())
         survivors = kill_subprocesses(proc)
-    assert not survivors, "child process did not exit"
 
+    if outcome == UNSUPPORTED:
+        pytest.skip(detail)
     if outcome == NO_EXHAUSTION:
-        pytest.skip(f"could not exhaust the address space; reserved {detail} pools")
+        pytest.skip(f"could not exhaust the address space: {detail}")
     if outcome == NOT_DEFERRED:
         pytest.skip("pool release completed too quickly to leave a deferred window")
-    assert outcome == RECOVERED, f"default pool lookup did not recover: {detail}"
+
+    assert outcome == RECOVERED, f"{outcome}: {detail}"
+    assert not survivors, "child process did not exit"
+
     # Recovery had to wait out the blocking kernel. Returning much faster would
     # mean the lookup succeeded for some reason other than draining the context,
     # leaving this test passing without exercising the retry.

--- a/cuda_core/tests/test_mempool_oom_retry.py
+++ b/cuda_core/tests/test_mempool_oom_retry.py
@@ -26,6 +26,7 @@ import queue
 import traceback
 
 import pytest
+from helpers import IS_WSL
 from helpers.child_processes import child_timeout_sec, kill_subprocesses
 
 # Fill coarsely first, then top up finely. A single pool size cannot do both:
@@ -206,6 +207,9 @@ def _worker_deferred_release(result_queue):
 
 @pytest.mark.agent_authored(model="claude-opus-5")
 @pytest.mark.thread_unsafe(reason="Reserves the device's entire virtual address space.")
+# Must be pre-spawn: the budgets below are checked between operations, and under
+# WSL control never returns to Python for them to run.
+@pytest.mark.skipif(IS_WSL, reason="child blocks in the CUDA driver; in-child budgets cannot preempt it")
 def test_default_mempool_lookup_recovers_from_deferred_release():
     ctx = _mp.get_context("spawn")
     result_queue = ctx.Queue()

--- a/cuda_core/tests/test_mempool_oom_retry.py
+++ b/cuda_core/tests/test_mempool_oom_retry.py
@@ -34,16 +34,55 @@ from helpers.child_processes import child_timeout_sec, kill_subprocesses
 # but would need far too many to cover a 48-bit space.
 POOL_BYTES_COARSE = 64 * 1024**3
 POOL_BYTES_FINE = 1024**3
-MAX_POOLS_PER_PASS = 4096
 BLOCK_MS = 2000
 
+# The cost that matters is the number of pools, not their size: every one has to
+# be created, then destroyed again with its stream-ordered free queued behind the
+# blocking kernel. This cap bounds both halves. A machine needing more than this
+# to exhaust its address space skips instead, which is how large-address-space
+# environments (WSL, for one) opt out without naming a platform.
+MAX_POOLS_TOTAL = 512
+# Ceiling for the address-space probe, reached by doubling from 1 GiB.
+VA_PROBE_LIMIT = 256 * 1024**4
+VA_ALIGNMENT = 2 * 1024**2
+
+# Outcomes meaning this machine cannot host the probe, so there is nothing to
+# assert. The parent skips on all of these.
+UNSUPPORTED = "unsupported"
+ADDRESS_SPACE_TOO_LARGE = "address-space-too-large"
 NO_EXHAUSTION = "no-exhaustion"
+BUDGET_EXPIRED = "budget-expired"
 NOT_DEFERRED = "not-deferred"
+SKIP_OUTCOMES = frozenset({UNSUPPORTED, ADDRESS_SPACE_TOO_LARGE, NO_EXHAUSTION, BUDGET_EXPIRED, NOT_DEFERRED})
+
+# Outcomes meaning the probe actually ran. The parent asserts on these.
 RECOVERED = "recovered"
 NOT_RECOVERED = "not-recovered"
-UNSUPPORTED = "unsupported"
 CRASHED = "crashed"
-TIMED_OUT = "timed-out"
+
+# Parent-side only: the child never reported anything, so its own budgets failed
+# to keep it inside the timeout. Distinct from BUDGET_EXPIRED, where the child
+# recognised it was out of time and bowed out cleanly -- that skips, this fails.
+NO_RESULT = "no-result"
+
+
+def _largest_va_reservation(driver):
+    """Largest single VA range that can be reserved, found by doubling.
+
+    A reservation costs address space but no physical memory, so this is cheap.
+    It is a lower bound on the total space, which is all that is needed to decide
+    whether exhausting it is affordable.
+    """
+    largest = 0
+    size = 1024**3
+    while size <= VA_PROBE_LIMIT:
+        err, ptr = driver.cuMemAddressReserve(size, VA_ALIGNMENT, 0, 0)
+        if err != driver.CUresult.CUDA_SUCCESS:
+            break
+        driver.cuMemAddressFree(ptr, size)
+        largest = size
+        size *= 2
+    return largest
 
 
 def _run_deferred_release():
@@ -70,6 +109,14 @@ def _run_deferred_release():
     err, dev = driver.cuDeviceGet(0)
     assert err == driver.CUresult.CUDA_SUCCESS, err
 
+    # Decide up front whether exhausting this address space is affordable, rather
+    # than discovering it by running out of budget partway through.
+    va_bytes = _largest_va_reservation(driver)
+    if va_bytes // POOL_BYTES_COARSE > MAX_POOLS_TOTAL:
+        return ADDRESS_SPACE_TOO_LARGE, (
+            f"address space of at least {va_bytes / 1024**4:.1f} TiB needs over {MAX_POOLS_TOTAL} pools to exhaust"
+        )
+
     def default_pool_available():
         err, _pool = driver.cuDeviceGetMemPool(dev)
         return err == driver.CUresult.CUDA_SUCCESS
@@ -82,15 +129,22 @@ def _run_deferred_release():
 
     pools = []
     buffers = []
-    # Stop well inside the parent's timeout. An address space too large to
-    # exhaust -- WSL, for one -- would otherwise grind through thousands of pool
-    # creations until the parent gave up, failing the run instead of skipping it.
-    deadline = time.monotonic() + child_timeout_sec() / 2
+    # Stay well inside the parent's timeout, in two stages. Reserving stops at
+    # the first deadline; the deferred-release phase that follows is expensive in
+    # its own right (destroying every pool, waiting out the blocking kernel, then
+    # retrying), so if that cannot also fit we skip instead of letting the parent
+    # time out. Capping only the reservation loop is not enough -- a large address
+    # space produces thousands of pools whose teardown alone overruns the budget.
+    budget = child_timeout_sec()
+    reserve_deadline = time.monotonic() + budget / 3
+    recovery_deadline = time.monotonic() + budget / 2
 
     def reserve_until_oom(pool_bytes):
         options = DeviceMemoryResourceOptions(max_size=pool_bytes)
-        for _ in range(MAX_POOLS_PER_PASS):
-            if time.monotonic() > deadline:
+        # The cap is shared across both passes: it bounds total teardown cost, so
+        # splitting it per pass would let the two together exceed the budget.
+        while len(pools) < MAX_POOLS_TOTAL:
+            if time.monotonic() > reserve_deadline:
                 return
             try:
                 mr = DeviceMemoryResource(device, options=options)
@@ -110,6 +164,8 @@ def _run_deferred_release():
 
     if default_pool_available():
         return NO_EXHAUSTION, f"{len(pools)} pools reserved, default pool still available"
+    if time.monotonic() > recovery_deadline:
+        return BUDGET_EXPIRED, f"exhausted with {len(pools)} pools, too slow to also test recovery"
 
     # Stall the deallocation stream behind a slow kernel on another stream, so
     # the frees below cannot retire until the context is drained.
@@ -122,7 +178,7 @@ def _run_deferred_release():
 
     if default_pool_available():
         # Release outran us; there was no deferred window to recover from.
-        return NOT_DEFERRED, None
+        return NOT_DEFERRED, "pool release completed before the retry could be tested"
 
     # The raw lookup just failed, so anything the retried lookup achieves below
     # is attributable to the retry itself -- no cross-build comparison needed.
@@ -158,17 +214,13 @@ def test_default_mempool_lookup_recovers_from_deferred_release():
     try:
         outcome, detail = result_queue.get(timeout=child_timeout_sec())
     except queue.Empty:
-        outcome, detail = TIMED_OUT, f"child produced no result within {child_timeout_sec()}s"
+        outcome, detail = NO_RESULT, f"child produced no result within {child_timeout_sec()}s"
     finally:
         proc.join(timeout=child_timeout_sec())
         survivors = kill_subprocesses(proc)
 
-    if outcome == UNSUPPORTED:
-        pytest.skip(detail)
-    if outcome == NO_EXHAUSTION:
-        pytest.skip(f"could not exhaust the address space: {detail}")
-    if outcome == NOT_DEFERRED:
-        pytest.skip("pool release completed too quickly to leave a deferred window")
+    if outcome in SKIP_OUTCOMES:
+        pytest.skip(f"{outcome}: {detail}")
 
     assert outcome == RECOVERED, f"{outcome}: {detail}"
     assert not survivors, "child process did not exit"

--- a/cuda_core/tests/test_mempool_oom_retry.py
+++ b/cuda_core/tests/test_mempool_oom_retry.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for the deferred-release retry in ``get_device_mempool``.
+
+Issue #2381: the driver reserves virtual address space per memory pool -- on
+Windows MCDM roughly 2x device memory against a 40-bit (1 TiB) cap -- so pools
+that are awaiting teardown can starve the *default* pool's reservation. cuda.core
+then reports ``CUDA_ERROR_OUT_OF_MEMORY`` on a device with ample free memory.
+
+A pool's address space comes back only once the pool is destroyed, and
+``cuMemPoolDestroy`` waits on the stream-ordered frees of the pool's outstanding
+allocations. So when those frees are queued behind unfinished work, the address
+space is recoverable but not yet recovered -- which is the window
+``get_device_mempool`` closes by draining the context once and retrying.
+
+This runs in a child process on purpose. The driver creates the default pool
+lazily, and once it exists ``cuDeviceGetMemPool`` is a handle lookup that cannot
+fail, so a process that has already touched it could never reproduce the failure.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as _mp
+
+import pytest
+from helpers.child_processes import child_timeout_sec, kill_subprocesses
+
+# Fill coarsely first, then top up finely. A single pool size cannot do both:
+# large pools exhaust a big address space in a feasible number of steps but
+# leave a gap the default pool still fits into, while small pools fill precisely
+# but would need far too many to cover a 48-bit space.
+POOL_BYTES_COARSE = 64 * 1024**3
+POOL_BYTES_FINE = 1024**3
+MAX_POOLS_PER_PASS = 4096
+BLOCK_MS = 2000
+
+NO_EXHAUSTION = "no-exhaustion"
+NOT_DEFERRED = "not-deferred"
+RECOVERED = "recovered"
+NOT_RECOVERED = "not-recovered"
+
+
+def _worker_deferred_release(result_queue):
+    """Drive a default-pool lookup into deferred-release failure, then retry it.
+
+    Reports one of the module-level outcome strings so the parent can tell a
+    genuine regression apart from a machine whose address space is too large to
+    exhaust.
+    """
+    import gc
+    import time
+
+    from helpers.nanosleep_kernel import NanosleepKernel
+
+    from cuda.bindings import driver
+    from cuda.core import Device, DeviceMemoryResource, DeviceMemoryResourceOptions
+    from cuda.core._utils.cuda_utils import CUDAError
+
+    def default_pool_available():
+        err, _pool = driver.cuDeviceGetMemPool(dev)
+        return err == driver.CUresult.CUDA_SUCCESS
+
+    device = Device(0)
+    device.set_current()
+    err, dev = driver.cuDeviceGet(0)
+    assert err == driver.CUresult.CUDA_SUCCESS, err
+
+    # Build everything before the address space is gone; afterwards even kernel
+    # compilation could fail for unrelated reasons.
+    sleeper = NanosleepKernel(device, sleep_duration_ms=BLOCK_MS)
+    work_stream = device.create_stream()
+    dealloc_stream = device.create_stream()
+
+    pools = []
+    buffers = []
+
+    def reserve_until_oom(pool_bytes):
+        options = DeviceMemoryResourceOptions(max_size=pool_bytes)
+        for _ in range(MAX_POOLS_PER_PASS):
+            try:
+                mr = DeviceMemoryResource(device, options=options)
+            except (CUDAError, RuntimeError):
+                return
+            # An empty pool is torn down immediately, which is the one case that
+            # cannot defer anything. Hold an allocation so teardown must wait.
+            buffers.append(mr.allocate(1024, stream=dealloc_stream))
+            pools.append(mr)
+
+    reserve_until_oom(POOL_BYTES_COARSE)
+    reserve_until_oom(POOL_BYTES_FINE)
+
+    if default_pool_available():
+        result_queue.put((NO_EXHAUSTION, len(pools)))
+        return
+
+    # Stall the deallocation stream behind a slow kernel on another stream, so
+    # the frees below cannot retire until the context is drained.
+    sleeper.launch(work_stream)
+    dealloc_stream.wait(work_stream.record())
+
+    buffers.clear()
+    pools.clear()
+    gc.collect()
+
+    if default_pool_available():
+        # Release outran us; there was no deferred window to recover from.
+        result_queue.put((NOT_DEFERRED, len(pools)))
+        return
+
+    # The raw lookup just failed, so anything the retried lookup achieves below
+    # is attributable to the retry itself -- no cross-build comparison needed.
+    # Time it too: recovering requires draining the blocking kernel, so a call
+    # that returns instantly would mean something other than the drain fixed it.
+    started = time.perf_counter()
+    try:
+        DeviceMemoryResource(device)
+    except (CUDAError, RuntimeError) as exc:
+        result_queue.put((NOT_RECOVERED, repr(exc)))
+        return
+    result_queue.put((RECOVERED, time.perf_counter() - started))
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+@pytest.mark.thread_unsafe(reason="Reserves the device's entire virtual address space.")
+def test_default_mempool_lookup_recovers_from_deferred_release():
+    ctx = _mp.get_context("spawn")
+    result_queue = ctx.Queue()
+    proc = ctx.Process(target=_worker_deferred_release, args=(result_queue,))
+    proc.start()
+    try:
+        outcome, detail = result_queue.get(timeout=child_timeout_sec())
+    finally:
+        proc.join(timeout=child_timeout_sec())
+        survivors = kill_subprocesses(proc)
+    assert not survivors, "child process did not exit"
+
+    if outcome == NO_EXHAUSTION:
+        pytest.skip(f"could not exhaust the address space; reserved {detail} pools")
+    if outcome == NOT_DEFERRED:
+        pytest.skip("pool release completed too quickly to leave a deferred window")
+    assert outcome == RECOVERED, f"default pool lookup did not recover: {detail}"
+    # Recovery had to wait out the blocking kernel. Returning much faster would
+    # mean the lookup succeeded for some reason other than draining the context,
+    # leaving this test passing without exercising the retry.
+    assert detail >= (BLOCK_MS / 1000) / 4, f"recovered suspiciously fast ({detail:.3f}s)"


### PR DESCRIPTION
Addresses #2381

`Device.memory_resource` could fail with `CUDA_ERROR_OUT_OF_MEMORY` on a device with
ample free memory. A memory pool's virtual address reservation is only returned when
the pool is torn down, and `cuMemPoolDestroy` waits on the stream-ordered
`cuMemFreeAsync` calls for the pool's outstanding allocations. While those frees sit
queued behind unfinished work, the address space is recoverable but not yet
recovered — enough to fail the *next* pool lookup wherever address space is scarce.
`get_device_mempool` now drains the context once and retries:
- Retries only on `CUDA_ERROR_OUT_OF_MEMORY`; every other status returns unchanged.
- Retries at most once, with a `cuCtxSynchronize`
- The happy path is untouched; the synchronize only runs where we were about to raise.
- If the synchronize itself fails, the original OOM is preserved. The handle layer has
  a single thread-local error slot, so reporting the drain's failure instead would
  misattribute *why* the pool was unavailable.

### Scope and cost
- **Best effort across devices.** The drain covers the *current* context, but
  `get_device_mempool` takes a `device_id`. When that device is not current, the retry
  retires unrelated work and will not recover the target pool. It then falls back to
  reporting the original OOM, so this is a missed recovery rather than a wrong result.
- **Bounded on the success path.** The driver creates the default pool lazily, and once
  it exists the lookup cannot fail. A retry that succeeds therefore costs one
  synchronize per device per process, not one per allocation. A retry that *fails* can
  recur, so a run that stays exhausted pays one drain per attempt — cheap on an idle
  GPU, but not free.
- **Not a blanket fix.** Only the default-pool path retries. `cuMemPoolCreate` (used by
  pinned, managed, and options-based resources) and `cuGraphAddMemAllocNode` can fail
  the same way and are unchanged.

### Testing
`cuda_core/tests/test_mempool_oom_retry.py` reproduces the failure and verifies recovery
in a single run: it exhausts the address space, blocks the deallocation stream on an
event behind a slow kernel, drops the pools, asserts the un-retried lookup still fails,
then asserts the retried one succeeds and actually blocked. It runs in a spawned child
process because the default pool is created lazily — once it exists the lookup cannot
fail, so a process that already touched it could not reproduce this. Confirmed to fail
against `main` for the right reason. It skips on machines whose address space is too
large to exhaust.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.