### PR TITLE
cuda.core: emit -numba-debug to libNVVM, not --numba-debug

### DIFF
--- a/cuda_core/cuda/core/_program.pyx
+++ b/cuda_core/cuda/core/_program.pyx
@@ -1233,7 +1233,7 @@ cdef inline object _prepare_nvvm_options_impl(object opts, bint as_bytes):
     if opts.debug is not None and opts.debug:
         options.append("-g")
     if opts.numba_debug:
-        options.append("--numba-debug")
+        options.append("-numba-debug")
     if opts.device_code_optimize is False:
         options.append("-opt=0")
     elif opts.device_code_optimize is True:

--- a/cuda_core/docs/source/release/1.2.0-notes.rst
+++ b/cuda_core/docs/source/release/1.2.0-notes.rst
@@ -73,6 +73,13 @@ Fixes and enhancements
   Windows, both ``ctypes.CFUNCTYPE`` and ``ctypes.WINFUNCTYPE`` are accepted.
   (`#2439 <https://github.com/NVIDIA/cuda-python/issues/2439>`__)
 
+- ``ProgramOptions(numba_debug=True)`` now works on the NVVM backend. The
+  option was emitted as ``--numba-debug``, and libNVVM accepts only the
+  single-dashed ``-numba-debug``, so every such compilation failed with
+  ``NVVM_ERROR_INVALID_OPTION``. The NVRTC backend, which tolerates both
+  spellings, was unaffected.
+  (`#2570 <https://github.com/NVIDIA/cuda-python/issues/2570>`__)
+
 Deprecation Notices
 -------------------
 

--- a/cuda_core/tests/test_program.py
+++ b/cuda_core/tests/test_program.py
@@ -93,12 +93,12 @@ def _check_nvvm_arch(arch: str) -> bool:
 
 
 def _check_nvvm_supports_numba_debug() -> bool:
-    """Check if the installed libNVVM recognizes --numba-debug (CTK 13.2+)."""
+    """Check if the installed libNVVM recognizes -numba-debug."""
     if not _has_check_nvvm_compiler_options():
         return False
     from cuda.bindings.utils import check_nvvm_compiler_options
 
-    return check_nvvm_compiler_options(["--numba-debug"])
+    return check_nvvm_compiler_options(["-numba-debug"])
 
 
 @pytest.fixture(scope="session")
@@ -762,18 +762,19 @@ def test_program_options_as_bytes_nvvm_unsupported_option():
 
 @nvvm_available
 def test_nvvm_program_options_as_bytes_numba_debug():
-    """numba_debug must be plumbed through to libNVVM as --numba-debug
-    (see #1287)."""
+    """numba_debug must be plumbed through to libNVVM as -numba-debug
+    (see #1287). libNVVM rejects the double-dashed form of every option."""
     options = ProgramOptions(arch="sm_80", debug=True, numba_debug=True)
     nvvm_bytes = options.as_bytes("nvvm")
-    assert b"--numba-debug" in nvvm_bytes
+    assert b"-numba-debug" in nvvm_bytes
+    assert b"--numba-debug" not in nvvm_bytes
     assert b"-g" in nvvm_bytes
 
 
 @nvvm_available
 @pytest.mark.skipif(
     not _check_nvvm_supports_numba_debug(),
-    reason="installed libNVVM does not recognize --numba-debug (needs CTK 13.2+)",
+    reason="installed libNVVM does not recognize -numba-debug",
 )
 def test_nvvm_program_numba_debug(init_cuda, nvvm_ir):
     options = ProgramOptions(arch="sm_80", debug=True, numba_debug=True)


### PR DESCRIPTION
## Summary

Closes #2570.

libNVVM accepts only single-dashed options, but `_prepare_nvvm_options_impl` emitted `--numba-debug`, so every `ProgramOptions(numba_debug=True)` compile on the NVVM backend failed with `NVVM_ERROR_INVALID_OPTION`. numba-cuda emits `-numba-debug` for the same path. The NVRTC backend tolerates both spellings and is left alone.

The guarding test never caught this because it probed libNVVM with the same wrong spelling, so it skipped on every configuration, including CUDA 13.3. It is one of the entries in #2077.

## Changes

- `_program.pyx`: emit `-numba-debug` in `_prepare_nvvm_options_impl`. The NVRTC call site is unchanged.
- `tests/test_program.py`: probe and assert the emitted spelling, add an assertion that the double-dashed form is absent, and drop the skip reason's claim that the option needs CTK 13.2 (libNVVM rejects the double-dashed form at any version).
- `docs/source/release/1.2.0-notes.rst`: release note. The wrong spelling is in released 1.1.0 and 1.1.1.

## Verification

`test_nvvm_program_numba_debug` previously skipped everywhere. It now runs and passes, and it fails without the production change:

```console
$ git stash push cuda_core/cuda/core/_program.pyx   # production only
$ python -m pytest tests/test_program.py -k numba_debug -v
tests/test_program.py::test_nvvm_program_options_as_bytes_numba_debug FAILED [ 50%]
tests/test_program.py::test_nvvm_program_numba_debug FAILED              [100%]
cuda.bindings.nvvm.nvvmError: ERROR_INVALID_OPTION (7)
NVVM program log: libnvvm : error: --numba-debug is an unsupported option
```

With the change:

```console
$ python -m pytest tests/test_program.py -k numba_debug -v
tests/test_program.py::test_nvvm_program_options_as_bytes_numba_debug PASSED [ 50%]
tests/test_program.py::test_nvvm_program_numba_debug PASSED              [100%]
```

Whole module, before and after:

```console
$ python -m pytest tests/test_program.py -q   # upstream/main
110 passed, 2 skipped in 2.01s
$ python -m pytest tests/test_program.py -q   # this branch
111 passed, 1 skipped in 2.61s
```
