### PR TITLE
build: report internal build dependency provenance

### DIFF
--- a/cuda_bindings/build_hooks.py
+++ b/cuda_bindings/build_hooks.py
@@ -16,6 +16,7 @@ import shutil
 import sys
 import sysconfig
 import tempfile
+from pathlib import Path
 from warnings import warn
 
 from setuptools import build_meta as _build_meta
@@ -50,9 +51,9 @@ def _import_get_cuda_path_or_home():
             cuda = None
 
         for p in sys.path:
-            sp_cuda = os.path.join(p, "cuda")
-            if os.path.isdir(os.path.join(sp_cuda, "pathfinder")):
-                cuda.__path__ = list(cuda.__path__) + [sp_cuda]
+            sp_cuda = Path(p) / "cuda"
+            if (sp_cuda / "pathfinder").is_dir():
+                cuda.__path__ = list(cuda.__path__) + [str(sp_cuda)]
                 break
         else:
             raise ModuleNotFoundError(
@@ -61,6 +62,11 @@ def _import_get_cuda_path_or_home():
             )
         import cuda.pathfinder
 
+    pathfinder_dir = Path(cuda.pathfinder.__file__).parent
+    print(
+        f"Using cuda-pathfinder {cuda.pathfinder.__version__} from {pathfinder_dir}",
+        file=sys.stderr,
+    )
     return cuda.pathfinder.get_cuda_path_or_home
 
 

--- a/cuda_core/build_hooks.py
+++ b/cuda_core/build_hooks.py
@@ -46,9 +46,9 @@ def _import_get_cuda_path_or_home():
             cuda = None
 
         for p in sys.path:
-            sp_cuda = os.path.join(p, "cuda")
-            if os.path.isdir(os.path.join(sp_cuda, "pathfinder")):
-                cuda.__path__ = list(cuda.__path__) + [sp_cuda]
+            sp_cuda = Path(p) / "cuda"
+            if (sp_cuda / "pathfinder").is_dir():
+                cuda.__path__ = list(cuda.__path__) + [str(sp_cuda)]
                 break
         else:
             raise ModuleNotFoundError(
@@ -57,6 +57,11 @@ def _import_get_cuda_path_or_home():
             )
         import cuda.pathfinder
 
+    pathfinder_dir = Path(cuda.pathfinder.__file__).parent
+    print(
+        f"Using cuda-pathfinder {cuda.pathfinder.__version__} from {pathfinder_dir}",
+        file=sys.stderr,
+    )
     return cuda.pathfinder.get_cuda_path_or_home
 
 
@@ -136,6 +141,7 @@ def _build_cuda_core(debug=False):
         import cuda.bindings
 
         bindings_path = Path(cuda.bindings.__file__).parent  # .../cuda/bindings/
+        print(f"Using cuda-bindings {cuda.bindings.__version__} from {bindings_path}", file=sys.stderr)
         cuda_package_dir = bindings_path.parent.parent  # .../cuda_bindings/ (contains cuda/)
         if str(cuda_package_dir) not in sys.path:
             sys.path.insert(0, str(cuda_package_dir))


### PR DESCRIPTION
## Description

Related to #2468. The stacked follow-up, #2510, addresses dependency selection itself.

PEP 517 build hooks execute in environments where the dependency actually imported at build time is not always obvious from the surrounding workflow. A locally built wheel, an editable or source installation, and a released package can all be present or eligible. Without explicit provenance in the build log, a successful build can appear to validate one combination of sources while actually using another, and discrepancies between local and CI builds can be unnecessarily difficult to diagnose.

This PR reports the internal dependency that each build hook imported, at the point where it is used:

- The `cuda.bindings` build reports the `cuda-pathfinder` version and package directory.
- The `cuda.core` build reports the `cuda-pathfinder` version and package directory.
- The `cuda.core` build reports the `cuda-bindings` version and package directory.

The resulting messages have this form:

```text
Using cuda-pathfinder <version> from <package directory>
Using cuda-bindings <version> from <package directory>
```

Both pieces of information are useful. A version alone may not distinguish a local artifact from an index-provided installation, while a path alone does not identify which release or development version was imported. Together they make the build log direct, self-contained evidence of dependency provenance.

The messages are written to stderr so they remain visible in build logs. This PR does not change dependency resolution or validation behavior. While touching the duplicated `cuda-pathfinder` import helpers, it also keeps them equivalent and narrowly replaces their `os.path` operations with `pathlib.Path` operations.