### PR TITLE
fix(core): four LinkerOptions fields that don't behave as documented

### DIFF
--- a/cuda_core/cuda/core/_linker.pyx
+++ b/cuda_core/cuda/core/_linker.pyx
@@ -310,6 +310,11 @@ class LinkerOptions:
 
     def __post_init__(self) -> None:
         _lazy_init()
+        # `name` is annotated `str | None`, so None must fall back to the
+        # documented default instead of raising AttributeError from
+        # `.encode()`. Mirrors the same fix for ProgramOptions (#2517).
+        if self.name is None:
+            self.name = "<default linker>"
         self._name = self.name.encode()
 
     def _prepare_nvjitlink_options(self, as_bytes: bool = False) -> list[bytes] | list[str]:
@@ -321,7 +326,11 @@ class LinkerOptions:
             options.append("-arch=sm_" + "".join(f"{i}" for i in Device().compute_capability))
         if self.max_register_count is not None:
             options.append(f"-maxrregcount={self.max_register_count}")
-        if self.time is not None:
+        # `-time` is a valueless switch, so it must be gated on truthiness
+        # like every other valueless flag here (verbose, -lto, -ptx, -g,
+        # -lineinfo, -no-cache). `is not None` is only right for the flags
+        # that emit an explicit value, e.g. `-ftz=true|false` below.
+        if self.time:
             options.append("-time")
         if self.verbose:
             options.append("-verbose")
@@ -343,19 +352,24 @@ class LinkerOptions:
             options.append(f"-prec-sqrt={'true' if self.prec_sqrt else 'false'}")
         if self.fma is not None:
             options.append(f"-fma={'true' if self.fma else 'false'}")
+        # Accept any sequence, not just `list`: both fields are annotated (and
+        # documented) `str | tuple[str] | list[str]`, and a tuple used to match
+        # neither branch, so it emitted no option and raised nothing.
+        # `ptxas_options` below already gets this right.
         if self.kernels_used is not None:
             if isinstance(self.kernels_used, str):
                 options.append(f"-kernels-used={self.kernels_used}")
-            elif isinstance(self.kernels_used, list):
+            elif is_sequence(self.kernels_used):
                 for kernel in self.kernels_used:
                     options.append(f"-kernels-used={kernel}")
         if self.variables_used is not None:
             if isinstance(self.variables_used, str):
                 options.append(f"-variables-used={self.variables_used}")
-            elif isinstance(self.variables_used, list):
+            elif is_sequence(self.variables_used):
                 for variable in self.variables_used:
                     options.append(f"-variables-used={variable}")
-        if self.optimize_unused_variables is not None:
+        # Valueless switch: see the `-time` note above.
+        if self.optimize_unused_variables:
             options.append("-optimize-unused-variables")
         if self.ptxas_options is not None:
             if isinstance(self.ptxas_options, str):
@@ -398,7 +412,9 @@ class LinkerOptions:
         if self.max_register_count is not None:
             formatted_options.append(self.max_register_count)
             option_keys.append(_driver.CUjit_option.CU_JIT_MAX_REGISTERS)
-        if self.time is not None:
+        # Only an option the caller actually turned ON is unsupported;
+        # `time=False` asks for nothing and must not be rejected.
+        if self.time:
             raise ValueError("time option is not supported by the driver API")
         if self.verbose:
             formatted_options.append(1)

--- a/cuda_core/docs/source/release/1.2.0-notes.rst
+++ b/cuda_core/docs/source/release/1.2.0-notes.rst
@@ -73,6 +73,16 @@ Fixes and enhancements
   Windows, both ``ctypes.CFUNCTYPE`` and ``ctypes.WINFUNCTYPE`` are accepted.
   (`#2439 <https://github.com/NVIDIA/cuda-python/issues/2439>`__)
 
+- Four :class:`LinkerOptions` fields now behave as documented.
+  ``time=False`` and ``optimize_unused_variables=False`` no longer *enable*
+  those flags -- both are valueless nvJitLink switches that were gated on
+  ``is not None``, so explicitly disabling them turned them on (and, on the
+  driver backend, ``time=False`` raised "not supported"). ``kernels_used`` and
+  ``variables_used`` now accept the documented ``tuple`` form, which
+  previously matched no branch and emitted nothing at all. ``name=None`` now
+  falls back to the documented default instead of raising ``AttributeError``,
+  matching :class:`ProgramOptions`.
+
 Deprecation Notices
 -------------------
 

