### PR TITLE
fix(ci): treat max_size=0 as an uncapped pool in check_mempool_hygiene

### DIFF
--- a/ci/tools/check_mempool_hygiene.py
+++ b/ci/tools/check_mempool_hygiene.py
@@ -3,7 +3,8 @@
 
 """Check that tests do not create uncapped CUDA memory pools.
 
-A pool created without ``max_size`` reserves an address-space window sized from
+A pool created without ``max_size`` -- or with ``max_size=0``, which is the
+same request expressed explicitly -- reserves an address-space window sized from
 installed device memory rather than from what the test allocates, and the whole
 cuda_core suite shares one process. Enough of those reservations exhaust the
 address space, after which the rest of the session fails with
@@ -39,18 +40,42 @@ def _callee_name(node: ast.Call) -> str:
     return ""
 
 
-def _is_capped(node: ast.Call) -> bool:
+MISSING_CAP = "without max_size"
+ZERO_CAP = "with max_size=0, which is the uncapped default"
+
+
+def _is_zero_literal(node: ast.expr) -> bool:
+    """True for a literal ``0``.
+
+    ``CUmemPoolProps.maxSize == 0`` asks the driver for its system-dependent
+    default, which is the uncapped pool this check exists to prevent -- see
+    "When set to 0, defaults to a system-dependent value" in the
+    ``DeviceMemoryResourceOptions`` / ``PinnedMemoryResourceOptions``
+    docstrings. Only literals are inspected: a named constant may well be the
+    suite-wide POOL_SIZE, and this checker does not guess.
+    """
+    return isinstance(node, ast.Constant) and node.value == 0
+
+
+def _cap_problem(node: ast.Call) -> str | None:
+    """Describe why ``node``'s options leave the pool uncapped, else ``None``."""
     # ``**kwargs`` (arg is None) may carry max_size; do not guess.
-    return any(kw.arg is None or kw.arg == "max_size" for kw in node.keywords)
+    if any(kw.arg is None for kw in node.keywords):
+        return None
+    for kw in node.keywords:
+        if kw.arg == "max_size":
+            return ZERO_CAP if _is_zero_literal(kw.value) else None
+    return MISSING_CAP
 
 
-def _dict_is_capped(node: ast.Dict) -> bool:
-    for key in node.keys:
-        if key is None:  # ``**other`` inside the literal
-            return True
+def _dict_cap_problem(node: ast.Dict) -> str | None:
+    """``_cap_problem`` for options given as a dict literal."""
+    if any(key is None for key in node.keys):  # ``**other`` inside the literal
+        return None
+    for key, value in zip(node.keys, node.values):
         if isinstance(key, ast.Constant) and key.value == "max_size":
-            return True
-    return False
+            return ZERO_CAP if _is_zero_literal(value) else None
+    return MISSING_CAP
 
 
 def _opted_out(lines: list[str], node: ast.AST) -> bool:
@@ -70,15 +95,16 @@ def violations_in(path: Path) -> list[str]:
             continue
         name = _callee_name(node)
         if name in CAPPABLE_OPTIONS:
-            uncapped = not _is_capped(node)
+            problem = _cap_problem(node)
         elif name in CAPPABLE_RESOURCES:
             # The options may also be given as a dict literal.
             dicts = [arg for arg in [*node.args, *(kw.value for kw in node.keywords)] if isinstance(arg, ast.Dict)]
-            uncapped = any(not _dict_is_capped(d) for d in dicts)
+            problems = [p for p in (_dict_cap_problem(d) for d in dicts) if p is not None]
+            problem = problems[0] if problems else None
         else:
             continue
-        if uncapped and not _opted_out(lines, node):
-            found.append(f"{path.as_posix()}:{node.lineno}: {name} without max_size")
+        if problem is not None and not _opted_out(lines, node):
+            found.append(f"{path.as_posix()}:{node.lineno}: {name} {problem}")
     return found
 
 
@@ -97,7 +123,7 @@ def main(argv: list[str] | None = None) -> int:
     if not violations:
         return 0
 
