### PR TITLE
fix(toolshed): accept `//` seals so C/C++ generated files can be sealed

### DIFF
--- a/toolshed/check_generated_file_seals.py
+++ b/toolshed/check_generated_file_seals.py
@@ -17,7 +17,10 @@ SUPPORTED_GENERATED_FILE_SEAL_FORMATS = frozenset({1})
 assert GENERATED_FILE_MARKER_FRAGMENT in GENERATED_FILE_SEAL_TOKEN
 _TOKEN_BYTES = GENERATED_FILE_SEAL_TOKEN.encode("ascii")
 _MARKER_REGEX = re.compile(
-    rb"^(?P<prefix>#|\.\.) "
+    # Keep the alternation in sync with the values of _COMMENT_CHARS below:
+    # a prefix that is not matched here can never reach the
+    # expected_comment_prefix() comparison in validate_generated_file_seal().
+    rb"^(?P<prefix>#|\.\.|//) "
     + re.escape(_TOKEN_BYTES)
     + rb" format=(?P<format>[0-9]+); content-sha256=(?P<digest>[0-9a-f]{64})\n$"
 )


### PR DESCRIPTION
## Problem

`toolshed/check_generated_file_seals.py` declares three comment styles for the seal line, one per generated-file family:

```python
_COMMENT_CHARS = {
    ".py": b"#", ".pxd": b"#", ".pxi": b"#", ".pyx": b"#",
    ".pyx.in": b"#", ".pxd.in": b"#", ".pxi.in": b"#",
    ".rst": b"..",
    ".c": b"//", ".cpp": b"//", ".h": b"//",
}
```

and `validate_generated_file_seal` deliberately compares the seal's captured prefix against `expected_comment_prefix(filepath)`, so a `.rst` file cannot be sealed with a `#`:

```python
if match.group("prefix") != expected_prefix:
    print(f"INVALID generated-file seal comment prefix in {filepath!r}")
```

But the marker regex only accepts two of the three declared prefixes:

```python
_MARKER_REGEX = re.compile(
    rb"^(?P<prefix>#|\.\.) "        # no //
    + re.escape(_TOKEN_BYTES)
    + rb" format=(?P<format>[0-9]+); content-sha256=(?P<digest>[0-9a-f]{64})\n$"
)
```

`//` can never be captured, so `fullmatch` returns `None` for a sealed `.c`/`.cpp`/`.h` file and it is rejected as `MALFORMED generated-file seal` before the prefix comparison ever runs. The `b"//"` entries in `_COMMENT_CHARS` — and the branch that would validate them — are dead.

Reproduced by writing one identical seal three ways and calling `validate_generated_file_seal` directly:

```
gen.c      prefix=b'//'  regex_match=False  ->  MALFORMED generated-file seal in '.../gen.c'   False
gen.pyx    prefix=b'#'   regex_match=True   ->  True
gen.rst    prefix=b'..'  regex_match=True   ->  True
```

Only the prefix differs; the token, format, digest, and body are byte-identical.

The hook runs over `^cuda_bindings/` with `types: [text]`, which already contains C headers (`cuda_bindings/cuda/bindings/_lib/param_packer.h`), so the first generated `.h` or `.cpp` to be sealed would be rejected with a message that points at the file rather than at the checker.

## Fix

Add `//` to the alternation, with a comment tying it to `_COMMENT_CHARS` so the two do not drift apart again. One line of behavior change; no other logic touched.

## Tests

This script had no tests. Added `toolshed/tests/test_check_generated_file_seals.py` covering the seal round-trip for **every** entry in `_COMMENT_CHARS` (parametrized off the dict itself, so a future entry the regex cannot match fails immediately rather than silently becoming dead code), plus the wrong-prefix-for-extension rejection, the tampered-content rejection, the unsupported-extension rejection, and the never-sealed passthrough. They call `validate_generated_file_seal(path, set())` directly, so no `git` subprocess and no CUDA are involved.

The new directory is wired into the existing nightly tooling job next to `ci/tools/tests`:

```yaml
python -m pytest -v --noconftest ci/tools/tests toolshed/tests
```

## Verification

All of this was actually executed (pure Python, no GPU):

```
# with the fix
18 passed

# with toolshed/check_generated_file_seals.py restored from upstream/main
FAILED test_every_declared_comment_prefix_validates[.c-//]
FAILED test_every_declared_comment_prefix_validates[.cpp-//]
FAILED test_every_declared_comment_prefix_validates[.h-//]
FAILED test_marker_regex_accepts_every_declared_prefix[//]
FAILED test_edited_content_is_rejected
5 failed, 13 passed
```

Combined `pytest --noconftest ci/tools/tests toolshed/tests`: 74 passed. `ruff check` / `ruff format --check` clean on both changed Python files (no new findings vs. an `upstream/main` baseline), `toolshed/check_spdx.py` clean on the new file, `python -m py_compile` clean.

Verified index-safely (`cp` aside, `git show upstream/main:<path> >`, run, restore) — no staged reverts.
