### PR TITLE
fix(core): validate Host(is_numa_current=...) as a bool

### DIFF
--- a/cuda_core/cuda/core/_host.py
+++ b/cuda_core/cuda/core/_host.py
@@ -47,6 +47,15 @@ class Host:
             raise ValueError("numa_id and is_numa_current are mutually exclusive")
         if numa_id is not None and (isinstance(numa_id, bool) or not isinstance(numa_id, int) or numa_id < 0):
             raise ValueError(f"numa_id must be a non-negative int, got {numa_id!r}")
+        # Require a real bool for the same reason numa_id rejects one: the
+        # value goes straight into the singleton cache key and into the
+        # is_numa_current property. `1` and `True` are the same dict key, so
+        # `Host(is_numa_current=1)` would hand `Host.numa_current()` an
+        # instance whose is_numa_current is the int 1 for the rest of the
+        # process, and any other truthy value would create a second,
+        # non-identical "numa_current" singleton.
+        if not isinstance(is_numa_current, bool):
+            raise ValueError(f"is_numa_current must be a bool, got {is_numa_current!r}")
         return cls._get_or_create(numa_id, is_numa_current)
 
     @classmethod

--- a/cuda_core/docs/source/release/1.2.0-notes.rst
+++ b/cuda_core/docs/source/release/1.2.0-notes.rst
@@ -244,6 +244,13 @@ Fixes and enhancements
   refreshed for CUDA 13.3 and now recognizes
   ``CUDA_ERROR_GRAPH_RECAPTURE_FAILURE``.
   (`#2383 <https://github.com/NVIDIA/cuda-python/pull/2383>`__)
+- :class:`Host` now requires ``is_numa_current`` to be a ``bool``, matching the
+  existing ``numa_id`` validation. The value was stored verbatim in the
+  process-wide singleton cache and in :attr:`Host.is_numa_current`, so
+  ``Host(is_numa_current=1)`` made :meth:`Host.numa_current` return an instance
+  whose ``is_numa_current`` was the int ``1``, and any other truthy value
+  created a second ``Host.numa_current()`` that compared unequal to the real
+  one while sharing its ``repr``.
 
 Deprecation Notices
 -------------------

--- a/cuda_core/tests/test_host.py
+++ b/cuda_core/tests/test_host.py
@@ -34,6 +34,29 @@ class TestHost:
         with pytest.raises(ValueError, match="numa_id must be a non-negative int"):
             Host(numa_id=False)
 
+    @pytest.mark.agent_authored(model="claude-opus-5")
+    @pytest.mark.parametrize("value", [1, 0, "yes", None, []], ids=["int-1", "int-0", "str", "none", "list"])
+    def test_is_numa_current_rejects_non_bool(self, value):
+        # Same hazard as test_numa_id_rejects_bool, from the other side: the
+        # value lands in the singleton cache key and in the is_numa_current
+        # property untouched. `1` and `True` hash and compare equal, so
+        # Host(is_numa_current=1) would seed the numa_current singleton with
+        # an instance whose is_numa_current is the int 1 -- process-wide, and
+        # for whichever call happens to come first. Any other truthy value
+        # would mint a second "numa_current" that is neither `is` nor `==` the
+        # real one while sharing its repr.
+        with pytest.raises(ValueError, match="is_numa_current must be a bool"):
+            Host(is_numa_current=value)
+
+    @pytest.mark.agent_authored(model="claude-opus-5")
+    def test_numa_current_singleton_survives_a_rejected_construction(self):
+        with pytest.raises(ValueError, match="is_numa_current must be a bool"):
+            Host(is_numa_current=1)
+
+        h = Host.numa_current()
+        assert h.is_numa_current is True
+        assert h is Host(is_numa_current=True)
+
     def test_numa_current_constructor_and_classmethod_agree(self):
         # Host(is_numa_current=True) and Host.numa_current() return the same singleton.
         assert Host(is_numa_current=True) is Host.numa_current()


### PR DESCRIPTION
## Problem

`Host.__new__` validates `numa_id` carefully, and the existing test explains exactly why:

```python
def test_numa_id_rejects_bool(self):
    # bool is an int subclass; reject explicitly so Host(True) doesn't
    # alias Host(1) (and vice versa) in the singleton cache.
```

`is_numa_current` gets no validation at all, even though it goes into the *same* process-wide singleton cache key and is stored verbatim as the `is_numa_current` property:

```python
def __new__(cls, numa_id=None, *, is_numa_current=False):
    if is_numa_current and numa_id is not None: ...
    if numa_id is not None and (isinstance(numa_id, bool) or ...): ...   # numa_id IS validated
    return cls._get_or_create(numa_id, is_numa_current)                  # is_numa_current is NOT

@classmethod
def _get_or_create(cls, numa_id, is_numa_current):
    key = (numa_id, is_numa_current)
    ...
    inst._is_numa_current = is_numa_current     # stored as-is
```

The same aliasing hazard applies from the other side.

**1. `1` poisons the `numa_current` singleton, process-wide.** `(None, 1)` and `(None, True)` are the same dict key, so whichever call runs first wins for the rest of the process:

```pycon
>>> Host(is_numa_current=1)          # int, not True
>>> h = Host.numa_current()
>>> h.is_numa_current
1
>>> h.is_numa_current is True
False
```

`test_host.py::TestHost::test_numa_current` already asserts `h.is_numa_current is True`, so that first call turns a shipped assertion into an order-dependent failure — the classic shape of a cross-test flake.

**2. Any other truthy value mints a *second* singleton** instead of poisoning the first:

```pycon
>>> dup = Host(is_numa_current="yes")
>>> repr(dup)
'Host.numa_current()'
>>> dup is Host.numa_current(), dup == Host.numa_current()
(False, False)
```

Both coerce to the same `_LocSpec(kind="host_numa_current")` in `_memory/_managed_location.py`, so they name one physical location while breaking the class's documented contract ("constructor calls with the same arguments return the same instance") and the identity-based set arithmetic in `ManagedBuffer.accessed_by`.

**3. Falsy non-bools hit the generic host.** `is_numa_current=0` / `=None` seed the `Host()` singleton with a non-bool `is_numa_current`, so `Host().is_numa_current is False` stops holding too.

**4. Unhashable values escape as `TypeError`.** `Host(is_numa_current=[])` raises `TypeError: unhashable type: 'list'` from the cache lookup rather than a `ValueError` from the constructor.

## Fix

Require a real `bool`, mirroring the `numa_id` check, with the same `ValueError` shape:

```
ValueError: is_numa_current must be a bool, got 1
```

Nothing else changes: the mutual-exclusion check still runs first (so `Host(numa_id=0, is_numa_current=True)` keeps its "mutually exclusive" message), and no in-tree caller passes a non-bool.

## Tests

Added to `cuda_core/tests/test_host.py`, directly alongside the `numa_id` bool test that documents the same hazard:

- `test_is_numa_current_rejects_non_bool`, parametrized over `1`, `0`, `"yes"`, `None`, `[]`.
- `test_numa_current_singleton_survives_a_rejected_construction`, which pins the point of the fix: a rejected construction must not leave anything in the cache, so `Host.numa_current().is_numa_current is True` still holds afterwards.

## Verification I could and could not do

- `_host.py` imports only `threading` and `typing`, so I loaded the `upstream/main` and fixed versions side by side and ran both the new assertions and a replica of every existing `test_host.py` assertion against each.
  - On `main`: `1`, `0`, `"yes"`, `None` raise nothing (the `pytest.raises` blocks fail) and `[]` raises `TypeError`, which `pytest.raises(ValueError)` does not catch — all five parametrizations fail.
  - With the fix: all five raise the expected `ValueError`.
  - Every existing behavior — default/`numa_id`/`numa_current` construction, singleton identity, `numa_id` rejection messages, mutual exclusion, `__eq__`/`__hash__`, `repr`, copy/pickle round-trip — is unchanged in both.
- `ruff check` / `ruff format --check` clean on both changed files; `python -m py_compile` clean.
- **Not run:** `pytest cuda_core/tests/test_host.py` itself. I have no environment where `cuda.core` is importable (no CUDA driver, no built extension modules), so the module-level `from cuda.core import Host` could not be exercised locally. Please treat CI as the first real run.

## Not in this PR

`Host._instances` is a single `ClassVar` dict keyed without `cls`, so a subclass shares the base class's cache and can be handed a base-class instance (`type(Sub()) is Host`). `__hash__` hardcodes the literal `Host` in its tuple, so the class looks intended to be final. Nothing in-tree subclasses `Host`, and fixing it is a separate decision (key on `cls`, per-subclass caches, or forbid subclassing) — happy to file it separately if you want it addressed.
