### PR TITLE
Fix the field-id enum name in the nvml test helper supports_nvlink

### DIFF
--- a/cuda_bindings/tests/nvml/test_util.py
+++ b/cuda_bindings/tests/nvml/test_util.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+
+from cuda.bindings import nvml
+
+from . import util
+
+
+class _FakeFieldValue:
+    nvml_return = nvml.Return.SUCCESS
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+def test_supports_nvlink_queries_a_real_field_id(monkeypatch):
+    """The helper has to name an enum that exists; nvml.FI never did."""
+    queried = {}
+
+    def fake_device_get_field_values(device, fields):
+        queried["field_id"] = fields[0].field_id
+        return [_FakeFieldValue()]
+
+    monkeypatch.setattr(nvml, "device_get_field_values", fake_device_get_field_values)
+
+    assert util.supports_nvlink(object()) is True
+    assert queried["field_id"] == nvml.FieldId.DEV_NVLINK_GET_STATE

--- a/cuda_bindings/tests/nvml/util.py
+++ b/cuda_bindings/tests/nvml/util.py
@@ -22,5 +22,5 @@ def supports_ecc(device):
 
 def supports_nvlink(device):
     fields = nvml.FieldValue(1)
-    fields[0].field_id = nvml.FI.DEV_NVLINK_GET_STATE
+    fields[0].field_id = nvml.FieldId.DEV_NVLINK_GET_STATE
     return nvml.device_get_field_values(device, fields)[0].nvml_return == nvml.Return.SUCCESS


### PR DESCRIPTION
```python
def supports_nvlink(device):
    fields = nvml.FieldValue(1)
    fields[0].field_id = nvml.FI.DEV_NVLINK_GET_STATE
    return nvml.device_get_field_values(device, fields)[0].nvml_return == nvml.Return.SUCCESS
```

There is no `FI` attribute on `cuda.bindings.nvml`. The enum is `FieldId`
(`nvml.pyx:1229`), with `DEV_NVLINK_GET_STATE` at `nvml.pyx:1454`. The sibling test uses
the correct spelling:

```python
# tests/nvml/test_nvlink.py:19
        fields[0].field_id = nvml.FieldId.DEV_NVLINK_LINK_COUNT
```

So the helper raises `AttributeError` on its first line of real work.

Nobody has noticed because it has **no callers** — a repo-wide grep for `supports_nvlink`
finds only its own definition. Contrast `util.supports_ecc` in the same file, which is
called from `test_page_retirement.py:35,61`. This is a guard that cannot fire because it
is never invoked, and would crash if it were.

### Why fix rather than delete

Deleting the dead helper is the other reasonable option, and I am happy to switch if you
prefer it. I went with the fix because `supports_nvlink` sits next to `supports_ecc` and
`is_vgpu` as part of an obviously intended capability-probe set, and because a test now
keeps it honest instead of letting it rot again.

### Test

New `cuda_bindings/tests/nvml/test_util.py`. It stubs `nvml.device_get_field_values`, so
the helper runs without an NVLink-capable device, and asserts both that it returns `True`
and that it queried `FieldId.DEV_NVLINK_GET_STATE`. It fails on `main` with
`AttributeError: module 'cuda.bindings.nvml' has no attribute 'FI'`.

The test uses the package-relative `from . import util` that `test_gpu.py` and
`test_page_retirement.py` already use, and inherits the `hardware_supports_nvml()` gate in
`tests/nvml/__init__.py`.

`ruff check` and `ruff format --check` are clean.
