### PR TITLE
fix(core): don't abort the build when an integer build knob is set but empty

### DIFF
--- a/cuda_core/build_hooks.py
+++ b/cuda_core/build_hooks.py
@@ -26,7 +26,31 @@ prepare_metadata_for_build_wheel = _build_meta.prepare_metadata_for_build_wheel
 build_sdist = _build_meta.build_sdist
 get_requires_for_build_sdist = _build_meta.get_requires_for_build_sdist
 
-COMPILE_FOR_COVERAGE = bool(int(os.environ.get("CUDA_PYTHON_COVERAGE", "0")))
+
+def env_int(name: str, default: int) -> int:
+    """Read an integer build knob from the environment.
+
+    Unset and empty mean the same thing. ``CUDA_PYTHON_COVERAGE= pip install .``
+    (and the equivalent empty value in a Dockerfile ``ENV`` or a CI job spec) is
+    how a variable gets neutralised, and it must not abort the build -- a bare
+    ``int()`` here raises while the PEP 517 backend module is still being
+    imported, so the failure arrives before any build output.
+
+    A value that is set to something non-integer is a typo worth stopping for:
+    silently ignoring ``CUDA_PYTHON_COVERAGE=yes`` would hand back a build with
+    no coverage instrumentation. It is reported with the variable's name rather
+    than as an anonymous ``invalid literal for int()``.
+    """
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        raise ValueError(f"environment variable {name}={os.environ[name]!r} must be an integer") from None
+
+
+COMPILE_FOR_COVERAGE = bool(env_int("CUDA_PYTHON_COVERAGE", 0))
 
 
 # Please keep in sync with the copy in cuda_bindings/build_hooks.py.
@@ -219,7 +243,9 @@ def _build_cuda_core(debug=False):
         for mod in module_names()
     )
 
