### PR TITLE
fix(toolshed): honour the find() -1 sentinel when rewriting generated stub headers

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           python -m pip install pytest
           # Standalone CI tool tests; skip repo-root conftest.py (imports cuda.pathfinder).
-          python -m pytest -v --noconftest ci/tools/tests
+          python -m pytest -v --noconftest ci/tools/tests toolshed/tests
 
   find-wheels:
     runs-on: ubuntu-latest

--- a/toolshed/run_stubgen_pyx.py
+++ b/toolshed/run_stubgen_pyx.py
@@ -30,10 +30,15 @@ def _normalize_stub_headers(root: pathlib.Path) -> None:
     for stub in root.rglob("*.pyi"):
         data = stub.read_bytes()
         newline = data.find(b"\n")
+        # ``find`` returns -1 when the stub is a single line with no trailing
+        # newline. Both slices must honour that sentinel: ``data[-1:]`` is the
+        # file's last byte, so the rest-of-file slice would append a duplicate
+        # of it to the rewritten header.
         first_line = data[:newline] if newline != -1 else data
+        rest = data[newline:] if newline != -1 else b""
         if not first_line.startswith(_HEADER_PREFIX) or b"\\" not in first_line:
             continue
-        stub.write_bytes(first_line.replace(b"\\", b"/") + data[newline:])
+        stub.write_bytes(first_line.replace(b"\\", b"/") + rest)
 
 
 def main() -> int:

--- a/toolshed/tests/test_run_stubgen_pyx.py
+++ b/toolshed/tests/test_run_stubgen_pyx.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from run_stubgen_pyx import _HEADER_PREFIX, _normalize_stub_headers
+
+WINDOWS_HEADER = _HEADER_PREFIX + b" from cuda_core\\cuda\\core\\_device.pyx"
+POSIX_HEADER = _HEADER_PREFIX + b" from cuda_core/cuda/core/_device.pyx"
+
+
+def write_stub(tmp_path, content):
+    stub = tmp_path / "_device.pyi"
+    stub.write_bytes(content)
+    return stub
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+@pytest.mark.parametrize(
+    ("body", "note"),
+    [
+        pytest.param(b"\n\nclass Device: ...\n", "header, blank line, body", id="body-with-trailing-newline"),
+        pytest.param(b"\nclass Device: ...", "body without a trailing newline", id="body-no-trailing-newline"),
+        pytest.param(b"\n", "header line only", id="header-only-with-newline"),
+        # `.pyi` is excluded from the end-of-file-fixer hook, so a stub with no
+        # trailing newline at all is a shape this repo tolerates -- and it is
+        # the one the -1 sentinel from `bytes.find` corrupted: `data[-1:]`
+        # appended a duplicate of the file's last byte to the header.
+        pytest.param(b"", "no trailing newline anywhere", id="header-only-no-newline"),
+    ],
+)
+def test_separator_is_rewritten_without_touching_anything_else(tmp_path, body, note):
+    stub = write_stub(tmp_path, WINDOWS_HEADER + body)
+
+    _normalize_stub_headers(tmp_path)
+
+    assert stub.read_bytes() == POSIX_HEADER + body, note
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param(POSIX_HEADER, id="already-posix-no-newline"),
+        pytest.param(POSIX_HEADER + b"\nclass Device: ...\n", id="already-posix"),
+        pytest.param(b"# hand-written stub\\with\\backslashes", id="not-a-generated-header"),
+        pytest.param(b"", id="empty-file"),
+    ],
+)
+def test_files_that_need_no_rewrite_are_left_byte_identical(tmp_path, content):
+    stub = write_stub(tmp_path, content)
+
+    _normalize_stub_headers(tmp_path)
+
+    assert stub.read_bytes() == content


### PR DESCRIPTION
> **Stacking note:** the one-line `ci-nightly.yml` change (adding `toolshed/tests` to the tooling test job) is byte-identical to the one in #2539 and #2548, so they merge cleanly in any order.

## Problem

`_normalize_stub_headers` rewrites the OS path separator in a generated stub's first-line comment, so committed `.pyi` files are identical across platforms. It splits the file on the first newline:

```python
newline = data.find(b"\n")
first_line = data[:newline] if newline != -1 else data
if not first_line.startswith(_HEADER_PREFIX) or b"\\" not in first_line:
    continue
stub.write_bytes(first_line.replace(b"\\", b"/") + data[newline:])
```

The **first** slice special-cases the `-1` that `bytes.find` returns when there is no newline. The **second** does not — and `data[-1:]` is the file's *last byte*. For a stub that is a single line with no trailing newline, the rewritten header gets a duplicate of its own final character appended:

```
in : b'# This file was generated by stubgen-pyx from cuda_core\\cuda\\core\\x.pyx'
out: b'# This file was generated by stubgen-pyx from cuda_core/cuda/core/x.pyxx'
                                                                            ^ duplicated
```

Two things make this worth fixing rather than shrugging at:

- A `.pyi` with no trailing newline is a shape this repo tolerates **on purpose**. `.pyi` is in the `end-of-file-fixer` exclude list in `.pre-commit-config.yaml`, so nothing adds one.
- This wrapper is the `stubgen-pyx-cuda-core` pre-commit hook — a *fixer*. The corrupted byte is written straight back into the working tree, and the next `git commit` takes it.

The `-1` handling one line above shows the sentinel was already known about; it just was not applied to both slices.

## Fix

Slice the remainder with the same sentinel check:

```python
rest = data[newline:] if newline != -1 else b""
```

No behavior change for any stub that has a newline, which is every stub in the tree today.

## Tests

`toolshed/run_stubgen_pyx.py` had no tests. Added `toolshed/tests/test_run_stubgen_pyx.py`, which calls `_normalize_stub_headers(tmp_path)` directly (no `stubgen-pyx` binary, no subprocess, no CUDA):

- the separator rewrite with a body and a trailing newline, with a body and no trailing newline, header-only with a newline, and **header-only with no newline** — asserting the result is byte-for-byte the input with only `\` → `/` changed;
- files that must be left byte-identical: an already-POSIX header (with and without a trailing newline), a hand-written stub containing backslashes but no generated-header prefix, and an empty file.

## Verification

Executed in full (pure Python, no GPU):

```
# with the fix
8 passed

# with toolshed/run_stubgen_pyx.py restored from upstream/main
FAILED test_separator_is_rewritten_without_touching_anything_else[header-only-no-newline]
1 failed, 7 passed
```

`ruff check` / `ruff format --check` clean on both changed Python files. Restore done with `cp` aside + `git show upstream/main:<path> >`; index verified clean before committing.
