### PR TITLE
ci: limit pytest duration reports to the slowest 20 tests

### DIFF
--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -428,7 +428,7 @@ jobs:
         if: ${{ inputs.test-mode == 'nightly-pytorch' }}
         run: |
           pushd cuda_core
-          pytest -rxXs -v --durations=20 tests/test_utils.py tests/example_tests/
+          pytest -rxXs -v tests/test_utils.py tests/example_tests/
           popd
 
       - name: Run numba-cuda tests
@@ -488,7 +488,7 @@ jobs:
               --deselect 'tests/numba_cuda_tests/cudadrv/test_nvjitlink.py::TestLinkerDumpAssembly::test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn'
             )
           fi
-          pytest -rxXs -v --durations=20 \
+          pytest -rxXs -v \
             --ignore=tests/benchmarks \
             --ignore=tests/doc_examples \
             "${DESELECTS[@]}" \
@@ -525,7 +525,7 @@ jobs:
               --deselect 'tests/test_enum_coverage.py::test_wrapper_covers_all_binding_members[NvlinkVersion]'
             )
           fi
-          pytest -rxXs -v --durations=20 --randomly-dont-reorganize \
+          pytest -rxXs -v --randomly-dont-reorganize \
             "${DESELECTS[@]}" \
             tests/
           popd

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -428,7 +428,7 @@ jobs:
         if: ${{ inputs.test-mode == 'nightly-pytorch' }}
         run: |
           pushd cuda_core
-          pytest -rxXs -v --durations=0 tests/test_utils.py tests/example_tests/
+          pytest -rxXs -v --durations=20 tests/test_utils.py tests/example_tests/
           popd
 
       - name: Run numba-cuda tests
@@ -488,7 +488,7 @@ jobs:
               --deselect 'tests/numba_cuda_tests/cudadrv/test_nvjitlink.py::TestLinkerDumpAssembly::test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn'
             )
           fi
-          pytest -rxXs -v --durations=0 \
+          pytest -rxXs -v --durations=20 \
             --ignore=tests/benchmarks \
             --ignore=tests/doc_examples \
             "${DESELECTS[@]}" \
@@ -525,7 +525,7 @@ jobs:
               --deselect 'tests/test_enum_coverage.py::test_wrapper_covers_all_binding_members[NvlinkVersion]'
             )
           fi
-          pytest -rxXs -v --durations=0 --randomly-dont-reorganize \
+          pytest -rxXs -v --durations=20 --randomly-dont-reorganize \
             "${DESELECTS[@]}" \
             tests/
           popd

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -409,7 +409,7 @@ jobs:
         shell: bash --noprofile --norc -xeuo pipefail {0}
         run: |
           pushd cuda_core
-          pytest -rxXs -v --durations=0 tests/test_utils.py tests/example_tests/
+          pytest -rxXs -v --durations=20 tests/test_utils.py tests/example_tests/
           popd
 
       - name: Run numba-cuda tests
@@ -452,7 +452,7 @@ jobs:
               --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_fortran_contiguous'
             )
           fi
-          pytest -rxXs -v --durations=0 \
+          pytest -rxXs -v --durations=20 \
             --ignore=tests/benchmarks \
             --ignore=tests/doc_examples \
             "${DESELECTS[@]}" \
@@ -494,7 +494,7 @@ jobs:
               --deselect 'tests/test_memory.py::test_non_managed_resources_report_not_managed[pinned]'
             )
           fi
-          pytest -rxXs -v --durations=0 --randomly-dont-reorganize \
+          pytest -rxXs -v --durations=20 --randomly-dont-reorganize \
             "${DESELECTS[@]}" \
             tests/
           popd

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -409,7 +409,7 @@ jobs:
         shell: bash --noprofile --norc -xeuo pipefail {0}
         run: |
           pushd cuda_core
-          pytest -rxXs -v --durations=20 tests/test_utils.py tests/example_tests/
+          pytest -rxXs -v tests/test_utils.py tests/example_tests/
           popd
 
       - name: Run numba-cuda tests
@@ -452,7 +452,7 @@ jobs:
               --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_fortran_contiguous'
             )
           fi
