### PR TITLE
test(cuda.core): centralize memory resource instrumentation in test helpers

### DIFF
--- a/cuda_core/tests/helpers/buffers.py
+++ b/cuda_core/tests/helpers/buffers.py
@@ -4,6 +4,7 @@
 import ctypes
 
 from cuda.core import Buffer, Device, MemoryResource
+from cuda.core._stream import Stream_accept
 from cuda.core._utils.cuda_utils import driver, handle_return
 
 from . import libc
@@ -12,11 +13,82 @@ __all__ = [
     "DummyDeviceMemoryResource",
     "DummyUnifiedMemoryResource",
     "PatternGen",
-    "TrackingMR",
+    "StubMemoryResource",
     "compare_buffer_to_constant",
     "compare_equal_buffers",
+    "make_instrumented_memory_resource",
     "make_scratch_buffer",
 ]
+
+
+class StubMemoryResource(MemoryResource):
+    """Device-only memory resource for tests that supply a fake pointer."""
+
+    def __init__(self, device):
+        self.device = device
+
+    def allocate(self, size, *, stream=None):
+        raise NotImplementedError("StubMemoryResource does not allocate")
+
+    def deallocate(self, ptr, size, *, stream=None):
+        Stream_accept(stream)
+
+    @property
+    def is_device_accessible(self):
+        return True
+
+    @property
+    def is_host_accessible(self):
+        return False
+
+    @property
+    def device_id(self):
+        return self.device.device_id
+
+
+def make_instrumented_memory_resource(
+    backing=StubMemoryResource,
+    *,
+    record_streams=False,
+    track_active=False,
+    deallocate_error=None,
+):
+    """Return an instrumented backing subclass and its shared telemetry.
+
+    Only calls dispatched through the Python ``allocate`` and ``deallocate``
+    methods are observed. Some built-in memory resources free their buffers
+    directly in C++ instead (see issue #2615).
+    """
+    if not isinstance(backing, type) or not issubclass(backing, MemoryResource):
+        raise TypeError("backing must be a MemoryResource subclass")
+
+    telemetry = {"active": {}, "deallocations": []}
+
+    class InstrumentedMemoryResource(backing):
+        __slots__ = ()
+
+        if track_active:
+
+            def allocate(self, size, *, stream=None):
+                buffer = super().allocate(size, stream=stream)
+                telemetry["active"][int(buffer.handle)] = size
+                return buffer
+
+        if record_streams or track_active or deallocate_error is not None:
+
+            def deallocate(self, ptr, size, *, stream=None):
+                if record_streams:
+                    telemetry["deallocations"].append(
+                        {"ptr": int(ptr), "size": size, "stream": stream}
+                    )
+                if deallocate_error is not None:
+                    raise deallocate_error
+                super().deallocate(ptr, size, stream=stream)
+                if track_active:
+                    telemetry["active"].pop(int(ptr), None)
+
+    InstrumentedMemoryResource.__name__ = f"Instrumented{backing.__name__}"
+    return InstrumentedMemoryResource, telemetry
 
 
 class DummyDeviceMemoryResource(MemoryResource):
@@ -69,39 +141,6 @@ class DummyUnifiedMemoryResource(MemoryResource):
     @property
     def device_id(self) -> int:
         return self.device
-
-
-class TrackingMR(MemoryResource):
-    """A MemoryResource that tracks active allocations via a dict.
-
-    Useful for verifying that deallocate is called at the expected time.
-    """
-
-    def __init__(self):
-        self.active = {}
-
-    # cuMemAlloc / cuMemFree are synchronous; stream is accepted for
-    # interface conformance but ignored.
-    def allocate(self, size, *, stream=None):
-        ptr = handle_return(driver.cuMemAlloc(size))
-        self.active[int(ptr)] = size
-        return Buffer.from_handle(ptr=ptr, size=size, mr=self)
-
-    def deallocate(self, ptr, size, *, stream=None):
-        handle_return(driver.cuMemFree(ptr))
-        del self.active[int(ptr)]
-
-    @property
-    def is_device_accessible(self):
-        return True
-
-    @property
-    def is_host_accessible(self):
-        return False
-
-    @property
-    def device_id(self):
-        return 0
 
 
 class PatternGen:

--- a/cuda_core/tests/helpers/buffers.py
+++ b/cuda_core/tests/helpers/buffers.py
@@ -78,9 +78,7 @@ def make_instrumented_memory_resource(
 
             def deallocate(self, ptr, size, *, stream=None):
                 if record_streams:
-                    telemetry["deallocations"].append(
-                        {"ptr": int(ptr), "size": size, "stream": stream}
-                    )
+                    telemetry["deallocations"].append({"ptr": int(ptr), "size": size, "stream": stream})
                 if deallocate_error is not None:
                     raise deallocate_error
                 super().deallocate(ptr, size, stream=stream)

--- a/cuda_core/tests/test_memory.py
+++ b/cuda_core/tests/test_memory.py
@@ -481,9 +481,7 @@ def test_mr_deallocate_called_on_close():
     """Buffer.from_handle(mr=mr) calls mr.deallocate() on close (issue #1619)."""
     device = Device()
     device.set_current()
-    TrackingMR, telemetry = make_instrumented_memory_resource(
-        DummyDeviceMemoryResource, track_active=True
-    )
+    TrackingMR, telemetry = make_instrumented_memory_resource(DummyDeviceMemoryResource, track_active=True)
     mr = TrackingMR(device)
     buf = mr.allocate(1024)
     assert len(telemetry["active"]) == 1
@@ -497,9 +495,7 @@ def test_mr_deallocate_called_on_gc():
 
     device = Device()
     device.set_current()
-    TrackingMR, telemetry = make_instrumented_memory_resource(
-        DummyDeviceMemoryResource, track_active=True
-    )
+    TrackingMR, telemetry = make_instrumented_memory_resource(DummyDeviceMemoryResource, track_active=True)
     mr = TrackingMR(device)
     buf = mr.allocate(1024)
     assert len(telemetry["active"]) == 1
@@ -513,9 +509,7 @@ def test_mr_deallocate_receives_stream():
     device = Device()
     device.set_current()
     stream = device.create_stream()
-    CapturingMR, telemetry = make_instrumented_memory_resource(
-        DummyDeviceMemoryResource, record_streams=True
-    )
+    CapturingMR, telemetry = make_instrumented_memory_resource(DummyDeviceMemoryResource, record_streams=True)
     mr = CapturingMR(device)
     buf = mr.allocate(1024)
     buf.close(stream)
@@ -643,9 +637,7 @@ def test_mr_deallocation_failure_warns(capfd):
     """Destructor-path MR failures are contained and reported."""
     device = Device()
     device.set_current()
-    FailingMR, _ = make_instrumented_memory_resource(
-        deallocate_error=RuntimeError("expected deallocation failure")
-    )
+    FailingMR, _ = make_instrumented_memory_resource(deallocate_error=RuntimeError("expected deallocation failure"))
     buf = Buffer.from_handle(1, 1024, mr=FailingMR(device))
     buf.close()
 
@@ -658,9 +650,7 @@ def test_mr_deallocation_failure_warns(capfd):
 @pytest.mark.parametrize("replace_stream", [False, True])
 def test_mr_deallocation_without_current_context(init_cuda, capsys, replace_stream):
     """MR-backed Buffer teardown activates the recorded context when none is current."""
-    TrackingMR, telemetry = make_instrumented_memory_resource(
-        DummyDeviceMemoryResource, track_active=True
-    )
+    TrackingMR, telemetry = make_instrumented_memory_resource(DummyDeviceMemoryResource, track_active=True)
     mr = TrackingMR(init_cuda)
     buf = mr.allocate(1024)
     stream = init_cuda.create_stream() if replace_stream else None
@@ -689,9 +679,7 @@ def test_mr_deallocation_with_foreign_context(capsys, replace_stream):
 
     alloc_dev = Device(0)
     alloc_dev.set_current()
-    TrackingMR, telemetry = make_instrumented_memory_resource(
-        DummyDeviceMemoryResource, track_active=True
-    )
+    TrackingMR, telemetry = make_instrumented_memory_resource(DummyDeviceMemoryResource, track_active=True)
     mr = TrackingMR(alloc_dev)
     buf = mr.allocate(1024)
     stream = alloc_dev.create_stream() if replace_stream else None

--- a/cuda_core/tests/test_memory.py
+++ b/cuda_core/tests/test_memory.py
@@ -21,7 +21,12 @@ from conftest import (
     skip_if_pinned_memory_unsupported,
 )
 from helpers import supports_ipc_mempool
-from helpers.buffers import DummyDeviceMemoryResource, DummyUnifiedMemoryResource, TrackingMR
+from helpers.buffers import (
+    DummyDeviceMemoryResource,
+    DummyUnifiedMemoryResource,
+    StubMemoryResource,
+    make_instrumented_memory_resource,
+)
 from helpers.constants import POOL_SIZE
 
 from cuda.core import (
@@ -45,7 +50,7 @@ from cuda.core import (
 )
 from cuda.core._dlpack import DLDeviceType
 from cuda.core._memory._ipc import IPCBufferDescriptor
-from cuda.core._stream import Stream_accept, default_stream
+from cuda.core._stream import default_stream
 from cuda.core._utils.cuda_utils import CUDAError, handle_return
 from cuda.core.typing import (
     ManagedMemoryLocationType,
@@ -476,11 +481,14 @@ def test_mr_deallocate_called_on_close():
     """Buffer.from_handle(mr=mr) calls mr.deallocate() on close (issue #1619)."""
     device = Device()
     device.set_current()
-    mr = TrackingMR()
+    TrackingMR, telemetry = make_instrumented_memory_resource(
+        DummyDeviceMemoryResource, track_active=True
+    )
+    mr = TrackingMR(device)
     buf = mr.allocate(1024)
-    assert len(mr.active) == 1
+    assert len(telemetry["active"]) == 1
     buf.close()
-    assert len(mr.active) == 0
+    assert len(telemetry["active"]) == 0
 
 
 def test_mr_deallocate_called_on_gc():
@@ -489,12 +497,15 @@ def test_mr_deallocate_called_on_gc():
 
     device = Device()
     device.set_current()
-    mr = TrackingMR()
+    TrackingMR, telemetry = make_instrumented_memory_resource(
+        DummyDeviceMemoryResource, track_active=True
+    )
+    mr = TrackingMR(device)
     buf = mr.allocate(1024)
-    assert len(mr.active) == 1
+    assert len(telemetry["active"]) == 1
     del buf
     gc.collect()
-    assert len(mr.active) == 0
+    assert len(telemetry["active"]) == 0
 
 
 def test_mr_deallocate_receives_stream():
@@ -502,17 +513,13 @@ def test_mr_deallocate_receives_stream():
     device = Device()
     device.set_current()
     stream = device.create_stream()
-    received = {}
-
-    class StreamCaptureMR(TrackingMR):
-        def deallocate(self, ptr, size, *, stream=None):
-            received["stream"] = stream
-            super().deallocate(ptr, size, stream=stream)
-
-    mr = StreamCaptureMR()
+    CapturingMR, telemetry = make_instrumented_memory_resource(
+        DummyDeviceMemoryResource, record_streams=True
+    )
+    mr = CapturingMR(device)
     buf = mr.allocate(1024)
     buf.close(stream)
-    assert received["stream"].handle == stream.handle
+    assert telemetry["deallocations"][-1]["stream"].handle == stream.handle
 
 
 @pytest.mark.parametrize("buffer_type", [Buffer, ManagedBuffer])
@@ -526,37 +533,15 @@ def test_from_handle_mr_records_default_stream(buffer_type):
 
     device = Device()
     device.set_current()
-    captured = {}
-
-    class StrictCapturingMR(MemoryResource):
-        # Models a stream-ordered MR: deallocate validates the stream
-        # the same way DeviceMemoryResource.deallocate does.
-        @property
-        def is_device_accessible(self):
-            return True
-
-        @property
-        def is_host_accessible(self):
-            return False
-
-        @property
-        def device_id(self):
-            return device.device_id
-
-        def allocate(self, size, *, stream):
-            raise NotImplementedError  # not used; we use from_handle below
-
-        def deallocate(self, ptr, size, *, stream):
-            captured["stream"] = Stream_accept(stream)
-
-    mr = StrictCapturingMR()
-    # ptr=1 is fine because StrictCapturingMR.deallocate does not free.
+    CapturingMR, telemetry = make_instrumented_memory_resource(record_streams=True)
+    mr = CapturingMR(device)
+    # ptr=1 is fine because StubMemoryResource.deallocate does not free.
     buf = buffer_type.from_handle(1, 1024, mr=mr)
     del buf
     gc.collect()
 
-    assert "stream" in captured, "deallocate was not invoked (callback raised and leaked)"
-    assert captured["stream"].handle == default_stream().handle
+    assert telemetry["deallocations"], "deallocate was not invoked (callback raised and leaked)"
+    assert telemetry["deallocations"][-1]["stream"].handle == default_stream().handle
 
 
 @pytest.mark.agent_authored(model="cursor-grok-4.5")
@@ -568,33 +553,13 @@ def test_from_handle_mr_records_explicit_stream(buffer_type):
     device = Device()
     device.set_current()
     stream = device.create_stream()
-    captured = {}
-
-    class StrictCapturingMR(MemoryResource):
-        @property
-        def is_device_accessible(self):
-            return True
-
-        @property
-        def is_host_accessible(self):
-            return False
-
-        @property
-        def device_id(self):
-            return device.device_id
-
-        def allocate(self, size, *, stream):
-            raise NotImplementedError
-
-        def deallocate(self, ptr, size, *, stream):
-            captured["stream"] = Stream_accept(stream)
-
-    mr = StrictCapturingMR()
+    CapturingMR, telemetry = make_instrumented_memory_resource(record_streams=True)
+    mr = CapturingMR(device)
     buf = buffer_type.from_handle(1, 1024, mr=mr, stream=stream)
     del buf
     gc.collect()
 
-    assert captured["stream"].handle == stream.handle
+    assert telemetry["deallocations"][-1]["stream"].handle == stream.handle
 
 
 @pytest.mark.agent_authored(model="cursor-grok-4.5")
@@ -618,27 +583,7 @@ def test_close_with_default_stream_requires_context():
     device = Device()
     device.set_current()
     stream = device.create_stream()
-
-    class NoopMR(MemoryResource):
-        @property
-        def is_device_accessible(self):
-            return True
-
-        @property
-        def is_host_accessible(self):
-            return False
-
-        @property
-        def device_id(self):
-            return device.device_id
-
-        def allocate(self, size, *, stream):
-            raise NotImplementedError
-
-        def deallocate(self, ptr, size, *, stream):
-            pass
-
-    mr = NoopMR()
+    mr = StubMemoryResource(device)
     # Use a real stream at creation so _init succeeds without a current context later.
     buf = Buffer.from_handle(1, 1024, mr=mr, stream=stream)
 
@@ -660,27 +605,7 @@ def test_from_handle_mr_default_stream_requires_context(buffer_type):
     """Owning from_handle with the default stream needs a current context."""
     device = Device()
     device.set_current()
-
-    class StrictCapturingMR(MemoryResource):
-        @property
-        def is_device_accessible(self):
-            return True
-
-        @property
-        def is_host_accessible(self):
-            return False
-
-        @property
-        def device_id(self):
-            return device.device_id
-
-        def allocate(self, size, *, stream):
-            raise NotImplementedError
-
-        def deallocate(self, ptr, size, *, stream):
-            pass
-
-    mr = StrictCapturingMR()
+    mr = StubMemoryResource(device)
     previous = handle_return(driver.cuCtxPopCurrent())
     assert int(previous) != 0
     try:
@@ -698,28 +623,8 @@ def test_from_handle_mr_explicit_stream_without_current_context(buffer_type):
     device = Device()
     device.set_current()
     stream = device.create_stream()
-    captured = {}
-
-    class StrictCapturingMR(MemoryResource):
-        @property
-        def is_device_accessible(self):
-            return True
-
-        @property
-        def is_host_accessible(self):
-            return False
-
-        @property
-        def device_id(self):
-            return device.device_id
-
-        def allocate(self, size, *, stream):
-            raise NotImplementedError
-
-        def deallocate(self, ptr, size, *, stream):
-            captured["stream"] = Stream_accept(stream)
-
-    mr = StrictCapturingMR()
+    CapturingMR, telemetry = make_instrumented_memory_resource(record_streams=True)
+    mr = CapturingMR(device)
     previous = handle_return(driver.cuCtxPopCurrent())
     assert int(previous) != 0
     try:
@@ -730,7 +635,7 @@ def test_from_handle_mr_explicit_stream_without_current_context(buffer_type):
     finally:
         handle_return(driver.cuCtxSetCurrent(previous))
 
-    assert captured["stream"].handle == stream.handle
+    assert telemetry["deallocations"][-1]["stream"].handle == stream.handle
 
 
 @pytest.mark.agent_authored(model="gpt-5.6")
@@ -738,27 +643,10 @@ def test_mr_deallocation_failure_warns(capfd):
     """Destructor-path MR failures are contained and reported."""
     device = Device()
     device.set_current()
-
-    class FailingMR(MemoryResource):
-        @property
-        def is_device_accessible(self):
-            return True
-
-        @property
-        def is_host_accessible(self):
-            return False
-
-        @property
-        def device_id(self):
-            return device.device_id
-
-        def allocate(self, size, *, stream):
-            raise NotImplementedError
-
-        def deallocate(self, ptr, size, *, stream):
-            raise RuntimeError("expected deallocation failure")
-
-    buf = Buffer.from_handle(1, 1024, mr=FailingMR())
+    FailingMR, _ = make_instrumented_memory_resource(
+        deallocate_error=RuntimeError("expected deallocation failure")
+    )
+    buf = Buffer.from_handle(1, 1024, mr=FailingMR(device))
     buf.close()
 
     assert (
@@ -770,10 +658,13 @@ def test_mr_deallocation_failure_warns(capfd):
 @pytest.mark.parametrize("replace_stream", [False, True])
 def test_mr_deallocation_without_current_context(init_cuda, capsys, replace_stream):
     """MR-backed Buffer teardown activates the recorded context when none is current."""
-    mr = TrackingMR()
+    TrackingMR, telemetry = make_instrumented_memory_resource(
+        DummyDeviceMemoryResource, track_active=True
+    )
+    mr = TrackingMR(init_cuda)
     buf = mr.allocate(1024)
     stream = init_cuda.create_stream() if replace_stream else None
-    assert len(mr.active) == 1
+    assert len(telemetry["active"]) == 1
 
     previous = handle_return(driver.cuCtxPopCurrent())
     assert int(previous) != 0
@@ -782,7 +673,7 @@ def test_mr_deallocation_without_current_context(init_cuda, capsys, replace_stre
 
         buf.close(stream)
 
-        assert len(mr.active) == 0
+        assert len(telemetry["active"]) == 0
         assert int(handle_return(driver.cuCtxGetCurrent())) == 0
         assert "mr.deallocate() failed" not in capsys.readouterr().err
     finally:
@@ -798,10 +689,13 @@ def test_mr_deallocation_with_foreign_context(capsys, replace_stream):
 
     alloc_dev = Device(0)
     alloc_dev.set_current()
-    mr = TrackingMR()
+    TrackingMR, telemetry = make_instrumented_memory_resource(
+        DummyDeviceMemoryResource, track_active=True
+    )
+    mr = TrackingMR(alloc_dev)
     buf = mr.allocate(1024)
     stream = alloc_dev.create_stream() if replace_stream else None
-    assert len(mr.active) == 1
+    assert len(telemetry["active"]) == 1
     alloc_ctx = int(handle_return(driver.cuCtxGetCurrent()))
 
     foreign_dev = Device(1)
@@ -813,7 +707,7 @@ def test_mr_deallocation_with_foreign_context(capsys, replace_stream):
     try:
         buf.close(stream)
 
-        assert len(mr.active) == 0
+        assert len(telemetry["active"]) == 0
         assert int(handle_return(driver.cuCtxGetCurrent())) == foreign_ctx
         assert "mr.deallocate() failed" not in capsys.readouterr().err
     finally:


### PR DESCRIPTION
## Summary

`test_memory.py` accumulated seven ad-hoc `MemoryResource` subclasses defined inline inside test bodies. Each re-declared the same `is_device_accessible` / `is_host_accessible` / `device_id` boilerplate and hand-rolled its own capture dict, so adding a test meant copying about 20 lines of scaffolding. This replaces them with two shared helpers in `tests/helpers/buffers.py`, letting each test declare the instrumentation it wants instead of re-implementing it. Net effect is 112 insertions against 193 deletions.

## Changes

- Add `StubMemoryResource`, a device-only resource that refuses to allocate and validates the deallocation stream through `Stream_accept`, for the tests that hand a fake pointer to `from_handle`.
- Add `make_instrumented_memory_resource(backing, *, record_streams, track_active, deallocate_error)`, which returns an instrumented subclass of any `MemoryResource` together with a shared telemetry dict. The `allocate` and `deallocate` overrides are only defined when the corresponding flag is set, so unrequested instrumentation leaves the backing resource's dispatch untouched.
- Replace `TrackingMR` with instrumentation over `DummyDeviceMemoryResource`. The old helper hardcoded `device_id` to 0, which was incorrect for the multi-device foreign-context tests; the instrumented resource reports the device it was constructed with.
- Rewrite the affected tests in `test_memory.py` to read from the telemetry dict rather than a per-test closure.

One limitation is documented on the factory: only calls dispatched through the Python `allocate` and `deallocate` methods are observed, because some built-in memory resources free their buffers directly in C++. That constrains which backings are useful to instrument until #2615 is resolved.

## Related

- #2615 (pool-backed buffers bypass overridden `deallocate()`; limits the choice of backing resource)
- #2526 (added most of the tests being consolidated here)