### PR TITLE
Fix CUDA Runtime CTK test fixture on Windows ARM64

### DIFF
--- a/cuda_pathfinder/tests/test_ctk_root_discovery.py
+++ b/cuda_pathfinder/tests/test_ctk_root_discovery.py
@@ -81,9 +81,9 @@ def _create_nvvm_in_ctk(ctk_root):
 def _create_cudart_in_ctk(ctk_root):
     """Create a fake cudart lib in the platform-appropriate CTK subdirectory."""
     if IS_WINDOWS:
-        lib_dir = ctk_root / "bin"
+        lib_dir = ctk_root / "bin" / windows_python_arch()
         lib_dir.mkdir(parents=True)
-        lib_file = lib_dir / "cudart64_12.dll"
+        lib_file = lib_dir / "cudart64_13.dll"
     else:
         lib_dir = ctk_root / "lib64"
         lib_dir.mkdir(parents=True)

--- a/cuda_pathfinder/tests/test_ctk_root_discovery.py
+++ b/cuda_pathfinder/tests/test_ctk_root_discovery.py
@@ -33,7 +33,7 @@ from cuda.pathfinder._dynamic_libs.subprocess_protocol import (
     DYNAMIC_LIB_SUBPROCESS_MODULE,
     MODE_CANARY,
 )
-from cuda.pathfinder._utils.platform_aware import IS_WINDOWS
+from cuda.pathfinder._utils.platform_aware import IS_WINDOWS, IS_WINDOWS_ARM64, IS_WINDOWS_X64
 from cuda.pathfinder._utils.windows_arch import windows_python_arch
 
 _MODULE = "cuda.pathfinder._dynamic_libs.load_nvidia_dynamic_lib"
@@ -80,14 +80,16 @@ def _create_nvvm_in_ctk(ctk_root):
 
 def _create_cudart_in_ctk(ctk_root):
     """Create a fake cudart lib in the platform-appropriate CTK subdirectory."""
-    if IS_WINDOWS:
-        lib_dir = ctk_root / "bin" / windows_python_arch()
-        lib_dir.mkdir(parents=True)
+    if IS_WINDOWS_X64:
+        lib_dir = ctk_root / "bin" / "x64"
+        lib_file = lib_dir / "cudart64_13.dll"
+    elif IS_WINDOWS_ARM64:
+        lib_dir = ctk_root / "bin" / "arm64"
         lib_file = lib_dir / "cudart64_13.dll"
     else:
         lib_dir = ctk_root / "lib64"
-        lib_dir.mkdir(parents=True)
         lib_file = lib_dir / "libcudart.so"
+    lib_dir.mkdir(parents=True)
     lib_file.write_bytes(b"fake")
     return lib_file
 


### PR DESCRIPTION
## What changed

Update the Windows CUDA Runtime CTK test fixture to model the current CUDA 13 layout explicitly:

- x64 creates `bin/x64/cudart64_13.dll`;
- Arm64 creates `bin/arm64/cudart64_13.dll`;
- Linux behavior is unchanged.

## Why

#2393 made Windows CTK dynamic-library searches architecture-aware. Native Arm64 Python now correctly searches `bin/arm64`, but `_create_cudart_in_ctk` still created `cudart64_12.dll` in the legacy unqualified `bin` directory. As a result, `test_try_via_ctk_root_regular_lib` failed only under native Windows Arm64.

The fixture now targets the latest CUDA layout for both Windows architectures. Production discovery continues to retain its legacy unqualified `bin` fallback for older x64 toolkits.

## Validation

- Native Windows Arm64 focused regression: 1 passed.
- `tests/test_ctk_root_discovery.py`: 37 passed.
