### PR TITLE
Remove timing-sensitive NVML total-energy test

### DIFF
--- a/cuda_bindings/tests/nvml/test_pynvml.py
+++ b/cuda_bindings/tests/nvml/test_pynvml.py
@@ -4,7 +4,6 @@
 # A set of tests ported from https://github.com/gpuopenanalytics/pynvml/blob/11.5.3/pynvml/tests/test_nvml.py
 
 import os
-import time
 
 import pytest
 
@@ -148,23 +147,6 @@ def test_device_get_power_usage(ngpus, handles, subtests):
             with unsupported_before(handles[i], None):
                 power_mwatts = nvml.device_get_power_usage(handles[i])
             assert power_mwatts >= 0.0
-
-
-def test_device_get_total_energy_consumption(ngpus, handles, subtests):
-    for i in range(ngpus):
-        with subtests.test(device_index=i):
-            with unsupported_before(handles[i], None):
-                energy_mjoules1 = nvml.device_get_total_energy_consumption(handles[i])
-
-            for _ in range(10):  # idle for 150 ms
-                time.sleep(0.015)  # and check for increase every 15 ms
-                with unsupported_before(handles[i], None):
-                    energy_mjoules2 = nvml.device_get_total_energy_consumption(handles[i])
-                assert energy_mjoules2 >= energy_mjoules1
-                if energy_mjoules2 > energy_mjoules1:
-                    break
-            else:
-                raise AssertionError("energy did not increase across 150 ms interval")
 
 
 # [Skipping] pynvml.nvmlDeviceGetGpuOperationMode


### PR DESCRIPTION
## Description

Addresses cuda-python-private issue 509.

Removes the timing-sensitive `test_device_get_total_energy_consumption` bootstrap test. NVML does not guarantee a refresh cadence, so requiring the cumulative energy counter to advance within 150 ms can fail even when the binding is working correctly.

## Checklist

- [x] New or existing tests cover these changes. (Not applicable: this removes a timing-sensitive bootstrap test without changing product code.)
- [x] The documentation is up to date with these changes. (No documentation changes are required.)