-    print("error: memory pools created by tests must set max_size:", file=sys.stderr)
+    print("error: memory pools created by tests must set max_size to a non-zero value:", file=sys.stderr)
     for violation in violations:
         print(f"  - {violation}", file=sys.stderr)
     print(

--- a/ci/tools/tests/test_check_mempool_hygiene.py
+++ b/ci/tools/tests/test_check_mempool_hygiene.py
@@ -22,12 +22,23 @@ UNCAPPED = [
     pytest.param("DeviceMemoryResource(dev, DeviceMemoryResourceOptions(ipc_enabled=True))", id="options-kwarg"),
     pytest.param("PinnedMemoryResource(PinnedMemoryResourceOptions())", id="options-empty"),
     pytest.param('DeviceMemoryResource(dev, {"ipc_enabled": True})', id="options-dict"),
+    # max_size=0 asks the driver for its system-dependent default, i.e. exactly
+    # the uncapped pool that omitting max_size produces.
+    pytest.param("DeviceMemoryResource(dev, DeviceMemoryResourceOptions(max_size=0))", id="zero-kwarg"),
+    pytest.param(
+        "PinnedMemoryResource(PinnedMemoryResourceOptions(ipc_enabled=True, max_size=0))", id="zero-kwarg-among-others"
+    ),
+    pytest.param('DeviceMemoryResource(dev, {"max_size": 0})', id="zero-dict"),
 ]
 
 CAPPED = [
     pytest.param("DeviceMemoryResource(dev, DeviceMemoryResourceOptions(max_size=POOL_SIZE))", id="capped-kwarg"),
     pytest.param('DeviceMemoryResource(dev, {"max_size": POOL_SIZE})', id="capped-dict"),
+    pytest.param("DeviceMemoryResource(dev, DeviceMemoryResourceOptions(max_size=1))", id="capped-nonzero-literal"),
     pytest.param("DeviceMemoryResource(dev, DeviceMemoryResourceOptions(**opts))", id="opaque-kwargs"),
+    # A literal 0 next to ``**opts`` is not decidable statically: opts may or
+    # may not override it, so the checker must not guess.
+    pytest.param('DeviceMemoryResource(dev, {"max_size": 0, **opts})', id="zero-dict-with-unpacking"),
     # No options at all wraps the device's default pool and reserves nothing, so
     # capping it would convert a free wrapper into a new pool.
     pytest.param("DeviceMemoryResource(dev)", id="default-pool-wrapper"),
@@ -70,6 +81,16 @@ def test_reported_message_names_file_line_and_symbol(tmp_path):
     assert violation.startswith(path.as_posix())
     assert ":2:" in violation
     assert "DeviceMemoryResourceOptions without max_size" in violation
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+def test_zero_cap_message_names_the_zero(tmp_path):
+    path = write(tmp_path, "DeviceMemoryResource(dev, DeviceMemoryResourceOptions(max_size=0))\n")
+
+    (violation,) = violations_in(path)
+
+    assert "max_size=0" in violation
+    assert "uncapped default" in violation
 
 
 @pytest.mark.agent_authored(model="claude-opus-5")

--- a/cuda_core/tests/AGENTS.md
+++ b/cuda_core/tests/AGENTS.md
@@ -25,6 +25,11 @@ mr = DeviceMemoryResource(dev, DeviceMemoryResourceOptions(max_size=POOL_SIZE))
 Use a larger value only if a test genuinely requires it, and prefer adding a
 shared constant to `helpers/constants.py` over redefining one per module.
 
+`max_size=0` does not cap anything: it is the default, and it asks the driver
+for a system-dependent size. `DeviceMemoryResourceOptions(max_size=0)` creates
+exactly the same uncapped pool as `DeviceMemoryResourceOptions()`, so it is
+reported the same way.
+
 ### Passing no options is different from passing empty options
 
 `DeviceMemoryResource(dev)` with no options does **not** create a pool. It


### PR DESCRIPTION
## Problem

`ci/tools/check_mempool_hygiene.py` enforces the rule in `cuda_core/tests/AGENTS.md`: a test-created pool without `max_size` reserves an address-space window sized from installed device memory rather than from what the test allocates, and the whole suite shares one process.

It decides "capped" by looking only for the **presence** of `max_size`, never its value:

```python
def _is_capped(node: ast.Call) -> bool:
    # ``**kwargs`` (arg is None) may carry max_size; do not guess.
    return any(kw.arg is None or kw.arg == "max_size" for kw in node.keywords)
```

But `max_size=0` is the *default*, and `CUmemPoolProps.maxSize == 0` asks the driver for its system-dependent size. From `DeviceMemoryResourceOptions` (and identically `PinnedMemoryResourceOptions`):

> `max_size : int, optional` — Maximum pool size. **When set to 0, defaults to a system-dependent value.** (Default to 0)

So these create exactly the uncapped pool the check exists to reject, and every one of them passes today:

```python
DeviceMemoryResource(dev, DeviceMemoryResourceOptions(max_size=0))
DeviceMemoryResource(dev, {"max_size": 0})
PinnedMemoryResource(PinnedMemoryResourceOptions(ipc_enabled=True, max_size=0))
```

Verified against `violations_in()` on `main`: all three return `[]`, while the equivalent `DeviceMemoryResourceOptions()` is correctly reported.

This is the worst shape for a hole in a lint: `max_size=0` is the natural thing to reach for when quieting the hook, it *looks* like a cap in review, and it reserves the full window anyway.

## Fix

Inspect the value and report a literal `0`.

- **Non-literals are still accepted, unchanged.** A named value is usually the suite-wide `POOL_SIZE`; the checker does not guess.
- **`**kwargs` / `**other` still short-circuit to "capped", unchanged** — including `{"max_size": 0, **opts}`, where the unpacking may override the literal. Not statically decidable, so not reported.
- The reported message names the actual problem (`max_size=0, which is the uncapped default`) instead of claiming `max_size` is missing. The omitted-`max_size` message is unchanged.

Also updated the corresponding rule in `cuda_core/tests/AGENTS.md`, which is what contributors read.

## Effect on the tree

None: `cuda_core/tests` has no `max_size=0` construction today, so the tightened rule leaves the suite clean. The existing `test_the_live_test_suite_is_clean` (which runs `main([])` over the real tree) still passes.

## Tests

`ci/tools/tests/test_check_mempool_hygiene.py` gains three `UNCAPPED` cases (kwarg, kwarg among other options, dict literal), two `CAPPED` regression guards (a non-zero literal, and `{"max_size": 0, **opts}`), and one assertion on the new message.

Verified with the index-safe swap (`cp` aside, `git show upstream/main:<path> >`, run, restore):

```
# with the fix
20 passed

# with ci/tools/check_mempool_hygiene.py restored from upstream/main
FAILED test_uncapped_pool_is_reported[zero-kwarg]
FAILED test_uncapped_pool_is_reported[zero-kwarg-among-others]
FAILED test_uncapped_pool_is_reported[zero-dict]
FAILED test_zero_cap_message_names_the_zero
4 failed, 16 passed
```

Full `pytest ci/tools/tests`: 62 passed. `ruff check` and `ruff format --check` clean on both changed files; `python -m py_compile` clean. No GPU is involved — this tool is pure AST analysis, so everything above was actually executed.
