### PR TITLE
fix(core): make cuda.core.system actually fall back when NVML is unimportable

### DIFF
--- a/cuda_core/cuda/core/system/_system.pyx
+++ b/cuda_core/cuda/core/system/_system.pyx
@@ -47,11 +47,17 @@ else:
 if CUDA_BINDINGS_NVML_IS_COMPATIBLE:
     try:
         from cuda.bindings import nvml
+        # _nvml_context imports cuda.bindings.nvml itself, so it has to be
+        # inside the same try: importing it after nvml failed would raise the
+        # very ImportError this block exists to absorb.
+        from cuda.core.system._nvml_context import initialize
     except ImportError:
         CUDA_BINDINGS_NVML_IS_COMPATIBLE = False
 
-    from cuda.core.system._nvml_context import initialize
-else:
+# Deliberately a second `if`, not an `else` on the one above: the flag can be
+# cleared by the import that just failed, and the non-NVML fallbacks are
+# exactly what every consumer below reaches for once it is False.
+if not CUDA_BINDINGS_NVML_IS_COMPATIBLE:
     from cuda.core._utils.cuda_utils import driver, handle_return, runtime
 
 

--- a/cuda_core/docs/source/release/1.2.0-notes.rst
+++ b/cuda_core/docs/source/release/1.2.0-notes.rst
@@ -244,6 +244,13 @@ Fixes and enhancements
   refreshed for CUDA 13.3 and now recognizes
   ``CUDA_ERROR_GRAPH_RECAPTURE_FAILURE``.
   (`#2383 <https://github.com/NVIDIA/cuda-python/pull/2383>`__)
+- ``cuda.core.system`` now really does fall back to its non-NVML
+  implementations when ``cuda.bindings.nvml`` cannot be imported. The
+  ``except ImportError`` cleared ``CUDA_BINDINGS_NVML_IS_COMPATIBLE``, but the
+  ``else`` that binds ``driver`` / ``handle_return`` / ``runtime`` hung off the
+  outer ``if``, which had already been evaluated, and the unconditional
+  ``_nvml_context`` import that followed pulls in ``cuda.bindings.nvml``
+  itself -- so ``import cuda.core.system`` raised instead of degrading.
 
 Deprecation Notices
 -------------------

--- a/cuda_core/tests/system/test_system_system.py
+++ b/cuda_core/tests/system/test_system_system.py
@@ -4,6 +4,8 @@
 
 
 import os
+import subprocess
+import sys
 
 import pytest
 from cuda_python_test_helpers.arch_check import skip_if_nvml_unsupported
@@ -82,3 +84,44 @@ def test_get_driver_branch():
     driver_branch = system.get_driver_branch()
     assert isinstance(driver_branch, str)
     assert len(driver_branch) > 0
+
+
+# The NVML-unavailable fallback is decided at import time, so it can only be
+# exercised in a fresh interpreter with cuda.bindings.nvml blocked.
+_NO_NVML_SCRIPT = """
+import sys
+
+
+class _BlockNvml:
+    def find_spec(self, name, path=None, target=None):
+        if name == "cuda.bindings.nvml":
+            raise ImportError("blocked for testing", name=name)
+        return None
+
+
+sys.meta_path.insert(0, _BlockNvml())
+
+# Used to raise ImportError out of this import: the flag was cleared, but the
+# `else` that binds the non-NVML fallbacks belonged to the outer `if`, which
+# had already been evaluated, and _nvml_context (imported unconditionally
+# right after) imports cuda.bindings.nvml itself.
+from cuda.core import system
+from cuda.core.system import _system
+
+assert system.CUDA_BINDINGS_NVML_IS_COMPATIBLE is False, "flag must be cleared when nvml is unimportable"
+for name in ("driver", "handle_return", "runtime"):
+    assert hasattr(_system, name), f"non-NVML fallback {name!r} is not bound"
+print("ok")
+"""
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+def test_system_falls_back_when_nvml_is_unimportable():
+    proc = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", _NO_NVML_SCRIPT],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    assert proc.stdout.strip().endswith("ok")


