### PR TITLE
Fix command line parsing in the cuda.bindings example helpers

### DIFF
--- a/cuda_bindings/cuda/bindings/_example_helpers/helper_string.py
+++ b/cuda_bindings/cuda/bindings/_example_helpers/helper_string.py
@@ -5,11 +5,20 @@ import sys
 
 
 def check_cmd_line_flag(string_ref):
-    return any(string_ref == i and k < len(sys.argv) - 1 for i, k in enumerate(sys.argv))
+    """Return whether ``string_ref`` was passed on the command line.
+
+    ``sys.argv[0]`` is the program name and is never considered a flag.
+    """
+    return string_ref in sys.argv[1:]
 
 
 def get_cmd_line_argument_int(string_ref):
-    for i, k in enumerate(sys.argv):
-        if string_ref == i and k < len(sys.argv) - 1:
-            return sys.argv[k + 1]
+    """Return the integer that follows ``string_ref`` on the command line.
+
+    Returns 0 if ``string_ref`` was not passed, or if nothing follows it.
+    """
+    args = sys.argv[1:]
+    for idx, arg in enumerate(args):
+        if arg == string_ref and idx + 1 < len(args):
+            return int(args[idx + 1])
     return 0

--- a/cuda_bindings/tests/test_example_helpers.py
+++ b/cuda_bindings/tests/test_example_helpers.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+import pytest
+
+from cuda.bindings._example_helpers import check_cmd_line_flag, get_cmd_line_argument_int
+
+
+@pytest.fixture
+def argv(monkeypatch):
+    """Replace sys.argv, keeping a realistic program name in argv[0]."""
+
+    def _argv(*args, prog="example.py"):
+        monkeypatch.setattr(sys, "argv", [prog, *args])
+
+    return _argv
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+@pytest.mark.parametrize(
+    ("args", "flag", "expected"),
+    [
+        ((), "device=", False),
+        (("device=", "0"), "device=", True),
+        (("help",), "help", True),  # a boolean flag has nothing after it
+        (("wA=", "128", "hA=", "256"), "hA=", True),
+        (("wA=", "128"), "hA=", False),
+    ],
+)
+def test_check_cmd_line_flag(argv, args, flag, expected):
+    argv(*args)
+    assert check_cmd_line_flag(flag) is expected
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+def test_check_cmd_line_flag_ignores_the_program_name(argv):
+    argv(prog="help")
+    assert check_cmd_line_flag("help") is False
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        ((), 0),
+        (("device=", "3"), 3),
+        (("wA=", "128", "device=", "2"), 2),
+        (("device=",), 0),  # nothing follows the flag
+        (("nomatch", "7"), 0),
+    ],
+)
+def test_get_cmd_line_argument_int(argv, args, expected):
+    argv(*args)
+    value = get_cmd_line_argument_int("device=")
+    assert value == expected
+    assert isinstance(value, int)
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+def test_get_cmd_line_argument_int_ignores_the_program_name(argv):
+    argv("3", prog="device=")
+    assert get_cmd_line_argument_int("device=") == 0


### PR DESCRIPTION
Both helpers in `cuda/bindings/_example_helpers/helper_string.py` unpack `enumerate()`
backwards:

```python
def check_cmd_line_flag(string_ref):
    return any(string_ref == i and k < len(sys.argv) - 1 for i, k in enumerate(sys.argv))


def get_cmd_line_argument_int(string_ref):
    for i, k in enumerate(sys.argv):
        if string_ref == i and k < len(sys.argv) - 1:
            return sys.argv[k + 1]
    return 0
```

`enumerate()` yields `(index, value)`, so `i` is an `int` and `k` is a `str` — but the
body uses `i` as the argument text and `k` as the index. `string_ref == i` compares `str`
to `int` and is therefore **always** `False`.

```
$ python -c "from cuda.bindings._example_helpers import check_cmd_line_flag, get_cmd_line_argument_int; \
             print(check_cmd_line_flag('device='), get_cmd_line_argument_int('device='))" device= 3
False 0
```

So `check_cmd_line_flag()` always returns `False` and `get_cmd_line_argument_int()` always
returns `0`. Every command line option in the examples is silently ignored — `device=`,
`wA=`, `hA=`, `wB=`, `hB=`, `kernel=`, `help`, `?`, `use_generic_memory` — reaching
`helper_cuda.find_cuda_device()` / `find_cuda_device_drv()`,
`3_CUDA_Features/global_to_shmem_async_copy.py`, `0_Introduction/simple_zero_copy.py`
and `2_Concepts_and_Techniques/stream_ordered_allocation.py`.

Note the dead branch would not have worked either: `k < len(sys.argv) - 1` is `str < int`
(`TypeError`) and `sys.argv[k + 1]` indexes with a `str`. Nothing here has ever run.

### Three judgement calls, since "the current behaviour" is not a guide

Because both functions are constant today, any fix defines new behaviour. I kept it as
close to the evident intent — and to the C samples' `helper_string.h` — as I could:

1. **`check_cmd_line_flag()` no longer requires a following argument.** That condition
   belongs to the value lookup. Keeping it would leave `help` and `?` broken whenever they
   are the last argument, which is the normal way to pass them.
2. **Both helpers skip `sys.argv[0]`**, matching `checkCmdLineFlag()` in the C samples,
   which scans from `argv[1]`.
3. **`get_cmd_line_argument_int()` returns an `int`**, as its name says and as its callers
   require: `helper_cuda.find_cuda_device()` passes the result straight to
   `cudaSetDevice()` and `find_cuda_device_drv()` to `cuDeviceGet()`. Returning
   `sys.argv[idx + 1]` unchanged would hand those APIs a `str` — i.e. fixing only the
   unpacking would turn a silent no-op into a `TypeError`. An `int` is also the only value
   this function has ever actually returned, since the literal `0` fallback was the sole
   reachable path.

Happy to change any of these if you'd prefer different semantics.

### Tests

New `cuda_bindings/tests/test_example_helpers.py` — pure `sys.argv` monkeypatching, no GPU
or toolkit needed. Five of its assertions fail against `upstream/main` (flag present,
trailing boolean flag, flag in the middle of a longer argv, and both value lookups); the
program-name and not-found cases pass either way and are there to pin the new edges down.

`tests/test_examples.py` runs each example in a subprocess as `[sys.executable, example]`,
so `sys.argv[1:]` is empty there and no flag can accidentally match under pytest.

Verified against `upstream/main` and with the change; `ruff check` and
`ruff format --check` are clean.
