### PR TITLE
fix: Remove unnecessary shell quoting from GITHUB_ENV write

### DIFF
--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -306,7 +306,7 @@ jobs:
 
       - name: Set up test repetition on nightly runs
         shell: bash --noprofile --norc -xeuo pipefail {0}
-        run: echo "PYTEST_ADDOPTS=\"--count=${{ inputs.nruns }}\"" >> "$GITHUB_ENV"
+        run: echo "PYTEST_ADDOPTS=--count=${{ inputs.nruns }}" >> "$GITHUB_ENV"
 
       # ── Standard test steps (skipped for nightly modes) ──
       - name: Run cuda.pathfinder tests with see_what_works


### PR DESCRIPTION
This PR addresses the following issue in `.github/workflows/test-wheel-windows.yml`: Remove unnecessary shell quoting from GITHUB_ENV write.

## Changes
- `.github/workflows/test-wheel-windows.yml`: Remove unnecessary shell quoting from GITHUB_ENV write.

## Details
```diff
--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -1,1 +1,1 @@
-        run: echo "PYTEST_ADDOPTS=\"--count=${{ inputs.nruns }}\"" >> "$GITHUB_ENV"
+        run: echo "PYTEST_ADDOPTS=--count=${{ inputs.nruns }}" >> "$GITHUB_ENV"
```

## Tests
- `cuda_core/tests/test_ci_env.py`

```diff
--- /dev/null
+++ b/cuda_core/tests/test_ci_env.py
@@ -0,0 +1,18 @@
+import os
+import shlex
+
+
+def test_pytest_addopts_no_literal_quotes():
+    """Ensure PYTEST_ADDOPTS, if set by CI, does not contain literal quotes.
+
+    GitHub Actions env-file values are taken literally after the '=', so
+    escaped quotes written to $GITHUB_ENV become part of the value.  This
+    test guards against that regression.
+    """
+    opts = os.environ.get("PYTEST_ADDOPTS", "")
+    if not opts:
+        return
+    assert not (opts.startswith('"') and opts.endswith('"')), (
+        f"PYTEST_ADDOPTS contains literal quotes: {opts!r}"
+    )
+    # Ensure pytest can still parse the value.
+    shlex.split(opts)
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).