### PR TITLE
fix(core): reject use_libdevice on the NVRTC and PTX backends

### DIFF
--- a/cuda_core/cuda/core/_program.pyx
+++ b/cuda_core/cuda/core/_program.pyx
@@ -771,6 +771,8 @@ cdef inline int Program_init(Program self, object code, str code_type, object op
         assert_type(code, str)
         if options.extra_sources is not None:
             raise ValueError("extra_sources is not supported by the NVRTC backend (C++ code_type)")
+        if options.use_libdevice:
+            raise ValueError("use_libdevice is not supported by the NVRTC backend (C++ code_type)")
 
         # TODO: support pre-loaded headers & include names
         code_bytes = code.encode()
@@ -789,6 +791,8 @@ cdef inline int Program_init(Program self, object code, str code_type, object op
         assert_type(code, str)
         if options.extra_sources is not None:
             raise ValueError("extra_sources is not supported by the PTX backend.")
+        if options.use_libdevice:
+            raise ValueError("use_libdevice is not supported by the PTX backend.")
         code_bytes = code.encode()
         self._code = code_bytes
         self._linker = Linker(
@@ -835,9 +839,12 @@ cdef inline int Program_init(Program self, object code, str code_type, object op
         self._linker = None
 
     else:
+        # No use_libdevice check here: this branch is only reached for a
+        # code_type that is not a backend at all, and an unrecognised
+        # code_type is the error worth reporting. The per-backend guards
+        # above mirror the extra_sources ones and are what actually
+        # enforce "NVVM only", which is what ProgramOptions documents.
         supported_code_types = tuple(x.value for x in SourceCodeType)
-        if options.use_libdevice:
-            raise ValueError("use_libdevice is only supported by the NVVM backend")
         raise RuntimeError(f"Unsupported {code_type=} ({supported_code_types=})")
 
     return 0

--- a/cuda_core/docs/source/release/1.2.0-notes.rst
+++ b/cuda_core/docs/source/release/1.2.0-notes.rst
@@ -73,6 +73,14 @@ Fixes and enhancements
   Windows, both ``ctypes.CFUNCTYPE`` and ``ctypes.WINFUNCTYPE`` are accepted.
   (`#2439 <https://github.com/NVIDIA/cuda-python/issues/2439>`__)
 
+- :class:`Program` now rejects ``use_libdevice=True`` for ``code_type="c++"``
+  and ``code_type="ptx"``, as :class:`ProgramOptions` documents. The guard was
+  written in ``Program_init``'s unrecognised-``code_type`` branch, so the two
+  real non-NVVM backends accepted the option silently and never linked
+  libdevice, leaving the caller with undefined-symbol errors at link time.
+  Conversely, an unrecognised ``code_type`` combined with ``use_libdevice=True``
+  now reports the ``code_type``, not libdevice.
+
 Deprecation Notices
 -------------------
 

--- a/cuda_core/tests/test_program.py
+++ b/cuda_core/tests/test_program.py
@@ -345,6 +345,20 @@ def test_program_init_invalid_code_type():
         Program(code, "FORTRAN")
 
 
+@pytest.mark.agent_authored(model="claude-opus-5")
+def test_program_init_invalid_code_type_reports_the_code_type():
+    """An unrecognised code_type is the error worth reporting, even when
+    use_libdevice is set.
+
+    The use_libdevice guard used to live in this branch, so a typo'd
+    code_type combined with use_libdevice=True reported
+    "use_libdevice is only supported by the NVVM backend" and never
+    mentioned that the code_type was the actual problem.
+    """
+    with pytest.raises(RuntimeError, match=r"^Unsupported code_type='fortran'"):
+        Program("goto 100", "FORTRAN", ProgramOptions(arch="sm_80", use_libdevice=True))
+
+
 def test_program_init_invalid_code_format():
     code = 12345
     with pytest.raises(TypeError):
@@ -718,6 +732,22 @@ def test_cpp_program_with_extra_sources():
         Program(code, "c++", options)
 
 
+@pytest.mark.agent_authored(model="claude-opus-5")
+def test_cpp_program_with_use_libdevice():
+    """NVRTC has no libdevice loading path.
+
+    The guard used to sit in Program_init's unrecognised-code_type branch, so
+    "c++" accepted use_libdevice=True silently: Program._use_libdevice stays
+    False (it is only set inside the nvvm branch), libdevice is never linked,
+    and the caller finds out from undefined-symbol errors at link time instead
+    of from the up-front ValueError ProgramOptions documents.
+    """
+    code = 'extern "C" __global__ void my_kernel(){}'
+    options = ProgramOptions(use_libdevice=True)
+    with pytest.raises(ValueError, match="use_libdevice is not supported by the NVRTC backend"):
+        Program(code, "c++", options)
+
+
 def test_program_options_as_bytes_nvrtc():
     """Test ProgramOptions.as_bytes() for NVRTC backend"""
     options = ProgramOptions(arch="sm_80", debug=True, lineinfo=True, ftz=True)
@@ -828,6 +858,14 @@ def test_ptx_program_extra_sources_unsupported(ptx_code_object):
     """PTX backend raises ValueError when extra_sources is specified."""
     options = ProgramOptions(extra_sources=[("module1", b"data")])
     with pytest.raises(ValueError, match="extra_sources is not supported by the PTX backend"):
+        Program(ptx_code_object.code.decode(), "ptx", options)
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+def test_ptx_program_use_libdevice_unsupported(ptx_code_object):
+    """PTX goes through the Linker, which has no libdevice loading path."""
+    options = ProgramOptions(use_libdevice=True)
+    with pytest.raises(ValueError, match="use_libdevice is not supported by the PTX backend"):
         Program(ptx_code_object.code.decode(), "ptx", options)
 
 


### PR DESCRIPTION
## Problem

`ProgramOptions.use_libdevice` is documented as *"Only supported for the NVVM backend"* (`_program.pyx:465-468`). The guard that was supposed to enforce that sits in `Program_init`'s final `else` — the branch reached only when `code_type` is **not a backend at all**:

```python
    else:
        supported_code_types = tuple(x.value for x in SourceCodeType)
        if options.use_libdevice:
            raise ValueError("use_libdevice is only supported by the NVVM backend")
        raise RuntimeError(f"Unsupported {code_type=} ({supported_code_types=})")
```

Two wrong behaviours follow:

**1. The two real non-NVVM backends accept the option silently.** `Program(src, "c++", ProgramOptions(use_libdevice=True))` and the `"ptx"` equivalent construct fine. `self._use_libdevice` is initialised to `False` (`_program.pyx:765`) and only flipped inside the `nvvm` branch, so libdevice is never loaded — the caller finds out via undefined-symbol errors at link time instead of via the documented up-front `ValueError`.

**2. A typo'd `code_type` reports the wrong error.** `Program(src, "bogus", ProgramOptions(use_libdevice=True))` raises `"use_libdevice is only supported by the NVVM backend"` and never mentions that `code_type` is the actual problem.

The sibling option shows the intended shape: `extra_sources` has the same "NVVM only" contract, and its guard *is* duplicated into each real branch — `_program.pyx:772-773` (`c++`) and `:790-791` (`ptx`).

## Fix

Move the `use_libdevice` check next to those `extra_sources` guards in the `c++` and `ptx` branches, and drop it from the `else` so an unrecognised `code_type` reports itself. No behaviour changes for `code_type="nvvm"`.

This is an error-path-only change: any program that compiled before still compiles, and any program that is newly rejected was already producing a build the user did not ask for.

## Tests

Three cases in `cuda_core/tests/test_program.py`, placed next to the existing `extra_sources` tests they mirror:

- `test_cpp_program_with_use_libdevice` — NVRTC rejects it.
- `test_ptx_program_use_libdevice_unsupported` — the PTX/linker path rejects it.
- `test_program_init_invalid_code_type_reports_the_code_type` — `use_libdevice=True` no longer shadows the unrecognised-`code_type` error.

## What I ran

Environment: macOS, no CUDA driver and no CUDA toolkit, so `cuda.core` cannot be built or imported here.

- **Did not run:** the three new tests, or anything else in `cuda_core/tests/` — they need a built `cuda.core` and a GPU. They are written against the existing `extra_sources` tests immediately adjacent to them, which use the same fixtures.
- **Ran:** a reduction of `Program_init`'s dispatch with the CUDA calls removed and the guard placement kept verbatim, before and after the change:

```
--- before ---
  code_type='c++'      use_libdevice=True -> accepted, _use_libdevice=False
  code_type='ptx'      use_libdevice=True -> accepted, _use_libdevice=False
  code_type='nvvm'     use_libdevice=True -> accepted, _use_libdevice=True
  code_type='fortran'  use_libdevice=True -> ValueError: use_libdevice is only supported by the NVVM backend
--- after ---
  code_type='c++'      use_libdevice=True -> ValueError: use_libdevice is not supported by the NVRTC backend (C++ code_type)
  code_type='ptx'      use_libdevice=True -> ValueError: use_libdevice is not supported by the PTX backend.
  code_type='nvvm'     use_libdevice=True -> accepted, _use_libdevice=True
  code_type='fortran'  use_libdevice=True -> RuntimeError: Unsupported code_type='fortran' (SUPPORTED=('c++', 'ptx', 'nvvm'))
```

- **Ran:** `ruff check` / `ruff format --check` on `cuda_core/tests/test_program.py` — clean, no new findings against a `main` baseline for that file.
- **Checked:** `use_libdevice` appears in `_program.pyx` only at the two sites above (the `nvvm` set and this guard), so nothing else depended on the old placement. `test_program_init_invalid_code_type` still passes unchanged because its `ProgramOptions` leaves `use_libdevice` at its `False` default.