### PR DESCRIPTION
## Problem

`cuda_core/cuda/core/system/_system.pyx` opens with the contract it is meant to satisfy:

```
# This file needs to either use NVML exclusively, or when `cuda.bindings.nvml`
# isn't available, fall back to non-NVML-based methods for backward
# compatibility.
```

The code that is supposed to implement that does neither:

```python
if CUDA_BINDINGS_NVML_IS_COMPATIBLE:
    try:
        from cuda.bindings import nvml
    except ImportError:
        CUDA_BINDINGS_NVML_IS_COMPATIBLE = False

    from cuda.core.system._nvml_context import initialize
else:
    from cuda.core._utils.cuda_utils import driver, handle_return, runtime
```

The `except` clears `CUDA_BINDINGS_NVML_IS_COMPATIBLE`, but the `else` hangs off the **outer** `if`, which has already been evaluated. So on the one path that clears the flag, the non-NVML names are never bound — while every consumer in the file keys off the now-`False` flag and reaches for exactly those names:

| consumer | line | falls back to |
| --- | --- | --- |
| `get_user_mode_driver_version()` | 74-75 | `handle_return(driver.cuDriverGetVersion())` |
| `get_num_devices()` | 139 | `handle_return(runtime.cudaGetDeviceCount())` |

Both would raise `NameError`. In practice the module never reaches them: `from cuda.core.system._nvml_context import initialize` on the next line runs unconditionally, and `_nvml_context.pyx:7` is itself `from cuda.bindings import nvml` — so the very `ImportError` the `try`/`except` exists to absorb is re-raised one statement later and `import cuda.core.system` fails outright.

`cuda.core.system.__init__` is built around the flag being usable in this state (`elif CUDA_BINDINGS_NVML_IS_COMPATIBLE:` gates the NVML-only submodules), and `cuda.core._device` reads it at `_device.pyx:1053`, so the degraded mode is a supported configuration — it just cannot be reached.

## Fix

Move the `_nvml_context` import into the same `try` (it depends on `nvml`, so it belongs there), and replace the `else` with a second `if not CUDA_BINDINGS_NVML_IS_COMPATIBLE:` so a flag cleared by the failed import selects the fallback.

## Tests

The branch is import-time, so it can only be exercised in a fresh interpreter. `test_system_falls_back_when_nvml_is_unimportable` runs a subprocess that installs a `sys.meta_path` finder raising `ImportError` for `cuda.bindings.nvml`, then imports `cuda.core.system` and asserts:

- the import succeeds (it used to raise),
- `CUDA_BINDINGS_NVML_IS_COMPATIBLE is False`,
- `driver`, `handle_return`, `runtime` are bound on `cuda.core.system._system`.

It does not call into the driver, so it needs no GPU.

## What I ran

Environment: macOS, no CUDA driver and no CUDA toolkit, so `cuda.core` cannot be built or imported here.

- **Did not run:** the new test, or anything else under `cuda_core/tests/` — they need a built `cuda.core`.
- **Ran:** a reduction of the import block with two stand-in modules (`repro_nvml`, unimportable; `repro_nvml_context`, which imports it), keeping the control flow verbatim:

```
before: import of the module FAILED -> ImportError: libnvidia-ml not present in this build
after:  CUDA_BINDINGS_NVML_IS_COMPATIBLE=False, non-NVML fallback bound=True
```

- **Ran:** the `sys.meta_path` blocker used by the new test, standalone against a stdlib submodule, to confirm it turns both `from X import Y` and `import X.Y` into `ImportError`.
- **Ran:** `python -m py_compile` on the changed test file and `compile()` on the embedded subprocess script (both parse), plus `ruff check` / `ruff format --check`. `ruff check` reports the same single pre-existing `I001` on this file as it does on `main`; no new findings.
- **Checked:** every reader of `CUDA_BINDINGS_NVML_IS_COMPATIBLE` in the tree (`_system.pyx`, `system/__init__.py`, `_device.pyx:1053`, and four test modules) — none of them depend on the `else` form.
