### PR TITLE
fix(core): credit an entry that vanishes at unlink time during cache eviction

### DIFF
--- a/cuda_core/cuda/core/utils/_program_cache/_file_stream.py
+++ b/cuda_core/cuda/core/utils/_program_cache/_file_stream.py
@@ -739,12 +739,22 @@ class FileStreamProgramCache(ProgramCacheResource):
             # problems -- surface them rather than silently exceed the cap.
             try:
                 _unlink_with_sharing_retry(path)
-                total -= size
             except FileNotFoundError:
+                # Someone else unlinked it between the stat-guard above and
+                # here. The bytes are off disk either way, so credit them --
+                # exactly as the stat-miss branch a few lines up already
+                # does. Leaving ``total`` unchanged keeps it above the cap,
+                # so this pass evicts a live entry that did not need to go,
+                # and then reseeds the tracker with the same overcount, which
+                # makes the next write over-evict again.
                 pass
             except PermissionError as exc:
                 if not _is_windows_sharing_violation(exc):
                     raise
+                # Retry budget exhausted on a Windows sharing violation: the
+                # file is still on disk, so its bytes must stay in ``total``.
+                continue
+            total -= size
         # Reconcile: after the eviction pass, ``total`` reflects what we
         # believe the disk now holds. Re-seed the tracker so the next write
         # accumulates from a fresh baseline.

--- a/cuda_core/docs/source/release/1.2.0-notes.rst
+++ b/cuda_core/docs/source/release/1.2.0-notes.rst
@@ -244,6 +244,13 @@ Fixes and enhancements
   refreshed for CUDA 13.3 and now recognizes
   ``CUDA_ERROR_GRAPH_RECAPTURE_FAILURE``.
   (`#2383 <https://github.com/NVIDIA/cuda-python/pull/2383>`__)
+- :class:`~cuda.core.utils.FileStreamProgramCache` no longer over-evicts when
+  another process removes an entry during a size-cap pass. The eviction loop
+  credited an entry that had already vanished by the time it was re-stat'ed,
+  but not one that vanished a few microseconds later at the ``unlink`` -- so
+  the pass believed it was still over the cap, evicted a live entry that did
+  not need to go, and reseeded the size tracker with the same overcount,
+  making the next write over-evict as well.
 
 Deprecation Notices
 -------------------

--- a/cuda_core/tests/test_program_cache.py
+++ b/cuda_core/tests/test_program_cache.py
@@ -1775,6 +1775,55 @@ def test_filestream_cache_size_cap_counts_tmp_files(tmp_path):
         assert cache.get(b"c") is not None
 
 
