### PR TITLE
Match private extension modules against the in-package path only

### DIFF
--- a/toolshed/check_cython_abi.py
+++ b/toolshed/check_cython_abi.py
@@ -92,6 +92,21 @@ def is_cython_module(module: object) -> bool:
     return hasattr(module, "__pyx_capi__")
 
 
+def iter_public_extension_modules(build_dir: Path):
+    """Yield the extension modules under `build_dir` that are part of the public ABI.
+
+    Private modules (e.g. cuda/bindings/_internal/utils.so) are skipped. Only the
+    path *inside* the package is inspected: directories above it routinely start
+    with an underscore (manylinux installs Python under /opt/_internal, GitHub
+    Actions containers check out under /__w), and those must not make every
+    module look private.
+    """
+    for so_path in Path(build_dir).glob(f"**/*{EXT_SUFFIX}"):
+        if any(part.startswith("_") for part in so_path.relative_to(build_dir).parts):
+            continue
+        yield so_path
+
+
 ######################################################################################
 # STRUCTS
 
@@ -473,7 +488,7 @@ def check(package: str, abi_dir: Path) -> bool:
             print(f"No module found for {abi_path.relative_to(abi_dir)}")
             has_errors = True
 
-    for so_path in Path(build_dir).glob(f"**/*{EXT_SUFFIX}"):
+    for so_path in iter_public_extension_modules(build_dir):
         module = import_from_path(package, build_dir, so_path)
         if hasattr(module, "__pyx_capi__"):
             abi_path = so_path_to_abi_path(so_path, build_dir, abi_dir)
@@ -498,10 +513,7 @@ def generate(package: str, abi_dir: Path) -> bool:
         return True
 
     build_dir = get_package_path(package)
-    for so_path in Path(build_dir).glob(f"**/*{EXT_SUFFIX}"):
-        if any(x.startswith("_") for x in so_path.parts):
-            # Skip private modules (e.g. _driver.so) since they are not part of the public ABI
-            continue
+    for so_path in iter_public_extension_modules(build_dir):
         try:
             module = import_from_path(package, build_dir, so_path)
         except ImportError:


### PR DESCRIPTION
Two related defects in `toolshed/check_cython_abi.py`'s private-module filter.

**1. The filter matched the absolute path.** `generate` skipped a module when `any(x.startswith("_") for x in so_path.parts)`, and `so_path` is absolute — so any ancestor directory beginning with an underscore made *every* module look private. That is the normal layout under manylinux (`/opt/_internal/cpython-*/`) and in GitHub Actions containers (`/__w/`):

```python
>>> build_dir = Path("/opt/_internal/cpython-3.12/lib/python3.12/site-packages/cuda/bindings")
>>> so = build_dir / "driver.cpython-312-x86_64-linux-gnu.so"   # public
>>> any(p.startswith("_") for p in so.parts)
True
```

`generate` then writes zero `.abi.json` files and exits 0 — a green run with no coverage at all.

**2. `check` had no filter.** `generate` deliberately skips private modules as "not part of the public ABI", but `check`'s new-module scan globs everything. Since `generate` never wrote an `.abi.json` for them, `check` reports every private module as `New module added` on every run and sets `has_allowed_changes`, so it can never print "No changes found" for a package that ships private submodules — `cuda.bindings` has `_bindings/`, `_internal/` and `_lib/`.

The fix extracts the predicate into `iter_public_extension_modules()`, calls it from both paths, and matches only on the path relative to the package root. Public `driver.so` under `/opt/_internal/...` is now kept; `_internal/utils.so` is still skipped.

Verified by reproducing the path defect directly, as above. I deliberately did not add a unit test: `toolshed/README.md` says these tools "do not warrant CI coverage, unit tests, or the rest of the production-code apparatus", and `pytest.ini`'s `testpaths` does not include `toolshed/`, so a test there would never run. Happy to add one if you would rather have it.

Related but not overlapping: #1030 tracks wiring this tool into CI. This fix would be a prerequisite for that to mean anything.

NOTE: developed with the assistance of an AI coding agent. I reviewed and verified the change before submitting.
