### PR TITLE
fix(test-helpers): load the C runtime portably instead of hard-coding libc.so.6

### DIFF
--- a/cuda_python_test_helpers/cuda_python_test_helpers/__init__.py
+++ b/cuda_python_test_helpers/cuda_python_test_helpers/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ctypes
+import ctypes.util
 import os
 import platform
 import sys
@@ -29,10 +30,36 @@ IS_WSL: bool = _detect_wsl()
 IS_WINDOWS: bool = platform.system() == "Windows" or sys.platform.startswith("win")
 IS_LINUX: bool = not IS_WINDOWS and not IS_WSL and platform.system() == "Linux"
 
-if IS_WINDOWS:
-    libc = ctypes.CDLL("msvcrt.dll")
-else:
-    libc = ctypes.CDLL("libc.so.6")
+
+def _load_libc() -> ctypes.CDLL:
+    """Load the C runtime.
+
+    ``libc.so.6`` is the glibc soname specifically: it does not exist on musl
+    (Alpine) or on macOS. It is tried first so the library resolved on the
+    platforms CI runs on is bit-for-bit what it was before, with
+    ``ctypes.util.find_library`` only as a fallback.
+
+    Failing here is expensive out of proportion to the one function that needs
+    it: this module is pulled in by ``cuda_core/tests/conftest.py`` through
+    ``pytest_plugins``, so an unloadable libc stops the entire suite from being
+    *collected*, including every test that never touches ``libc``.
+    """
+    if IS_WINDOWS:
+        return ctypes.CDLL("msvcrt.dll")
+
+    tried = []
+    for candidate in ("libc.so.6", ctypes.util.find_library("c")):
+        if candidate is None:
+            continue
+        tried.append(candidate)
+        try:
+            return ctypes.CDLL(candidate)
+        except OSError:
+            continue
+    raise OSError(f"could not load the C runtime on {platform.system()}; tried {tried}")
+
+
+libc = _load_libc()
 
 
 def under_compute_sanitizer() -> bool:

--- a/cuda_python_test_helpers/tests/test_libc_loading.py
+++ b/cuda_python_test_helpers/tests/test_libc_loading.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The C-runtime load must not be able to break test collection.
+
+``cuda_python_test_helpers`` is registered as a pytest plugin by
+``cuda_core/tests/conftest.py``, so anything that raises at its import time
+stops the whole cuda_core suite from being collected.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import importlib
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import cuda_python_test_helpers as helpers
+
+
+@pytest.fixture
+def reimport_helpers(monkeypatch):
+    """Re-execute the package with a filtered ``ctypes.CDLL``, then restore it."""
+
+    def _reimport(blocked):
+        real_cdll = ctypes.CDLL
+
+        def fake_cdll(name, *args, **kwargs):
+            if name in blocked:
+                raise OSError(f"{name}: cannot open shared object file (simulated)")
+            return real_cdll(name, *args, **kwargs)
+
+        monkeypatch.setattr(ctypes, "CDLL", fake_cdll)
+        return importlib.reload(helpers)
+
+    yield _reimport
+    monkeypatch.undo()
+    importlib.reload(helpers)
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+def test_libc_exposes_a_working_memcmp():
+    assert helpers.libc.memcmp(b"ab", b"ab", 2) == 0
+    assert helpers.libc.memcmp(b"ab", b"ac", 2) != 0
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+@pytest.mark.skipif(helpers.IS_WINDOWS, reason="the glibc soname is not used on Windows")
+def test_import_survives_without_the_glibc_soname(reimport_helpers):
+    """`libc.so.6` is glibc-specific and absent on musl (Alpine) and macOS.
+
+    It used to be loaded unconditionally on every non-Windows platform, so the
+    import raised OSError there -- even though the package computes IS_LINUX
+    right above and only one helper (`memcmp`, used by
+    cuda_core/tests/helpers/buffers.py) needs the library at all.
+    """
+    reloaded = reimport_helpers({"libc.so.6"})
+
+    assert reloaded.libc.memcmp(b"ab", b"ab", 2) == 0
+    assert reloaded.libc.memcmp(b"ab", b"ac", 2) != 0
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+@pytest.mark.skipif(helpers.IS_WINDOWS, reason="the glibc soname is not used on Windows")
+def test_error_names_what_was_tried_when_no_c_runtime_loads(reimport_helpers, monkeypatch):
+    """A genuinely unloadable C runtime must still fail, with a useful message."""
+    monkeypatch.setattr(ctypes.util, "find_library", lambda _name: None)
+
+    with pytest.raises(OSError, match=r"could not load the C runtime.*libc\.so\.6"):
+        reimport_helpers({"libc.so.6"})


