### PR TITLE
Query the newest DLL first in the Windows already-loaded check

### DIFF
--- a/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/load_dl_windows.py
+++ b/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/load_dl_windows.py
@@ -121,7 +121,9 @@ def abs_path_for_dynamic_library(libname: str, handle: ctypes.wintypes.HMODULE) 
 
 
 def check_if_already_loaded_from_elsewhere(desc: LibDescriptor, have_abs_path: bool) -> LoadedDL | None:
-    for dll_name in desc.windows_dlls:
+    # Reverse tabulated names to achieve new -> old search order, matching
+    # load_with_system_search() below and both Linux entry points.
+    for dll_name in reversed(desc.windows_dlls):
         handle = kernel32.GetModuleHandleW(dll_name)
         if handle:
             abs_path = abs_path_for_dynamic_library(desc.name, handle)

--- a/cuda_pathfinder/tests/test_load_dl_windows.py
+++ b/cuda_pathfinder/tests/test_load_dl_windows.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from cuda.pathfinder._dynamic_libs.descriptor_catalog import DescriptorSpec
+
+# load_dl_windows imports ctypes.wintypes and requires ctypes.windll at module
+# scope, so it cannot even be imported elsewhere; keep the import inside the test.
+pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="Exercises the Windows-only DLL loader")
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+def test_already_loaded_check_queries_newest_dll_first(monkeypatch):
+    """The already-loaded probe must use the same new -> old order as the system search.
+
+    ``windows_dlls`` is tabulated oldest-first and every other entry point
+    reverses it, so querying it forward here would report the oldest loaded
+    version of a library that is present in more than one version.
+    """
+    from cuda.pathfinder._dynamic_libs import load_dl_windows
+
+    queried: list[str] = []
+
+    class FakeKernel32:
+        @staticmethod
+        def GetModuleHandleW(dll_name: str) -> int:
+            queried.append(dll_name)
+            return 0  # nothing is loaded, so every name is probed
+
+    monkeypatch.setattr(load_dl_windows, "kernel32", FakeKernel32)
+
+    desc = DescriptorSpec(
+        name="test_lib",
+        packaged_with="other",
+        windows_dlls=("testlib64_11.dll", "testlib64_12.dll", "testlib64_13.dll"),
+    )
+
+    assert load_dl_windows.check_if_already_loaded_from_elsewhere(desc, False) is None
+    assert queried == ["testlib64_13.dll", "testlib64_12.dll", "testlib64_11.dll"]


### PR DESCRIPTION
`windows_dlls` is tabulated oldest-first, and the other entry points reverse it "to achieve new -> old search order":

- `load_dl_windows.load_with_system_search()` — `for dll_name in reversed(desc.windows_dlls)`
- `load_dl_linux.check_if_already_loaded_from_elsewhere()` and `load_with_system_search()` — both via `_candidate_sonames()`, which reverses

`load_dl_windows.check_if_already_loaded_from_elsewhere()` iterates forward instead. For a library present in more than one version it reports the *oldest* already-loaded one, while the system search on the same platform — and both paths on Linux — prefer the newest. Since the already-loaded check runs first in `load_nvidia_dynamic_lib`, that is the version the caller ends up with.

The new test is Windows-only, and deliberately so: `load_dl_windows` does `import ctypes.wintypes` and raises `RuntimeError` if `ctypes.windll` is missing, both at module scope, so it cannot be imported on other platforms at all. It stubs `kernel32.GetModuleHandleW` to record the probe order and asserts newest-first. On Linux it is collected and skipped — I confirmed that on a Linux runner: 1276 passed with skips going 4 → 5, no collection error. I have no Windows machine, so the assertion itself has only run in my head; the symmetry with `load_with_system_search()` 25 lines below is the real argument.

This pairs with #2499, which fixes the one catalog entry whose `linux_sonames` were tabulated in the wrong order. That one is a data fix, this one is a code fix; they are independent.

NOTE: developed with the assistance of an AI coding agent. The new test carries `@pytest.mark.agent_authored` per AGENTS.md. I reviewed and verified the change before submitting.
