### PR TITLE
Skip, not error, when nvJitLink is not installed

### DIFF
--- a/cuda_bindings/tests/test_nvjitlink.py
+++ b/cuda_bindings/tests/test_nvjitlink.py
@@ -65,21 +65,55 @@ def arch_ptx_parametrized(func):
     return ARCH_PTX_PARAMETRIZED_CALLABLE(func)
 
 
-def check_nvjitlink_usable():
-    from cuda.bindings._internal import nvjitlink as inner_nvjitlink
+def _nvjitlink_exports(symbol_name):
+    """Whether the loaded nvJitLink exports *symbol_name*.
 
-    return inner_nvjitlink._inspect_function_pointer("__nvJitLinkVersion") != 0
+    A zero pointer means "loaded, but the symbol is absent". When nvJitLink is
+    not installed at all, _inspect_function_pointer() loads it lazily and
+    raises instead, which is equally "not usable".
+    """
+    from cuda.bindings._internal import nvjitlink as inner_nvjitlink
+    from cuda.pathfinder import DynamicLibNotFoundError
+
+    try:
+        return inner_nvjitlink._inspect_function_pointer(symbol_name) != 0
+    except DynamicLibNotFoundError:
+        return False
+
+
+def check_nvjitlink_usable():
+    return _nvjitlink_exports("__nvJitLinkVersion")
 
 
 def check_nvjitlink_get_linked_ltoir_usable():
-    from cuda.bindings._internal import nvjitlink as inner_nvjitlink
-
-    return inner_nvjitlink._inspect_function_pointer("__nvJitLinkGetLinkedLTOIR") != 0
+    return _nvjitlink_exports("__nvJitLinkGetLinkedLTOIR")
 
 
 pytestmark = pytest.mark.skipif(
     not check_nvjitlink_usable(), reason="nvJitLink not usable, maybe not installed or too old (<12.3)"
 )
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+def test_check_nvjitlink_usable_without_the_library(monkeypatch):
+    """An absent nvJitLink must read as "not usable", not break collection."""
+    import sys
+    import types
+
+    import cuda.bindings._internal as internal_pkg
+    from cuda.pathfinder import DynamicLibNotFoundError
+
+    def raise_not_found(_symbol_name):
+        raise DynamicLibNotFoundError("libnvJitLink not found (simulated)")
+
+    fake = types.ModuleType("cuda.bindings._internal.nvjitlink")
+    fake._inspect_function_pointer = raise_not_found
+    # Cover both routes a `from ... import ...` can take to the submodule.
+    monkeypatch.setitem(sys.modules, "cuda.bindings._internal.nvjitlink", fake)
+    monkeypatch.setattr(internal_pkg, "nvjitlink", fake, raising=False)
+
+    assert check_nvjitlink_usable() is False
+    assert check_nvjitlink_get_linked_ltoir_usable() is False
 
 
 # create a valid LTOIR input for testing


### PR DESCRIPTION
```python
def check_nvjitlink_usable():
    from cuda.bindings._internal import nvjitlink as inner_nvjitlink

    return inner_nvjitlink._inspect_function_pointer("__nvJitLinkVersion") != 0


pytestmark = pytest.mark.skipif(
    not check_nvjitlink_usable(), reason="nvJitLink not usable, maybe not installed or too old (<12.3)"
)
```

The reason string covers *"maybe not installed"*, but the check cannot detect that case. A
zero pointer only means "library loaded, symbol not exported".
`_inspect_function_pointer()` loads nvJitLink **lazily**:

`_inspect_function_pointer` → `_inspect_function_pointers` → `_check_or_init_nvjitlink` →
`load_library()` → `load_nvidia_dynamic_lib("nvJitLink")`

which raises `DynamicLibNotFoundError` when the library is absent. Nothing catches it — and
because this runs at **module import time** (the `pytestmark` line), the whole module is a
collection **ERROR** on a machine without nvJitLink, rather than the skip it asks for.

The repo already handles exactly this call shape correctly in two other places:

- `tests/test_cudart.py::test_getLocalRuntimeVersion` → `except pathfinder.DynamicLibNotFoundError: pytest.skip(...)`
- `tests/test_utils.py::_is_libnvvm_available` → `except DynamicLibNotFoundError: return False`

### Fix

Fold both probes into one `_nvjitlink_exports(symbol_name)` helper that catches
`DynamicLibNotFoundError` and returns `False`. That covers
`check_nvjitlink_get_linked_ltoir_usable()` too, which has the identical shape and gates
the `skipif` on line 182.

### Test

`test_check_nvjitlink_usable_without_the_library` stubs
`cuda.bindings._internal.nvjitlink` with an `_inspect_function_pointer` that raises
`DynamicLibNotFoundError` — reproducing the not-installed condition **on a machine that
does have nvJitLink**, so it actually runs in CI. It fails on `main` (the exception escapes)
and passes with this change. Both probes are asserted.

I verified the stubbing mechanism locally against both the old and new helper shapes: the
old one propagates `DynamicLibNotFoundError`, the new one returns `False`.

`ruff check` and `ruff format --check` are clean.

This is the same defect class as #2541, which fixes the production-code copy in
`cuda.bindings.utils.check_nvvm_compiler_options()`.
