### PR TITLE
fix(core): use the NVVM numba debug option spelling

### DIFF
--- a/cuda_core/cuda/core/_program.pyx
+++ b/cuda_core/cuda/core/_program.pyx
@@ -1216,7 +1216,7 @@ cdef inline list _prepare_nvrtc_options_impl(object opts):
             f"--instantiate-templates-in-pch={_handle_boolean_option(opts.instantiate_templates_in_pch)}"
         )
     if opts.numba_debug:
-        options.append("--numba-debug")
+        options.append("-numba-debug")
     return [o.encode() for o in options]
 
 

--- a/cuda_core/docs/source/release/1.2.0-notes.rst
+++ b/cuda_core/docs/source/release/1.2.0-notes.rst
@@ -9,6 +9,9 @@
 Fixes and enhancements
 ----------------------
 
+- Fixed ``ProgramOptions(numba_debug=True)`` for the NVVM backend by emitting
+  the single-dash ``-numba-debug`` option accepted by libNVVM.
+
 - Graph node resources are now retained independently across graph clones,
   executable graphs, updates, node deletion, and in-flight launches. Previously,
   modifying a graph definition could release resources still used by an

--- a/cuda_core/tests/test_program.py
+++ b/cuda_core/tests/test_program.py
@@ -93,12 +93,12 @@ def _check_nvvm_arch(arch: str) -> bool:
 
 
 def _check_nvvm_supports_numba_debug() -> bool:
-    """Check if the installed libNVVM recognizes --numba-debug (CTK 13.2+)."""
+    """Check if the installed libNVVM recognizes -numba-debug."""
     if not _has_check_nvvm_compiler_options():
         return False
     from cuda.bindings.utils import check_nvvm_compiler_options
 
-    return check_nvvm_compiler_options(["--numba-debug"])
+    return check_nvvm_compiler_options(["-numba-debug"])
 
 
 @pytest.fixture(scope="session")
@@ -762,18 +762,18 @@ def test_program_options_as_bytes_nvvm_unsupported_option():
 
 @nvvm_available
 def test_nvvm_program_options_as_bytes_numba_debug():
-    """numba_debug must be plumbed through to libNVVM as --numba-debug
+    """numba_debug must be plumbed through to libNVVM as -numba-debug
     (see #1287)."""
     options = ProgramOptions(arch="sm_80", debug=True, numba_debug=True)
     nvvm_bytes = options.as_bytes("nvvm")
-    assert b"--numba-debug" in nvvm_bytes
+    assert b"-numba-debug" in nvvm_bytes
     assert b"-g" in nvvm_bytes
 
 
 @nvvm_available
 @pytest.mark.skipif(
     not _check_nvvm_supports_numba_debug(),
-    reason="installed libNVVM does not recognize --numba-debug (needs CTK 13.2+)",
+    reason="installed libNVVM does not recognize -numba-debug",
 )
 def test_nvvm_program_numba_debug(init_cuda, nvvm_ir):
     options = ProgramOptions(arch="sm_80", debug=True, numba_debug=True)


### PR DESCRIPTION
Fixes #2570.

libNVVM accepts the single-dash `-numba-debug` option, while cuda-core emitted `--numba-debug` for the NVVM backend. The latter is rejected as `NVVM_ERROR_INVALID_OPTION`.

This change:
- emits `-numba-debug` for NVVM only;
- updates the capability probe so the regression test no longer skips because it probes the invalid spelling;
- updates the option serialization and compile-path tests;
- adds a release note.

Validation:
- Ruff check and format passed.
- Cython lint passed.
- Focused pytest collection was blocked on macOS because the CUDA test helper requires Linux `libc.so.6`.
- Lychee was blocked by sandbox network access to existing external links.