### PR TITLE
fix(core): reject IPC registration without IPC state

### DIFF
--- a/cuda_core/cuda/core/_memory/_ipc.pyx
+++ b/cuda_core/cuda/core/_memory/_ipc.pyx
@@ -268,6 +268,8 @@ cdef _MemPool MP_register(_MemPool self, uuid):
     existing = registry.get(uuid)
     if existing is not None:
         return existing
+    if self._ipc_data is None:
+        raise RuntimeError("Memory resource is not IPC-enabled")
     assert self.uuid is None or self.uuid == uuid
     registry[uuid] = self
     self._ipc_data._alloc_handle._uuid = uuid

--- a/cuda_core/docs/source/release/1.2.0-notes.rst
+++ b/cuda_core/docs/source/release/1.2.0-notes.rst
@@ -9,6 +9,10 @@
 Fixes and enhancements
 ----------------------
 
+- ``DeviceMemoryResource.register()`` and ``PinnedMemoryResource.register()``
+  now raise ``RuntimeError`` when called on a resource without IPC enabled,
+  instead of dereferencing missing IPC state.
+
 - Graph node resources are now retained independently across graph clones,
   executable graphs, updates, node deletion, and in-flight launches. Previously,
   modifying a graph definition could release resources still used by an

--- a/cuda_core/tests/test_memory.py
+++ b/cuda_core/tests/test_memory.py
@@ -3,6 +3,7 @@
 
 import ctypes
 import sys
+import uuid
 
 from cuda.bindings import driver
 
@@ -568,6 +569,24 @@ def test_memory_resource_and_owner_disallowed():
         a = (ctypes.c_byte * 20)()
         ptr = ctypes.addressof(a)
         Buffer.from_handle(ptr, 20, mr=DummyDeviceMemoryResource(Device()), owner=a)
+
+
+@pytest.mark.parametrize("resource_type", [DeviceMemoryResource, PinnedMemoryResource])
+def test_register_without_ipc_raises(init_cuda, resource_type):
+    device = Device()
+    device.set_current()
+
+    if resource_type is DeviceMemoryResource:
+        mr = resource_type(device)
+    else:
+        skip_if_pinned_memory_unsupported(device)
+        mr = create_pinned_memory_resource_or_xfail(xfail_device=device)
+
+    try:
+        with pytest.raises(RuntimeError, match="Memory resource is not IPC-enabled"):
+            mr.register(uuid.uuid4())
+    finally:
+        mr.close()
 
 
 def test_owner_close():


### PR DESCRIPTION
Fixes #2568.

`DeviceMemoryResource.register()` and `PinnedMemoryResource.register()` can reach `MP_register` without IPC enabled. The current implementation dereferences `self._ipc_data`, causing a process-level segmentation fault instead of a Python exception.

This change:
- raises `RuntimeError("Memory resource is not IPC-enabled")` before the dereference;
- preserves the existing-resource fast path;
- adds coverage for both device and pinned memory resources;
- adds a release note.

Validation:
- Ruff check and format passed.
- Cython lint passed.
- Focused pytest collection was blocked on macOS because the CUDA test helper requires Linux `libc.so.6`.
- Lychee was blocked by sandbox network access to existing external links.