-          pytest -rxXs -v --durations=20 \
+          pytest -rxXs -v \
             --ignore=tests/benchmarks \
             --ignore=tests/doc_examples \
             "${DESELECTS[@]}" \
@@ -494,7 +494,7 @@ jobs:
               --deselect 'tests/test_memory.py::test_non_managed_resources_report_not_managed[pinned]'
             )
           fi
-          pytest -rxXs -v --durations=20 --randomly-dont-reorganize \
+          pytest -rxXs -v --randomly-dont-reorganize \
             "${DESELECTS[@]}" \
             tests/
           popd

--- a/ci/tools/run-tests
+++ b/ci/tools/run-tests
@@ -36,7 +36,7 @@ if [[ "${test_module}" == "pathfinder" ]]; then
     "LD:${CUDA_PATHFINDER_TEST_LOAD_NVIDIA_DYNAMIC_LIB_STRICTNESS} " \
     "FH:${CUDA_PATHFINDER_TEST_FIND_NVIDIA_HEADERS_STRICTNESS} " \
     "BC:${CUDA_PATHFINDER_TEST_FIND_NVIDIA_BITCODE_LIB_STRICTNESS}"
-  pytest -ra -s -v --durations=0 tests/ |& tee /tmp/pathfinder_test_log.txt
+  pytest -ra -s -v --durations=20 tests/ |& tee /tmp/pathfinder_test_log.txt
   # Report the number of "INFO test_" lines (including zero)
   # to support quick validations based on GHA log archives.
   line_count=$(awk '/^INFO test_/ {count++} END {print count+0}' /tmp/pathfinder_test_log.txt)
