### PR TITLE
[no-ci] cuda.core: fix host memcpy source pointer cast

### DIFF
--- a/cuda_core/cuda/core/graph/_graph_node.pyx
+++ b/cuda_core/cuda/core/graph/_graph_node.pyx
@@ -1003,7 +1003,7 @@ cdef void _init_memcpy_params(
     params.srcMemoryType = src_type[0]
     params.dstMemoryType = dst_type[0]
     if src_type[0] == cydriver.CU_MEMORYTYPE_HOST:
-        params.srcHost = <const void*><uintptr_t>src
+        params.srcHost = <void*><uintptr_t>src
     else:
         params.srcDevice = src
     if dst_type[0] == cydriver.CU_MEMORYTYPE_HOST:


### PR DESCRIPTION
## Description

This extracts the one-line host memcpy source-pointer fix from #2470 so it can merge independently while the broader CI dependency-selection work continues through review and coordination with #2464.

Landing the correction separately prevents this known source-build failure from continuing to block work based on current `main`.

### Root cause

PR #2395 refactored graph memcpy parameter initialization and inadvertently changed the `CUDA_MEMCPY3D.srcHost` assignment from a `void *` cast to a `const void *` cast.

The current in-tree `cuda-bindings` declaration exposes `CUDA_MEMCPY3D.srcHost` as `void *`. Cython therefore rejects the assignment because it would discard the const qualifier:

```text
Assigning to 'void *' from 'const void *' discards const qualifier
```

The regression initially escaped CI because `cuda.core` was being Cythonized against a published `cuda-bindings` wheel from PyPI rather than the wheel built from the same checkout. That published declaration accepted the const-qualified pointer. The current bindings wheel was installed only after the core wheel had already been Cythonized, so subsequent tests could not detect the mismatch.

### Fix

Cast the source address to `void *`, matching the current in-tree declaration.

A mutable pointer remains assignable to an older declaration accepting `const void *`, so the correction remains compatible with the intentional published-bindings compatibility builds. It does not change structure layout, ABI, ownership, or runtime copy behavior.

### Why this is separate and `[no-ci]`

This exact commit was extracted unchanged from #2470. There, the local-wheel dependency-selection fix forced `cuda.core` to build against the same-checkout `cuda-bindings` wheel, exposed the original compiler error, and fully exercised this correction across the relevant Linux and Windows wheel builds. The sole failure in the latest #2470 run occurred later in an unrelated Windows NumPy source build.

A standalone PR based on `main` does not contain #2470's dependency-selection fix. Its normal CI can therefore take the same published-wheel path that masked the regression and would not independently validate this compatibility boundary. Re-running the full matrix would provide little additional signal over the directly relevant coverage already completed in #2470.

Splitting the correction out lets the blocker merge quickly. PR #2464 independently contains the same one-line correction as part of broader selective-wheel-build work; whichever lands second can drop the overlapping patch.

### Validation

- The exact change was exercised by same-checkout bindings/core builds in #2470.
- `pre-commit run --all-files` passes on this extracted branch.
- `git diff --check` passes.

Related: #2395, #2468, #2464, #2470.

## Checklist

- [x] Existing build coverage in #2470 exercises this compile-time correction.
- [x] Documentation is up to date; this internal type correction has no user-facing behavior change.