### PR TITLE
cuda.bindings: Fix API status handling

### DIFF
--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -346,9 +346,6 @@ jobs:
         env:
           CUDA_VER: ${{ matrix.CUDA_VER }}
           LOCAL_CTK: ${{ matrix.LOCAL_CTK }}
-          # #2299: BAR-size query returns CUDA_ERROR_NOT_SUPPORTED on G+H;
-          # skip the test on gh200 runners until upstream cufile guards it.
-          PYTEST_ADDOPTS: ${{ matrix.GPU == 'gh200' && '--deselect tests/test_cufile.py::test_get_bar_size_in_kb' || '' }}
         run: run-tests bindings
 
       - name: Run cuda.bindings benchmarks (smoke test)

--- a/cuda_bindings/cuda/bindings/_internal/cufile.pxd
+++ b/cuda_bindings/cuda/bindings/_internal/cufile.pxd
@@ -3,8 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.9.1 to 13.3.0. Do not modify it directly.
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=1788ebb3c332e99a6dc0dcd98c5af472bf42c1c960ba70cb65f294a81712491d
 
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=b70fdd33eb00b70224c097fb28dd1031d82e8a2930356a4428c93e3bd1b52a86
+
+# <<<< PREAMBLE CONTENT >>>>
+
+from libcpp cimport bool as _cyb_bool
+
+
+# <<<< END OF PREAMBLE CONTENT >>>>
+
 from ..cycufile cimport *
 
 
@@ -23,7 +31,7 @@ cdef CUfileError_t _cuFileDriverClose() except?<CUfileError_t>CUFILE_LOADING_ERR
 cdef CUfileError_t _cuFileDriverClose_v2() except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef long _cuFileUseCount() except* nogil
 cdef CUfileError_t _cuFileDriverGetProperties(CUfileDrvProps_t* props) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
