### PR TITLE
docs(core): fix three cuda.core.system docs defects

### DIFF
--- a/cuda_core/cuda/core/system/_device.pyi
+++ b/cuda_core/cuda/core/system/_device.pyi
@@ -798,7 +798,7 @@ class _NvlinkInfoMeta(type):
         To find the actual number of Nvlinks available on a device, use
         :py:attr:`Device.get_nvlink_count`.
 
-        .. version-deprecated:: 1.1.0
+        .. deprecated:: 1.1.0
             This property is deprecated and will be removed in a future release.
             Use :py:attr:`Device.get_nvlink_count` instead.
         """
@@ -1484,15 +1484,15 @@ class Device:
 
     def get_cpu_affinity(self, scope: AffinityScope | str=...) -> list[int]:
         """
-        Retrieves a list of indices of NUMA nodes or CPU sockets with the ideal
-        CPU affinity for the device.
+        Retrieves a list of logical CPU indices with the ideal CPU affinity for
+        the device.
 
         For Kepler™ or newer fully supported devices.
 
         Supported on Linux only.
 
         If requested scope is not applicable to the target topology, the API
-        will fall back to reporting the memory affinity for the immediate non-I/O
+        will fall back to reporting the CPU affinity for the immediate non-I/O
         ancestor of the device.
 
         Parameters
@@ -1504,8 +1504,9 @@ class Device:
         Returns
         -------
         list[int]
-            A list of indices of NUMA nodes or CPU sockets with the ideal memory
-            affinity for the device.
+            A list of logical CPU indices with the ideal CPU affinity for the
+            device.  Contrast :meth:`get_memory_affinity`, which returns NUMA
+            node / CPU socket indices.
         """
 
     def set_cpu_affinity(self) -> None:
@@ -1743,7 +1744,7 @@ class Device:
 
         For devices with NVLink support.
 
-        .. version-changed:: 1.1.0
+        .. versionchanged:: 1.1.0
             Any link number not supported by this specific device will raise a `ValueError`.
         """
 
@@ -1753,7 +1754,7 @@ class Device:
 
         For devices with NVLink support.
 
-        .. version-added:: 1.1.0
+        .. versionadded:: 1.1.0
         """
 
     def get_nvlinks(self) -> Iterable[NvlinkInfo]:
@@ -1762,7 +1763,7 @@ class Device:
 
         For devices with NVLink support.
 
-        .. version-added:: 1.1.0
+        .. versionadded:: 1.1.0
         """
 
     @property

--- a/cuda_core/cuda/core/system/_device.pyx
+++ b/cuda_core/cuda/core/system/_device.pyx
@@ -521,15 +521,15 @@ cdef class Device:
 
     def get_cpu_affinity(self, scope: AffinityScope | str=AffinityScope.NODE) -> list[int]:
         """
-        Retrieves a list of indices of NUMA nodes or CPU sockets with the ideal
-        CPU affinity for the device.
+        Retrieves a list of logical CPU indices with the ideal CPU affinity for
+        the device.
 
         For Kepler™ or newer fully supported devices.
 
         Supported on Linux only.
 
         If requested scope is not applicable to the target topology, the API
-        will fall back to reporting the memory affinity for the immediate non-I/O
+        will fall back to reporting the CPU affinity for the immediate non-I/O
         ancestor of the device.
 
         Parameters
@@ -541,8 +541,9 @@ cdef class Device:
         Returns
         -------
         list[int]
-            A list of indices of NUMA nodes or CPU sockets with the ideal memory
-            affinity for the device.
+            A list of logical CPU indices with the ideal CPU affinity for the
+            device.  Contrast :meth:`get_memory_affinity`, which returns NUMA
+            node / CPU socket indices.
         """
         try:
             scope = _AFFINITY_SCOPE_MAPPING[scope]
@@ -892,7 +893,7 @@ cdef class Device:
 
         For devices with NVLink support.
 
-        .. version-changed:: 1.1.0
+        .. versionchanged:: 1.1.0
             Any link number not supported by this specific device will raise a `ValueError`.
         """
         link_count = self.get_nvlink_count()
@@ -906,7 +907,7 @@ cdef class Device:
 
         For devices with NVLink support.
 
-        .. version-added:: 1.1.0
+        .. versionadded:: 1.1.0
         """
         return self.get_field_values([FieldId.DEV_NVLINK_LINK_COUNT])[0].value
 
@@ -916,7 +917,7 @@ cdef class Device:
 
         For devices with NVLink support.
 
-        .. version-added:: 1.1.0
+        .. versionadded:: 1.1.0
         """
         for link in range(self.get_nvlink_count()):
             yield self.get_nvlink(link)

--- a/cuda_core/cuda/core/system/_nvlink.pxi
+++ b/cuda_core/cuda/core/system/_nvlink.pxi
@@ -28,7 +28,7 @@ class _NvlinkInfoMeta(type):
         To find the actual number of Nvlinks available on a device, use
         :py:attr:`Device.get_nvlink_count`.
 
-        .. version-deprecated:: 1.1.0
+        .. deprecated:: 1.1.0
             This property is deprecated and will be removed in a future release.
             Use :py:attr:`Device.get_nvlink_count` instead.
         """

--- a/cuda_core/cuda/core/system/_system_events.pyi
+++ b/cuda_core/cuda/core/system/_system_events.pyi
@@ -111,9 +111,11 @@ def register_events(events: SystemEventType | str | list[SystemEventType | str])
     Examples
     --------
     >>> from cuda.core import system
+    >>> from cuda.core.system.typing import SystemEventType
     >>> events = system.register_events([SystemEventType.UNBIND])
