### PR TITLE
fix(core): stop `key in cache` falling back to the legacy sequence protocol

### DIFF
--- a/cuda_core/cuda/core/utils/_program_cache/_abc.py
+++ b/cuda_core/cuda/core/utils/_program_cache/_abc.py
@@ -111,7 +111,20 @@ class ProgramCacheResource(abc.ABC):
         ``__contains__`` invites that pattern. ``get`` answers
         both questions in one filesystem-level operation, so a
         successful return always carries the bytes.
+
+        ``key in cache`` therefore raises ``TypeError``, and a cache
+        is not iterable.
     """
+
+    # Opt out of the legacy sequence-iteration protocol. Defining
+    # ``__getitem__`` without ``__iter__`` makes ``key in cache`` fall back to
+    # ``cache[0], cache[1], ...`` compared against the *values* -- which
+    # defeats the "no ``__contains__``" design above: on these backends it
+    # raises a baffling "cache keys must be bytes or str, got int", and on a
+    # subclass whose ``__getitem__`` accepts integers it silently answers about
+    # values instead of keys. ``__iter__ = None`` restores the plain
+    # ``TypeError: argument of type '...' is not iterable``.
+    __iter__ = None
 
     @abc.abstractmethod
     def __getitem__(self, key: bytes | str) -> bytes:

--- a/cuda_core/docs/source/release/1.2.0-notes.rst
+++ b/cuda_core/docs/source/release/1.2.0-notes.rst
@@ -244,6 +244,13 @@ Fixes and enhancements
   refreshed for CUDA 13.3 and now recognizes
   ``CUDA_ERROR_GRAPH_RECAPTURE_FAILURE``.
   (`#2383 <https://github.com/NVIDIA/cuda-python/pull/2383>`__)
+- ``key in cache`` on a :class:`~cuda.core.utils.ProgramCacheResource` now
+  raises ``TypeError`` instead of walking the cache as a legacy sequence.
+  The class deliberately provides no ``__contains__``, but defining
+  ``__getitem__`` without ``__iter__`` made ``in`` fall back to
+  ``cache[0], cache[1], ...`` compared against the values. Use
+  :meth:`~cuda.core.utils.ProgramCacheResource.get`, which answers presence and
+  retrieval in one operation.
 
 Deprecation Notices
 -------------------

--- a/cuda_core/tests/test_program_cache.py
+++ b/cuda_core/tests/test_program_cache.py
@@ -38,6 +38,37 @@ def test_program_cache_resource_requires_core_methods():
     assert "__contains__" not in ProgramCacheResource.__abstractmethods__
 
 
+@pytest.mark.agent_authored(model="claude-opus-5")
+@pytest.mark.parametrize("factory", ["inmemory", "filestream"])
+def test_program_cache_is_not_iterable_and_rejects_in(tmp_path, factory):
+    """The ABC documents having no ``__contains__``, but defining
+    ``__getitem__`` without ``__iter__`` handed ``key in cache`` to the legacy
+    sequence protocol: it walked ``cache[0], cache[1], ...`` and compared
+    against the *values*. On these backends that surfaced as a baffling
+    "cache keys must be bytes or str, got int"; on a subclass whose
+    ``__getitem__`` accepts integers it silently answered about values instead
+    of keys.
+    """
+    from cuda.core.utils import FileStreamProgramCache, InMemoryProgramCache
+
+    cache = InMemoryProgramCache() if factory == "inmemory" else FileStreamProgramCache(tmp_path / "fc")
+    with cache:
+        cache[b"k"] = b"v"
+
+        with pytest.raises(TypeError, match="not iterable"):
+            b"k" in cache  # noqa: B015
+        with pytest.raises(TypeError, match="not iterable"):
+            iter(cache)
+        with pytest.raises(TypeError, match="not iterable"):
+            list(cache)
+
+        # The supported lookups are unaffected.
+        assert cache[b"k"] == b"v"
+        assert cache.get(b"k") == b"v"
+        assert cache.get(b"absent") is None
+        assert len(cache) == 1
+
+
 def _build_empty_subclass():
     from cuda.core.utils import ProgramCacheResource
 


### PR DESCRIPTION
## Problem

`ProgramCacheResource` documents, at length, that it deliberately has no `__contains__`:

> There is intentionally no ``__contains__``: the obvious ``if key in cache: data = cache[key]`` idiom is racy across processes (another writer can ``os.replace`` over the entry, or eviction can unlink it, between the check and the read), and exposing ``__contains__`` invites that pattern. ``get`` answers both questions in one filesystem-level operation…

The class defines `__getitem__` and **neither** `__iter__` nor `__contains__`. CPython then falls back to the **legacy sequence-iteration protocol**: `key in cache` becomes `cache[0]`, `cache[1]`, … compared against the *values*.

On the shipped backends that surfaces as an error about a lookup the user never wrote:

```pycon
>>> b"k" in InMemoryProgramCache()
TypeError: cache keys must be bytes or str, got int
>>> list(cache)
TypeError: cache keys must be bytes or str, got int
>>> iter(cache)          # succeeds, and only blows up on the first next()
<iterator object at ...>
```

Worse: `ProgramCacheResource` is public (exported from `cuda.core.utils`) and exists to be subclassed. For a backend whose `__getitem__` tolerates integers — a list-backed cache, say — the fallback answers **silently and inverted**. Verified against a minimal subclass of the real ABC:

```
b"v" in cache   ->  True     # b"v" is a VALUE
b"k" in cache   ->  False    # b"k" IS a key
```

So the one idiom the docstring set out to prevent is available, returns wrong answers, and does so without any error.

## Fix

`__iter__ = None` — the standard way to opt a class out of the legacy protocol. `in` and iteration now raise:

```
TypeError: argument of type 'InMemoryProgramCache' is not iterable
```

which points at the real mistake, and the documented design actually holds. The docstring note gains one sentence saying so.

Everything else is untouched — `__getitem__`, `get()`, `len()`, `clear()`, `update()` with a mapping and with pairs, and the context-manager form all behave exactly as before. `update()` iterates its *argument*, not `self`, so it is unaffected. `__contains__` remains non-abstract, as the existing `test_program_cache_resource_requires_core_methods` asserts.

## Tests

Added `test_program_cache_is_not_iterable_and_rejects_in`, parametrized over both shipped backends: `in`, `iter()`, and `list()` each raise `TypeError`, while `cache[k]`, `get()` (hit and miss) and `len()` keep working.

## Verification I could and could not do

- `_abc.py` / `_in_memory.py` / `_file_stream.py` import only stdlib plus `cuda.core._module.ObjectCode`, so I loaded them by path with a three-line stub for that symbol and ran the behaviour before and after:

```
--- upstream/main ---
  b'k' in cache -> TypeError: cache keys must be bytes or str, got int
  list(cache)   -> TypeError: cache keys must be bytes or str, got int
  iter(cache)   -> <iterator>            # no error at all
  subclass: b'v' in cache -> True (a VALUE);  b'k' in cache -> False (a KEY)

--- with the fix ---
  b'k' in cache / iter / list / dict -> TypeError: ... is not iterable
  cache[b'k'], get(hit), get(miss), len(), update(mapping), update(pairs),
  clear(), context manager, FileStream backend -> all unchanged
```

- `ruff check` compared against an `upstream/main` baseline of `_abc.py`: **no new findings** (2 pre-existing `UP038` under my local ruff 0.12.11, unchanged; the repo pins v0.15.9, where that rule no longer exists). `ruff format --check` and `python -m py_compile` clean.
- **Not run:** `pytest cuda_core/tests/test_program_cache.py` itself — it imports `cuda.core`, which is not importable here (no CUDA driver, no built extension modules). The stub run exercises the same code path. Please treat CI as the first real run.

## Related

Touches `_abc.py` only; independent of #2553 (`_in_memory.py` / `_file_stream.py` constructors) and #2555 (`_keys.py`).
