### PR TITLE
Stop _gl_context from converting test failures into skips

### DIFF
--- a/cuda_bindings/tests/test_graphics_apis.py
+++ b/cuda_bindings/tests/test_graphics_apis.py
@@ -12,15 +12,14 @@ import pytest
 from cuda.bindings import runtime as cudart
 
 
-@contextlib.contextmanager
-def _gl_context():
-    """
-    Yield a (tex_id, tex_target) with a current GL context.
+def _create_gl_texture():
+    """Create a hidden/headless GL context plus a tiny texture to register.
+
+    Returns ``(win, tex_id, target)``. Raises on any pyglet/GL failure.
     Tries:
       1) Windows: hidden WGL window (no EGL)
       2) Linux with DISPLAY/wayland: hidden window
       3) Linux headless: EGL headless if available
-    Skips if none work.
     """
     pyglet = pytest.importorskip("pyglet")
 
@@ -32,41 +31,55 @@ def _gl_context():
 
     # Create a minimal offscreen/hidden context
     win = None
+    if not pyglet.options.get("headless"):
+        # Hidden window path (WGL on Windows, GLX/WLS on Linux)
+        from pyglet import gl
+
+        config = gl.Config(double_buffer=False)
+        win = pyglet.window.Window(visible=False, config=config)
+        win.switch_to()
+    else:
+        # Headless EGL path; pyglet will arrange a pbuffer-like headless context
+        from pyglet.gl import headless  # noqa: F401
+
+    # Make a tiny texture so we have a real GL object to register
+    from pyglet.gl import gl as _gl
+
+    tex_id = _gl.GLuint(0)
+    target = _gl.GL_TEXTURE_2D
+    _gl.glGenTextures(1, ctypes.byref(tex_id))
+    _gl.glBindTexture(target, tex_id.value)
+    _gl.glTexParameteri(target, _gl.GL_TEXTURE_MIN_FILTER, _gl.GL_NEAREST)
+    _gl.glTexParameteri(target, _gl.GL_TEXTURE_MAG_FILTER, _gl.GL_NEAREST)
+    width, height = 16, 16
+    _gl.glTexImage2D(target, 0, _gl.GL_RGBA8, width, height, 0, _gl.GL_RGBA, _gl.GL_UNSIGNED_BYTE, None)
+
+    return win, tex_id, target
+
+
+@contextlib.contextmanager
+def _gl_context():
+    """Yield a (tex_id, tex_target) with a current GL context, or skip."""
+    win = None
+    tex_id = None
     try:
-        if not pyglet.options.get("headless"):
-            # Hidden window path (WGL on Windows, GLX/WLS on Linux)
-            from pyglet import gl
-
-            config = gl.Config(double_buffer=False)
-            win = pyglet.window.Window(visible=False, config=config)
-            win.switch_to()
-        else:
-            # Headless EGL path; pyglet will arrange a pbuffer-like headless context
-            from pyglet.gl import headless  # noqa: F401
-
-        # Make a tiny texture so we have a real GL object to register
-        from pyglet.gl import gl as _gl
-
-        tex_id = _gl.GLuint(0)
-        _gl.glGenTextures(1, ctypes.byref(tex_id))
-        target = _gl.GL_TEXTURE_2D
-        _gl.glBindTexture(target, tex_id.value)
-        _gl.glTexParameteri(target, _gl.GL_TEXTURE_MIN_FILTER, _gl.GL_NEAREST)
-        _gl.glTexParameteri(target, _gl.GL_TEXTURE_MAG_FILTER, _gl.GL_NEAREST)
-        width, height = 16, 16
-        _gl.glTexImage2D(target, 0, _gl.GL_RGBA8, width, height, 0, _gl.GL_RGBA, _gl.GL_UNSIGNED_BYTE, None)
+        try:
+            win, tex_id, target = _create_gl_texture()
+        except Exception as e:
+            # Convert any pyglet/GL creation failure into a clean skip.
+            # The yield below is deliberately NOT inside this handler:
+            # @contextmanager re-raises the with-body's exception at the yield,
+            # so catching there would turn a failing assertion in the test into
+            # a skip, and the test could never fail.
+            pytest.skip(f"Could not create GL context/texture: {type(e).__name__}: {e}")
 
         yield int(tex_id.value), int(target)
-
-    except Exception as e:
-        # Convert any pyglet/GL creation failure into a clean skip
-        pytest.skip(f"Could not create GL context/texture: {type(e).__name__}: {e}")
     finally:
         # Best-effort cleanup
         try:
             from pyglet.gl import gl as _gl
 
-            if tex_id.value:
+            if tex_id is not None and tex_id.value:
                 _gl.glDeleteTextures(1, ctypes.byref(tex_id))
         except Exception:  # noqa: S110
             pass
@@ -75,6 +88,20 @@ def _gl_context():
                 win.close()
         except Exception:  # noqa: S110
             pass
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+def test_gl_context_lets_body_failures_fail(monkeypatch):
+    """A failing assertion inside the with-body must not be reported as a skip."""
+
+    class FakeTexId:
+        value = 7
+
+    monkeypatch.setattr(sys.modules[__name__], "_create_gl_texture", lambda: (None, FakeTexId(), 0x0DE1))
+
+    with pytest.raises(AssertionError, match="body failure"), _gl_context() as (tex_id, tex_target):
+        assert (tex_id, tex_target) == (7, 0x0DE1)
+        raise AssertionError("body failure")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`_gl_context()` yields from inside a `try` whose handler turns everything into a skip:

```python
    try:
        ...create context and texture...
        yield int(tex_id.value), int(target)

    except Exception as e:
        # Convert any pyglet/GL creation failure into a clean skip
        pytest.skip(f"Could not create GL context/texture: {type(e).__name__}: {e}")
```

`@contextmanager` re-raises the with-body's exception **at the yield point**, so
`except Exception` also catches failures from the *test body*. `AssertionError` is an
`Exception`; pytest's `Skipped` is a `BaseException`, so the replacement skip escapes
cleanly and the run is reported as SKIPPED.

That means neither assertion in `test_cuda_gl_register_image_smoketest` can fail the suite:

```python
        assert name in acceptable, f"cudaGraphicsGLRegisterImage returned {name}"
        if name == "cudaSuccess":
            assert int(resource) != 0
```

A genuinely wrong `cudaGraphicsGLRegisterImage` return is reported as
`Could not create GL context/texture: AssertionError: ...`. The handler's own comment says
*"creation failure"*, which is what it was meant to cover.

Demonstrated with a minimal standalone reproduction of the same shape:

```
test_yield_in_try.py::test_body_failure_under_main_shape   SKIPPED
    Could not create GL context/texture: AssertionError: this assertion should FAIL the test
test_yield_in_try.py::test_body_failure_under_fixed_shape  FAILED
    AssertionError: this assertion should FAIL the test
```

Both tests in this module are on the always-skipped list in #2077, so this has never been
visible in CI.

### Fix

Move the context/texture creation into `_create_gl_texture()` so the handler wraps only
that, and keep the `yield` outside it. Cleanup stays in the outer `finally`, so a
partially built context is still torn down on the skip path. `tex_id` is now initialized,
which also removes an `UnboundLocalError` that the `finally` block was silently swallowing
when creation failed before the texture existed.

`pytest.importorskip` and the no-EGL `pytest.skip` inside `_create_gl_texture` still
propagate correctly — `Skipped` is a `BaseException`, so `except Exception` does not catch
them.

### Test

`test_gl_context_lets_body_failures_fail` stubs `_create_gl_texture()` and asserts that an
`AssertionError` raised inside the `with` body propagates. **No GL context, no display, no
GPU, no pyglet** — so unlike the two smoketests it actually runs in CI. I verified it
passes against the restructured contextmanager and that the pre-existing shape converts
the same failure into a skip.

`ruff check` and `ruff format --check` are clean.