### PR DESCRIPTION
> **I'll state the counter-argument up front:** `cuda_python_test_helpers/pyproject.toml` declares `Operating System :: POSIX :: Linux`, so failing on macOS is arguably out of contract and you may reasonably decline this. Two things are still true regardless: **musl (Alpine) is Linux and has no `libc.so.6` either**, and the cost of the current behaviour is that the *entire cuda_core suite cannot be collected* rather than one helper being unavailable. Your call.

## Problem

`cuda_python_test_helpers/__init__.py` loads the C runtime at import time:

```python
if IS_WINDOWS:
    libc = ctypes.CDLL("msvcrt.dll")
else:
    libc = ctypes.CDLL("libc.so.6")
```

`libc.so.6` is the **glibc soname** specifically — it does not exist on musl or macOS:

```pycon
>>> import cuda_python_test_helpers
OSError: dlopen(libc.so.6, 0x0006): tried: 'libc.so.6' (no such file),
  '/System/Volumes/Preboot/Cryptexes/OSlibc.so.6' (no such file),
  '/usr/lib/libc.so.6' (no such file, not in dyld cache), 'libc.so.6' (no such file)
```

Three things make that more expensive than it first looks.

**1. The file already computes the right predicate and does not use it.** Four lines above:

```python
IS_LINUX: bool = not IS_WINDOWS and not IS_WSL and platform.system() == "Linux"
```

The `else` branch covers every non-Windows platform, not Linux. This is the same validation-asymmetry shape as the `numa_id` / `is_numa_current` split in `Host` — the correct check exists and the guard next to it doesn't use it.

**2. Exactly one function needs the library.** `libc` is used only for `memcmp`, in `cuda_core/tests/helpers/buffers.py` (two call sites). Everything else the package exports — `IS_WSL`, `IS_LINUX`, `IS_WINDOWS`, `under_compute_sanitizer`, `driver_version_less_than` — is pure Python.

**3. It breaks collection, not just that helper.** `cuda_core/tests/conftest.py` registers this package as a pytest plugin:

```python
pytest_plugins = ["cuda_python_test_helpers._pytest_plugin"]
```

so an unloadable libc stops the whole cuda_core suite from being *collected*, including every test that never touches `libc`.

## Fix

Try the glibc soname **first** — so the library resolved on the platforms CI runs on is bit-for-bit what it was before — and fall back to `ctypes.util.find_library("c")`. If nothing loads, raise an `OSError` naming the platform and what was tried, rather than a raw dlopen dump.

On a glibc host this is a no-op: `CDLL("libc.so.6")` succeeds on the first candidate and `find_library` is never called.

## Tests

`cuda_python_test_helpers` has no test directory today; this adds `cuda_python_test_helpers/tests/test_libc_loading.py`:

- `libc` exposes a working `memcmp` (equal and differing inputs);
- **`test_import_survives_without_the_glibc_soname`** — monkeypatches `ctypes.CDLL` to reject `"libc.so.6"` and re-imports the package, simulating musl/macOS on any host. This is the regression test, and it fails on `main` **on a glibc runner too**, so it has teeth in CI rather than only on my machine;
- a genuinely unloadable C runtime still raises, with a message naming what was tried.

The fixture restores the real `ctypes.CDLL` and re-imports the package on teardown, so the reload does not leak into other tests.

**Not wired into CI:** this new directory is not in any job's test paths. #2539 / #2548 / #2549 each add `toolshed/tests` to the nightly tooling job with a byte-identical one-line change; extending that same line to pick this up would be trivial, but I left it out rather than create a four-way conflict on one line. Happy to fold it in whichever way you prefer.

## Verification

- `pytest cuda_python_test_helpers/tests` → **3 passed** on macOS (the package imports only stdlib, so this runs natively).
- With `__init__.py` restored from `upstream/main`, the module cannot even be imported on macOS, so the test file fails at collection with the `OSError` above. On a glibc host the meaningful teeth are in `test_import_survives_without_the_glibc_soname`, which fails there because the unconditional `CDLL("libc.so.6")` raises under the simulated block.
- The restore was done with a `try/finally` harness (`cp` aside → `git show upstream/main:<path> >` → run → restore in `finally`), so the working tree is put back even when the run under test fails. Index verified clean before committing.
- `ruff check` / `ruff format --check` clean on both files.
