### PR TITLE
fix(bindings): two silent wrong results in the vector_add examples

### DIFF
--- a/cuda_bindings/examples/0_Introduction/vector_add_drv.py
+++ b/cuda_bindings/examples/0_Introduction/vector_add_drv.py
@@ -101,9 +101,15 @@ def main():
     # h_C contains the result in host memory
     check_cuda_errors(cuda.cuMemcpyDtoH(h_c, d_c, nbytes))
 
+    # A completed C `for` loop leaves i == n, which is why the C sample can
+    # test `i == N` for success. A completed Python loop leaves i == n - 1, so
+    # a flag is needed: `i + 1 != n` is also what `break` at the last index
+    # produces, and a wrong value in h_c[n - 1] would be reported as a pass.
+    mismatch = False
     for i in range(n):
         sum_all = h_a[i] + h_b[i]
         if math.fabs(h_c[i] - sum_all) > 1e-7:
+            mismatch = True
             break
 
     # Free device memory
@@ -112,7 +118,7 @@ def main():
     check_cuda_errors(cuda.cuMemFree(d_c))
 
     check_cuda_errors(cuda.cuCtxDestroy(cu_context))
-    if i + 1 != n:
+    if mismatch:
         print("Result = FAIL", file=sys.stderr)
         sys.exit(1)
 

--- a/cuda_bindings/examples/0_Introduction/vector_add_mmap.py
+++ b/cuda_bindings/examples/0_Introduction/vector_add_mmap.py
@@ -157,8 +157,13 @@ def simple_malloc_multi_device_mmap(size, resident_devices, mapping_devices, ali
             simple_free_multi_device_mmap(dptr, size)
             return status, None, None
 
-    # Each accessDescriptor will describe the mapping requirement for a single device
-    access_descriptors = [cuda.CUmemAccessDesc()] * len(mapping_devices)
+    # Each accessDescriptor will describe the mapping requirement for a single device.
+    # One CUmemAccessDesc per device: `[CUmemAccessDesc()] * n` would store n
+    # references to a single mutable object, so the loop below would overwrite
+    # the same descriptor n times and cuMemSetAccess would receive the last
+    # device repeated n times -- succeeding, while every other device faults on
+    # first touch.
+    access_descriptors = [cuda.CUmemAccessDesc() for _ in mapping_devices]
 
     # Prepare the access descriptor array indicating where and how the backings should be visible.
     for idx in range(len(mapping_devices)):
@@ -290,10 +295,16 @@ def main():
     # h_C contains the result in host memory
     check_cuda_errors(cuda.cuMemcpyDtoH(h_c, d_c, size))
 
-    # Verify result
+    # Verify result.
+    # A completed C `for` loop leaves i == n, which is why the C sample can
+    # test `i == N` for success. A completed Python loop leaves i == n - 1, so
+    # a flag is needed: `i + 1 != n` is also what `break` at the last index
+    # produces, and a wrong value in h_c[n - 1] would be reported as a pass.
+    mismatch = False
     for i in range(n):
         sum_all = h_a[i] + h_b[i]
         if math.fabs(h_c[i] - sum_all) > 1e-7:
+            mismatch = True
             break
 
     check_cuda_errors(simple_free_multi_device_mmap(d_a, allocation_size))
@@ -302,7 +313,7 @@ def main():
 
     check_cuda_errors(cuda.cuCtxDestroy(cu_context))
 
-    if i + 1 != n:
+    if mismatch:
         print("Result = FAIL", file=sys.stderr)
         sys.exit(1)
 


### PR DESCRIPTION
Two independent defects in the `vector_add` examples, both of which produce a wrong result rather than an error. Grouped because they are the same pair of files and the same failure mode.

## 1. A wrong value in the last element is reported as a pass

`vector_add_drv.py:104-117` and `vector_add_mmap.py:294-307`:

```python
    for i in range(n):
        sum_all = h_a[i] + h_b[i]
        if math.fabs(h_c[i] - sum_all) > 1e-7:
            break
    ...
    if i + 1 != n:
        print("Result = FAIL", file=sys.stderr)
        sys.exit(1)
```

This is the C sample's `if (i == N) PASS`, which works only because a completed C `for` loop leaves `i == N`. A completed Python loop leaves `i == n - 1`, so the check was rewritten as `i + 1 != n` — but `break` at the final index `n - 1` yields `i + 1 == n` as well. A kernel that computes `h_c[n-1]` incorrectly therefore exits 0 and prints nothing.

Fixed with an explicit flag, which does not depend on where the loop stopped.

## 2. `simple_malloc_multi_device_mmap` grants access to only the last device

`vector_add_mmap.py:161`:

```python
    access_descriptors = [cuda.CUmemAccessDesc()] * len(mapping_devices)

    for idx in range(len(mapping_devices)):
        access_descriptors[idx].location.type = ...
        access_descriptors[idx].location.id = mapping_devices[idx]
        access_descriptors[idx].flags = ...

    (status,) = cuda.cuMemSetAccess(dptr, size, access_descriptors, len(access_descriptors))
```

List multiplication stores N references to **one** `CUmemAccessDesc`, which is mutable, so the loop overwrites the same object N times and `cuMemSetAccess` receives `mapping_devices[-1]` repeated N times. The call succeeds; the devices that were supposed to be granted access instead fault on first touch.

The helper is written as a general multi-device routine — that is what `mapping_devices` and the surrounding comments are for — and the bug is masked today only because `main()` passes a single device (`vector_add_mmap.py:235`). Fixed with a list comprehension.

## What I ran

Environment: macOS, no CUDA driver and no CUDA toolkit.

- **Did not run:** either example, or `cuda_bindings/tests/test_examples.py` — both need a GPU, and `vector_add_mmap` additionally needs VMM support. Note that `test_examples.py` would not catch either defect anyway: it runs each example with no arguments on a machine where the kernel is correct, so neither the last-element path nor a multi-device `mapping_devices` is ever exercised.
- **Ran:** reductions of both idioms, verbatim, before and after:

```
--- verification loop ---
  all correct      before -> PASS   after -> PASS
  h_c[0] wrong     before -> FAIL   after -> FAIL
  h_c[n-1] wrong   before -> PASS   after -> FAIL      <-- the defect
--- access descriptors ---
  before -> [desc(device_id=2), desc(device_id=2), desc(device_id=2)]
  after  -> [desc(device_id=0), desc(device_id=1), desc(device_id=2)]
```

- **Ran:** `python -m py_compile`, `ruff check`, `ruff format --check` on both files — clean, no new findings against a `main` baseline for the same files.
- **Checked:** `i` is not read anywhere else in either function after the loop, and `[...] * len(...)` on a mutable element appears nowhere else in `cuda_bindings/examples` or `cuda_core/examples`.