+@pytest.mark.agent_authored(model="claude-opus-5")
+def test_filestream_size_cap_credits_an_entry_that_vanished_at_unlink(tmp_path):
+    """An entry another process removed mid-pass must be credited to ``total``.
+
+    ``_enforce_size_cap`` already credits an entry that has vanished by the
+    time it re-stats it. The unlink a few lines later is the same "already
+    gone" condition a few microseconds later, but its ``FileNotFoundError``
+    branch left ``total`` unchanged -- so the pass believed it was still over
+    the cap and evicted a second, live entry that did not need to go, then
+    reseeded the tracker with that same overcount, making the *next* write
+    over-evict too.
+    """
+    from cuda.core.utils import FileStreamProgramCache
+    from cuda.core.utils._program_cache import _file_stream
+
+    cap = 100
+    with FileStreamProgramCache(tmp_path / "fc", max_size_bytes=cap) as cache:
+        for i in range(3):
+            time.sleep(0.02)  # distinct atimes so eviction order is deterministic
+            cache[f"k{i}".encode()] = b"X" * 30
+        assert cache._tracked_size_bytes == 90
+
+        real_unlink = _file_stream._unlink_with_sharing_retry
+        raced = []
+
+        def racing_unlink(path):
+            # The first victim of this pass is unlinked by "another process"
+            # in the window between our stat-guard and our own unlink.
+            if not raced:
+                raced.append(path)
+                path.unlink()
+                raise FileNotFoundError(path)
+            real_unlink(path)
+
+        _file_stream._unlink_with_sharing_retry = racing_unlink
+        try:
+            time.sleep(0.02)
+            cache[b"k3"] = b"X" * 30  # 120 > 100 -> eviction pass runs
+        finally:
+            _file_stream._unlink_with_sharing_retry = real_unlink
+
+        assert raced, "the eviction pass never reached an unlink"
+        # 30 bytes had to go to get under the cap and 30 bytes did go, so the
+        # three remaining entries must all survive.
+        assert len(cache) == 3
+        assert cache._compute_total_size() == 90
+        assert cache._tracked_size_bytes == 90
+
+
 def test_filestream_cache_handles_long_keys(tmp_path):
     """Arbitrary-length keys must not overflow per-component filename limits.
     The filename is a fixed-length 256-bit digest; key uniqueness


### PR DESCRIPTION
## Problem

`FileStreamProgramCache._enforce_size_cap` walks its snapshot oldest-atime-first and subtracts each evicted entry's size from `total` until it is back under the cap. It handles "the file is already gone" twice, inconsistently (`_file_stream.py:740-761`):

```python
            try:
                stat_now = path.stat()
            except FileNotFoundError:
                total -= size          # credited
                continue
            ...
            try:
                _unlink_with_sharing_retry(path)
                total -= size
            except FileNotFoundError:
                pass                   # NOT credited
```

Both branches are the same condition — another process removed the entry — observed a few microseconds apart, and the bytes are off disk either way. This backend is explicitly designed for multi-process use, and a concurrent `__delitem__` or another process's eviction pass lands in exactly this window.

Not crediting the second one has two compounding effects:

1. `total` stays above the cap, so the pass evicts a **second, live entry** that did not need to go — a needless cache miss and recompile.
2. The pass then reseeds `self._tracked_size_bytes = total` with that same overcount, so the **next** write trips the cap early and over-evicts again.

Measured on the real module (three 30-byte entries, a 100-byte cap, one racing unlink): 2 entries survive instead of 3, and the tracker reports 90 bytes against 60 on disk.

## Fix

Move the single `total -= size` past the handler so the `FileNotFoundError` branch reaches it, matching the stat-miss branch above. The `PermissionError` branch becomes an explicit `continue`: an exhausted Windows sharing-violation retry leaves the file **on disk**, so its bytes must stay in `total`. That was already the behaviour — making it explicit is what keeps the single `total -= size` at the end honest.

No behaviour change on the non-racing path.

## Tests

`test_filestream_size_cap_credits_an_entry_that_vanished_at_unlink` monkeypatches `_file_stream._unlink_with_sharing_retry` so the pass's first victim is unlinked by "another process" in the window between our stat-guard and our own unlink — the same injection style as the existing `test_filestream_cache_tracker_clamps_at_zero_under_delete_race`. It asserts all three remaining entries survive and that the tracker agrees with `_compute_total_size()`.

## What I ran

Environment: macOS, no CUDA driver and no CUDA toolkit, so `cuda.core` cannot be built or imported here.

- **Did not run:** `cuda_core/tests/test_program_cache.py` itself — it imports `cuda.core.utils`.
- **Ran (teeth check):** `_file_stream.py`'s only `cuda.core` dependency is `ObjectCode`, used for an `isinstance` check in `_extract_bytes`, so I loaded **the real module** with `cuda.core._module` stubbed and ran the new test's exact assertions against it:
  - against `main`: `FAIL: len(cache) == 2, expected 3`
  - with this change: `PASS`
- **Ran:** a 30-trial randomised set/get/del/clear probe against the same standalone load, comparing `_tracked_size_bytes` to `_compute_total_size()` after each trial — no drift before or after the change, confirming the single-process accounting is untouched.
- **Ran:** `ruff check` and `ruff format --check` on both changed files — clean, no new findings against a `main` baseline.
- **Checked:** the two other `_enforce_size_cap` outcomes are unaffected — the stat-guard mismatch branch still does its own `total += stat_now.st_size - size` and `continue`, and the Windows sharing-violation branch still leaves `total` alone.

Overlap note: #2553 also touches `_file_stream.py`, but only `__init__` (argument validation); the two changes are in different methods.
