### PR TITLE
fix(cuda.core): declare cdef attrs for system event wrappers and decode packed gpu_id

### DIFF
--- a/cuda_core/cuda/core/system/_device_attributes.pxi
+++ b/cuda_core/cuda/core/system/_device_attributes.pxi
@@ -7,6 +7,8 @@ cdef class DeviceAttributes:
     """
     Various device attributes.
     """
+    cdef object _attributes
+
     def __init__(self, attributes: nvml.DeviceAttributes):
         self._attributes = attributes
 

--- a/cuda_core/cuda/core/system/_event.pxi
+++ b/cuda_core/cuda/core/system/_event.pxi
@@ -29,6 +29,8 @@ cdef class EventData:
     """
     Data about a single event.
     """
+    cdef object _event_data
+
     def __init__(self, event_data: nvml.EventData):
         self._event_data = event_data
 

--- a/cuda_core/cuda/core/system/_system_events.pyi
+++ b/cuda_core/cuda/core/system/_system_events.pyi
@@ -84,10 +84,9 @@ class RegisteredSystemEvents:
 
 def _pci_bus_id_from_gpu_id(gpu_id: int) -> str:
     """
-    Decode a packed NVML ``gpu_id`` (``domain[31:16] | bus[15:8] | device[7:0]``)
-    into an NVML-style PCI bus ID (``NVML_DEVICE_PCI_BUS_ID_FMT``).
+    Decode an NVML System Event packed ``gpu_id`` into an NVML-style PCI bus ID
+    string.
     """
-
 def register_events(events: SystemEventType | str | list[SystemEventType | str]) -> RegisteredSystemEvents:
     """
     Starts recording of events on test system.

--- a/cuda_core/cuda/core/system/_system_events.pyi
+++ b/cuda_core/cuda/core/system/_system_events.pyi
@@ -82,6 +82,12 @@ class RegisteredSystemEvents:
             If the GPU has fallen off the bus or is otherwise inaccessible.
         """
 
+def _pci_bus_id_from_gpu_id(gpu_id: int) -> str:
+    """
+    Decode a packed NVML ``gpu_id`` (``domain[31:16] | bus[15:8] | device[7:0]``)
+    into an NVML-style PCI bus ID (``NVML_DEVICE_PCI_BUS_ID_FMT``).
+    """
+
 def register_events(events: SystemEventType | str | list[SystemEventType | str]) -> RegisteredSystemEvents:
     """
     Starts recording of events on test system.

--- a/cuda_core/cuda/core/system/_system_events.pyx
+++ b/cuda_core/cuda/core/system/_system_events.pyx
@@ -24,8 +24,8 @@ _SYSTEM_EVENT_TYPE_INV_MAPPING = {v: k for k, v in _SYSTEM_EVENT_TYPE_MAPPING.it
 
 def _pci_bus_id_from_gpu_id(gpu_id: int) -> str:
     """
