### PR TITLE
fix(bindings): repair the two example command-line paths that #2546 revives

### DIFF
--- a/cuda_bindings/examples/0_Introduction/simple_zero_copy.py
+++ b/cuda_bindings/examples/0_Introduction/simple_zero_copy.py
@@ -69,7 +69,9 @@ def main():
 
     # Get the device selected by the user or default to 0, and then set it.
     if check_cmd_line_flag("device="):
-        device_count = cudart.cudaGetDeviceCount()
+        # cudaGetDeviceCount returns (cudaError_t, count); comparing the raw
+        # tuple against an int below raises TypeError.
+        device_count = check_cuda_errors(cudart.cudaGetDeviceCount())
         idev = int(get_cmd_line_argument_int("device="))
 
         if idev >= device_count or idev < 0:

--- a/cuda_bindings/examples/3_CUDA_Features/global_to_shmem_async_copy.py
+++ b/cuda_bindings/examples/3_CUDA_Features/global_to_shmem_async_copy.py
@@ -799,6 +799,11 @@ def matrix_multiply(dims_a, dims_b, kernel_number):
     grid_shared_state_kernel = cudart.dim3()
     grid_shared_state_kernel.x = dims_b.x / threads_shared_state_kernel.x
     grid_shared_state_kernel.y = dims_a.y / threads_shared_state_kernel.x
+    # C++ dim3 defaults every component to 1; cudart.dim3 wraps a
+    # zero-initialised struct, so .z must be set explicitly or the two
+    # cuLaunchKernel calls below pass gridDimZ=0 and fail with
+    # CUDA_ERROR_INVALID_VALUE.
+    grid_shared_state_kernel.z = 1
 
     print(f"Running kernel = {kernel_number} - {kernel_names[kernel_number.value]}")
     # Create and start timer


### PR DESCRIPTION
Two defects that both sit behind an argv option. `check_cmd_line_flag` currently always returns `False` (`enumerate` unpacked backwards — that is #2546), so neither can fire today; fixing the helper turns both into immediate failures. `tests/test_examples.py` runs every example with **no** arguments, so CI catches neither. Grouped because they are the same class and the same trigger.

## 1. `simple_zero_copy.py`: `cudaGetDeviceCount()` is not unwrapped

`cuda_bindings/examples/0_Introduction/simple_zero_copy.py:71-75`:

```python
    if check_cmd_line_flag("device="):
        device_count = cudart.cudaGetDeviceCount()
        idev = int(get_cmd_line_argument_int("device="))

        if idev >= device_count or idev < 0:
```

The bindings return `(cudaError_t, count)` (`runtime.pyx:21309`), so `device_count` is a tuple and the comparison raises:

```
TypeError: '>=' not supported between instances of 'int' and 'tuple'
```

Every other call site in the examples wraps it — e.g. `simple_p2p.py:52`, `gpu_n = check_cuda_errors(cudart.cudaGetDeviceCount())`. Fixed the same way.

## 2. `global_to_shmem_async_copy.py`: `grid_shared_state_kernel.z` is never set

`cuda_bindings/examples/3_CUDA_Features/global_to_shmem_async_copy.py:795-801`:

```python
    grid_shared_state_kernel = cudart.dim3()
    grid_shared_state_kernel.x = dims_b.x / threads_shared_state_kernel.x
    grid_shared_state_kernel.y = dims_a.y / threads_shared_state_kernel.x
```

C++ `dim3` defaults every component to **1**, which is why the C sample can write `dim3 gridSharedStateKernel(a, b)`. `cudart.dim3` is a `cdef class` whose backing struct is zero-initialised (`runtime.pyx:7639-7643` — `self._pvt_ptr = &self._pvt_val`), so `.z` stays **0**. It is then passed as `gridDimZ` at both `cuLaunchKernel` sites for `Kernels.AsyncCopyMultiStageSharedState` (lines 866 and 1003), which the driver rejects with `CUDA_ERROR_INVALID_VALUE`.

Every other `dim3` in the file and in the sibling examples sets `.z` explicitly — including `grid` twelve lines above (`grid.z = 1`), `threads_shared_state_kernel.z` immediately before it, `simple_cubemap_texture.py:162`, and `simple_p2p.py:151` — so this one omission is clearly unintended. Reachable via `kernel=3`.

Deliberately not touched: `grid_shared_state_kernel.y = dims_a.y / threads_shared_state_kernel.x` uses `.x` where the sibling `grid.y` uses `.y`. That matches the upstream C sample and is intentional — the 16x18 block has only 16 consumer rows.

## What I ran

Environment: macOS, no CUDA driver and no CUDA toolkit.

- **Did not run:** either example, or `cuda_bindings/tests/test_examples.py` — both need a GPU, and #2 additionally needs `kernel=3`, which is unreachable until #2546 lands.
- **Ran:** a reduction of the comparison in #1 with the tuple the bindings actually return:

```
before -> TypeError: '>=' not supported between instances of 'int' and 'tuple'
after  -> False
```

- **Ran:** `python -m py_compile`, `ruff check`, `ruff format --check` on both files — clean, no new findings against a `main` baseline.
- **Checked by inspection (not executed):** `cudart.dim3().z == 0`. I could not import `cuda.bindings` here, so this rests on `runtime.pyx:7639-7643` (the wrapper points at an in-object struct member, which CPython zero-fills on allocation) plus the fact that `dim3` exposes no constructor arguments other than `_ptr`.

Overlap notes: `simple_zero_copy.py` is one of the files #2266 (samples migration) deletes; `global_to_shmem_async_copy.py` is not. If #2266 lands first, fix #1 should travel with the migrated copy — flagging rather than guessing.

Refs #2546
