### PR TITLE
Use pathlib in cuda.pathfinder._static_libs (part 2 of #2410)

### DIFF
--- a/cuda_pathfinder/cuda/pathfinder/_static_libs/find_bitcode_lib.py
+++ b/cuda_pathfinder/cuda/pathfinder/_static_libs/find_bitcode_lib.py
@@ -36,7 +36,7 @@ class _BitcodeLibInfo(TypedDict):
 _SUPPORTED_BITCODE_LIBS_INFO: dict[str, _BitcodeLibInfo] = {
     "device": {
         "filename": "libdevice.10.bc",
-        "rel_path": str(Path("nvvm", "libdevice")),
+        "rel_path": "nvvm/libdevice",
         "site_packages_dirs": (
             "nvidia/cu13/nvvm/libdevice",
             "nvidia/cuda_nvcc/nvvm/libdevice",
@@ -65,15 +65,14 @@ SUPPORTED_BITCODE_LIBS: tuple[str, ...] = tuple(
 )
 
 
-def _no_such_file_in_dir(dir_path: str, filename: str, error_messages: list[str], attachments: list[str]) -> None:
-    directory = Path(dir_path)
+def _no_such_file_in_dir(directory: Path, filename: str, error_messages: list[str], attachments: list[str]) -> None:
     error_messages.append(f"No such file: {directory / filename}")
     if directory.is_dir():
-        attachments.append(f'  listdir("{dir_path}"):')
+        attachments.append(f'  listdir("{directory}"):')
         for node in sorted(node_path.name for node_path in directory.iterdir()):
             attachments.append(f"    {node}")
     else:
-        attachments.append(f'  Directory does not exist: "{dir_path}"')
+        attachments.append(f'  Directory does not exist: "{directory}"')
 
 
 class _FindBitcodeLib:
@@ -88,16 +87,16 @@ class _FindBitcodeLib:
         self.error_messages: list[str] = []
         self.attachments: list[str] = []
 
-    def try_site_packages(self) -> str | None:
+    def try_site_packages(self) -> Path | None:
         for rel_dir in self.site_packages_dirs:
             sub_dir = tuple(rel_dir.split("/"))
             for abs_dir in find_sub_dirs_all_sitepackages(sub_dir):
                 file_path = Path(abs_dir, self.filename)
                 if file_path.is_file():
-                    return str(file_path)
+                    return file_path
         return None
 
-    def try_with_conda_prefix(self) -> str | None:
+    def try_with_conda_prefix(self) -> Path | None:
         conda_prefix = os.environ.get("CONDA_PREFIX")
         if not conda_prefix:
             return None
@@ -105,22 +104,22 @@ class _FindBitcodeLib:
         anchor = Path(conda_prefix, "Library") if IS_WINDOWS else Path(conda_prefix)
         file_path = anchor / self.rel_path / self.filename
         if file_path.is_file():
-            return str(file_path)
+            return file_path
         return None
 
-    def try_with_cuda_home(self) -> str | None:
+    def try_with_cuda_home(self) -> Path | None:
         cuda_home = get_cuda_path_or_home()
         if cuda_home is None:
             self.error_messages.append("CUDA_HOME/CUDA_PATH not set")
             return None
 
-        cuda_home_path = Path(cuda_home)
-        file_path = cuda_home_path / self.rel_path / self.filename
+        anchor = Path(cuda_home)
+        file_path = anchor / self.rel_path / self.filename
         if file_path.is_file():
-            return str(file_path)
+            return file_path
 
         _no_such_file_in_dir(
-            str(cuda_home_path / self.rel_path),
+            anchor / self.rel_path,
             self.filename,
             self.error_messages,
             self.attachments,
@@ -146,7 +145,7 @@ def locate_bitcode_lib(name: str) -> LocatedBitcodeLib:
     if abs_path is not None:
         return LocatedBitcodeLib(
             name=name,
-            abs_path=abs_path,
+            abs_path=str(abs_path),
             filename=finder.filename,
             found_via="site-packages",
         )
@@ -155,7 +154,7 @@ def locate_bitcode_lib(name: str) -> LocatedBitcodeLib:
     if abs_path is not None:
         return LocatedBitcodeLib(
             name=name,
-            abs_path=abs_path,
+            abs_path=str(abs_path),
             filename=finder.filename,
             found_via="conda",
         )
@@ -164,7 +163,7 @@ def locate_bitcode_lib(name: str) -> LocatedBitcodeLib:
     if abs_path is not None:
         return LocatedBitcodeLib(
             name=name,
-            abs_path=abs_path,
+            abs_path=str(abs_path),
             filename=finder.filename,
             found_via="CUDA_PATH",
         )

--- a/cuda_pathfinder/cuda/pathfinder/_static_libs/find_bitcode_lib.py
+++ b/cuda_pathfinder/cuda/pathfinder/_static_libs/find_bitcode_lib.py
@@ -4,6 +4,7 @@
 import functools
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import NoReturn, TypedDict
 
 from cuda.pathfinder._utils.env_vars import get_cuda_path_or_home
@@ -35,7 +36,7 @@ class _BitcodeLibInfo(TypedDict):
 _SUPPORTED_BITCODE_LIBS_INFO: dict[str, _BitcodeLibInfo] = {
     "device": {
         "filename": "libdevice.10.bc",
-        "rel_path": os.path.join("nvvm", "libdevice"),
+        "rel_path": str(Path("nvvm", "libdevice")),
         "site_packages_dirs": (
             "nvidia/cu13/nvvm/libdevice",
             "nvidia/cuda_nvcc/nvvm/libdevice",
@@ -65,10 +66,11 @@ SUPPORTED_BITCODE_LIBS: tuple[str, ...] = tuple(
 
 
 def _no_such_file_in_dir(dir_path: str, filename: str, error_messages: list[str], attachments: list[str]) -> None:
-    error_messages.append(f"No such file: {os.path.join(dir_path, filename)}")
-    if os.path.isdir(dir_path):
+    directory = Path(dir_path)
+    error_messages.append(f"No such file: {directory / filename}")
+    if directory.is_dir():
         attachments.append(f'  listdir("{dir_path}"):')
-        for node in sorted(os.listdir(dir_path)):
+        for node in sorted(node_path.name for node_path in directory.iterdir()):
             attachments.append(f"    {node}")
     else:
         attachments.append(f'  Directory does not exist: "{dir_path}"')
@@ -90,9 +92,9 @@ class _FindBitcodeLib:
         for rel_dir in self.site_packages_dirs:
             sub_dir = tuple(rel_dir.split("/"))
             for abs_dir in find_sub_dirs_all_sitepackages(sub_dir):
-                file_path = os.path.join(abs_dir, self.filename)
-                if os.path.isfile(file_path):
-                    return file_path
+                file_path = Path(abs_dir, self.filename)
+                if file_path.is_file():
+                    return str(file_path)
         return None
 
     def try_with_conda_prefix(self) -> str | None:
@@ -100,10 +102,10 @@ class _FindBitcodeLib:
         if not conda_prefix:
             return None
 
-        anchor = os.path.join(conda_prefix, "Library") if IS_WINDOWS else conda_prefix
-        file_path = os.path.join(anchor, self.rel_path, self.filename)
-        if os.path.isfile(file_path):
-            return file_path
+        anchor = Path(conda_prefix, "Library") if IS_WINDOWS else Path(conda_prefix)
+        file_path = anchor / self.rel_path / self.filename
+        if file_path.is_file():
+            return str(file_path)
         return None
 
     def try_with_cuda_home(self) -> str | None:
@@ -112,12 +114,13 @@ class _FindBitcodeLib:
             self.error_messages.append("CUDA_HOME/CUDA_PATH not set")
             return None
 
-        file_path = os.path.join(cuda_home, self.rel_path, self.filename)
-        if os.path.isfile(file_path):
-            return file_path
+        cuda_home_path = Path(cuda_home)
+        file_path = cuda_home_path / self.rel_path / self.filename
+        if file_path.is_file():
+            return str(file_path)
 
         _no_such_file_in_dir(
-            os.path.join(cuda_home, self.rel_path),
+            str(cuda_home_path / self.rel_path),
             self.filename,
             self.error_messages,
             self.attachments,

--- a/cuda_pathfinder/cuda/pathfinder/_static_libs/find_static_lib.py
+++ b/cuda_pathfinder/cuda/pathfinder/_static_libs/find_static_lib.py
@@ -61,15 +61,14 @@ _SUPPORTED_STATIC_LIBS_INFO: dict[str, _StaticLibInfo] = {
 SUPPORTED_STATIC_LIBS: tuple[str, ...] = tuple(sorted(_SUPPORTED_STATIC_LIBS_INFO.keys()))
 
 
-def _no_such_file_in_dir(dir_path: str, filename: str, error_messages: list[str], attachments: list[str]) -> None:
-    directory = Path(dir_path)
+def _no_such_file_in_dir(directory: Path, filename: str, error_messages: list[str], attachments: list[str]) -> None:
     error_messages.append(f"No such file: {directory / filename}")
     if directory.is_dir():
-        attachments.append(f'  listdir("{dir_path}"):')
+        attachments.append(f'  listdir("{directory}"):')
         for node in sorted(node_path.name for node_path in directory.iterdir()):
             attachments.append(f"    {node}")
     else:
-        attachments.append(f'  Directory does not exist: "{dir_path}"')
+        attachments.append(f'  Directory does not exist: "{directory}"')
 
 
 class _FindStaticLib:
@@ -85,16 +84,16 @@ class _FindStaticLib:
         self.error_messages: list[str] = []
         self.attachments: list[str] = []
 
-    def try_site_packages(self) -> str | None:
+    def try_site_packages(self) -> Path | None:
         for rel_dir in self.site_packages_dirs:
             sub_dir = tuple(rel_dir.split("/"))
             for abs_dir in find_sub_dirs_all_sitepackages(sub_dir):
                 file_path = Path(abs_dir, self.filename)
                 if file_path.is_file():
-                    return str(file_path)
+                    return file_path
         return None
 
-    def try_with_conda_prefix(self) -> str | None:
+    def try_with_conda_prefix(self) -> Path | None:
         conda_prefix = os.environ.get("CONDA_PREFIX")
         if not conda_prefix:
             return None
@@ -103,23 +102,23 @@ class _FindStaticLib:
         for rel_path in self.conda_rel_paths:
             file_path = anchor / rel_path / self.filename
             if file_path.is_file():
-                return str(file_path)
+                return file_path
         return None
 
-    def try_with_cuda_home(self) -> str | None:
+    def try_with_cuda_home(self) -> Path | None:
         cuda_home = get_cuda_path_or_home()
         if cuda_home is None:
             self.error_messages.append("CUDA_HOME/CUDA_PATH not set")
             return None
 
-        cuda_home_path = Path(cuda_home)
+        anchor = Path(cuda_home)
         for rel_path in self.ctk_rel_paths:
-            file_path = cuda_home_path / rel_path / self.filename
+            file_path = anchor / rel_path / self.filename
             if file_path.is_file():
-                return str(file_path)
+                return file_path
 
         _no_such_file_in_dir(
-            str(cuda_home_path / self.ctk_rel_paths[0]),
+            anchor / self.ctk_rel_paths[0],
             self.filename,
             self.error_messages,
             self.attachments,
@@ -145,7 +144,7 @@ def locate_static_lib(name: str) -> LocatedStaticLib:
     if abs_path is not None:
         return LocatedStaticLib(
             name=name,
-            abs_path=abs_path,
+            abs_path=str(abs_path),
             filename=finder.filename,
             found_via="site-packages",
         )
@@ -154,7 +153,7 @@ def locate_static_lib(name: str) -> LocatedStaticLib:
     if abs_path is not None:
         return LocatedStaticLib(
             name=name,
-            abs_path=abs_path,
+            abs_path=str(abs_path),
             filename=finder.filename,
             found_via="conda",
         )
@@ -163,7 +162,7 @@ def locate_static_lib(name: str) -> LocatedStaticLib:
     if abs_path is not None:
         return LocatedStaticLib(
             name=name,
-            abs_path=abs_path,
+            abs_path=str(abs_path),
             filename=finder.filename,
             found_via="CUDA_PATH",
         )

--- a/cuda_pathfinder/cuda/pathfinder/_static_libs/find_static_lib.py
+++ b/cuda_pathfinder/cuda/pathfinder/_static_libs/find_static_lib.py
@@ -4,6 +4,7 @@
 import functools
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import NoReturn, TypedDict
 
 from cuda.pathfinder._utils.env_vars import get_cuda_path_or_home
@@ -35,8 +36,8 @@ class _StaticLibInfo(TypedDict):
 _SUPPORTED_STATIC_LIBS_INFO: dict[str, _StaticLibInfo] = {
     "cudadevrt": {
         "filename": "cudadevrt.lib" if IS_WINDOWS else "libcudadevrt.a",
-        "ctk_rel_paths": (os.path.join("lib", "x64"),) if IS_WINDOWS else ("lib64", "lib"),
-        "conda_rel_paths": ((os.path.join("lib", "x64"), "lib") if IS_WINDOWS else ("lib",)),
+        "ctk_rel_paths": (str(Path("lib", "x64")),) if IS_WINDOWS else ("lib64", "lib"),
+        "conda_rel_paths": ((str(Path("lib", "x64")), "lib") if IS_WINDOWS else ("lib",)),
         "site_packages_dirs": (
             ("nvidia/cu13/lib/x64", "nvidia/cuda_runtime/lib/x64")
             if IS_WINDOWS
@@ -49,10 +50,11 @@ SUPPORTED_STATIC_LIBS: tuple[str, ...] = tuple(sorted(_SUPPORTED_STATIC_LIBS_INF
 
 
 def _no_such_file_in_dir(dir_path: str, filename: str, error_messages: list[str], attachments: list[str]) -> None:
-    error_messages.append(f"No such file: {os.path.join(dir_path, filename)}")
-    if os.path.isdir(dir_path):
+    directory = Path(dir_path)
+    error_messages.append(f"No such file: {directory / filename}")
+    if directory.is_dir():
         attachments.append(f'  listdir("{dir_path}"):')
-        for node in sorted(os.listdir(dir_path)):
+        for node in sorted(node_path.name for node_path in directory.iterdir()):
             attachments.append(f"    {node}")
     else:
         attachments.append(f'  Directory does not exist: "{dir_path}"')
@@ -75,9 +77,9 @@ class _FindStaticLib:
         for rel_dir in self.site_packages_dirs:
             sub_dir = tuple(rel_dir.split("/"))
             for abs_dir in find_sub_dirs_all_sitepackages(sub_dir):
-                file_path = os.path.join(abs_dir, self.filename)
-                if os.path.isfile(file_path):
-                    return file_path
+                file_path = Path(abs_dir, self.filename)
+                if file_path.is_file():
+                    return str(file_path)
         return None
 
     def try_with_conda_prefix(self) -> str | None:
@@ -85,11 +87,11 @@ class _FindStaticLib:
         if not conda_prefix:
             return None
 
-        anchor = os.path.join(conda_prefix, "Library") if IS_WINDOWS else conda_prefix
+        anchor = Path(conda_prefix, "Library") if IS_WINDOWS else Path(conda_prefix)
         for rel_path in self.conda_rel_paths:
-            file_path = os.path.join(anchor, rel_path, self.filename)
-            if os.path.isfile(file_path):
-                return file_path
+            file_path = anchor / rel_path / self.filename
+            if file_path.is_file():
+                return str(file_path)
         return None
 
     def try_with_cuda_home(self) -> str | None:
@@ -98,13 +100,14 @@ class _FindStaticLib:
             self.error_messages.append("CUDA_HOME/CUDA_PATH not set")
             return None
 
+        cuda_home_path = Path(cuda_home)
         for rel_path in self.ctk_rel_paths:
-            file_path = os.path.join(cuda_home, rel_path, self.filename)
-            if os.path.isfile(file_path):
-                return file_path
+            file_path = cuda_home_path / rel_path / self.filename
+            if file_path.is_file():
+                return str(file_path)
 
         _no_such_file_in_dir(
-            os.path.join(cuda_home, self.ctk_rel_paths[0]),
+            str(cuda_home_path / self.ctk_rel_paths[0]),
             self.filename,
             self.error_messages,
             self.attachments,

--- a/cuda_pathfinder/cuda/pathfinder/_static_libs/find_static_lib.py
+++ b/cuda_pathfinder/cuda/pathfinder/_static_libs/find_static_lib.py
@@ -4,6 +4,7 @@
 import functools
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import NoReturn, TypedDict
 
 from cuda.pathfinder._utils.env_vars import get_cuda_path_or_home
@@ -47,8 +48,8 @@ def _cudadevrt_info() -> _StaticLibInfo:
     conda_fallback_dirs = ("lib",) if arch_dir == "x64" else ()
     return {
         "filename": "cudadevrt.lib",
-        "ctk_rel_paths": (os.path.join("lib", arch_dir),),
-        "conda_rel_paths": (os.path.join("lib", arch_dir), *conda_fallback_dirs),
+        "ctk_rel_paths": (str(Path("lib", arch_dir)),),
+        "conda_rel_paths": (str(Path("lib", arch_dir)), *conda_fallback_dirs),
         "site_packages_dirs": (f"nvidia/cu13/lib/{arch_dir}", *component_wheel_dirs),
     }
 
@@ -61,10 +62,11 @@ SUPPORTED_STATIC_LIBS: tuple[str, ...] = tuple(sorted(_SUPPORTED_STATIC_LIBS_INF
 
 
 def _no_such_file_in_dir(dir_path: str, filename: str, error_messages: list[str], attachments: list[str]) -> None:
-    error_messages.append(f"No such file: {os.path.join(dir_path, filename)}")
-    if os.path.isdir(dir_path):
+    directory = Path(dir_path)
+    error_messages.append(f"No such file: {directory / filename}")
+    if directory.is_dir():
         attachments.append(f'  listdir("{dir_path}"):')
-        for node in sorted(os.listdir(dir_path)):
+        for node in sorted(node_path.name for node_path in directory.iterdir()):
             attachments.append(f"    {node}")
     else:
         attachments.append(f'  Directory does not exist: "{dir_path}"')
@@ -87,9 +89,9 @@ class _FindStaticLib:
         for rel_dir in self.site_packages_dirs:
             sub_dir = tuple(rel_dir.split("/"))
             for abs_dir in find_sub_dirs_all_sitepackages(sub_dir):
-                file_path = os.path.join(abs_dir, self.filename)
-                if os.path.isfile(file_path):
-                    return file_path
+                file_path = Path(abs_dir, self.filename)
+                if file_path.is_file():
+                    return str(file_path)
         return None
 
     def try_with_conda_prefix(self) -> str | None:
@@ -97,11 +99,11 @@ class _FindStaticLib:
         if not conda_prefix:
             return None
 
-        anchor = os.path.join(conda_prefix, "Library") if IS_WINDOWS else conda_prefix
+        anchor = Path(conda_prefix, "Library") if IS_WINDOWS else Path(conda_prefix)
         for rel_path in self.conda_rel_paths:
-            file_path = os.path.join(anchor, rel_path, self.filename)
-            if os.path.isfile(file_path):
-                return file_path
+            file_path = anchor / rel_path / self.filename
+            if file_path.is_file():
+                return str(file_path)
         return None
 
     def try_with_cuda_home(self) -> str | None:
@@ -110,13 +112,14 @@ class _FindStaticLib:
             self.error_messages.append("CUDA_HOME/CUDA_PATH not set")
             return None
 
+        cuda_home_path = Path(cuda_home)
         for rel_path in self.ctk_rel_paths:
-            file_path = os.path.join(cuda_home, rel_path, self.filename)
-            if os.path.isfile(file_path):
-                return file_path
+            file_path = cuda_home_path / rel_path / self.filename
+            if file_path.is_file():
+                return str(file_path)
 
         _no_such_file_in_dir(
-            os.path.join(cuda_home, self.ctk_rel_paths[0]),
+            str(cuda_home_path / self.ctk_rel_paths[0]),
             self.filename,
             self.error_messages,
             self.attachments,

--- a/cuda_pathfinder/cuda/pathfinder/_static_libs/find_static_lib.py
+++ b/cuda_pathfinder/cuda/pathfinder/_static_libs/find_static_lib.py
@@ -36,8 +36,8 @@ class _StaticLibInfo(TypedDict):
 _SUPPORTED_STATIC_LIBS_INFO: dict[str, _StaticLibInfo] = {
     "cudadevrt": {
         "filename": "cudadevrt.lib" if IS_WINDOWS else "libcudadevrt.a",
-        "ctk_rel_paths": (str(Path("lib", "x64")),) if IS_WINDOWS else ("lib64", "lib"),
-        "conda_rel_paths": ((str(Path("lib", "x64")), "lib") if IS_WINDOWS else ("lib",)),
+        "ctk_rel_paths": ("lib/x64",) if IS_WINDOWS else ("lib64", "lib"),
+        "conda_rel_paths": (("lib/x64", "lib") if IS_WINDOWS else ("lib",)),
         "site_packages_dirs": (
             ("nvidia/cu13/lib/x64", "nvidia/cuda_runtime/lib/x64")
             if IS_WINDOWS
@@ -49,15 +49,14 @@ _SUPPORTED_STATIC_LIBS_INFO: dict[str, _StaticLibInfo] = {
 SUPPORTED_STATIC_LIBS: tuple[str, ...] = tuple(sorted(_SUPPORTED_STATIC_LIBS_INFO.keys()))
 
 
-def _no_such_file_in_dir(dir_path: str, filename: str, error_messages: list[str], attachments: list[str]) -> None:
-    directory = Path(dir_path)
+def _no_such_file_in_dir(directory: Path, filename: str, error_messages: list[str], attachments: list[str]) -> None:
     error_messages.append(f"No such file: {directory / filename}")
     if directory.is_dir():
-        attachments.append(f'  listdir("{dir_path}"):')
+        attachments.append(f'  listdir("{directory}"):')
         for node in sorted(node_path.name for node_path in directory.iterdir()):
             attachments.append(f"    {node}")
     else:
-        attachments.append(f'  Directory does not exist: "{dir_path}"')
+        attachments.append(f'  Directory does not exist: "{directory}"')
 
 
 class _FindStaticLib:
@@ -73,16 +72,16 @@ class _FindStaticLib:
         self.error_messages: list[str] = []
         self.attachments: list[str] = []
 
-    def try_site_packages(self) -> str | None:
+    def try_site_packages(self) -> Path | None:
         for rel_dir in self.site_packages_dirs:
             sub_dir = tuple(rel_dir.split("/"))
             for abs_dir in find_sub_dirs_all_sitepackages(sub_dir):
                 file_path = Path(abs_dir, self.filename)
                 if file_path.is_file():
-                    return str(file_path)
+                    return file_path
         return None
 
-    def try_with_conda_prefix(self) -> str | None:
+    def try_with_conda_prefix(self) -> Path | None:
         conda_prefix = os.environ.get("CONDA_PREFIX")
         if not conda_prefix:
             return None
@@ -91,23 +90,23 @@ class _FindStaticLib:
         for rel_path in self.conda_rel_paths:
             file_path = anchor / rel_path / self.filename
             if file_path.is_file():
-                return str(file_path)
+                return file_path
         return None
 
-    def try_with_cuda_home(self) -> str | None:
+    def try_with_cuda_home(self) -> Path | None:
         cuda_home = get_cuda_path_or_home()
         if cuda_home is None:
             self.error_messages.append("CUDA_HOME/CUDA_PATH not set")
             return None
 
-        cuda_home_path = Path(cuda_home)
+        anchor = Path(cuda_home)
         for rel_path in self.ctk_rel_paths:
-            file_path = cuda_home_path / rel_path / self.filename
+            file_path = anchor / rel_path / self.filename
             if file_path.is_file():
-                return str(file_path)
+                return file_path
 
         _no_such_file_in_dir(
-            str(cuda_home_path / self.ctk_rel_paths[0]),
+            anchor / self.ctk_rel_paths[0],
             self.filename,
             self.error_messages,
             self.attachments,
@@ -133,7 +132,7 @@ def locate_static_lib(name: str) -> LocatedStaticLib:
     if abs_path is not None:
         return LocatedStaticLib(
             name=name,
-            abs_path=abs_path,
+            abs_path=str(abs_path),
             filename=finder.filename,
             found_via="site-packages",
         )
@@ -142,7 +141,7 @@ def locate_static_lib(name: str) -> LocatedStaticLib:
     if abs_path is not None:
         return LocatedStaticLib(
             name=name,
-            abs_path=abs_path,
+            abs_path=str(abs_path),
             filename=finder.filename,
             found_via="conda",
         )
@@ -151,7 +150,7 @@ def locate_static_lib(name: str) -> LocatedStaticLib:
     if abs_path is not None:
         return LocatedStaticLib(
             name=name,
-            abs_path=abs_path,
+            abs_path=str(abs_path),
             filename=finder.filename,
             found_via="CUDA_PATH",
         )


### PR DESCRIPTION
Follow-up to the review on #2489: the str-compatibility constraint applies only to the public API, so the finder internals now pass and return `Path`. `str()` is applied once, where `abs_path` is stored on `LocatedStaticLib` / `LocatedBitcodeLib`.

The rel-path constants are now forward-slash literals, matching `site_packages_dirs` in the same dicts.

One behaviour change: a `CUDA_PATH` or `CONDA_PREFIX` containing redundant separators now gives a normalized `abs_path`, because `Path` collapses them.

Verified on Linux CI: full pytest output byte-identical to the base commit apart from elapsed time (1276 passed, 4 skipped, 0 errors). Differential fuzzing against the previous revision — 16k lookups over randomized trees, comparing located paths and error text — shows no other difference.

Part 2 of #2410.