-    Decode a packed NVML ``gpu_id`` (``domain[31:16] | bus[15:8] | device[7:0]``)
-    into an NVML-style PCI bus ID (``NVML_DEVICE_PCI_BUS_ID_FMT``).
+    Decode an NVML System Event packed ``gpu_id`` into an NVML-style PCI bus ID
+    string.
     """
     domain = (gpu_id >> 16) & 0xFFFF
     bus = (gpu_id >> 8) & 0xFF

--- a/cuda_core/cuda/core/system/_system_events.pyx
+++ b/cuda_core/cuda/core/system/_system_events.pyx
@@ -22,10 +22,23 @@ _SYSTEM_EVENT_TYPE_MAPPING = {
 _SYSTEM_EVENT_TYPE_INV_MAPPING = {v: k for k, v in _SYSTEM_EVENT_TYPE_MAPPING.items()}
 
 
+def _pci_bus_id_from_gpu_id(gpu_id: int) -> str:
+    """
+    Decode a packed NVML ``gpu_id`` (``domain[31:16] | bus[15:8] | device[7:0]``)
+    into an NVML-style PCI bus ID (``NVML_DEVICE_PCI_BUS_ID_FMT``).
+    """
+    domain = (gpu_id >> 16) & 0xFFFF
+    bus = (gpu_id >> 8) & 0xFF
+    device = gpu_id & 0xFF
+    return f"{domain:08X}:{bus:02X}:{device:02X}.0"
+
+
 cdef class SystemEvent:
     """
     Data about a collection of system events.
     """
+    cdef object _event_data
+
     def __init__(self, event_data: nvml.SystemEventData_v1):
         assert len(event_data) == 1
         self._event_data = event_data
@@ -49,13 +62,15 @@ cdef class SystemEvent:
         """
         The :obj:`~_device.Device` associated with this event.
         """
-        return _device.Device(pci_bus_id=self.gpu_id)
+        return _device.Device(pci_bus_id=_pci_bus_id_from_gpu_id(self.gpu_id))
 
 
 cdef class SystemEvents:
     """
     Data about a collection of system events.
     """
+    cdef object _event_data
+
     def __init__(self, event_data: nvml.SystemEventData_v1):
         self._event_data = event_data
 

--- a/cuda_core/tests/system/test_system_device.py
+++ b/cuda_core/tests/system/test_system_device.py
@@ -344,6 +344,30 @@ def test_device_attributes(subtests):
             assert attributes.memory_size_mb > 0
 
 
+@pytest.mark.agent_authored(model="claude-opus-4.7")
+def test_device_attributes_wraps_nvml_struct():
+    # Use synthetic data because NVML exposes these attributes only for MIG
+    # devices.
+    raw = nvml.DeviceAttributes()
+    raw.multiprocessor_count = 14
+    raw.memory_size_mb = 9728
+
+    attrs = _device.DeviceAttributes(raw)
+    assert isinstance(attrs, _device.DeviceAttributes)
+    assert attrs.multiprocessor_count == 14
+    assert attrs.memory_size_mb == 9728
+
+
+@pytest.mark.agent_authored(model="claude-opus-4.7")
+def test_event_data_wraps_nvml_struct():
+    raw = nvml.EventData()
+    raw.event_type = nvml.EventType.PSTATE
+
+    event = _device.EventData(raw)
+    assert isinstance(event, _device.EventData)
+    assert event.event_type is typing.EventType.PSTATE
+
+
 def test_c2c_mode_enabled(subtests):
     for device in system.Device.get_all_devices():
         with subtests.test(device_index=device.index):

--- a/cuda_core/tests/system/test_system_events.py
+++ b/cuda_core/tests/system/test_system_events.py
@@ -52,7 +52,8 @@ def test_pci_bus_id_from_gpu_id(gpu_id, expected):
 
 @pytest.mark.agent_authored(model="claude-opus-4.7")
 def test_system_event_device_resolves_pci_bus_id():
-    # Pack live PCI data as RM does, then resolve it through SystemEvent.device.
+    # Round-trip: pack pci_info with the inverse of _pci_bus_id_from_gpu_id,
+    # then resolve Device through SystemEvent.device.
     if system.get_num_devices() == 0:
         pytest.skip("No GPUs available")
 

--- a/cuda_core/tests/system/test_system_events.py
+++ b/cuda_core/tests/system/test_system_events.py
@@ -13,6 +13,64 @@ import pytest
 from cuda.core import system
 from cuda.core.system import typing
 
+if system.CUDA_BINDINGS_NVML_IS_COMPATIBLE:
+    from cuda.bindings import nvml
+    from cuda.core.system._system_events import SystemEvent, SystemEvents, _pci_bus_id_from_gpu_id
+
+
+@pytest.mark.agent_authored(model="claude-opus-4.7")
+def test_system_events_wraps_event_data():
+    # Use synthetic data because real bind/unbind events are difficult to
+    # trigger reliably.
+    event_data = nvml.SystemEventData_v1(2)
+    event_data.event_type = nvml.SystemEventType.GPU_DRIVER_BIND
+    event_data.gpu_id = [0x0000_0200, 0x0000_C100]
+
+    events = SystemEvents(event_data)
+    assert len(events) == 2
+
+    event = events[0]
+    assert isinstance(event, SystemEvent)
+    assert event.event_type is typing.SystemEventType.BIND
+    assert event.gpu_id == 0x0000_0200
+
+
+@pytest.mark.agent_authored(model="claude-opus-4.7")
+@pytest.mark.parametrize(
+    ("gpu_id", "expected"),
+    [
+        (0x0000_0200, "00000000:02:00.0"),
+        (0x0000_C100, "00000000:C1:00.0"),
+        # The device occupies bits [7:0]; the function is always 0.
+        (0x0001_0A0F, "00000001:0A:0F.0"),
+        (0xFFFF_FFFF, "0000FFFF:FF:FF.0"),
+    ],
+)
+def test_pci_bus_id_from_gpu_id(gpu_id, expected):
+    assert _pci_bus_id_from_gpu_id(gpu_id) == expected
+
+
+@pytest.mark.agent_authored(model="claude-opus-4.7")
+def test_system_event_device_resolves_pci_bus_id():
+    # Pack live PCI data as RM does, then resolve it through SystemEvent.device.
+    if system.get_num_devices() == 0:
+        pytest.skip("No GPUs available")
+
+    for device in system.Device.get_all_devices():
+        pci = device.pci_info
+        if pci.domain > 0xFFFF:
+            pytest.skip(f"PCI domain {pci.domain:#x} does not fit in a packed gpu_id")
+        gpu_id = (pci.domain << 16) | (pci.bus << 8) | (pci.device & 0xFF)
+
+        event_data = nvml.SystemEventData_v1(1)
+        event_data.event_type = nvml.SystemEventType.GPU_DRIVER_BIND
+        event_data.gpu_id = gpu_id
+        event = SystemEvent(event_data)
+        resolved_device = event.device
+
+        assert resolved_device.pci_bus_id == device.pci_bus_id
+        assert resolved_device.index == device.index
+
 
 @pytest.mark.skipif(helpers.IS_WSL or helpers.IS_WINDOWS, reason="System events not supported on WSL or Windows")
 def test_register_events():


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
Two issues were found when adding coverage tests (internal bug 6595639):
1. **Missing `cdef` attributes** on `SystemEvent`, `SystemEvents`, `EventData`,  and `DeviceAttributes`. These are Cython `cdef class` types (no `__dict__`),  so undeclared `self._event_data` / `self._attributes` assignments raise `AttributeError`. `RegisteredSystemEvents.wait()` therefore crashes as soon as a real bind/unbind event arrives.

2. **`SystemEvent.device` type mismatch.** NVML's packed int `gpu_id`  (`domain[31:16] | bus[15:8] | device[7:0]`), which requires an NVML-style PCI bus ID string (`NVML_DEVICE_PCI_BUS_ID_FMT`). Decode at the call site  via `_pci_bus_id_from_gpu_id`.

Adds regression tests for construction, packing decode, and end-to-end `SystemEvent.device` resolution against live `pci_info`.

**Verification:**
- B10: new regression tests 8 passed; live unbind of `0000:c1:00.0`
  yields `SystemEvents` with `gpu_id=0xC100` → `00000000:C1:00.0`, and
  post-rebind `SystemEvent.device` resolves correctly
- A100 MIG: `DeviceAttributes` cdef fix verified
- System Event register/wait remains Linux-only (Windows/WSL/WOA skip)