### PR TITLE
fix(cuda.core): explicit exception chaining in GB_callback cleanup path

### DIFF
--- a/cuda_core/cuda/core/graph/_graph_builder.pyx
+++ b/cuda_core/cuda/core/graph/_graph_builder.pyx
@@ -931,11 +931,14 @@ cdef inline void GB_callback(
         if fail_tail_discovery_for_testing:
             raise RuntimeError("forced capture tail discovery failure")
         host_node = _capture_tail_node(c_stream)
-    except:
+    except BaseException as orig_exc:
         # CUDA added the callback, but its node cannot be identified.
         # Retain its owners anonymously to prevent dangling pointers.
         commit_status = graph_commit_attachment(prepared, NULL)
-        HANDLE_RETURN(commit_status)
+        try:
+            HANDLE_RETURN(commit_status)
+        except Exception as commit_exc:
+            raise commit_exc from orig_exc
         raise
     HANDLE_RETURN(graph_commit_attachment(prepared, host_node))
 


### PR DESCRIPTION
## Summary

- In `GB_callback`, when `_capture_tail_node` fails the handler calls `graph_commit_attachment` and `HANDLE_RETURN` as anonymous-owner cleanup. If that `HANDLE_RETURN` raises, Python implicitly sets `__context__` to the caught exception, producing a confusing "During handling of the above exception, another exception occurred" traceback that buries the real CUDA error.
- Changed `except:` to `except BaseException as orig_exc:` and wrapped the cleanup `HANDLE_RETURN` in a `try/except` that uses `raise commit_exc from orig_exc` to make the causal relationship explicit.

## Test plan

- [ ] Existing graph builder tests (`pytest cuda_core/tests/`) cover the `_capture_tail_node` path including `_capture_callback_with_tail_failure_for_testing`
- [ ] Verify the commit failure path emits a clean traceback with explicit exception chaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)