### PR TITLE
Fix cufftMp soname priority: tabulate linux_sonames oldest-first

### DIFF
--- a/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/descriptor_catalog.py
+++ b/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/descriptor_catalog.py
@@ -59,6 +59,8 @@ def _ctk_windows_wheel_dirs(cuda13_bin_dir: str, cuda12_dir: str) -> WindowsSear
 class DescriptorSpec:
     name: str
     packaged_with: PackagedWith
+    # Tabulate oldest version first: the loader reverses these to search
+    # newest -> oldest (see load_dl_linux._candidate_sonames).
     linux_sonames: tuple[str, ...] = ()
     windows_dlls: tuple[str, ...] = ()
     supported_windows_arch: tuple[WindowsArch, ...] = ()
@@ -406,7 +408,7 @@ DESCRIPTOR_CATALOG: tuple[DescriptorSpec, ...] = (
     DescriptorSpec(
         name="cufftMp",
         packaged_with="other",
-        linux_sonames=("libcufftMp.so.12", "libcufftMp.so.11"),
+        linux_sonames=("libcufftMp.so.11", "libcufftMp.so.12"),
         site_packages_linux=("nvidia/cufftmp/cu13/lib", "nvidia/cufftmp/cu12/lib"),
         dependencies=("nvshmem_host",),
         requires_rtld_deepbind=True,

--- a/cuda_pathfinder/tests/test_descriptor_catalog.py
+++ b/cuda_pathfinder/tests/test_descriptor_catalog.py
@@ -80,6 +80,22 @@ def test_linux_sonames_look_like_sonames(spec: DescriptorSpec):
         assert ".so" in soname, f"Unexpected Linux soname format: {soname}"
 
 
+def _linux_soname_version_key(soname: str) -> tuple[int, ...]:
+    """Version components of a ``lib<name>.so[.<major>[.<minor>...]]`` file name."""
+    _, _, version_suffix = soname.partition(".so")
+    return tuple(int(part) for part in version_suffix.split(".") if part)
+
+
+@pytest.mark.parametrize("spec", DESCRIPTOR_CATALOG, ids=lambda s: s.name)
+@pytest.mark.agent_authored(model="claude-opus-5")
+def test_linux_sonames_are_tabulated_oldest_first(spec: DescriptorSpec):
+    """``load_dl_linux._candidate_sonames()`` reverses this tuple to search
+    newest -> oldest, so a newest-first table silently inverts the priority.
+    """
+    versions = [_linux_soname_version_key(soname) for soname in spec.linux_sonames]
+    assert versions == sorted(versions), f"{spec.name} linux_sonames are not oldest-first: {spec.linux_sonames}"
+
+
 @pytest.mark.parametrize("spec", DESCRIPTOR_CATALOG, ids=lambda s: s.name)
 def test_windows_dlls_look_like_dlls(spec: DescriptorSpec):
     for dll in spec.windows_dlls:


### PR DESCRIPTION
`load_dl_linux._candidate_sonames()` reverses `desc.linux_sonames` "to achieve new -> old search order", so the catalog has to tabulate oldest version first.

`cufftMp` is the only one of the 49 catalog entries that lists them newest-first:

```python
linux_sonames=("libcufftMp.so.12", "libcufftMp.so.11"),
```

After the reversal that becomes `.so.11` then `.so.12`, so on a system where both are reachable, `load_nvidia_dynamic_lib("cufftMp")` picks the older one — both in `check_if_already_loaded_from_elsewhere()` and in the system search. Every other library prefers the newest.

The entry started as `("libcufftMp.so.11",)` and `.so.12` was prepended rather than appended in #1194.

This swaps the two, documents the convention on the `DescriptorSpec.linux_sonames` field, and adds a parametrized catalog invariant so a future entry can't regress the same way silently. The invariant fails on `cufftMp` alone before the swap.

Not addressed here: `cupti.windows_dlls` is also tabulated newest-first. It looked like the same mistake, but correcting the data would also change `check_if_already_loaded_from_elsewhere()`, which — unlike its Linux counterpart and unlike `load_with_system_search` — does not reverse the tuple. I have no way to test that path, so I left it for someone who can.

NOTE: developed with the assistance of an AI coding agent. The new test carries `@pytest.mark.agent_authored` per AGENTS.md. I reviewed and verified the change before submitting.
