### PR TITLE
test(core): stop four cuda_core tests from reporting failures as skips

### DIFF
--- a/cuda_core/tests/test_device.py
+++ b/cuda_core/tests/test_device.py
@@ -14,7 +14,7 @@ from helpers.nanosleep_kernel import NanosleepKernel
 
 import cuda.core
 from cuda.bindings import driver, runtime
-from cuda.core import Device, StreamOptions
+from cuda.core import Device, StreamOptions, system
 from cuda.core._utils.cuda_utils import ComputeCapability, handle_return
 from cuda.core._utils.version import driver_version
 
@@ -472,14 +472,12 @@ def test_device_equality_reflexive(init_cuda):
 
 def test_device_inequality_different_id(init_cuda):
     """Devices with different device_id should not be equal."""
-    try:
-        dev0 = Device(0)
-        dev1 = Device(1)
-
-        assert dev0 != dev1, "Different devices should not be equal"
-        assert dev0 != dev1, "Different devices should be not-equal"
-    except (ValueError, Exception):
+    if system.get_num_devices() < 2:
         pytest.skip("Test requires at least 2 CUDA devices")
+    dev0 = Device(0)
+    dev1 = Device(1)
+
+    assert dev0 != dev1, "Different devices should not be equal"
 
 
 def test_device_type_safety(init_cuda):
@@ -518,16 +516,14 @@ def test_device_equality_same_id_hash(init_cuda):
 
 def test_device_inequality_different_id_hash(init_cuda):
     """Devices with different device_id should not be equal."""
-    try:
-        # Only run test when two devices are available.
-        dev0 = Device(0)
-        dev1 = Device(1)
-
-        assert dev0 != dev1, "Different devices should not be equal"
-        assert hash(dev0) != hash(dev1), "Different devices should have different hashes"
-    except (ValueError, Exception):
-        # Test is skipped if only one device available
+    # Only run test when two devices are available.
+    if system.get_num_devices() < 2:
         pytest.skip("Test requires at least 2 CUDA devices")
+    dev0 = Device(0)
+    dev1 = Device(1)
+
+    assert dev0 != dev1, "Different devices should not be equal"
+    assert hash(dev0) != hash(dev1), "Different devices should have different hashes"
 
 
 def test_device_dict_key(init_cuda):


### PR DESCRIPTION
Four `cuda_core` tests can currently only pass or skip — a genuine regression is reported as a skipped test. Two different shapes, grouped because they are the same defect and the same fix story.

## 1. `test_graphics.py`: `yield` inside `except Exception: pytest.skip(...)`

`_gl_context_and_buffer` and `_gl_context_and_texture` wrap both the GL setup **and** the `yield` in one `try`:

```python
    try:
        ...  # create context + buffer
        yield int(buf_id.value), nbytes
    except Exception as e:
        pytest.skip(f"Could not create GL context/buffer: {type(e).__name__}: {e}")
```

`@contextmanager` re-throws the `with`-body's exception *at the yield*, so anything a test raises — a failed assertion, a `CUDAError` out of `GraphicsResource` — lands in that handler and is reported as `Could not create GL context/buffer: AssertionError: ...`. Every test that uses these two helpers is unfailable.

Fixed by splitting creation into `_make_gl_context` / `_create_gl_buffer` / `_create_gl_texture` and keeping the `yield` outside the handler, so only a genuine environment failure skips. This is the same fix #2565 makes for the `cuda.bindings` twin (`test_graphics_apis.py::_gl_context`); the two files are independent, so this is a separate change rather than a rebase of that one.

## 2. `test_device.py`: `except (ValueError, Exception)` around the assertions

```python
    try:
        dev0 = Device(0)
        dev1 = Device(1)

        assert dev0 != dev1, "Different devices should not be equal"
        assert hash(dev0) != hash(dev1), "Different devices should have different hashes"
    except (ValueError, Exception):
        pytest.skip("Test requires at least 2 CUDA devices")
```

`AssertionError` **is** an `Exception`, so on a machine with two GPUs a real failure — two distinct devices comparing equal, or hashing equal — is reported as `Test requires at least 2 CUDA devices`. (`(ValueError, Exception)` is also redundant: `ValueError` is already covered.)

Fixed by deciding up front with `system.get_num_devices() < 2` — the idiom already used by `test_stream.py:413`, `test_green_context.py:296`, `test_object_protocols.py:173` and `test_tensor_map.py:389` — and leaving the assertions unguarded. Also drops a duplicated `assert dev0 != dev1` that differed only in its message.

## What I ran

Environment: macOS, no CUDA driver and no CUDA toolkit, so `cuda.core` cannot be built or imported here.

- **Did not run:** the four tests themselves — `test_graphics.py` needs a GPU *and* a GL context, `test_device.py` needs two GPUs.
- **Ran:** a pytest reduction of both shapes, with the CUDA/GL work replaced by a body that fails, to confirm the mechanism and that the fixes preserve the intended skip:

```
SKIPPED test_before_body_assertion_is_swallowed
        -> Could not create GL context/buffer: AssertionError: this is a real regression
FAILED  test_after_body_assertion_fails            <-- now visible
SKIPPED test_before_creation_failure_still_skips   <-- genuine env skip, unchanged
SKIPPED test_after_creation_failure_still_skips    <-- genuine env skip, preserved
SKIPPED test_device_inequality_before
        -> Test requires at least 2 CUDA devices   (the assertion had failed)
FAILED  test_device_inequality_after               <-- now visible
```

- **Ran:** `python -m py_compile`, `ruff check`, `ruff format --check` on both changed files — clean, no new findings against a `main` baseline.
- **Checked:** `pytest.skip` raises `Skipped`, which derives from `BaseException`, so the `pytest.importorskip("pyglet")` and the no-DISPLAY skip inside the extracted `_make_gl_context` still propagate through the new `except Exception` handler rather than being converted into a "could not create" message.
- **Checked:** `from cuda.core import system` is the same import the four sibling test modules use; `cuda.core.system` is already imported by `cuda/core/__init__.py`.

Refs #2565
