### PR TITLE
fix(core): report unhashable string-enum arguments as ValueError, not TypeError

### DIFF
--- a/cuda_core/cuda/core/_utils/validators.py
+++ b/cuda_core/cuda/core/_utils/validators.py
@@ -28,7 +28,11 @@ def check_str_enum(value, enum_class, *, allow_none=False):
     """
     if allow_none and value is None:
         return
-    if value not in {m.value for m in enum_class}:
+    # Membership is tested against a tuple rather than a set on purpose:
+    # ``x in {...}`` hashes ``x``, so an unhashable argument (a list, a dict,
+    # a bytearray) would raise ``TypeError: unhashable type`` from inside the
+    # check instead of the ValueError this function exists to raise.
+    if value not in tuple(m.value for m in enum_class):
         valid = sorted(m.value for m in enum_class)
         if allow_none:
             valid = [None, *valid]

--- a/cuda_core/docs/source/release/1.2.0-notes.rst
+++ b/cuda_core/docs/source/release/1.2.0-notes.rst
@@ -73,6 +73,12 @@ Fixes and enhancements
   Windows, both ``ctypes.CFUNCTYPE`` and ``ctypes.WINFUNCTYPE`` are accepted.
   (`#2439 <https://github.com/NVIDIA/cuda-python/issues/2439>`__)
 
+- String-enum options now report an unhashable argument the same way as any
+  other invalid value. Passing a ``list`` or ``dict`` where a string enum was
+  expected -- for example ``WorkqueueResourceOptions(sharing_scope=[...])`` --
+  raised ``TypeError: unhashable type`` from inside the validator instead of
+  the documented ``ValueError`` naming the accepted values.
+
 Deprecation Notices
 -------------------
 

--- a/cuda_core/tests/test_utils_validators.py
+++ b/cuda_core/tests/test_utils_validators.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from cuda.core import WorkqueueResourceOptions
+from cuda.core._utils.validators import check_str_enum, format_or_list
+from cuda.core.typing import SourceCodeType
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        pytest.param([], "", id="empty"),
+        pytest.param(["a"], "'a'", id="one"),
+        pytest.param(["a", "b"], "'a' or 'b'", id="two"),
+        pytest.param(["a", "b", "c"], "'a', 'b' or 'c'", id="three"),
+        pytest.param([None, "a"], "None or 'a'", id="none-first"),
+    ],
+)
+def test_format_or_list(values, expected):
+    assert format_or_list(values) == expected
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+@pytest.mark.parametrize("value", ["c++", "ptx", "nvvm", SourceCodeType.CXX])
+def test_check_str_enum_accepts_members_and_their_values(value):
+    check_str_enum(value, SourceCodeType)
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+def test_check_str_enum_allow_none():
+    check_str_enum(None, SourceCodeType, allow_none=True)
+
+    with pytest.raises(ValueError, match="None is not a valid SourceCodeType"):
+        check_str_enum(None, SourceCodeType)
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("fortran", id="str"),
+        pytest.param(5, id="int"),
+        # Unhashable arguments used to blow up inside the membership test with
+        # "TypeError: unhashable type" before the ValueError was ever built.
+        pytest.param(["c++"], id="list"),
+        pytest.param({"code_type": "c++"}, id="dict"),
+        pytest.param(bytearray(b"c++"), id="bytearray"),
+    ],
+)
+def test_check_str_enum_rejects_invalid_values_with_value_error(value):
+    with pytest.raises(ValueError, match="is not a valid SourceCodeType. Must be "):
+        check_str_enum(value, SourceCodeType)
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+def test_options_reject_an_unhashable_scope_with_value_error():
+    """A public entry point must report a bad option the same way for every
+    kind of bad value. ``WorkqueueResourceOptions.__post_init__`` validates
+    ``sharing_scope`` through ``check_str_enum``, so an unhashable argument
+    used to surface as ``TypeError: unhashable type: 'list'`` while a plain
+    string got the documented ValueError."""
+    with pytest.raises(ValueError, match="is not a valid WorkqueueSharingScopeType. Must be "):
+        WorkqueueResourceOptions(sharing_scope=["green_ctx_balanced"])


### PR DESCRIPTION
## Problem

`cuda/core/_utils/validators.py::check_str_enum` exists to turn a bad option value into a `ValueError` that names the accepted values. It tests membership against a set:

```python
if value not in {m.value for m in enum_class}:
    valid = sorted(m.value for m in enum_class)
    ...
    raise ValueError(f"{value!r} is not a valid {enum_class.__name__}. Must be {format_or_list(valid)}")
```

`x in <set>` hashes `x`, so an unhashable argument dies *inside* the membership test, before the `ValueError` is ever built:

```pycon
>>> WorkqueueResourceOptions(sharing_scope=["green_ctx_balanced"])
TypeError: unhashable type: 'list'

>>> WorkqueueResourceOptions(sharing_scope="bogus")
ValueError: 'bogus' is not a valid WorkqueueSharingScopeType. Must be 'device' or 'green_ctx_balanced'
```

The outcome depends on the *type* of the argument rather than on its validity. Measured against `check_str_enum(value, SourceCodeType)` on `main`:

| argument | result on `main` |
| --- | --- |
| `"fortran"` | `ValueError` (intended) |
| `5`, `None`, `object()` | `ValueError` (intended) |
| `{"c++"}` (a `set`) | `ValueError` — CPython special-cases `set.__contains__` to retry an unhashable argument as a frozenset |
| `["c++"]` | **`TypeError: unhashable type: 'list'`** |
| `{"code_type": "c++"}` | **`TypeError: unhashable type: 'dict'`** |
| `bytearray(b"c++")` | **`TypeError: unhashable type: 'bytearray'`** |

A helper whose entire job is to raise `ValueError` leaks a `TypeError` from its own implementation detail, and the message says nothing about which values are accepted.

`WorkqueueResourceOptions.__post_init__` is a plain dataclass hook — the failure happens at construction, with no device or context involved.

## Fix

Test membership against a tuple. Tuple membership compares with `==` and never hashes, so an unhashable value simply compares unequal and falls into the existing error path.

- Every currently-accepted value stays accepted, including enum members themselves (`SourceCodeType.CXX`) and the `allow_none=True` path.
- Every currently-rejected value keeps its exact message.
- Only the three `TypeError` rows above change, and they change to the `ValueError` the function documents.

The enums involved have at most a handful of members, so tuple membership is not a meaningful cost.

## Where this is reachable

`check_str_enum` validates user input from:

- `WorkqueueResourceOptions.__post_init__` (`_device_resources.pyx:152`)
- `ManagedMemoryResourceOptions` preferred-location handling (`_memory/_managed_memory_resource.pyx:178`)
- `make_program_cache_key(code_type=...)` (`utils/_program_cache/_keys.py:756`; the preceding `code_type.lower() if isinstance(code_type, str) else code_type` passes non-str values straight through)
- graph alloc-node memory types (`graph/_graph_node.pyx:851`)

## Tests

`validators.py` had no tests at all — `grep -rn "check_str_enum" cuda_core/tests/` returns nothing today. This adds `cuda_core/tests/test_utils_validators.py` covering `format_or_list` (0/1/2/3 values and the `None`-first shape used by `allow_none`), `check_str_enum`'s accept path (raw values and enum members), the `allow_none` behavior, the invalid-value path parametrized over hashable *and* unhashable arguments, and the public `WorkqueueResourceOptions` entry point. None of it needs a GPU.

## Verification I could and could not do

- Loaded `validators.py` standalone (it has no imports) and ran the full parametrization against both the `upstream/main` implementation and the fixed one. On `main` the `list`, `dict`, and `bytearray` cases raise `TypeError` and fail; with the fix all cases raise the expected `ValueError`. Every accept case and every `format_or_list` output is byte-identical before and after.
- `ruff check` / `ruff format --check` clean on both changed Python files; `toolshed/check_spdx.py` clean on the new file; `python -m py_compile` clean.
- **Not run:** `pytest cuda_core/tests/test_utils_validators.py` as written. I have no environment where `cuda.core` is importable (no CUDA driver, no built extension modules), so the file's imports could not be exercised locally. The two names it pulls from `cuda.core` — `WorkqueueResourceOptions` and `cuda.core.typing.SourceCodeType` — follow existing usage in `test_green_context.py` and `test_program_cache.py`. Please treat CI as the first real run.
