### PR TITLE
Report host_numa virtual memory as host-accessible

### DIFF
--- a/cuda_core/cuda/core/_memory/_virtual_memory_resource.py
+++ b/cuda_core/cuda/core/_memory/_virtual_memory_resource.py
@@ -33,6 +33,16 @@ from cuda.core.typing import (
 
 __all__ = ["VirtualMemoryResource", "VirtualMemoryResourceOptions"]
 
+# Location types whose physical backing lives in host memory. Shared by
+# VirtualMemoryResource.__init__ and is_host_accessible so the two cannot drift.
+_HOST_LOCATION_TYPES = frozenset(
+    {
+        VirtualMemoryLocationType.HOST,
+        VirtualMemoryLocationType.HOST_NUMA,
+        VirtualMemoryLocationType.HOST_NUMA_CURRENT,
+    }
+)
+
 
 @dataclass
 class VirtualMemoryResourceOptions:
@@ -169,8 +179,7 @@ class VirtualMemoryResource(MemoryResource):
         self.config: VirtualMemoryResourceOptions = check_or_create_options(  # type: ignore[assignment]
             VirtualMemoryResourceOptions, config, "VirtualMemoryResource options", keep_none=False
         )
-        # Matches ("host", "host_numa", "host_numa_current")
-        if "host" in self.config.location_type:
+        if self.config.location_type in _HOST_LOCATION_TYPES:
             self.device = None
 
         if not self.device and self.config.location_type == "device":
@@ -609,7 +618,7 @@ class VirtualMemoryResource(MemoryResource):
         """
         Indicates whether the allocated memory is accessible from the host.
         """
-        return self.config.location_type == "host"
+        return self.config.location_type in _HOST_LOCATION_TYPES
 
     @property
     def device_id(self) -> int:

--- a/cuda_core/tests/test_memory.py
+++ b/cuda_core/tests/test_memory.py
@@ -1854,6 +1854,23 @@ def test_vmm_options_handle_type_win32_raises():
         VirtualMemoryResourceOptions._handle_type_to_driver("win32")
 
 
+@pytest.mark.agent_authored(model="claude-opus-5")
+@pytest.mark.parametrize("location_type", ["host", "host_numa", "host_numa_current"])
+def test_vmm_host_location_types_report_host_accessible(location_type):
+    """Every host-backed location type reports is_host_accessible.
+
+    __init__ classifies "host", "host_numa" and "host_numa_current" alike when
+    deciding the resource is not bound to a device, so is_host_accessible must
+    agree; otherwise a NUMA-located resource claims to be neither host- nor
+    device-accessible.
+    """
+    device = Device()
+    device.set_current()
+    mr = VirtualMemoryResource(device, config=VirtualMemoryResourceOptions(location_type=location_type))
+    assert mr.device is None
+    assert mr.is_host_accessible is True
+
+
 def test_device_memory_resource_peer_accessible_by_non_owned(mempool_device):
     """peer_accessible_by on a non-owned (default) DMR queries the driver live."""
     dev = mempool_device


### PR DESCRIPTION
A `VirtualMemoryResource` configured with `location_type="host_numa"` or `"host_numa_current"` reports `is_host_accessible is False` *and* `is_device_accessible is False` — it claims the memory is reachable from nowhere.

`__init__` classifies host-located resources with a substring test:

```python
# Matches ("host", "host_numa", "host_numa_current")
if "host" in self.config.location_type:
    self.device = None
```

but `is_host_accessible` used exact equality:

```python
return self.config.location_type == "host"
```

Both were introduced in cec0efbb64 (#2016) and disagreed from the start. The answer propagates to `Buffer.is_host_accessible`, which forwards straight to the memory resource, so anything choosing CPU vs GPU from a buffer — DLPack/`StridedMemoryView` device selection, copy validation — sees the wrong answer.

`host_numa_current` is a working configuration today: the driver ignores `location.id` for that type, so the resource allocates fine and only the reported accessibility is wrong.

The fix gives both sites a shared `_HOST_LOCATION_TYPES` frozenset so they cannot drift again. `VirtualMemoryLocationType` is a `StrEnum`, so membership behaves identically for raw strings and enum members. `is_device_accessible` is deliberately left alone.

On verification, plainly: I have no GPU and no `cuda.bindings` build here, so nothing under `cuda_core/tests/` can even import and I did not run the new test. What I did run is the old and new expressions plus `__init__`'s classifier extracted against a verbatim copy of the enum — that reproduces both NUMA types returning False on both properties before the change, and agreement with `__init__` for all four members after. The regression test is GPU-gated by construction and will fail on `main` for the two NUMA parameters.

NOTE: developed with the assistance of an AI coding agent. The new test carries `@pytest.mark.agent_authored` per AGENTS.md. I reviewed and verified the change before submitting.
