### PR TITLE
Make cuda.core.system.Temperature.get_threshold forward-compatible with newer GPU architectures

### DIFF
--- a/cuda_core/cuda/core/system/_temperature.pxi
+++ b/cuda_core/cuda/core/system/_temperature.pxi
@@ -173,7 +173,9 @@ cdef class Temperature:
             nvml.TemperatureThresholds.TEMPERATURE_THRESHOLD_MEM_MAX,
             nvml.TemperatureThresholds.TEMPERATURE_THRESHOLD_GPU_MAX
         ):
-            device_arch = nvml.DeviceArch(nvml.device_get_architecture(self._handle))
+            # Compare the raw value so newer NVML architecture constants remain
+            # forward-compatible.
+            device_arch = nvml.device_get_architecture(self._handle)
             if device_arch >= nvml.DeviceArch.ADA:
                 warnings.warn(
                     f"{threshold_type} is no longer recommended for Ada and later architectures. "

--- a/cuda_core/tests/system/test_system_device.py
+++ b/cuda_core/tests/system/test_system_device.py
@@ -722,6 +722,25 @@ def test_temperature():
             assert sensor.default_min_temp <= sensor.current_temp <= sensor.default_max_temp
 
 
+@pytest.mark.thread_unsafe(reason="Temporarily replaces process-global NVML functions")
+@pytest.mark.agent_authored(model="gpt-5.6-sol")
+def test_temperature_threshold_unrecognized_device_arch(monkeypatch):
+    temperature = system.Device(index=0).temperature
+    unrecognized_arch = int(nvml.DeviceArch.UNKNOWN) - 1
+    with pytest.raises(ValueError):
+        nvml.DeviceArch(unrecognized_arch)
+
+    monkeypatch.setattr(nvml, "device_get_architecture", lambda _handle: unrecognized_arch)
+    monkeypatch.setattr(
+        nvml,
+        "device_get_temperature_threshold",
+        lambda _handle, _threshold: 42,
+    )
+
+    with pytest.warns(DeprecationWarning, match="no longer recommended"):
+        assert temperature.get_threshold(typing.TemperatureThresholds.SHUTDOWN) == 42
+
+
 @pytest.mark.agent_authored(model="claude-opus-4.8")
 def test_temperature_arg_validation():
     # Both getters reject an unknown key before issuing any NVML call.


### PR DESCRIPTION
## Description

Compare raw NVML device architecture values so architectures newer than the generated `DeviceArch` enum do not raise `ValueError` before the threshold query.

Add regression coverage for an unrecognized architecture value.

Fixes nvbug 6084457.

Extracted from ctk-next PR 497 (merged).