-    >>> while event := events.wait(timeout_ms=10000):
-    ...     print(f"Event {event.event_type} occurred.")
+    >>> while batch := events.wait(timeout_ms=10000):
+    ...     for i in range(len(batch)):
+    ...         print(f"Event {batch[i].event_type} occurred.")
 
     Parameters
     ----------

--- a/cuda_core/cuda/core/system/_system_events.pyx
+++ b/cuda_core/cuda/core/system/_system_events.pyx
@@ -155,9 +155,11 @@ def register_events(events: SystemEventType | str | list[SystemEventType | str])
     Examples
     --------
     >>> from cuda.core import system
+    >>> from cuda.core.system.typing import SystemEventType
     >>> events = system.register_events([SystemEventType.UNBIND])
-    >>> while event := events.wait(timeout_ms=10000):
-    ...     print(f"Event {event.event_type} occurred.")
+    >>> while batch := events.wait(timeout_ms=10000):
+    ...     for i in range(len(batch)):
+    ...         print(f"Event {batch[i].event_type} occurred.")
 
     Parameters
     ----------


### PR DESCRIPTION
Three documentation defects in `cuda.core.system`, all of which mislead or silently drop information in the rendered docs. Documentation only — no behaviour changes.

## 1. Four Sphinx version directives are misspelled, so their content never renders

```
cuda_core/cuda/core/system/_device.pyx:895   .. version-changed:: 1.1.0
cuda_core/cuda/core/system/_device.pyx:909   .. version-added:: 1.1.0
cuda_core/cuda/core/system/_device.pyx:919   .. version-added:: 1.1.0
cuda_core/cuda/core/system/_nvlink.pxi:31    .. version-deprecated:: 1.1.0
```

The directives are `versionchanged`, `versionadded` and `deprecated` — no hyphen. Sphinx emits `Unknown directive type` and drops the body, so two notices users need are missing from the published docs:

- `Device.get_nvlink` — *"Any link number not supported by this specific device will raise a `ValueError`."*
- `NvlinkInfo.max_links` — the deprecation notice pointing at `Device.get_nvlink_count`.

This is a typo rather than a local convention: `grep` over `cuda_core/`, `cuda_bindings/` and `cuda_python/` finds `.. versionadded::` spelled correctly **31 times** (in `texture/`, `graph/`, …) against 4 hyphenated ones, and 0 correct uses of `versionchanged`/`deprecated` anywhere — i.e. every hyphenated instance is in these two files.

The generated `_device.pyi` stub carries the same four typos verbatim (stubgen-pyx copies the docstrings), so it is fixed alongside.

## 2. `Device.get_cpu_affinity`'s docstring describes memory affinity, in the wrong units

The summary, the fallback sentence and the whole Returns section were copied from `get_memory_affinity` twenty lines above, so they promise *"indices of NUMA nodes or CPU sockets"* with the *"ideal memory affinity"*. The body calls `nvmlDeviceGetCpuAffinityWithinScope`, sizes the bitmask in **CPU** words (`ceil(cpu_count() / 64)`, `:557`) and runs it through `_unpack_bitmask` (`_device_utils.pxi:8-24`), so the returned `list[int]` holds **logical CPU indices**.

The docstring even contradicts itself: the summary says *"ideal CPU affinity"*, the Returns section says *"ideal memory affinity"*. A caller who believes the Returns section will index NUMA nodes with CPU numbers. Corrected, with an explicit pointer to `get_memory_affinity` for the node/socket form.

## 3. The `register_events` example calls `.event_type` on the wrong object

```python
    >>> events = system.register_events([SystemEventType.UNBIND])
    >>> while event := events.wait(timeout_ms=10000):
    ...     print(f"Event {event.event_type} occurred.")
```

`RegisteredSystemEvents.wait()` returns `SystemEvents` (`_system_events.pyx:143`), which defines only `__init__`, `__len__` and `__getitem__` (`:55-69`); `event_type` lives on the **singular** `SystemEvent` (`:34`). The documented snippet therefore raises `AttributeError`. It was copied from the device-level example at `_device.pyx:728-734`, where `DeviceEvents.wait()` genuinely does return a single event.

Rewritten to index the batch via the documented `__len__`/`__getitem__` (rather than relying on the legacy sequence-iteration protocol), and to import `SystemEventType`, which the snippet used without ever importing.

## What I ran

Environment: macOS, no CUDA driver and no CUDA toolkit, so `cuda.core` cannot be built or imported here, and Sphinx is not installed.

- **Did not run:** the docs build, or any test.
- **Verified by counting**, on `main`: `.. versionadded::` 31 uses vs `.. version-added::` 4; `.. versionchanged::` 0 vs `.. version-changed::` 2; `.. deprecated::` 0 vs `.. version-deprecated::` 2. All 8 hyphenated uses are the ones changed here (4 in `.pyx`/`.pxi`, 4 in the generated `.pyi`); no hyphenated directive remains anywhere in the tree afterwards.
- **Verified by reading:** `SystemEvents` really has no `event_type` (`_system_events.pyx:55-69`), and `SystemEventType` is exported from `cuda.core.system.typing` (`typing.py:21,247`) — which is the import path `_system_events.pyx:13` itself uses.
- **Verified by reading:** `get_cpu_affinity` calls `nvml.device_get_cpu_affinity_within_scope`, not the memory variant, and both helpers feed `_unpack_bitmask`, which yields set-bit indices.
- **Not changed, deliberately:** `get_memory_affinity` sizes its **NUMA-node** bitmask with `ceil(cpu_count() / 64)` — a CPU count used for a node-set length. It over-allocates, which NVML tolerates, so I could not prove a wrong result and left it alone.
