### PR TITLE
fix(core): honour DLTensor.byte_offset in StridedMemoryView.from_dlpack

### DIFF
--- a/cuda_core/cuda/core/_memoryview.pyx
+++ b/cuda_core/cuda/core/_memoryview.pyx
@@ -1102,7 +1102,13 @@ cdef StridedMemoryView view_as_dlpack(obj, stream_ptr, view=None):
     cdef StridedMemoryView buf = StridedMemoryView() if view is None else view
     buf.dl_tensor = dl_tensor
     buf.metadata = capsule
-    buf.ptr = <intptr_t>(dl_tensor.data)
+    # byte_offset is a mandatory DLTensor field and a producer may leave the
+    # allocation base in ``data`` and encode a slice in ``byte_offset``. It
+    # must be folded into ``ptr`` here (as _smv_from_dlpack_capsule does),
+    # because every consumer -- as_tensor_map(), the __dlpack__ re-export
+    # (which writes ``byte_offset = 0`` and uses ``ptr`` as ``data``), the
+    # alignment checks -- reads ``ptr`` alone.
+    buf.ptr = <intptr_t>(dl_tensor.data) + <intptr_t>(dl_tensor.byte_offset)
     buf.device_id = device_id
     buf.is_device_accessible = is_device_accessible
     buf.readonly = is_readonly

--- a/cuda_core/docs/source/release/1.2.0-notes.rst
+++ b/cuda_core/docs/source/release/1.2.0-notes.rst
@@ -73,6 +73,13 @@ Fixes and enhancements
   Windows, both ``ctypes.CFUNCTYPE`` and ``ctypes.WINFUNCTYPE`` are accepted.
   (`#2439 <https://github.com/NVIDIA/cuda-python/issues/2439>`__)
 
+- :meth:`StridedMemoryView.from_dlpack` (and therefore
+  :meth:`StridedMemoryView.from_any_interface` on a DLPack producer) now folds
+  the ``DLTensor.byte_offset`` field into ``ptr``. A producer that reports the
+  allocation base in ``data`` and encodes a slice in ``byte_offset`` produced a
+  view whose ``ptr`` was short by exactly ``byte_offset`` bytes, with no error
+  raised. The capsule-consuming path already handled it.
+
 Deprecation Notices
 -------------------
 

--- a/cuda_core/tests/test_utils_dlpack.py
+++ b/cuda_core/tests/test_utils_dlpack.py
@@ -251,6 +251,51 @@ def test_from_dlpack_null_deleter_dealloc(max_version, capsule_name, managed_cls
     producer_deleter(dlm)
 
 
+@pytest.mark.agent_authored(model="claude-opus-5")
+@pytest.mark.parametrize(
+    "max_version, capsule_name, managed_cls",
+    [
+        pytest.param(None, b"dltensor", _DLManagedTensor, id="unversioned"),
+        pytest.param((1, 0), b"dltensor_versioned", _DLManagedTensorVersioned, id="versioned"),
+    ],
+)
+def test_from_dlpack_honours_byte_offset(max_version, capsule_name, managed_cls):
+    """``byte_offset`` must be folded into ``ptr``.
+
+    It is a mandatory ``DLTensor`` field, and a producer is free to leave the
+    allocation base in ``data`` and encode a slice in ``byte_offset``. The
+    capsule-consuming helper does add it; the ``__dlpack__``-consuming one used
+    to drop it, so ``ptr`` pointed ``byte_offset`` bytes before the data with
+    no error anywhere -- and every consumer (``as_tensor_map``, the
+    ``__dlpack__`` re-export, the alignment checks) reads ``ptr`` alone.
+    """
+    src = np.arange(8, dtype=np.int32)
+    offset = src.itemsize  # skip exactly one element
+    base = StridedMemoryView.from_any_interface(src, stream_ptr=-1)
+    capsule = base.__dlpack__(max_version=max_version)
+    dlm = ctypes.cast(_PyCapsule_GetPointer(capsule, capsule_name), ctypes.POINTER(managed_cls))
+    assert dlm.contents.dl_tensor.data == src.ctypes.data
+    assert dlm.contents.dl_tensor.byte_offset == 0
+
+    # Re-describe the same allocation as src[1:], the way a producer that
+    # reports the base pointer plus an offset would.
+    dlm.contents.dl_tensor.byte_offset = offset
+    dlm.contents.dl_tensor.shape[0] = src.size - 1
+
+    class _Export:
+        def __dlpack_device__(self):
+            return base.__dlpack_device__()
+
+        def __dlpack__(self, stream=None, max_version=None, **kwargs):
+            if capsule_name == b"dltensor" and max_version is not None:
+                raise TypeError("force unversioned")
+            return capsule
+
+    view = StridedMemoryView.from_dlpack(_Export(), stream_ptr=-1)
+    assert view.shape == (src.size - 1,)
+    assert view.ptr == src.ctypes.data + offset
+
+
 _FN_FROM_PY = ctypes.PYFUNCTYPE(ctypes.c_int, ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p))
 _FN_TO_PY = ctypes.PYFUNCTYPE(ctypes.c_int, ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p))
 _FN_DLTENSOR_FROM_PY = ctypes.PYFUNCTYPE(ctypes.c_int, ctypes.c_void_p, ctypes.c_void_p)