@@ -51,9 +51,9 @@ elif [[ "${test_module}" == "bindings" ]]; then
     pip install $(ls "${CUDA_BINDINGS_ARTIFACTS_DIR}"/*.whl)[all] --group test
   fi
   echo "Running bindings tests"
-  ${SANITIZER_CMD} pytest -rxXs -v --durations=0 --randomly-dont-reorganize tests/
+  ${SANITIZER_CMD} pytest -rxXs -v --durations=20 --randomly-dont-reorganize tests/
   if [[ "${SKIP_CYTHON_TEST}" == 0 ]]; then
-    ${SANITIZER_CMD} pytest -rxXs -v --durations=0 --randomly-dont-reorganize tests/cython
+    ${SANITIZER_CMD} pytest -rxXs -v --durations=20 --randomly-dont-reorganize tests/cython
   fi
   popd
 elif [[ "${test_module}" == "core" || "${test_module}" == nightly-* ]]; then
@@ -105,11 +105,11 @@ elif [[ "${test_module}" == "core" || "${test_module}" == nightly-* ]]; then
     echo "Installed packages before core tests:"
     pip list
     echo "Running core tests"
-    ${SANITIZER_CMD} pytest -rxXs -v --durations=0 --randomly-dont-reorganize tests/
+    ${SANITIZER_CMD} pytest -rxXs -v --durations=20 --randomly-dont-reorganize tests/
     # Currently our CI always installs the latest bindings (from either major version).
     # This is not compatible with the test requirements.
     if [[ "${SKIP_CYTHON_TEST}" == 0 ]]; then
-      ${SANITIZER_CMD} pytest -rxXs -v --durations=0 --randomly-dont-reorganize tests/cython
+      ${SANITIZER_CMD} pytest -rxXs -v --durations=20 --randomly-dont-reorganize tests/cython
     fi
     popd
   elif [[ "${test_module}" == "nightly-cuda-core" ]]; then

--- a/ci/tools/run-tests
+++ b/ci/tools/run-tests
@@ -36,7 +36,7 @@ if [[ "${test_module}" == "pathfinder" ]]; then
     "LD:${CUDA_PATHFINDER_TEST_LOAD_NVIDIA_DYNAMIC_LIB_STRICTNESS} " \
     "FH:${CUDA_PATHFINDER_TEST_FIND_NVIDIA_HEADERS_STRICTNESS} " \
     "BC:${CUDA_PATHFINDER_TEST_FIND_NVIDIA_BITCODE_LIB_STRICTNESS}"
-  pytest -ra -s -v --durations=20 tests/ |& tee /tmp/pathfinder_test_log.txt
+  pytest -ra -s -v tests/ |& tee /tmp/pathfinder_test_log.txt
   # Report the number of "INFO test_" lines (including zero)
   # to support quick validations based on GHA log archives.
   line_count=$(awk '/^INFO test_/ {count++} END {print count+0}' /tmp/pathfinder_test_log.txt)
@@ -51,9 +51,9 @@ elif [[ "${test_module}" == "bindings" ]]; then
     pip install $(ls "${CUDA_BINDINGS_ARTIFACTS_DIR}"/*.whl)[all] --group test
   fi
   echo "Running bindings tests"
-  ${SANITIZER_CMD} pytest -rxXs -v --durations=20 --randomly-dont-reorganize tests/
+  ${SANITIZER_CMD} pytest -rxXs -v --randomly-dont-reorganize tests/
   if [[ "${SKIP_CYTHON_TEST}" == 0 ]]; then
-    ${SANITIZER_CMD} pytest -rxXs -v --durations=20 --randomly-dont-reorganize tests/cython
+    ${SANITIZER_CMD} pytest -rxXs -v --randomly-dont-reorganize tests/cython
   fi
   popd
 elif [[ "${test_module}" == "core" || "${test_module}" == nightly-* ]]; then
@@ -105,11 +105,11 @@ elif [[ "${test_module}" == "core" || "${test_module}" == nightly-* ]]; then
     echo "Installed packages before core tests:"
     pip list
     echo "Running core tests"
-    ${SANITIZER_CMD} pytest -rxXs -v --durations=20 --randomly-dont-reorganize tests/
+    ${SANITIZER_CMD} pytest -rxXs -v --randomly-dont-reorganize tests/
     # Currently our CI always installs the latest bindings (from either major version).
     # This is not compatible with the test requirements.
     if [[ "${SKIP_CYTHON_TEST}" == 0 ]]; then
-      ${SANITIZER_CMD} pytest -rxXs -v --durations=20 --randomly-dont-reorganize tests/cython
+      ${SANITIZER_CMD} pytest -rxXs -v --randomly-dont-reorganize tests/cython
     fi
     popd
   elif [[ "${test_module}" == "nightly-cuda-core" ]]; then

--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -89,7 +89,7 @@ repair-wheel-command = "delvewheel repair --namespace-pkg cuda -w {dest_dir} {wh
 
 [tool.pytest.ini_options]
 required_plugins = "pytest-benchmark"
-addopts = "--benchmark-disable --showlocals"
+addopts = "--benchmark-disable --showlocals --durations=20"
 norecursedirs = ["tests/cython", "examples"]
 xfail_strict = true
 # Keep this authorship marker registry in sync across all pytest config roots.

--- a/cuda_core/pytest.ini
+++ b/cuda_core/pytest.ini
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [pytest]
-addopts = --showlocals
+addopts = --showlocals --durations=20
 norecursedirs = cython
 markers =
     # Keep this authorship marker registry in sync across all pytest config roots.

--- a/cuda_pathfinder/pyproject.toml
+++ b/cuda_pathfinder/pyproject.toml
@@ -103,7 +103,7 @@ tag_regex = "^cuda-pathfinder-(?P<version>v\\d+\\.\\d+\\.\\d+(?:[ab]\\d+)?)"
 git_describe_command = [ "git", "describe", "--dirty", "--tags", "--long", "--match", "cuda-pathfinder-v*[0-9]*" ]
 
 [tool.pytest.ini_options]
-addopts = "--showlocals"
+addopts = "--showlocals --durations=20"
 thread_unsafe_fixtures = ['mocker']
 # Keep this authorship marker registry in sync across all pytest config roots.
 # Search for "agent_authored(model)" before editing.

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [pytest]
-addopts = --showlocals
+addopts = --showlocals --durations=20
 norecursedirs =
     cuda_bindings/examples
     cuda_core/examples


### PR DESCRIPTION
## Summary
CI was passing `--durations=0`, which prints a duration line for every test phase and makes job logs hard to scan. Switch wheel-test workflows and `ci/tools/run-tests` to `--durations=20` so only the slowest 20 entries are reported.

## Changes
- `.github/workflows/test-wheel-linux.yml`
- `.github/workflows/test-wheel-windows.yml`
- `ci/tools/run-tests`