### PR TITLE
docs(cuda.core): don't document APIs accept dict for options

### DIFF
--- a/cuda_core/cuda/core/_memory/_device_memory_resource.pyi
+++ b/cuda_core/cuda/core/_memory/_device_memory_resource.pyi
@@ -120,7 +120,7 @@ class DeviceMemoryResource(_MemPool):
     def __cinit__(self, *args, **kwargs) -> None:
         ...
 
-    def __init__(self, device_id: Device | int, options: DeviceMemoryResourceOptions | dict[str, object] | None=None) -> None:
+    def __init__(self, device_id: Device | int, options: DeviceMemoryResourceOptions | None=None) -> None:
         ...
 
     def __reduce__(self) -> tuple[object, ...]:

--- a/cuda_core/cuda/core/_memory/_device_memory_resource.pyx
+++ b/cuda_core/cuda/core/_memory/_device_memory_resource.pyx
@@ -148,7 +148,7 @@ cdef class DeviceMemoryResource(_MemPool):
     def __init__(
         self,
         device_id: Device | int,
-        options: DeviceMemoryResourceOptions | dict[str, object] | None = None
+        options: DeviceMemoryResourceOptions | None = None
     ) -> None:
         _DMR_init(self, device_id, options)
 

--- a/cuda_core/cuda/core/_memory/_managed_memory_resource.pyi
+++ b/cuda_core/cuda/core/_memory/_managed_memory_resource.pyi
@@ -77,7 +77,7 @@ class ManagedMemoryResource(_MemPool):
     memory pools.
     """
 
-    def __init__(self, options: ManagedMemoryResourceOptions | dict[str, object] | None=None) -> None:
+    def __init__(self, options: ManagedMemoryResourceOptions | None=None) -> None:
         ...
 
     def allocate(self, size: int, *, stream: Stream | GraphBuilder) -> ManagedBuffer:

--- a/cuda_core/cuda/core/_memory/_managed_memory_resource.pyx
+++ b/cuda_core/cuda/core/_memory/_managed_memory_resource.pyx
@@ -97,7 +97,7 @@ cdef class ManagedMemoryResource(_MemPool):
     memory pools.
     """
 
-    def __init__(self, options: ManagedMemoryResourceOptions | dict[str, object] | None = None) -> None:
+    def __init__(self, options: ManagedMemoryResourceOptions | None = None) -> None:
         _MMR_init(self, options)
 
     def allocate(self, size_t size, *, stream: Stream | GraphBuilder) -> ManagedBuffer:

--- a/cuda_core/cuda/core/_memory/_pinned_memory_resource.pyi
+++ b/cuda_core/cuda/core/_memory/_pinned_memory_resource.pyi
@@ -84,7 +84,7 @@ class PinnedMemoryResource(_MemPool):
     See :class:`DeviceMemoryResource` for more details on IPC usage patterns.
     """
 
-    def __init__(self, options: PinnedMemoryResourceOptions | dict[str, object] | None=None) -> None:
+    def __init__(self, options: PinnedMemoryResourceOptions | None=None) -> None:
         ...
 
     def allocate(self, size: int, *, stream: Stream | GraphBuilder) -> Buffer:

--- a/cuda_core/cuda/core/_memory/_pinned_memory_resource.pyx
+++ b/cuda_core/cuda/core/_memory/_pinned_memory_resource.pyx
@@ -103,7 +103,7 @@ cdef class PinnedMemoryResource(_MemPool):
     See :class:`DeviceMemoryResource` for more details on IPC usage patterns.
     """
 
-    def __init__(self, options: PinnedMemoryResourceOptions | dict[str, object] | None = None) -> None:
+    def __init__(self, options: PinnedMemoryResourceOptions | None = None) -> None:
         _PMR_init(self, options)
 
     def allocate(self, size_t size, *, stream: Stream | GraphBuilder) -> Buffer:

--- a/cuda_core/tests/test_memory.py
+++ b/cuda_core/tests/test_memory.py
@@ -1981,11 +1981,11 @@ def test_mempool_attributes_repr(memory_resource_factory):
     device.set_current()
 
     if MR is DeviceMemoryResource:
-        mr = MR(device, options={"max_size": 2048})
+        mr = MR(device, options=DeviceMemoryResourceOptions(max_size=2048))
     elif MR is PinnedMemoryResource:
-        mr = MR(options={"max_size": 2048})
+        mr = MR(options=PinnedMemoryResourceOptions(max_size=2048))
     elif MR is ManagedMemoryResource:
-        mr = create_managed_memory_resource_or_skip(options={})
+        mr = create_managed_memory_resource_or_skip(options=ManagedMemoryResourceOptions())
 
     buffer1 = mr.allocate(64, stream=device.default_stream)
     buffer2 = mr.allocate(64, stream=device.default_stream)
@@ -2018,11 +2018,11 @@ def test_mempool_attributes_ownership(memory_resource_factory):
     device.set_current()
 
     if MR is DeviceMemoryResource:
-        mr = MR(device, {"max_size": POOL_SIZE})
+        mr = MR(device, DeviceMemoryResourceOptions(max_size=POOL_SIZE))
     elif MR is PinnedMemoryResource:
-        mr = MR({"max_size": POOL_SIZE})
+        mr = MR(PinnedMemoryResourceOptions(max_size=POOL_SIZE))
     elif MR is ManagedMemoryResource:
-        mr = create_managed_memory_resource_or_skip({})
+        mr = create_managed_memory_resource_or_skip(ManagedMemoryResourceOptions())
 
     attributes = mr.attributes
     mr.close()


### PR DESCRIPTION
Removes `| dict[str, object]` from the `options` parameter annotations of `DeviceMemoryResource`, `ManagedMemoryResource`, and `PinnedMemoryResource`.

Because Cython enforces `def`-function type annotations at the call boundary, this is a **behavioral change**: passing a plain `dict` to any of these constructors now raises `TypeError` at runtime instead of being silently accepted.

Tests are updated to use Options dataclasses instead of dicts.

Addresses #2248.