--- a/cuda_core/tests/test_linker.py
+++ b/cuda_core/tests/test_linker.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect
+import warnings
 
 import pytest
 
@@ -433,6 +434,66 @@ def test_prepare_driver_options_unsupported_raises(driver_binding, kwargs, match
     """Each nvjitlink-only option raises ValueError on the driver backend."""
     opts = LinkerOptions(**kwargs)
     with pytest.raises(ValueError, match=match):
+        opts._prepare_driver_options()
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+@pytest.mark.parametrize(
+    ("field", "flag"),
+    [("time", "-time"), ("optimize_unused_variables", "-optimize-unused-variables")],
+)
+def test_valueless_flags_are_gated_on_truthiness(field, flag):
+    """A valueless nvJitLink switch must not be emitted for ``False``.
+
+    Both were gated on ``is not None``, which is only correct for the flags
+    that emit an explicit value (``-ftz=true|false`` and friends). So
+    ``time=False`` turned timing *on*, and ``optimize_unused_variables=False``
+    turned the optimization *on* -- silently changing the linked binary by
+    dropping device variables the caller asked to keep.
+    """
+    assert flag in LinkerOptions(arch=ARCH, **{field: True})._prepare_nvjitlink_options()
+    assert flag not in LinkerOptions(arch=ARCH, **{field: False})._prepare_nvjitlink_options()
+    assert flag not in LinkerOptions(arch=ARCH)._prepare_nvjitlink_options()
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+@pytest.mark.parametrize(
+    ("field", "flag"),
+    [("kernels_used", "-kernels-used"), ("variables_used", "-variables-used")],
+)
+@pytest.mark.parametrize("factory", [list, tuple], ids=["list", "tuple"])
+def test_sequence_options_accept_tuples(field, flag, factory):
+    """``str | tuple[str] | list[str]`` must all reach the linker.
+
+    The dispatch tested ``isinstance(..., list)``, so the documented tuple form
+    matched neither branch: no option was emitted and nothing was raised, and
+    the link silently kept every kernel/variable the caller meant to filter.
+    """
+    emitted = LinkerOptions(arch=ARCH, **{field: factory(("A", "B"))})._prepare_nvjitlink_options()
+    assert f"{flag}=A" in emitted
+    assert f"{flag}=B" in emitted
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+def test_linker_options_accepts_name_none():
+    """``name`` is annotated ``str | None``; ``None`` must fall back to the
+    documented default instead of raising ``AttributeError`` from ``.encode()``.
+    Same fix as ProgramOptions received in #2517."""
+    assert LinkerOptions(arch=ARCH, name=None).name == "<default linker>"
+
+
+@pytest.mark.agent_authored(model="claude-opus-5")
+@pytest.mark.parametrize("field", ["time", "optimize_unused_variables"])
+def test_prepare_driver_options_ignores_disabled_flags(driver_binding, field):
+    """An option the caller turned OFF is not an option the driver must support.
+
+    ``time=False`` raised "time option is not supported by the driver API" and
+    ``optimize_unused_variables=False`` emitted a DeprecationWarning, both for
+    a flag that would never have been sent.
+    """
+    opts = LinkerOptions(arch="sm_80", **{field: False})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         opts._prepare_driver_options()
 
 


### PR DESCRIPTION
Four `LinkerOptions` fields whose behaviour contradicts their own annotation and docstring. Grouped: one class, one file, and the first three are literally the same mistake in the same function.

## 1. `time=False` **enables** timing

```python
        if self.time is not None:
            options.append("-time")
```

`-time` is a valueless nvJitLink switch, so the gate must be truthiness. Every other valueless flag in `_prepare_nvjitlink_options` gets that right — `if self.verbose:` (`:326`), `-lto` (`:328`), `-ptx` (`:330`), `-g` (`:334`), `-lineinfo` (`:336`), `if self.no_cache is True:` (`:370`). `is not None` is only correct for the flags that emit an explicit value, e.g. `-ftz=true|false` (`:338`).

`_prepare_driver_options` has the mirror image (`:401`): a user who explicitly **disabled** timing gets `ValueError: time option is not supported by the driver API`.

## 2. `optimize_unused_variables=False` **enables** the optimization

Same shape (`:358`), same valueless switch — and this one silently changes the linked binary: the linker drops device variables the caller asked it to keep. The driver path (`:432`) also emits a `DeprecationWarning` for the disabled value.

## 3. `kernels_used` / `variables_used` silently ignore the documented `tuple` form

```python
        if self.kernels_used is not None:
            if isinstance(self.kernels_used, str):
                options.append(f"-kernels-used={self.kernels_used}")
            elif isinstance(self.kernels_used, list):
                ...
```

Both are annotated **and** documented `str | tuple[str] | list[str]`. A tuple matches neither branch, so no option is emitted and nothing is raised — the link keeps every kernel/variable the caller meant to filter out. `ptxas_options`, eleven lines below (`:363`), already uses `is_sequence()`.

Worth noting: `tests/test_linker.py:83,86` **already parametrize the tuple form** — but only assert that linking succeeds, which it does, with no filtering applied. That is why this has gone unnoticed.

## 4. `LinkerOptions(name=None)` raises `AttributeError`

```python
    def __post_init__(self) -> None:
        _lazy_init()
        self._name = self.name.encode()
```

`name: str | None = "<default linker>"`. `ProgramOptions` had the identical bug and was fixed in #2517 by falling back to its documented default; this does the same.

(Observation, deliberately **not** changed here to keep the diff a straight mirror of #2517: `LinkerOptions._name` is written on this line and never read — `grep -n '\._name\b'` over `cuda_core/` shows the only readers are `ProgramOptions._name` in `_program.pyx:778,810,978` and the unrelated `ObjectCode._name`. Happy to drop the dead store in a follow-up if you want it gone.)

## Compatibility

All four are error-path or option-emission changes. No configuration that linked correctly before links differently now: `True` still emits, `None` still emits nothing, `str`/`list` are unchanged. The inputs whose behaviour changes are exactly `time=False`, `optimize_unused_variables=False`, tuple sequences, and `name=None` — each of which is currently doing the opposite of, or nothing about, what the caller asked for.

## Tests

Five new cases in `cuda_core/tests/test_linker.py`, next to the existing `_prepare_driver_options` unit tests:

- `test_valueless_flags_are_gated_on_truthiness` — `True` emits, `False` and unset do not (parametrised over both flags).
- `test_sequence_options_accept_tuples` — parametrised over `list`/`tuple` × `kernels_used`/`variables_used`.
- `test_linker_options_accepts_name_none`.
- `test_prepare_driver_options_ignores_disabled_flags` — a disabled flag neither raises nor warns on the driver backend.

The existing `test_prepare_driver_options_deprecated_warnings` / `_unsupported_raises` parametrisations all use `True` and are unchanged.

## What I ran

Environment: macOS, no CUDA driver and no CUDA toolkit, so `cuda.core` cannot be built or imported here.

- **Did not run:** the new tests or the rest of `test_linker.py` — `LinkerOptions.__post_init__` calls `_lazy_init()`, which probes nvJitLink, so the class cannot even be constructed without a toolkit.
- **Ran:** a reduction of the three gate expressions and `__post_init__`, verbatim, before and after:

```
  time=False                         before -> ['-time']   after -> []
  time=True                          before -> ['-time']   after -> ['-time']
  optimize_unused_variables=False    before -> ['-optimize-unused-variables']   after -> []
  optimize_unused_variables=True     before -> ['-optimize-unused-variables']   after -> ['-optimize-unused-variables']
  kernels_used=['C','B']             before -> ['-kernels-used=C', '-kernels-used=B']   after -> same
  kernels_used=('C','B')             before -> []                                       after -> ['-kernels-used=C', '-kernels-used=B']
  kernels_used='A'                   before -> ['-kernels-used=A']                      after -> same
  LinkerOptions(name=None)           before -> AttributeError                            after -> ok
```

- **Ran:** `python -m py_compile`, `ruff check`, `ruff format --check` on `cuda_core/tests/test_linker.py` — clean, no new findings against a `main` baseline. (`ruff` cannot parse `.pyx`, so `_linker.pyx` was reviewed by hand.)
- **Checked:** `is_sequence` is `isinstance(obj, Sequence)` (`_utils/cuda_utils.pyx:292`), so `str` matches it too — which is why the `isinstance(..., str)` branch must stay first, exactly as `ptxas_options` already orders it. `is_sequence` was already imported and used in `_linker.pyx`.
- **Checked:** no existing test asserts any of the old behaviours — `grep` for `time=`, `optimize_unused_variables`, `kernels_used`, `variables_used`, `LinkerOptions(name` across `cuda_core/tests/` shows only `True`/`str`/`list`/`tuple` inputs and `name="ABC"`.

Refs #2517
