### PR TITLE
test: skip LatchKernel event test without __nanosleep

### DIFF
--- a/cuda_core/tests/test_event.py
+++ b/cuda_core/tests/test_event.py
@@ -222,6 +222,7 @@ def test_event_ipc_descriptor_non_ipc(init_cuda):
         _ = event.ipc_descriptor
 
 
+@pytest.mark.skipif(Device().compute_capability.major < 7, reason="__nanosleep is only available starting Volta (sm70)")
 def test_event_is_done_false(init_cuda):
     """Event.is_done returns False when captured work has not yet completed."""
     device = Device()


### PR DESCRIPTION
## Description
This is to fix the internal bug 6179497 which failed test_event_is_done_false for Pascal GPU.

 cuda.core._utils.cuda_utils.NVRTCError: 6: NVRTC_ERROR_COMPILATION, compilation log:
E
E   nvrtc: warning: Architectures prior to '<compute/sm>_75' are deprecated and may be removed in a future release
E   default_program(23): error: identifier "__nanosleep" is undefined
E                            __nanosleep(1000000); // 1 ms

The fix is to skip the test for device with sm < 7.
