### PR TITLE
chore: avoid some warnings when running cuda.core tests

### DIFF
--- a/cuda_core/pytest.ini
+++ b/cuda_core/pytest.ini
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -11,3 +11,5 @@ markers =
     agent_authored(model): agent-authored test not yet materially human-reviewed
     human_reviewed: agent-authored test materially reviewed or rewritten by a human
     human_authored: test authored primarily by a human
+    thread_unsafe(reason): test is not safe to run concurrently with other tests (e.g. uses mocks, patches globals, or mutates shared CUDA state)
+    parallel_threads_limit(n): cap the number of parallel threads pytest-run-parallel uses for this test or module

--- a/cuda_core/tests/system/test_system_device.py
+++ b/cuda_core/tests/system/test_system_device.py
@@ -684,6 +684,7 @@ def test_cooler():
         assert all(isinstance(t, typing.CoolerTarget) for t in target)
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_temperature():
     for device in system.Device.get_all_devices():
         temperature = device.temperature
@@ -695,6 +696,9 @@ def test_temperature():
 
         # By docs, should be supported on KEPLER or newer, but experimentally,
         # is also unsupported on other hardware.
+        # get_threshold emits DeprecationWarning for some thresholds on Ada+;
+        # that behaviour is tested separately in
+        # test_temperature_threshold_unrecognized_device_arch.
         with unsupported_before(device, None):
             for threshold in list(typing.TemperatureThresholds):
                 t = temperature.get_threshold(threshold)

--- a/cuda_core/tests/test_object_protocols.py
+++ b/cuda_core/tests/test_object_protocols.py
@@ -750,7 +750,7 @@ def test_hash_distinct_same_type(a_name, b_name, request):
     assert hash(obj_a) != hash(obj_b)  # extremely unlikely
 
 
-@pytest.mark.parametrize("a_name,b_name", itertools.combinations(HASH_TYPES, 2))
+@pytest.mark.parametrize("a_name,b_name", list(itertools.combinations(HASH_TYPES, 2)))
 def test_hash_distinct_cross_type(a_name, b_name, request):
     """Distinct objects of different types have different hashes."""
     obj_a = request.getfixturevalue(a_name)
@@ -774,7 +774,7 @@ def test_equality_basic(fixture_name, request):
         assert obj != obj.handle
 
 
-@pytest.mark.parametrize("a_name,b_name", itertools.combinations(EQ_TYPES, 2))
+@pytest.mark.parametrize("a_name,b_name", list(itertools.combinations(EQ_TYPES, 2)))
 def test_no_cross_type_equality(a_name, b_name, request):
     """No two distinct objects of different types should compare equal."""
     obj_a = request.getfixturevalue(a_name)


### PR DESCRIPTION
Fix pytest warnings in cuda_core test suite

Register the `thread_unsafe` and `parallel_threads_limit` custom marks in
`pytest.ini` to eliminate `PytestUnknownMarkWarning` noise across the suite.

Wrap `itertools.combinations(...)` arguments in `list()` in
`test_object_protocols.py` to fix `PytestRemovedIn10Warning` about passing
lazy iterators to `@pytest.mark.parametrize` (deprecated ahead of pytest 10).

Add `@pytest.mark.filterwarnings("ignore::DeprecationWarning")` to
`test_temperature` in `test_system_device.py`. The test exercises
`get_threshold` for all threshold types, including the four that
intentionally emit a `DeprecationWarning` on Ada+ hardware. The warning
behaviour itself is covered by the dedicated
`test_temperature_threshold_unrecognized_device_arch` test.