### PR TITLE
fix(ci): read backport_branch from the top-level key only, and honour an empty value

### DIFF
--- a/ci/tools/check_release_notes.py
+++ b/ci/tools/check_release_notes.py
@@ -42,7 +42,10 @@ COMPONENT_TO_TAG_RE: dict[str, re.Pattern[str]] = {
 
 BACKPORT_PLANNING_COMPONENTS = frozenset({"cuda-bindings", "cuda-python"})
 BACKPORT_NOT_PLANNED = "not planned"
-BACKPORT_BRANCH_RE = re.compile(r"""^backport_branch:\s*["']?(?P<branch>[^"'\s#]+)""")
+# The value may legitimately be empty ("no backport branch configured"), so the
+# capture is `*` rather than `+` -- otherwise an explicitly empty value looks
+# exactly like an absent key.
+BACKPORT_BRANCH_RE = re.compile(r"""^backport_branch:\s*["']?(?P<branch>[^"'\s#]*)""")
 BACKPORT_BRANCH_NAME_RE = re.compile(r"^\d+\.\d+\.x$")
 
 
@@ -68,9 +71,16 @@ def load_backport_branch(repo_root: Path = Path(".")) -> str | None:
     try:
         with open(path, encoding="utf-8") as f:
             for line in f:
-                m = BACKPORT_BRANCH_RE.match(line.strip())
+                # Match the raw line: the regex is anchored at column 0, so a
+                # `backport_branch:` nested under some other key does not count.
+                # Stripping first erased the indentation and let a nested key
+                # win over the real top-level one.
+                m = BACKPORT_BRANCH_RE.match(line)
                 if m:
-                    return m.group("branch")
+                    # An explicitly empty value means "no backport branch is
+                    # configured". Falling through to GITHUB_REF_NAME here let
+                    # the environment silently override that decision.
+                    return m.group("branch") or None
     except FileNotFoundError:
         pass
     github_ref_name = os.environ.get("GITHUB_REF_NAME", "")

--- a/ci/tools/tests/test_check_release_notes.py
+++ b/ci/tools/tests/test_check_release_notes.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from check_release_notes import (
     check_release_notes,
@@ -144,6 +146,55 @@ class TestLoadBackportBranch:
         monkeypatch.setenv("GITHUB_REF_NAME", "main")
 
         assert load_backport_branch(tmp_path) is None
+
+    @pytest.mark.agent_authored(model="claude-opus-5")
+    def test_explicitly_empty_value_is_not_overridden_by_the_environment(self, tmp_path, monkeypatch):
+        """`backport_branch: ""` is a decision, not a missing key.
+
+        The value capture required at least one character, so an empty value
+        matched nothing and was indistinguishable from an absent key -- control
+        fell through to GITHUB_REF_NAME, and a maintainer who blanked the
+        setting to disable backport gating got it re-enabled from whatever
+        branch the workflow happened to run on.
+        """
+        d = tmp_path / "ci"
+        d.mkdir(parents=True)
+        (d / "versions.yml").write_text('backport_branch: ""\n')
+        monkeypatch.setenv("GITHUB_REF_NAME", "12.9.x")
+
+        assert load_backport_branch(tmp_path) is None
+
+    @pytest.mark.agent_authored(model="claude-opus-5")
+    def test_configured_value_wins_over_the_environment(self, tmp_path, monkeypatch):
+        d = tmp_path / "ci"
+        d.mkdir(parents=True)
+        (d / "versions.yml").write_text('backport_branch: "12.9.x"\n')
+        monkeypatch.setenv("GITHUB_REF_NAME", "11.8.x")
+
+        assert load_backport_branch(tmp_path) == "12.9.x"
+
+    @pytest.mark.agent_authored(model="claude-opus-5")
+    def test_nested_key_does_not_shadow_the_top_level_one(self, tmp_path, monkeypatch):
+        """Only a column-0 `backport_branch:` is the real setting.
+
+        The line was stripped before matching, so indentation was erased and a
+        `backport_branch:` nested under any other key won on line order.
+        """
+        monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
+        d = tmp_path / "ci"
+        d.mkdir(parents=True)
+        (d / "versions.yml").write_text('cuda:\n  legacy:\n    backport_branch: "11.8.x"\nbackport_branch: "12.9.x"\n')
+
+        assert load_backport_branch(tmp_path) == "12.9.x"
+
+    @pytest.mark.agent_authored(model="claude-opus-5")
+    def test_commented_out_key_is_ignored(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
+        d = tmp_path / "ci"
+        d.mkdir(parents=True)
+        (d / "versions.yml").write_text('# backport_branch: "9.9.x"\nbackport_branch: "12.9.x"\n')
+
+        assert load_backport_branch(tmp_path) == "12.9.x"
 
 
 class TestMain:


### PR DESCRIPTION
> **Stacking note:** #2496 also touches `ci/tools/check_release_notes.py` and its test file (the `os.path` → `pathlib` migration, part 7 of #2410). That PR rewrites the `path = os.path.join(...)` line in this same function; this one changes the loop body and the regex. Adjacent but disjoint — flagging it so a conflict here is expected rather than surprising.

## Problem

`load_backport_branch` reads `backport_branch` out of `ci/versions.yml` with a regex, then falls back to `GITHUB_REF_NAME`:

```python
BACKPORT_BRANCH_RE = re.compile(r"""^backport_branch:\s*["']?(?P<branch>[^"'\s#]+)""")
...
for line in f:
    m = BACKPORT_BRANCH_RE.match(line.strip())
    if m:
        return m.group("branch")
...
github_ref_name = os.environ.get("GITHUB_REF_NAME", "")
if BACKPORT_BRANCH_NAME_RE.match(github_ref_name):
    return github_ref_name
```

**1. An explicitly empty value is treated as an absent key.** The capture is `+`, so it needs at least one character. `backport_branch: ""` matches nothing, which is indistinguishable from the key not being there — and control falls through to the environment.

**2. `.strip()` erases the indentation the anchor depends on.** The regex is anchored at column 0 precisely so it matches the *top-level* key. Stripping first makes any nesting level match, and the first one in file order wins.

Measured against the real `load_backport_branch` on `main`:

| `ci/versions.yml` | `GITHUB_REF_NAME` | result on `main` | should be |
| --- | --- | --- | --- |
| `backport_branch: "12.9.x"` | unset | `'12.9.x'` | ✓ |
| `backport_branch: "12.9.x"` | `11.8.x` | `'12.9.x'` | ✓ |
| `backport_branch: ""` | unset | `None` | `None` |
| `backport_branch: ""` | `12.9.x` | **`'12.9.x'`** | `None` |
| nested `backport_branch: "11.8.x"` above top-level `"12.9.x"` | unset | **`'11.8.x'`** | `'12.9.x'` |
| `# backport_branch: "9.9.x"` above `"12.9.x"` | unset | `'12.9.x'` | ✓ |

Row 4 is the one that bites: a maintainer who blanks `backport_branch` to disable backport gating gets it silently re-enabled from whatever branch the workflow happened to run on. `backport_branch` feeds `validate_backport_decision`, so this decides whether a release is allowed to proceed without backport notes.

## Fix

- Match the **raw** line, so only a column-0 `backport_branch:` counts. (The anchor was already there; it just could not do its job after `.strip()`.)
- Let the capture be `*`, and return `None` for an empty value **without** consulting the environment — an explicit blank is a decision, not a missing key.

Everything already working is unchanged: a quoted value still wins over `GITHUB_REF_NAME`, an absent file still falls back to it, a non-backport `GITHUB_REF_NAME` is still ignored, and a commented-out key is still skipped.

## Tests

`TestLoadBackportBranch` covered only three cases (quoted-non-empty, file-absent + env set, file-absent + env `main`). Added:

- an explicitly empty value with `GITHUB_REF_NAME` set — the silent-override case;
- a configured value with a *different* `GITHUB_REF_NAME`, pinning precedence;
- a nested `backport_branch` above the top-level one;
- a commented-out key above the real one.

The new tests `monkeypatch.delenv("GITHUB_REF_NAME", raising=False)` where the environment must not participate; the existing tests do not, so they were order-sensitive.

## Verification

Executed in full (stdlib only, no GPU, no network):

```
# with the fix
pytest ci/tools/tests  ->  60 passed

# with ci/tools/check_release_notes.py restored from upstream/main
FAILED TestLoadBackportBranch::test_explicitly_empty_value_is_not_overridden_by_the_environment
FAILED TestLoadBackportBranch::test_nested_key_does_not_shadow_the_top_level_one
2 failed, 44 passed
```

`ruff check` / `ruff format --check` clean on both files. Restore done with `cp` aside + `git show upstream/main:<path> >`; index verified clean before committing.
