### PR TITLE
Suppress the pathfinder INFO summary on repeats, not on plugin presence

### DIFF
--- a/cuda_pathfinder/tests/conftest.py
+++ b/cuda_pathfinder/tests/conftest.py
@@ -12,7 +12,7 @@ def pytest_configure(config):
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
     if not config.getoption("verbose"):
         return
-    if hasattr(config.option, "iterations"):  # pytest-freethreaded runs all tests at least twice
+    if getattr(config.option, "iterations", 1) > 1:  # pytest-freethreaded runs all tests at least twice
         return
     if getattr(config.option, "count", 1) > 1:  # pytest-repeat
         return

--- a/cuda_pathfinder/tests/test_conftest_info_summary.py
+++ b/cuda_pathfinder/tests/test_conftest_info_summary.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The INFO summary is the only output of the info_summary_append fixture.
+
+Several suites (test_load_nvidia_dynamic_lib, test_driver_lib_loading,
+test_find_*) report what they discovered exclusively through it, so the
+conditions that suppress it are worth pinning down.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+from conftest import pytest_terminal_summary
+
+
+class FakeTerminalReporter:
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+
+    def write_sep(self, sep: str, title: str) -> None:
+        self.lines.append(f"{sep} {title}")
+
+    def line(self, message: str) -> None:
+        self.lines.append(message)
+
+
+def make_config(**option_attrs: object) -> types.SimpleNamespace:
+    option = types.SimpleNamespace(verbose=1, **option_attrs)
+    return types.SimpleNamespace(
+        option=option,
+        custom_info=["some_test: hdr_dir='/somewhere'"],
+        getoption=lambda name: getattr(option, name),
+    )
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+@pytest.mark.parametrize(
+    "option_attrs",
+    [
+        {},  # neither plugin installed
+        {"iterations": 1},  # pytest-freethreaded installed, single iteration
+        {"count": 1},  # pytest-repeat installed, single run
+        {"iterations": 1, "count": 1},
+    ],
+    ids=["no-plugins", "freethreaded-single", "repeat-single", "both-single"],
+)
+def test_info_summary_is_emitted_for_a_single_pass(option_attrs):
+    reporter = FakeTerminalReporter()
+    pytest_terminal_summary(reporter, 0, make_config(**option_attrs))
+    assert reporter.lines == ["= INFO summary", "INFO some_test: hdr_dir='/somewhere'"]
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+@pytest.mark.parametrize(
+    "option_attrs",
+    [{"iterations": 2}, {"count": 2}],
+    ids=["freethreaded-repeats", "repeat-repeats"],
+)
+def test_info_summary_is_suppressed_when_tests_repeat(option_attrs):
+    reporter = FakeTerminalReporter()
+    pytest_terminal_summary(reporter, 0, make_config(**option_attrs))
+    assert reporter.lines == []
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+def test_info_summary_is_suppressed_without_verbose():
+    reporter = FakeTerminalReporter()
+    config = make_config()
+    config.option.verbose = 0
+    pytest_terminal_summary(reporter, 0, config)
+    assert reporter.lines == []


### PR DESCRIPTION
```python
def pytest_terminal_summary(terminalreporter, exitstatus, config):
    if not config.getoption("verbose"):
        return
    if hasattr(config.option, "iterations"):  # pytest-freethreaded runs all tests at least twice
        return
    if getattr(config.option, "count", 1) > 1:  # pytest-repeat
        return
```

The comment states the intent: suppress the summary only when the run **repeats** tests.
The pytest-repeat line implements exactly that (`count > 1`). The pytest-freethreaded line
checks only that the option *exists*.

`--iterations` is registered by the plugin with a default of `1`, so merely having
pytest-freethreaded installed suppresses the summary on an ordinary `pytest -v` run — no
repetition required.

That matters because the INFO summary is the *only* output of the `info_summary_append`
fixture, which `test_load_nvidia_dynamic_lib`, `test_driver_lib_loading`,
`test_find_nvidia_headers`, `test_find_static_lib` and `test_find_bitcode_lib` use to
report what they actually discovered on the host. It would silently disappear.

The plugin is not currently in `cuda_pathfinder`'s test dependency group
(`pytest`, `pytest-mock`, `pytest-repeat`, `pytest-randomly`), so this is dormant today —
but #2114 moves the repo toward parallel-test plugins, and `pytest.ini` already registers
the `thread_unsafe` / `parallel_threads_limit` markers, so it is worth having right before
that lands rather than after.

### Fix

Make the check symmetric with the pytest-repeat one:
`getattr(config.option, "iterations", 1) > 1`.

### Test

New `cuda_pathfinder/tests/test_conftest_info_summary.py` drives the hook directly with
stub `config` / `terminalreporter` objects — no plugin install and no CUDA needed — across
the matrix of *plugin absent / present-with-1 / present-with-2* for both plugins, plus the
`-v` gate.

Two of its cases (`freethreaded-single`, `both-single`) **fail on `main`**: the summary is
suppressed even though nothing repeats.

Verified: `pytest cuda_pathfinder/tests` has the same pass/fail set as `main` otherwise;
`ruff check`, `ruff format --check` and the pre-commit `mypy-pathfinder` invocation are all
clean.
