### PR TITLE
cuda.core: accept dict for XyzOptions that are extension types

### DIFF
--- a/cuda_core/cuda/core/_context.pyx
+++ b/cuda_core/cuda/core/_context.pyx
@@ -8,6 +8,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+import cython
+
 from cuda.bindings cimport cydriver
 from cuda.core._device_resources cimport DeviceResources, SMResource, WorkqueueResource
 from cuda.core._device_resources import SMResource, WorkqueueResource
@@ -99,6 +101,7 @@ cdef class Context:
         Context_check_open(self)
         return DeviceResources._init_from_ctx(self._h_context, self._device_id)
 
+    @cython.annotation_typing(False)
     def create_stream(self, options: StreamOptions | None = None) -> Stream:
         """Create a new stream bound to this green context.
 

--- a/cuda_core/cuda/core/_memory/_device_memory_resource.pyx
+++ b/cuda_core/cuda/core/_memory/_device_memory_resource.pyx
@@ -149,7 +149,7 @@ cdef class DeviceMemoryResource(_MemPool):
     def __init__(
         self,
         device_id: Device | int,
-        options: DeviceMemoryResourceOptions | None = None
+        options=None
     ) -> None:
         _DMR_init(self, device_id, options)
 

--- a/cuda_core/cuda/core/_memory/_device_memory_resource.pyx
+++ b/cuda_core/cuda/core/_memory/_device_memory_resource.pyx
@@ -20,6 +20,8 @@ from cuda.core._utils.cuda_utils cimport (
     check_or_create_options,
     HANDLE_RETURN,
 )
+
+import cython
 from dataclasses import dataclass
 import multiprocessing
 import platform  # no-cython-lint
@@ -146,10 +148,11 @@ cdef class DeviceMemoryResource(_MemPool):
     def __cinit__(self, *args, **kwargs) -> None:
         self._dev_id = cydriver.CU_DEVICE_INVALID
 
+    @cython.annotation_typing(False)
     def __init__(
         self,
         device_id: Device | int,
-        options=None
+        options: DeviceMemoryResourceOptions | None = None
     ) -> None:
         _DMR_init(self, device_id, options)
 

--- a/cuda_core/cuda/core/_memory/_managed_memory_resource.pyx
+++ b/cuda_core/cuda/core/_memory/_managed_memory_resource.pyx
@@ -13,6 +13,7 @@ from cuda.core._utils.cuda_utils cimport HANDLE_RETURN
 from cuda.core._utils.cuda_utils cimport check_or_create_options  # no-cython-lint
 from cuda.core._utils.cuda_utils import CUDAError  # no-cython-lint
 
+import cython
 from dataclasses import dataclass
 import threading
 from typing import TYPE_CHECKING
@@ -97,7 +98,8 @@ cdef class ManagedMemoryResource(_MemPool):
     memory pools.
     """
 
-    def __init__(self, options=None) -> None:
+    @cython.annotation_typing(False)
+    def __init__(self, options: ManagedMemoryResourceOptions | None = None) -> None:
         _MMR_init(self, options)
 
     def allocate(self, size_t size, *, stream: Stream | GraphBuilder) -> ManagedBuffer:

--- a/cuda_core/cuda/core/_memory/_managed_memory_resource.pyx
+++ b/cuda_core/cuda/core/_memory/_managed_memory_resource.pyx
@@ -97,7 +97,7 @@ cdef class ManagedMemoryResource(_MemPool):
     memory pools.
     """
 
-    def __init__(self, options: ManagedMemoryResourceOptions | None = None) -> None:
+    def __init__(self, options=None) -> None:
         _MMR_init(self, options)
 
     def allocate(self, size_t size, *, stream: Stream | GraphBuilder) -> ManagedBuffer:

--- a/cuda_core/cuda/core/_memory/_pinned_memory_resource.pyx
+++ b/cuda_core/cuda/core/_memory/_pinned_memory_resource.pyx
@@ -109,7 +109,7 @@ cdef class PinnedMemoryResource(_MemPool):
     See :class:`DeviceMemoryResource` for more details on IPC usage patterns.
     """
 
-    def __init__(self, options: PinnedMemoryResourceOptions | None = None) -> None:
+    def __init__(self, options=None) -> None:
         _PMR_init(self, options)
 
     def allocate(self, size_t size, *, stream: Stream | GraphBuilder) -> Buffer:

--- a/cuda_core/cuda/core/_memory/_pinned_memory_resource.pyx
+++ b/cuda_core/cuda/core/_memory/_pinned_memory_resource.pyx
@@ -21,6 +21,7 @@ from cuda.core._utils.cuda_utils cimport (
     HANDLE_RETURN,
 )
 
+import cython
 from dataclasses import dataclass
 import multiprocessing
 import platform  # no-cython-lint
