### PR TITLE
Fix the function name in the get_minimal_required_cuda_ver_from_ptx_ver examples

### DIFF
--- a/cuda_bindings/cuda/bindings/utils/_ptx_utils.py
+++ b/cuda_bindings/cuda/bindings/utils/_ptx_utils.py
@@ -77,9 +77,9 @@ def get_minimal_required_cuda_ver_from_ptx_ver(ptx_version: str) -> int:
 
     Examples
     --------
-    >>> get_minimal_required_driver_ver_from_ptx_ver("8.8")
+    >>> get_minimal_required_cuda_ver_from_ptx_ver("8.8")
     12090
-    >>> get_minimal_required_driver_ver_from_ptx_ver("7.0")
+    >>> get_minimal_required_cuda_ver_from_ptx_ver("7.0")
     11000
     """
     try:

--- a/cuda_bindings/tests/test_utils.py
+++ b/cuda_bindings/tests/test_utils.py
@@ -72,6 +72,18 @@ def test_ptx_utils(kernel, actual_ptx_ver, min_cuda_ver):
     assert cuda_ver == min_cuda_ver
 
 
+@pytest.mark.agent_authored(model="claude-opus-5")
+def test_ptx_utils_docstring_examples():
+    """The examples are rendered into the public docs; they have to run."""
+    import doctest
+
+    from cuda.bindings.utils import _ptx_utils
+
+    results = doctest.testmod(_ptx_utils, verbose=False, report=False)
+    assert results.attempted > 0
+    assert results.failed == 0
+
+
 @pytest.mark.parametrize(
     "target",
     (


### PR DESCRIPTION
The `Examples` section of `get_minimal_required_cuda_ver_from_ptx_ver()` calls a function
that does not exist:

```python
    Examples
    --------
    >>> get_minimal_required_driver_ver_from_ptx_ver("8.8")
    12090
    >>> get_minimal_required_driver_ver_from_ptx_ver("7.0")
    11000
```

`get_minimal_required_**driver**_ver_from_ptx_ver` appears nowhere else in the repo — I
grepped every `.py`, `.pyx`, `.rst` and `.md`; these two lines are the only hits. The
export in `cuda/bindings/utils/__init__.py`, the test in `tests/test_utils.py`,
`docs/source/module/utils.rst` and both release-notes files all use the `..._cuda_ver_...`
spelling. It is a rename that missed its own docstring.

These are doctests, and autodoc renders this docstring into the public API docs, so users
are shown two calls that raise:

```
NameError: name 'get_minimal_required_driver_ver_from_ptx_ver' is not defined.
Did you mean: 'get_minimal_required_cuda_ver_from_ptx_ver'?
```

Nothing caught it because pytest is not run with `--doctest-modules`
(`cuda_bindings/pyproject.toml` sets `addopts = "--benchmark-disable --showlocals"`).

### Test

`test_ptx_utils_docstring_examples` runs `doctest.testmod()` over the module, next to the
existing `test_ptx_utils`. It reports **2 failures on `main`** and 0 with this change, and
needs no GPU and no toolkit — `_ptx_utils` imports only `re`. It also covers the
`get_ptx_ver` example, which is correct today and now stays that way.

I scoped the test to this one module rather than turning on `--doctest-modules` repo-wide;
that is a bigger decision and would pull in the Cython modules' docstrings too.

Note: #2541 and #2551 also touch `cuda_bindings/tests/test_utils.py` — at the end of the
file and around line 117 respectively. This one lands next to `test_ptx_utils` near the
top, so the three are independent. Happy to rebase whichever lands last.
