### PR TITLE
Consider the NVRTC major version when deciding whether cubin is available

### DIFF
--- a/cuda_bindings/cuda/bindings/_example_helpers/common.py
+++ b/cuda_bindings/cuda/bindings/_example_helpers/common.py
@@ -21,6 +21,19 @@ def requirement_not_met(message):
     return sys.exit(int(exitcode))
 
 
+#: NVRTC gained cubin output (nvrtcGetCUBIN) in CUDA 11.1.
+NVRTC_CUBIN_MIN_VERSION = (11, 1)
+
+
+def nvrtc_supports_cubin(nvrtc_version):
+    """Whether this NVRTC can emit cubin rather than only PTX.
+
+    Compares (major, minor) as a tuple: looking at the minor alone reports
+    "no cubin" for every x.0 release, e.g. NVRTC 12.0 and 13.0.
+    """
+    return tuple(nvrtc_version) >= NVRTC_CUBIN_MIN_VERSION
+
+
 def check_compute_capability_too_low(dev_id, required_cc_major_minor):
     cc_major = check_cuda_errors(
         cudart.cudaDeviceGetAttribute(cudart.cudaDeviceAttr.cudaDevAttrComputeCapabilityMajor, dev_id)
@@ -55,8 +68,7 @@ class KernelHelper:
         minor = check_cuda_errors(
             cudart.cudaDeviceGetAttribute(cudart.cudaDeviceAttr.cudaDevAttrComputeCapabilityMinor, dev_id)
         )
-        _, nvrtc_minor = nvrtc.version()
-        use_cubin = nvrtc_minor >= 1
+        use_cubin = nvrtc_supports_cubin(nvrtc.version())
         prefix = "sm" if use_cubin else "compute"
         arch_arg = bytes(f"--gpu-architecture={prefix}_{major}{minor}", "ascii")
 

--- a/cuda_bindings/examples/extra/jit_program.py
+++ b/cuda_bindings/examples/extra/jit_program.py
@@ -68,8 +68,10 @@ def main():
         cuda.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, cu_device
     )
     assert_drv(err)
-    nvrtc_major, nvrtc_minor = nvrtc.version()
-    use_cubin = nvrtc_minor >= 1
+    # NVRTC gained cubin output in CUDA 11.1. Compare (major, minor) as a
+    # tuple: looking at the minor alone reports "no cubin" for every x.0
+    # release, e.g. NVRTC 12.0 and 13.0.
+    use_cubin = nvrtc.version() >= (11, 1)
     prefix = "sm" if use_cubin else "compute"
     arch_arg = bytes(f"--gpu-architecture={prefix}_{major}{minor}", "ascii")
 

--- a/cuda_bindings/tests/test_kernel_helper.py
+++ b/cuda_bindings/tests/test_kernel_helper.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from cuda.bindings._example_helpers.common import nvrtc_supports_cubin
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+@pytest.mark.parametrize(
+    ("nvrtc_version", "expected"),
+    [
+        ((11, 0), False),  # predates nvrtcGetCUBIN
+        ((11, 1), True),  # the release that added it
+        ((11, 8), True),
+        ((12, 0), True),  # x.0 releases: minor alone would say False
+        ((12, 9), True),
+        ((13, 0), True),
+        ((13, 4), True),
+    ],
+)
+def test_nvrtc_supports_cubin(nvrtc_version, expected):
+    assert nvrtc_supports_cubin(nvrtc_version) is expected
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+@pytest.mark.parametrize("nvrtc_version", [(12, 0), (13, 0)])
+def test_minor_only_check_would_be_wrong_for_x_0_releases(nvrtc_version):
+    """Pins the exact regression: `nvrtc_minor >= 1` disagrees on every x.0."""
+    _, nvrtc_minor = nvrtc_version
+    assert (nvrtc_minor >= 1) is False
+    assert nvrtc_supports_cubin(nvrtc_version) is True


### PR DESCRIPTION
```python
        _, nvrtc_minor = nvrtc.version()
        use_cubin = nvrtc_minor >= 1
```

`nvrtc.version()` returns `(major, minor)` and the major is discarded, so the test is
really *"is the minor at least 1"*. That is wrong for every `x.0` release:

| `nvrtc.version()` | `nvrtc_minor >= 1` | correct? |
| --- | --- | --- |
| `(11, 0)` | `False` | yes |
| `(11, 1)` | `True` | yes |
| `(12, 0)` | `False` | **no** |
| `(12, 9)` | `True` | yes |
| `(13, 0)` | `False` | **no** |

The intent is "NVRTC is new enough to emit cubin" — `nvrtcGetCUBIN` arrived in CUDA 11.1.
On a 12.0 or 13.0 toolkit the check silently selects
`--gpu-architecture=compute_XX` + `nvrtc.get_ptx()` instead of `sm_XX` +
`nvrtc.get_cubin()`, so the examples JIT-compile PTX at module-load time rather than using
the cubin they asked for. It is a silent fallback, not a crash — which is why it has gone
unnoticed. Every example here carries a `cuda-bindings>13.2.1` PEP-723 header, so a `13.0`
toolkit is a realistic configuration.

Both copies of the expression are affected:
`cuda/bindings/_example_helpers/common.py:58-59` (used by `KernelHelper`, i.e. most
examples) and `examples/extra/jit_program.py:71-72`.

### Fix

Compare `(major, minor)` as a tuple against `(11, 1)`.

In `common.py` this becomes a named `nvrtc_supports_cubin()` helper, so the decision table
is unit-testable without an NVRTC install. `jit_program.py` does not import the example
helpers, so it gets the equivalent inline comparison plus a comment rather than a new
dependency.

I kept the 11.1 threshold exactly as-is — this PR is only about the major being ignored,
not about re-deciding where cubin support starts.

### Test

New `cuda_bindings/tests/test_kernel_helper.py` covers the full table above, plus a case
that pins the exact disagreement between the old and new expressions for `(12, 0)` and
`(13, 0)`. Pure Python — no NVRTC, no toolkit, no GPU.

`ruff check` and `ruff format --check` are clean on all three files.