-    nthreads = int(os.environ.get("CUDA_PYTHON_PARALLEL_LEVEL", os.cpu_count() // 2))
+    # ``os.cpu_count()`` is documented to return None when it cannot be
+    # determined; fall back to a serial build rather than a TypeError.
+    nthreads = env_int("CUDA_PYTHON_PARALLEL_LEVEL", (os.cpu_count() or 1) // 2)
     compile_time_env = {"CUDA_CORE_BUILD_MAJOR": int(_determine_cuda_major_version())}
     compiler_directives = {"embedsignature": True, "warn.deprecated.IF": False, "freethreading_compatible": True}
     _CythonOptions.warning_errors = True

--- a/cuda_core/setup.py
+++ b/cuda_core/setup.py
@@ -10,8 +10,10 @@ from setuptools import setup
 from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.build_py import build_py as _build_py
 
-nthreads = int(os.environ.get("CUDA_PYTHON_PARALLEL_LEVEL", os.cpu_count() // 2))
-coverage_mode = bool(int(os.environ.get("CUDA_PYTHON_COVERAGE", "0")))
+# Shared with build_hooks so the two build entry points parse these knobs
+# identically (see build_hooks.env_int for why a bare int() is not enough).
+nthreads = build_hooks.env_int("CUDA_PYTHON_PARALLEL_LEVEL", (os.cpu_count() or 1) // 2)
+coverage_mode = bool(build_hooks.env_int("CUDA_PYTHON_COVERAGE", 0))
 _ROOT_DIR = Path(__file__).resolve().parent
 _AOTI_SHIM_DEF_FILE = _ROOT_DIR / "cuda" / "core" / "_include" / "aoti_shim.def"
 _AOTI_SHIM_LIB_FILE = _ROOT_DIR / "build" / "aoti_shim.lib"

--- a/cuda_core/tests/test_build_hooks.py
+++ b/cuda_core/tests/test_build_hooks.py
@@ -165,3 +165,49 @@ class TestGetCudaMajorVersion:
             pytest.raises(RuntimeError, match="CUDA_PATH or CUDA_HOME"),
         ):
             build_hooks._determine_cuda_major_version()
+
+
+class TestEnvInt:
+    """Integer build knobs read from the environment."""
+
+    @pytest.mark.agent_authored(model="claude-opus-5")
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            pytest.param(None, 7, id="unset"),
+            # `VAR= pip install .` is how a shell neutralizes a variable, and
+            # the same shape appears in Dockerfile ENV and CI job specs.
+            pytest.param("", 7, id="empty"),
+            pytest.param("   ", 7, id="whitespace-only"),
+            pytest.param("0", 0, id="zero"),
+            pytest.param("4", 4, id="positive"),
+            pytest.param(" 4 ", 4, id="padded"),
+        ],
+    )
+    def test_env_int_reads_the_value_or_falls_back(self, value, expected):
+        env = {} if value is None else {"CUDA_PYTHON_TEST_KNOB": value}
+        with mock.patch.dict(os.environ, env, clear=True):
+            assert build_hooks.env_int("CUDA_PYTHON_TEST_KNOB", 7) == expected
+
+    @pytest.mark.agent_authored(model="claude-opus-5")
+    def test_env_int_names_the_variable_for_a_non_integer(self):
+        with (
+            mock.patch.dict(os.environ, {"CUDA_PYTHON_TEST_KNOB": "yes"}, clear=True),
+            pytest.raises(ValueError, match=r"CUDA_PYTHON_TEST_KNOB='yes' must be an integer"),
+        ):
+            build_hooks.env_int("CUDA_PYTHON_TEST_KNOB", 7)
+
+    @pytest.mark.agent_authored(model="claude-opus-5")
+    @pytest.mark.parametrize("value", ["", "   "], ids=["empty", "whitespace-only"])
+    def test_backend_imports_with_an_empty_coverage_flag(self, value):
+        """An empty CUDA_PYTHON_COVERAGE must not break the PEP 517 backend.
+
+        COMPILE_FOR_COVERAGE is evaluated at module scope, so a bare int() there
+        raised while the build backend was still being imported -- pip reported
+        `ValueError: invalid literal for int() with base 10: ''` before any
+        build output appeared.
+        """
+        with mock.patch.dict(os.environ, {"CUDA_PYTHON_COVERAGE": value}, clear=True):
+            reloaded = _load_build_hooks()
+
+        assert reloaded.COMPILE_FOR_COVERAGE is False


### PR DESCRIPTION
> **Stacking note:** `cuda_core/build_hooks.py` is also touched by #2500 (the `os.path` → `pathlib` migration, part 5 of #2410). The hunks are disjoint — #2500 rewrites the `os.path` call sites, this one changes the two environment reads — so they merge in either order.

## Problem

`cuda_core/build_hooks.py` reads two integer build knobs with a bare `int()`:

```python
COMPILE_FOR_COVERAGE = bool(int(os.environ.get("CUDA_PYTHON_COVERAGE", "0")))
...
nthreads = int(os.environ.get("CUDA_PYTHON_PARALLEL_LEVEL", os.cpu_count() // 2))
```

`os.environ.get(name, default)` returns the **empty string**, not the default, when a variable is set but empty — and `VAR= pip install .`, an empty `ENV` in a Dockerfile, or an unfilled CI job variable is exactly how these get neutralised.

The first line runs at module scope, so the failure lands while pip is still importing the PEP 517 backend, before any build output:

```console
$ CUDA_PYTHON_COVERAGE= pip install ./cuda_core
  File ".../cuda_core/build_hooks.py", line 29, in <module>
    COMPILE_FOR_COVERAGE = bool(int(os.environ.get("CUDA_PYTHON_COVERAGE", "0")))
ValueError: invalid literal for int() with base 10: ''
```

`cuda_core/setup.py` carries the same two expressions verbatim (lines 13–14), so the second build entry point fails the same way.

Measured against the module as it stands on `main`:

| `CUDA_PYTHON_COVERAGE` | backend import on `main` |
| --- | --- |
| unset / `0` / `1` | ok |
| `""` | **`ValueError: invalid literal for int() with base 10: ''`** |
| `"   "` | **`ValueError`** |
| `"yes"` | **`ValueError`** (correct to reject, but the message names nothing) |

Separately, `os.cpu_count()` is documented to return `None` when the count cannot be determined, which makes the `nthreads` default `None // 2` → `TypeError`.

## Fix

Add `build_hooks.env_int(name, default)` and route all four call sites through it:

- unset and empty/whitespace-only both fall back to the default;
- a value that **is** set to something non-integer still raises — silently ignoring `CUDA_PYTHON_COVERAGE=yes` would hand back a build with no coverage instrumentation, which is worse than stopping — but names the variable:
  `environment variable CUDA_PYTHON_COVERAGE='yes' must be an integer`;
- `os.cpu_count() or 1` so an undetermined CPU count falls back to a serial build instead of a `TypeError`.

`setup.py` already does `import build_hooks`, so both entry points now share one helper instead of duplicating the expression.

Integer values keep their exact current meaning: `0` → off, non-zero → on, and `CUDA_PYTHON_PARALLEL_LEVEL=4` still yields 4.

## Tests

Added `TestEnvInt` to the existing `cuda_core/tests/test_build_hooks.py` (which already loads `build_hooks.py` by path via `_load_build_hooks()` and needs no built `cuda.core`):

- `env_int` over unset / `""` / `"   "` / `"0"` / `"4"` / `" 4 "`;
- the error message names the variable for a non-integer;
- `test_backend_imports_with_an_empty_coverage_flag` reloads the backend module with `CUDA_PYTHON_COVERAGE=""` and `"   "` and asserts it imports with `COMPILE_FOR_COVERAGE is False` — this is the regression test for the crash above.

## Verification I could and could not do

- Loaded both the `upstream/main` and the fixed `build_hooks.py` by path and ran the new test bodies against each. On `main`, importing the backend with `CUDA_PYTHON_COVERAGE=""` and `"   "` raises `ValueError` (both new cases fail); with the fix both import cleanly with `COMPILE_FOR_COVERAGE is False`. The `env_int` table above was produced the same way.
- `ruff check` / `ruff format --check` and `python -m py_compile` clean on all three changed files.
- **Not run:** `pytest cuda_core/tests/test_build_hooks.py` itself. The module does `from cuda.pathfinder import get_cuda_path_or_home` at import, and `cuda.pathfinder` cannot be imported on macOS (it resolves `dlinfo`, which does not exist there), so collection fails locally for reasons unrelated to this change. Cython and setuptools are present, and `build_hooks.py` itself loads fine — that is what the verification above exercises. Please treat CI as the first real run of the test file.
