### PR TITLE
build: report cuda-bindings provenance in PEP 517 builds

### DIFF
--- a/cuda_core/build_hooks.py
+++ b/cuda_core/build_hooks.py
@@ -133,6 +133,9 @@ def _build_cuda_core(debug=False):
     # This function populates "_extensions".
     global _extensions
 
+    # Resolve CUDA first so the pathfinder import repairs PEP 517 namespace shadowing before importing bindings.
+    cuda_path = _get_cuda_path()
+
     # Add cuda-bindings to sys.path so Cython can find .pxd files
     # This is needed for editable installs where meta path finders don't work for Cython
     # We need to add the directory containing the 'cuda' package so Cython can resolve
@@ -178,7 +181,7 @@ def _build_cuda_core(debug=False):
 
         return sources
 
-    all_include_dirs = [os.path.join(_get_cuda_path(), "include")]
+    all_include_dirs = [os.path.join(cuda_path, "include")]
     extra_compile_args = []
     extra_link_args = []
     extra_cythonize_kwargs = {}

--- a/cuda_core/tests/test_build_hooks.py
+++ b/cuda_core/tests/test_build_hooks.py
@@ -16,6 +16,7 @@ conftest.py which imports cuda.core modules:
 These tests require Cython to be installed (build_hooks.py imports it).
 """
 
+import builtins
 import importlib.util
 import os
 import tempfile
@@ -48,6 +49,35 @@ def _load_build_hooks():
 
 # Load the module once at import time
 build_hooks = _load_build_hooks()
+
+
+@pytest.mark.agent_authored(model="gpt-5.6")
+def test_cuda_path_is_resolved_before_importing_bindings(monkeypatch):
+    """PEP 517 namespace repair runs before cuda.bindings is imported."""
+    events = []
+
+    class StopBuildError(Exception):
+        pass
+
+    def get_cuda_path():
+        events.append("cuda-path")
+        return "/cuda"
+
+    original_import = builtins.__import__
+
+    def stop_at_bindings_import(name, *args, **kwargs):
+        if name == "cuda.bindings":
+            events.append("cuda-bindings")
+            raise StopBuildError
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(build_hooks, "_get_cuda_path", get_cuda_path)
+    monkeypatch.setattr(builtins, "__import__", stop_at_bindings_import)
+
+    with pytest.raises(StopBuildError):
+        build_hooks._build_cuda_core()
+
+    assert events == ["cuda-path", "cuda-bindings"]
 
 
 def _check_version_detection(


### PR DESCRIPTION
## Description

Related to #1824 and #2468.

Follow-up to #2509. This PR is intended to merge before #2510; it is submitted separately because contributor branches must be hosted on a fork and GitHub does not currently support cross-fork stacked bases. #2510 separately enforces exact local-wheel selection, while this PR only makes the build hook's existing provenance reporting work consistently.

#2509 added a `cuda.core` build-hook message that reports the imported `cuda-bindings` version and package directory. The message appears for previous-CTK CUDA 12 builds, but not for the 24 current-CTK CUDA 13 builds.

The difference comes from call ordering in the PEP 517 in-tree backend. `cuda_core/build_hooks.py` tries to import `cuda.bindings` before calling `_get_cuda_path()`. At that point, `backend-path = ["."]` can leave the repository's `cuda_core/cuda` directory cached as the only path in the `cuda` namespace, so the installed build dependency is not visible. The import failure is then suppressed by the existing best-effort guard. `_get_cuda_path()` invokes the namespace repair documented in #1824, but currently does so only after that import attempt.

CUDA 12 wheels happen not to expose the problem because they still contain the historical `_cuda_bindings_redirector.pth`, which imports `cuda` during interpreter startup. That redirector stopped shipping with CUDA 13 as part of #792, explaining why only the previous-CTK builds currently reach the provenance print.

This PR moves the existing `_get_cuda_path()` call ahead of the `cuda.bindings` import and reuses its result later in the build. The namespace is therefore repaired before the import, allowing the existing #2509 message to report the CUDA 13 dependency's version and location and allowing the existing Cython path setup to use that imported package.

This does not change build requirements or dependency-resolution policy. `_get_cuda_path()` was already mandatory later in the same function, so the functional change is limited to performing that lookup earlier.

## Testing

- `TestVenv/bin/python -m pytest cuda_core/tests/test_build_hooks.py -v --noconftest` (15 passed)
- `pre-commit run --all-files`
- The current-CTK CI matrix provides end-to-end verification: its build logs should now contain `Using cuda-bindings 13...` messages.
