### PR TITLE
[doc-only] fix: remove unrelated Database classifier from cuda-bindings metadata

### DIFF
--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -21,7 +21,6 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 classifiers = [
     "Intended Audience :: Developers",
-    "Topic :: Database",
     "Topic :: Scientific/Engineering",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
This PR addresses the following issue in `cuda_bindings/pyproject.toml`: remove unrelated Database classifier from cuda-bindings metadata.

## Changes
- `cuda_bindings/pyproject.toml`: remove unrelated Database classifier from cuda-bindings metadata.

## Details
```diff
--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -1,3 +1,2 @@
-    "Intended Audience :: Developers",
-    "Topic :: Database",
-    "Topic :: Scientific/Engineering",
+    "Intended Audience :: Developers",
+    "Topic :: Scientific/Engineering",
```

## Tests
- `cuda_bindings/tests/test_metadata.py`

```diff
diff --git a/cuda_bindings/tests/test_metadata.py b/cuda_bindings/tests/test_metadata.py
new file mode 100644
--- /dev/null
+++ b/cuda_bindings/tests/test_metadata.py
@@ -0,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import pathlib
+import re
+
+
+def test_no_database_classifier():
+    pyproject = pathlib.Path(__file__).resolve().parents[1] / "pyproject.toml"
+    content = pyproject.read_text()
+    match = re.search(r"classifiers\s*=\s*\[(.*?)\]", content, re.DOTALL)
+    assert match is not None
+    classifiers_block = match.group(1)
+    assert '"Topic :: Database"' not in classifiers_block
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).