### PR TITLE
[no-ci] CI: avoid SIGPIPE when selecting core release tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,11 +255,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # --paginate fetches all pages; jq outputs one name per line per page;
-          # head -1 takes the first (newest) match since GitHub returns tags
-          # newest-first. Fails hard if no cuda-core-v* tag is found.
+          # sed prints the first (newest) match while consuming all pages, so
+          # gh can complete without SIGPIPE. Fails if no cuda-core-v* tag is found.
           tag="$(gh api "repos/$GITHUB_REPOSITORY/tags" --paginate \
             --jq '.[] | select(.name | startswith("cuda-core-v")) | .name' \
-            | head -1)"
+            | sed -n '1p')"
           if [[ -z "${tag}" ]]; then
             echo "::error::No cuda-core-v* tag found in the repository." >&2
             exit 1


### PR DESCRIPTION
## Description

This extracts the API-check fix from #2470 so it can merge independently of the broader build-dependency work there. The regression can block CI for pull requests that modify `cuda_core`, so landing the focused fix quickly prevents it from continuing to interfere with unrelated work.

### Root cause

The latest-release API check selected the newest `cuda-core-v*` tag with:

```bash
gh api ... --paginate | head -1
```

The step runs under `bash -e -o pipefail`. Once `head` received the first matching tag, it closed the pipe while `gh` was still paginating. `gh` then received SIGPIPE and exited with status 141, causing the step to fail even though it had successfully found a release tag.

This slipped through because the API-check job is gated on changes under `cuda_core/`. The job was introduced by #2300, whose own changes were confined to CI files, while #2393 only changed `cuda_pathfinder`; neither PR exercised the new path.

### Fix

Replace `head -1` with `sed -n '1p'`. `sed` prints the first matching tag while continuing to consume the complete paginated stream, allowing `gh` to finish normally. A genuine `gh api` failure still propagates through `pipefail`, and the existing explicit failure for an empty result remains unchanged.

This also incorporates the review concern raised on #2462: unlike the current `|| true` implementation there, it does not suppress producer failures. PR #2464 carries overlapping work as part of its broader selective-wheel-build stack.

### Why this is separate and `[no-ci]`

The exact commit was extracted unchanged from #2470, where the affected API check passed in multiple CI runs, including [run 30650439462](https://github.com/NVIDIA/cuda-python/actions/runs/30650439462/job/91222293543) and [run 30688456702](https://github.com/NVIDIA/cuda-python/actions/runs/30688456702/job/91343963182). It was also manually checked against live tag pagination and a simulated producer failure.

A standalone workflow-only PR does not set the `cuda_core` changed-path flag, so the affected API-check job would be skipped even without `[no-ci]`. Running the remaining matrix would therefore consume CI resources without exercising this fix. Splitting it out lets the blocker merge quickly while #2470 and #2464 continue their broader coordination.

### Validation

- The exact change passed the affected API check in #2470.
- `pre-commit run --all-files` passes on this extracted branch, including YAML validation and actionlint.

Related: #2462, #2464, #2470.

## Checklist

- [x] Existing CI coverage in #2470 exercises this change.
- [x] Documentation is not affected.