@@ -109,7 +110,8 @@ cdef class PinnedMemoryResource(_MemPool):
     See :class:`DeviceMemoryResource` for more details on IPC usage patterns.
     """
 
-    def __init__(self, options=None) -> None:
+    @cython.annotation_typing(False)
+    def __init__(self, options: PinnedMemoryResourceOptions | None = None) -> None:
         _PMR_init(self, options)
 
     def allocate(self, size_t size, *, stream: Stream | GraphBuilder) -> Buffer:

--- a/cuda_core/cuda/core/_stream.pyx
+++ b/cuda_core/cuda/core/_stream.pyx
@@ -123,6 +123,7 @@ cdef class Stream:
         return Stream._from_handle(cls, get_per_thread_stream())
 
     @classmethod
+    @cython.annotation_typing(False)
     def _init(cls, obj: IsStreamType | None = None, options: StreamOptions | None = None,
               device_id: int | None = None, ctx: Context | None = None) -> Stream:
         cdef StreamHandle h_stream

--- a/cuda_core/tests/memory/test_backward_compatibility.py
+++ b/cuda_core/tests/memory/test_backward_compatibility.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backward-compatibility checks for undocumented dict options in MR constructors."""
+
+import pytest
+from helpers.constants import POOL_SIZE
+from helpers.memory import (
+    create_managed_memory_resource_or_skip,
+    create_pinned_memory_resource_or_xfail,
+    skip_if_managed_memory_unsupported,
+    skip_if_pinned_memory_unsupported,
+)
+
+from cuda.core import Device, DeviceMemoryResource
+
+
+@pytest.mark.agent_authored(model="gpt-5.3-codex")
+def test_device_mr_accepts_dict_keyword(init_cuda):
+    device = Device()
+    if not device.properties.memory_pools_supported:
+        pytest.skip("Device does not support memory pool operations")
+    device.set_current()
+    mr = DeviceMemoryResource(device, options={"max_size": POOL_SIZE})
+    buf = mr.allocate(64, stream=device.default_stream)
+    buf.close(stream=device.default_stream)
+    mr.close()
+
+
+@pytest.mark.agent_authored(model="gpt-5.3-codex")
+def test_pinned_mr_accepts_dict_keyword(init_cuda):
+    device = Device()
+    skip_if_pinned_memory_unsupported(device)
+    device.set_current()
+    mr = create_pinned_memory_resource_or_xfail(options={"max_size": POOL_SIZE}, xfail_device=device)
+    buf = mr.allocate(64, stream=device.default_stream)
+    buf.close(stream=device.default_stream)
+    mr.close()
+
+
+@pytest.mark.agent_authored(model="gpt-5.3-codex")
+def test_managed_mr_accepts_dict_keyword(init_cuda):
+    device = Device()
+    skip_if_managed_memory_unsupported(device)
+    device.set_current()
+    mr = create_managed_memory_resource_or_skip(options={})
+    buf = mr.allocate(64, stream=device.default_stream)
+    buf.close(stream=device.default_stream)
+    mr.close()

--- a/cuda_core/tests/test_stream.py
+++ b/cuda_core/tests/test_stream.py
@@ -28,6 +28,14 @@ def test_stream_init_with_options(init_cuda):
     assert stream.priority == 0
 
 
+@pytest.mark.agent_authored(model="glm-5.2")
+def test_stream_init_with_dict_options(init_cuda):
+    """Device.create_stream accepts a plain dict for options (backward compat)."""
+    stream = Device().create_stream(options={"nonblocking": True, "priority": 0})
+    assert stream.is_nonblocking is True
+    assert stream.priority == 0
+
+
 def test_stream_handle(init_cuda):
     stream = Device().create_stream(options=StreamOptions())
     assert isinstance(stream.handle, driver.CUstream)


### PR DESCRIPTION
Restores undocumented dict acceptance for `options` in several `cuda.core` constructors/methods, which was inadvertently removed by #2619. Covers the three memory-resource constructors and the stream-creation path (`Stream._init`, `Context.create_stream`).

## Why this is necessary

`check_or_create_options` (`cuda_core/cuda/core/_utils/cuda_utils.pyx`) normalizes a plain `dict` into the options dataclass via `cls(**options)`, so passing a dict for `options` has always worked at runtime. The options classes (`DeviceMemoryResourceOptions`, `StreamOptions`, etc.) are `@dataclass cdef class` — Cython extension types.

Cython enforces PEP-484 parameter annotations at the call boundary of `def` methods on `cdef class`es: when a parameter is annotated with an extension type, Cython emits a runtime `isinstance` check that rejects other types (including `dict`) with `TypeError` before the method body runs. See the ["Extension types and None" section of the Extension Types guide](https://docs.cython.org/en/latest/src/userguide/extension_types.html#extension-types-and-none).

#2619 removed `| dict[str, object]` from these annotations so the public stubs would show only the typed dataclass. That was correct in spirit, but it turned the call-boundary check into a regression: dicts that previously flowed through to `check_or_create_options` now get rejected at the boundary, silently breaking any code relying on the dict shorthand.

## What this PR does

Applies Cython's `@cython.annotation_typing(False)` compiler directive to each affected `def` method. The directive tells Cython to ignore the PEP-484 annotations for its own type analysis, so the parameter is treated as a generic `object` at the call boundary and dicts pass through to `check_or_create_options`. The annotations remain in the source and are still picked up by `stubgen-pyx`, so the generated `.pyi` stubs naturally show the clean `XxxOptions | None` signature — no stub postprocessor needed. See the ["Disabling annotations" section of the Pure Python Mode guide](https://docs.cython.org/en/latest/src/tutorial/pure.html#disabling-annotations).

## Changes

- `cuda_core/cuda/core/_memory/_device_memory_resource.pyx`, `_managed_memory_resource.pyx`, `_pinned_memory_resource.pyx`: `@cython.annotation_typing(False)` on each `__init__`; `options` annotation restored to `XxxOptions | None = None`.
- `cuda_core/cuda/core/_stream.pyx`: `@cython.annotation_typing(False)` on `Stream._init`.
- `cuda_core/cuda/core/_context.pyx`: `@cython.annotation_typing(False)` on `Context.create_stream`.
- `tests/memory/test_backward_compatibility.py`: tests asserting each memory-resource constructor accepts a plain dict for `options`.
- `tests/test_stream.py`: test asserting `Device.create_stream` accepts a plain dict for `options`.

Generated `.pyi` stubs are unchanged by re-running `stubgen-pyx` (idempotent): the directive is invisible to the stub generator and the source annotations are preserved verbatim.

closes #2248