### PR DESCRIPTION
## Problem

`view_as_dlpack` builds the view pointer from `data` alone (`_memoryview.pyx:1105`):

```python
    buf.ptr = <intptr_t>(dl_tensor.data)
```

`byte_offset` is a mandatory `DLTensor` field (`_dlpack.pxd:55`), and a producer may legally leave the allocation base in `data` and encode a slice in `byte_offset`. The sibling capsule-consuming helper in the same file already handles it (`_smv_from_dlpack_capsule`, `_memoryview.pyx:866`):

```python
    view.ptr = <intptr_t>(dl_tensor.data) + <intptr_t>(dl_tensor.byte_offset)
```

`view_as_dlpack` is the public consumer path — `StridedMemoryView.from_dlpack()` (`:228`), `StridedMemoryView.from_any_interface()` (via `:283`), and the deprecated `StridedMemoryView(obj, stream_ptr)` constructor (`:194`) all funnel through it. Nothing downstream recovers the offset: `layout_from_dlpack()` (`:1305`) reads only `ndim` / `shape` / `strides` / `dtype`.

So for any exporter with `byte_offset != 0`, `view.ptr` is short by exactly `byte_offset` bytes, and every consumer that reads `ptr` alone operates on the wrong memory with no exception raised:

- `as_tensor_map()` (`_tensor_map.pyx:599`)
- the `__dlpack__` re-export (`_smv_setup_dl_tensor_common:740-741`, which writes `byte_offset = 0` and uses `ptr` as `data` — so the offset is lost permanently on a round-trip)
- the 16-byte alignment check at `_tensor_map.pyx:391`

## Fix

One line, matching the sibling helper.

## Tests

`test_from_dlpack_honours_byte_offset` in `cuda_core/tests/test_utils_dlpack.py`, built on the ctypes `DLTensor` / `DLManagedTensor` structures already defined in that file and following `test_from_dlpack_null_deleter_dealloc`'s pattern: export a real capsule, rewrite it in place to describe `src[1:]` as `data = base, byte_offset = itemsize, shape[0] = n - 1`, then import it and assert `ptr == src.ctypes.data + itemsize`. Parametrised over the versioned and unversioned capsule flavours. It uses the CPU device path (`stream_ptr=-1`), like the neighbouring tests, so it needs no GPU.

## What I ran

Environment: macOS, no CUDA driver and no CUDA toolkit, so `cuda.core` cannot be built or imported here.

- **Did not run:** the new test, or anything else under `cuda_core/tests/` — they need a built `cuda.core`.
- **Ran:** `python -m py_compile`, `ruff check`, `ruff format --check` on `cuda_core/tests/test_utils_dlpack.py` — clean, no new findings against a `main` baseline.
- **Checked by inspection:** `byte_offset` appears at exactly four places in the tree (`_dlpack.pxd:55` declaration; `_dlpack.pyx:88` and `_memoryview.pyx:741` both on the *export* side, where the offset is folded into `data` and the field set to 0; `_memoryview.pyx:866` on the capsule *import* side). `_memoryview.pyx:1105` was the only import site missing it, and the export side's `byte_offset = 0` convention is exactly why folding it into `ptr` on import is the correct fix rather than propagating the field.
- **Checked:** no other open PR touches `_memoryview.pyx`; #2194 touches `test_utils_dlpack.py` but not this region.