-cdef CUfileError_t _cuFileDriverSetPollMode(cpp_bool poll, size_t poll_threshold_size) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t _cuFileDriverSetPollMode(_cyb_bool poll, size_t poll_threshold_size) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t _cuFileDriverSetMaxDirectIOSize(size_t max_direct_io_size) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t _cuFileDriverSetMaxCacheSize(size_t max_cache_size) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t _cuFileDriverSetMaxPinnedMemSize(size_t max_pinned_size) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
@@ -38,10 +46,10 @@ cdef CUfileError_t _cuFileStreamRegister(CUstream stream, unsigned flags) except
 cdef CUfileError_t _cuFileStreamDeregister(CUstream stream) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t _cuFileGetVersion(int* version) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t _cuFileGetParameterSizeT(CUFileSizeTConfigParameter_t param, size_t* value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
-cdef CUfileError_t _cuFileGetParameterBool(CUFileBoolConfigParameter_t param, cpp_bool* value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t _cuFileGetParameterBool(CUFileBoolConfigParameter_t param, _cyb_bool* value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t _cuFileGetParameterString(CUFileStringConfigParameter_t param, char* desc_str, int len) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t _cuFileSetParameterSizeT(CUFileSizeTConfigParameter_t param, size_t value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
-cdef CUfileError_t _cuFileSetParameterBool(CUFileBoolConfigParameter_t param, cpp_bool value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t _cuFileSetParameterBool(CUFileBoolConfigParameter_t param, _cyb_bool value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t _cuFileSetParameterString(CUFileStringConfigParameter_t param, const char* desc_str) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t _cuFileGetParameterMinMaxValue(CUFileSizeTConfigParameter_t param, size_t* min_value, size_t* max_value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t _cuFileSetStatsLevel(int level) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil

--- a/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx
+++ b/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.9.1 to 13.3.0. Do not modify it directly.
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=73d6889e33bb56f1e0e63be7a0ba1f176c5c09e6e1adf9c4360d23335e131260
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=5b6e0791dac3bac268169b02ebc748d7375de7189fe7114151716d47791519ad
 
 
 # <<<< PREAMBLE CONTENT >>>>
@@ -45,7 +45,8 @@ cdef extern from "<dlfcn.h>":
     const void * _cyb_RTLD_DEFAULT "RTLD_DEFAULT"
 
 cimport cython as _cyb_cython
-from libc.stdint cimport intptr_t as _cyb_intptr_t
+from libc.stdint cimport intptr_t
+from libcpp cimport bool as _cyb_bool
 
 import threading as _cyb_threading
 
@@ -435,133 +436,133 @@ cpdef dict _inspect_function_pointers():
     _check_or_init_cufile()
     cdef dict data = {}
     global __cuFileHandleRegister
-    data["__cuFileHandleRegister"] = <_cyb_intptr_t>__cuFileHandleRegister
+    data["__cuFileHandleRegister"] = <intptr_t>__cuFileHandleRegister
 
     global __cuFileHandleDeregister
-    data["__cuFileHandleDeregister"] = <_cyb_intptr_t>__cuFileHandleDeregister
+    data["__cuFileHandleDeregister"] = <intptr_t>__cuFileHandleDeregister
 
     global __cuFileBufRegister
-    data["__cuFileBufRegister"] = <_cyb_intptr_t>__cuFileBufRegister
+    data["__cuFileBufRegister"] = <intptr_t>__cuFileBufRegister
 
     global __cuFileBufDeregister
-    data["__cuFileBufDeregister"] = <_cyb_intptr_t>__cuFileBufDeregister
+    data["__cuFileBufDeregister"] = <intptr_t>__cuFileBufDeregister
 
     global __cuFileRead
-    data["__cuFileRead"] = <_cyb_intptr_t>__cuFileRead
+    data["__cuFileRead"] = <intptr_t>__cuFileRead
 
     global __cuFileWrite
-    data["__cuFileWrite"] = <_cyb_intptr_t>__cuFileWrite
+    data["__cuFileWrite"] = <intptr_t>__cuFileWrite
 
     global __cuFileDriverOpen
-    data["__cuFileDriverOpen"] = <_cyb_intptr_t>__cuFileDriverOpen
+    data["__cuFileDriverOpen"] = <intptr_t>__cuFileDriverOpen
 
     global __cuFileDriverClose
-    data["__cuFileDriverClose"] = <_cyb_intptr_t>__cuFileDriverClose
+    data["__cuFileDriverClose"] = <intptr_t>__cuFileDriverClose
 
     global __cuFileDriverClose_v2
-    data["__cuFileDriverClose_v2"] = <_cyb_intptr_t>__cuFileDriverClose_v2
+    data["__cuFileDriverClose_v2"] = <intptr_t>__cuFileDriverClose_v2
 
     global __cuFileUseCount
-    data["__cuFileUseCount"] = <_cyb_intptr_t>__cuFileUseCount
+    data["__cuFileUseCount"] = <intptr_t>__cuFileUseCount
 
     global __cuFileDriverGetProperties
-    data["__cuFileDriverGetProperties"] = <_cyb_intptr_t>__cuFileDriverGetProperties
+    data["__cuFileDriverGetProperties"] = <intptr_t>__cuFileDriverGetProperties
 
     global __cuFileDriverSetPollMode
-    data["__cuFileDriverSetPollMode"] = <_cyb_intptr_t>__cuFileDriverSetPollMode
+    data["__cuFileDriverSetPollMode"] = <intptr_t>__cuFileDriverSetPollMode
 
     global __cuFileDriverSetMaxDirectIOSize
-    data["__cuFileDriverSetMaxDirectIOSize"] = <_cyb_intptr_t>__cuFileDriverSetMaxDirectIOSize
+    data["__cuFileDriverSetMaxDirectIOSize"] = <intptr_t>__cuFileDriverSetMaxDirectIOSize
 
     global __cuFileDriverSetMaxCacheSize
-    data["__cuFileDriverSetMaxCacheSize"] = <_cyb_intptr_t>__cuFileDriverSetMaxCacheSize
+    data["__cuFileDriverSetMaxCacheSize"] = <intptr_t>__cuFileDriverSetMaxCacheSize
 
     global __cuFileDriverSetMaxPinnedMemSize
-    data["__cuFileDriverSetMaxPinnedMemSize"] = <_cyb_intptr_t>__cuFileDriverSetMaxPinnedMemSize
+    data["__cuFileDriverSetMaxPinnedMemSize"] = <intptr_t>__cuFileDriverSetMaxPinnedMemSize
 
     global __cuFileBatchIOSetUp
-    data["__cuFileBatchIOSetUp"] = <_cyb_intptr_t>__cuFileBatchIOSetUp
+    data["__cuFileBatchIOSetUp"] = <intptr_t>__cuFileBatchIOSetUp
 
     global __cuFileBatchIOSubmit
-    data["__cuFileBatchIOSubmit"] = <_cyb_intptr_t>__cuFileBatchIOSubmit
+    data["__cuFileBatchIOSubmit"] = <intptr_t>__cuFileBatchIOSubmit
 
     global __cuFileBatchIOGetStatus
-    data["__cuFileBatchIOGetStatus"] = <_cyb_intptr_t>__cuFileBatchIOGetStatus
+    data["__cuFileBatchIOGetStatus"] = <intptr_t>__cuFileBatchIOGetStatus
 
     global __cuFileBatchIOCancel
-    data["__cuFileBatchIOCancel"] = <_cyb_intptr_t>__cuFileBatchIOCancel
+    data["__cuFileBatchIOCancel"] = <intptr_t>__cuFileBatchIOCancel
 
     global __cuFileBatchIODestroy
-    data["__cuFileBatchIODestroy"] = <_cyb_intptr_t>__cuFileBatchIODestroy
+    data["__cuFileBatchIODestroy"] = <intptr_t>__cuFileBatchIODestroy
 
     global __cuFileReadAsync
-    data["__cuFileReadAsync"] = <_cyb_intptr_t>__cuFileReadAsync
+    data["__cuFileReadAsync"] = <intptr_t>__cuFileReadAsync
 
     global __cuFileWriteAsync
-    data["__cuFileWriteAsync"] = <_cyb_intptr_t>__cuFileWriteAsync
+    data["__cuFileWriteAsync"] = <intptr_t>__cuFileWriteAsync
 
     global __cuFileStreamRegister
-    data["__cuFileStreamRegister"] = <_cyb_intptr_t>__cuFileStreamRegister
+    data["__cuFileStreamRegister"] = <intptr_t>__cuFileStreamRegister
 
     global __cuFileStreamDeregister
-    data["__cuFileStreamDeregister"] = <_cyb_intptr_t>__cuFileStreamDeregister
+    data["__cuFileStreamDeregister"] = <intptr_t>__cuFileStreamDeregister
 
     global __cuFileGetVersion
-    data["__cuFileGetVersion"] = <_cyb_intptr_t>__cuFileGetVersion
+    data["__cuFileGetVersion"] = <intptr_t>__cuFileGetVersion
 
     global __cuFileGetParameterSizeT
-    data["__cuFileGetParameterSizeT"] = <_cyb_intptr_t>__cuFileGetParameterSizeT
+    data["__cuFileGetParameterSizeT"] = <intptr_t>__cuFileGetParameterSizeT
 
     global __cuFileGetParameterBool
-    data["__cuFileGetParameterBool"] = <_cyb_intptr_t>__cuFileGetParameterBool
+    data["__cuFileGetParameterBool"] = <intptr_t>__cuFileGetParameterBool
 
     global __cuFileGetParameterString
-    data["__cuFileGetParameterString"] = <_cyb_intptr_t>__cuFileGetParameterString
+    data["__cuFileGetParameterString"] = <intptr_t>__cuFileGetParameterString
 
     global __cuFileSetParameterSizeT
-    data["__cuFileSetParameterSizeT"] = <_cyb_intptr_t>__cuFileSetParameterSizeT
+    data["__cuFileSetParameterSizeT"] = <intptr_t>__cuFileSetParameterSizeT
 
     global __cuFileSetParameterBool
-    data["__cuFileSetParameterBool"] = <_cyb_intptr_t>__cuFileSetParameterBool
+    data["__cuFileSetParameterBool"] = <intptr_t>__cuFileSetParameterBool
 
     global __cuFileSetParameterString
-    data["__cuFileSetParameterString"] = <_cyb_intptr_t>__cuFileSetParameterString
+    data["__cuFileSetParameterString"] = <intptr_t>__cuFileSetParameterString
 
     global __cuFileGetParameterMinMaxValue
-    data["__cuFileGetParameterMinMaxValue"] = <_cyb_intptr_t>__cuFileGetParameterMinMaxValue
+    data["__cuFileGetParameterMinMaxValue"] = <intptr_t>__cuFileGetParameterMinMaxValue
 
     global __cuFileSetStatsLevel
-    data["__cuFileSetStatsLevel"] = <_cyb_intptr_t>__cuFileSetStatsLevel
+    data["__cuFileSetStatsLevel"] = <intptr_t>__cuFileSetStatsLevel
 
     global __cuFileGetStatsLevel
-    data["__cuFileGetStatsLevel"] = <_cyb_intptr_t>__cuFileGetStatsLevel
+    data["__cuFileGetStatsLevel"] = <intptr_t>__cuFileGetStatsLevel
 
     global __cuFileStatsStart
-    data["__cuFileStatsStart"] = <_cyb_intptr_t>__cuFileStatsStart
+    data["__cuFileStatsStart"] = <intptr_t>__cuFileStatsStart
 
     global __cuFileStatsStop
-    data["__cuFileStatsStop"] = <_cyb_intptr_t>__cuFileStatsStop
+    data["__cuFileStatsStop"] = <intptr_t>__cuFileStatsStop
 
     global __cuFileStatsReset
-    data["__cuFileStatsReset"] = <_cyb_intptr_t>__cuFileStatsReset
+    data["__cuFileStatsReset"] = <intptr_t>__cuFileStatsReset
 
     global __cuFileGetStatsL1
-    data["__cuFileGetStatsL1"] = <_cyb_intptr_t>__cuFileGetStatsL1
+    data["__cuFileGetStatsL1"] = <intptr_t>__cuFileGetStatsL1
 
     global __cuFileGetStatsL2
-    data["__cuFileGetStatsL2"] = <_cyb_intptr_t>__cuFileGetStatsL2
+    data["__cuFileGetStatsL2"] = <intptr_t>__cuFileGetStatsL2
 
     global __cuFileGetStatsL3
-    data["__cuFileGetStatsL3"] = <_cyb_intptr_t>__cuFileGetStatsL3
+    data["__cuFileGetStatsL3"] = <intptr_t>__cuFileGetStatsL3
 
     global __cuFileGetBARSizeInKB
-    data["__cuFileGetBARSizeInKB"] = <_cyb_intptr_t>__cuFileGetBARSizeInKB
+    data["__cuFileGetBARSizeInKB"] = <intptr_t>__cuFileGetBARSizeInKB
 
     global __cuFileSetParameterPosixPoolSlabArray
-    data["__cuFileSetParameterPosixPoolSlabArray"] = <_cyb_intptr_t>__cuFileSetParameterPosixPoolSlabArray
+    data["__cuFileSetParameterPosixPoolSlabArray"] = <intptr_t>__cuFileSetParameterPosixPoolSlabArray
 
     global __cuFileGetParameterPosixPoolSlabArray
-    data["__cuFileGetParameterPosixPoolSlabArray"] = <_cyb_intptr_t>__cuFileGetParameterPosixPoolSlabArray
+    data["__cuFileGetParameterPosixPoolSlabArray"] = <intptr_t>__cuFileGetParameterPosixPoolSlabArray
     _cyb_func_ptrs = data
     return data
 
@@ -694,13 +695,13 @@ cdef CUfileError_t _cuFileDriverGetProperties(CUfileDrvProps_t* props) except?<C
         props)
 
 
-cdef CUfileError_t _cuFileDriverSetPollMode(cpp_bool poll, size_t poll_threshold_size) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+cdef CUfileError_t _cuFileDriverSetPollMode(_cyb_bool poll, size_t poll_threshold_size) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
     global __cuFileDriverSetPollMode
     _check_or_init_cufile()
     if __cuFileDriverSetPollMode == NULL:
         with gil:
             raise FunctionNotFoundError("function cuFileDriverSetPollMode is not found")
-    return (<CUfileError_t (*)(cpp_bool, size_t) noexcept nogil>__cuFileDriverSetPollMode)(
+    return (<CUfileError_t (*)(_cyb_bool, size_t) noexcept nogil>__cuFileDriverSetPollMode)(
         poll, poll_threshold_size)
 
 
@@ -845,13 +846,13 @@ cdef CUfileError_t _cuFileGetParameterSizeT(CUFileSizeTConfigParameter_t param, 
         param, value)
 
 
-cdef CUfileError_t _cuFileGetParameterBool(CUFileBoolConfigParameter_t param, cpp_bool* value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+cdef CUfileError_t _cuFileGetParameterBool(CUFileBoolConfigParameter_t param, _cyb_bool* value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
     global __cuFileGetParameterBool
     _check_or_init_cufile()
     if __cuFileGetParameterBool == NULL:
         with gil:
             raise FunctionNotFoundError("function cuFileGetParameterBool is not found")
-    return (<CUfileError_t (*)(CUFileBoolConfigParameter_t, cpp_bool*) noexcept nogil>__cuFileGetParameterBool)(
+    return (<CUfileError_t (*)(CUFileBoolConfigParameter_t, _cyb_bool*) noexcept nogil>__cuFileGetParameterBool)(
         param, value)
 
 
@@ -875,13 +876,13 @@ cdef CUfileError_t _cuFileSetParameterSizeT(CUFileSizeTConfigParameter_t param, 
         param, value)
 
 
-cdef CUfileError_t _cuFileSetParameterBool(CUFileBoolConfigParameter_t param, cpp_bool value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+cdef CUfileError_t _cuFileSetParameterBool(CUFileBoolConfigParameter_t param, _cyb_bool value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
     global __cuFileSetParameterBool
     _check_or_init_cufile()
     if __cuFileSetParameterBool == NULL:
         with gil:
             raise FunctionNotFoundError("function cuFileSetParameterBool is not found")
-    return (<CUfileError_t (*)(CUFileBoolConfigParameter_t, cpp_bool) noexcept nogil>__cuFileSetParameterBool)(
+    return (<CUfileError_t (*)(CUFileBoolConfigParameter_t, _cyb_bool) noexcept nogil>__cuFileSetParameterBool)(
         param, value)
 
 

--- a/cuda_bindings/cuda/bindings/cufile.pxd
+++ b/cuda_bindings/cuda/bindings/cufile.pxd
@@ -3,9 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.9.1 to 13.3.0. Do not modify it directly.
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=b10e4f1751ee5423db23c6fc953cb0ae37bff7e8937bf1d39ac5fd6eeb0e4e87
 
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=232df43b5a8960f10286c172abc71222a3822087a1f6134e12d9341f3b53886c
+
+
+# <<<< PREAMBLE CONTENT >>>>
+
 from libc.stdint cimport intptr_t
+from libcpp cimport bool as _cyb_bool
+
+
+# <<<< END OF PREAMBLE CONTENT >>>>
 
 from .cycufile cimport *
 

--- a/cuda_bindings/cuda/bindings/cufile.pyx
+++ b/cuda_bindings/cuda/bindings/cufile.pyx
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.9.1 to 13.3.0. Do not modify it directly.
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=f107413ea0012a1a854cd3de77d57f649bebd0f586901d4e6384f37288ac5421
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=1ca8c2d672c5799154a85a73ac7f0f3661943ece8f4d7c1d2e11649a0a537c81
 
 
 # <<<< PREAMBLE CONTENT >>>>
@@ -12,6 +12,10 @@ cimport cpython as _cyb_cpython
 cimport cpython.buffer as _cyb_cpython_buffer
 cimport cpython.memoryview as _cyb_cpython_memoryview
 from cython cimport view as _cyb_view
+from libc.stdint cimport (
+    intptr_t,
+    uint64_t,
+)
 from libc.stdlib cimport (
     calloc as _cyb_calloc,
     free as _cyb_free,
@@ -21,6 +25,7 @@ from libc.string cimport (
     memcmp as _cyb_memcmp,
     memcpy as _cyb_memcpy,
 )
+from libcpp cimport bool as _cyb_bool
 
 from cuda.bindings._internal._fast_enum import FastEnum as _cyb_FastEnum
 
@@ -2986,9 +2991,12 @@ class cuFileError(Exception):
 @cython.profile(False)
 cdef int check_status(ReturnT status) except 1 nogil:
     if ReturnT is CUfileError_t:
-        if status.err != 0 or status.cu_err != 0:
+        if IS_CUDA_ERR(status):
             with gil:
                 raise cuFileError(status.err, status.cu_err)
+        elif IS_CUFILE_ERR(status.err):
+            with gil:
+                raise cuFileError(status.err)
     elif ReturnT is ssize_t:
         if status == -1:
             # note: this assumes cuFile already properly resets errno in each API
@@ -3107,7 +3115,7 @@ cpdef driver_set_poll_mode(bint poll, size_t poll_threshold_size):
     .. seealso:: `cuFileDriverSetPollMode`
     """
     with nogil:
-        __status__ = cuFileDriverSetPollMode(<cpp_bool>poll, poll_threshold_size)
+        __status__ = cuFileDriverSetPollMode(<_cyb_bool>poll, poll_threshold_size)
     check_status(__status__)
 
 
@@ -3232,7 +3240,7 @@ cpdef size_t get_parameter_size_t(int param) except? 0:
 
 
 cpdef bint get_parameter_bool(int param) except? 0:
-    cdef cpp_bool value
+    cdef _cyb_bool value
     with nogil:
         __status__ = cuFileGetParameterBool(<_BoolConfigParameter>param, &value)
     check_status(__status__)
@@ -3256,7 +3264,7 @@ cpdef set_parameter_size_t(int param, size_t value):
 
 cpdef set_parameter_bool(int param, bint value):
     with nogil:
-        __status__ = cuFileSetParameterBool(<_BoolConfigParameter>param, <cpp_bool>value)
+        __status__ = cuFileSetParameterBool(<_BoolConfigParameter>param, <_cyb_bool>value)
     check_status(__status__)
 
 

--- a/cuda_bindings/cuda/bindings/cycufile.pxd
+++ b/cuda_bindings/cuda/bindings/cycufile.pxd
@@ -3,11 +3,21 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.9.1 to 13.3.0. Do not modify it directly.
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=1051fa856de24c84b3c8d3b2996adb28c5db2530a86f49c240b05eb0dab0954d
 
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=f840820f160e36eebe6e052b5a5d3a35b55704060301ee2ab7d5cd7a7d580418
-from libc.stdint cimport uint32_t, uint64_t
+
+# <<<< PREAMBLE CONTENT >>>>
+
+from libc.stdint cimport (
+    uint32_t,
+    uint64_t,
+)
+from libcpp cimport bool as _cyb_bool
+
+
+# <<<< END OF PREAMBLE CONTENT >>>>
+
 from libc.time cimport time_t
-from libcpp cimport bool as cpp_bool
 from posix.types cimport off_t
 
 cimport cuda.bindings.cydriver
@@ -371,6 +381,13 @@ cdef extern from 'cufile.h':
         CUfilePerGpuStats_t per_gpu_stats[16]
 
 
+# Error-inspection macros from cufile.h (declared as functions so Cython
+# emits calls that the C preprocessor expands).
+cdef extern from 'cufile.h' nogil:
+    bint IS_CUDA_ERR(CUfileError_t status)
+    bint IS_CUFILE_ERR(CUfileOpError err)
+
+
 cdef extern from *:
     """
     // This is the missing piece we need to supply to help Cython & C++ compilers.
@@ -400,7 +417,7 @@ cdef CUfileError_t cuFileDriverClose() except?<CUfileError_t>CUFILE_LOADING_ERRO
 cdef CUfileError_t cuFileDriverClose_v2() except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef long cuFileUseCount() except* nogil
 cdef CUfileError_t cuFileDriverGetProperties(CUfileDrvProps_t* props) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
-cdef CUfileError_t cuFileDriverSetPollMode(cpp_bool poll, size_t poll_threshold_size) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t cuFileDriverSetPollMode(_cyb_bool poll, size_t poll_threshold_size) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t cuFileDriverSetMaxDirectIOSize(size_t max_direct_io_size) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t cuFileDriverSetMaxCacheSize(size_t max_cache_size) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t cuFileDriverSetMaxPinnedMemSize(size_t max_pinned_size) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
@@ -415,10 +432,10 @@ cdef CUfileError_t cuFileStreamRegister(CUstream stream, unsigned flags) except?
 cdef CUfileError_t cuFileStreamDeregister(CUstream stream) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t cuFileGetVersion(int* version) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t cuFileGetParameterSizeT(CUFileSizeTConfigParameter_t param, size_t* value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
-cdef CUfileError_t cuFileGetParameterBool(CUFileBoolConfigParameter_t param, cpp_bool* value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t cuFileGetParameterBool(CUFileBoolConfigParameter_t param, _cyb_bool* value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t cuFileGetParameterString(CUFileStringConfigParameter_t param, char* desc_str, int len) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t cuFileSetParameterSizeT(CUFileSizeTConfigParameter_t param, size_t value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
-cdef CUfileError_t cuFileSetParameterBool(CUFileBoolConfigParameter_t param, cpp_bool value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
+cdef CUfileError_t cuFileSetParameterBool(CUFileBoolConfigParameter_t param, _cyb_bool value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t cuFileSetParameterString(CUFileStringConfigParameter_t param, const char* desc_str) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t cuFileGetParameterMinMaxValue(CUFileSizeTConfigParameter_t param, size_t* min_value, size_t* max_value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil
 cdef CUfileError_t cuFileSetStatsLevel(int level) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil

--- a/cuda_bindings/cuda/bindings/cycufile.pyx
+++ b/cuda_bindings/cuda/bindings/cycufile.pyx
@@ -3,12 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.9.1 to 13.3.0. Do not modify it directly.
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=a68ff13250f4b5131f4b4adf8a37a4283b27749e8429b5f6e57bfc68bf656b00
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=21f23d353f9a8d02c92a5c5740cfa8bed67c952fbf262b8181fdfb6f65e52a73
 
 
 # <<<< PREAMBLE CONTENT >>>>
 
 cimport cython as _cyb_cython
+from libcpp cimport bool as _cyb_bool
 
 
 # <<<< END OF PREAMBLE CONTENT >>>>
@@ -66,7 +67,7 @@ cdef CUfileError_t cuFileDriverGetProperties(CUfileDrvProps_t* props) except?<CU
     return _cufile._cuFileDriverGetProperties(props)
 
 
-cdef CUfileError_t cuFileDriverSetPollMode(cpp_bool poll, size_t poll_threshold_size) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+cdef CUfileError_t cuFileDriverSetPollMode(_cyb_bool poll, size_t poll_threshold_size) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
     return _cufile._cuFileDriverSetPollMode(poll, poll_threshold_size)
 
 
@@ -127,7 +128,7 @@ cdef CUfileError_t cuFileGetParameterSizeT(CUFileSizeTConfigParameter_t param, s
     return _cufile._cuFileGetParameterSizeT(param, value)
 
 
-cdef CUfileError_t cuFileGetParameterBool(CUFileBoolConfigParameter_t param, cpp_bool* value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+cdef CUfileError_t cuFileGetParameterBool(CUFileBoolConfigParameter_t param, _cyb_bool* value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
     return _cufile._cuFileGetParameterBool(param, value)
 
 
@@ -139,7 +140,7 @@ cdef CUfileError_t cuFileSetParameterSizeT(CUFileSizeTConfigParameter_t param, s
     return _cufile._cuFileSetParameterSizeT(param, value)
 
 
-cdef CUfileError_t cuFileSetParameterBool(CUFileBoolConfigParameter_t param, cpp_bool value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
+cdef CUfileError_t cuFileSetParameterBool(CUFileBoolConfigParameter_t param, _cyb_bool value) except?<CUfileError_t>CUFILE_LOADING_ERROR nogil:
     return _cufile._cuFileSetParameterBool(param, value)
 
 


### PR DESCRIPTION
closes #2299

Test `get_bar_size_in_kb` failed on an GH200 system. The clue is in the error shared in #2299:
```
tests/test_cufile.py::test_get_bar_size_in_kb FAILED

bar_size_kb = cufile.get_bar_size_in_kb(0)

cuda.bindings.cufile.cuFileError:
SUCCESS (0): cufile success; CUDA status: CUDA_ERROR_NOT_SUPPORTED (801)
```

The `cufile` status struct has two fields, one for `cufile` proper, and a second for forwarding potential CUDA driver errors. The CUDA driver error field should be ignored unless the `cufile` error is `CU_FILE_CUDA_DRIVER_ERROR`. So the test failed because `cuda.bindings` incorrectly raised a `cuFileError`.

The issue fix is [here](https://github.com/NVIDIA/cuda-python/pull/2530/changes#diff-9036f7baf6b5c9a4f3a56ffd5573c29f83dbed63b4f665f125db00ca65f89549L2986). The PR contains other unrelated changes from re-generating `cufile` bindings.