### PR TITLE
Fix Windows Cython test build paths

### DIFF
--- a/cuda_bindings/tests/cython/build_tests.bat
+++ b/cuda_bindings/tests/cython/build_tests.bat
@@ -4,7 +4,9 @@ REM SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIA
 REM SPDX-License-Identifier: Apache-2.0
 
 setlocal
-	set CL=%CL% /I"%CUDA_HOME%\include"
-	REM Use -j 1 to side-step any process-pool issues and ensure deterministic single-threaded builds
-	cythonize -3 -j 1 -i -Xfreethreading_compatible=True %~dp0test_*.pyx
-endlocal
+set CL=%CL% /I"%CUDA_HOME%\include"
+REM The Python driver provides Cython's .pxd include path and builds in this
+REM directory so Windows does not duplicate the checkout path in link outputs.
+python "%~dp0build_tests.py"
+set "BUILD_RESULT=%ERRORLEVEL%"
+endlocal & exit /b %BUILD_RESULT%

--- a/cuda_bindings/tests/cython/build_tests.py
+++ b/cuda_bindings/tests/cython/build_tests.py
@@ -34,7 +34,10 @@ def _bindings_source_root() -> Path:
 
 def main() -> None:
     script_dir = Path(__file__).resolve().parent
-    pyx_files = sorted(str(p) for p in script_dir.glob("test_*.pyx"))
+    # Avoid appending the absolute checkout path under build/temp: the
+    # concatenated path can exceed Windows' path limit. These files are siblings.
+    os.chdir(script_dir)
+    pyx_files = sorted(p.name for p in script_dir.glob("test_*.pyx"))
     if not pyx_files:
         raise SystemExit(f"no test_*.pyx files under {script_dir}")
 
@@ -46,13 +49,8 @@ def main() -> None:
         compiler_directives={"freethreading_compatible": True},
     )
 
-    # `build_ext --inplace` places the compiled .so relative to the current
-    # working directory, but pixi runs this task from the project root. pytest
-    # imports each extension by bare module name (see test_cython.py), which
-    # only resolves when the .so sits in tests/cython (the dir pytest puts on
-    # sys.path). chdir here so the .so lands next to its .pyx regardless of the
-    # invoking cwd.
-    os.chdir(script_dir)
+    # pytest imports each extension by bare module name (see test_cython.py),
+    # so build in-place next to its .pyx regardless of the invoking cwd.
     sys.argv = [sys.argv[0], "build_ext", "--inplace"]
     setup(name="cuda_bindings_cython_tests", ext_modules=ext_modules)
 


### PR DESCRIPTION
## Description

Extracted from ctk-next 13.4 developments (PR 501).

Use the existing Python Cython-test build driver from the Windows batch wrapper, and pass source names relative to `tests/cython` after changing into that directory. This avoids duplicating the absolute checkout path under `build/temp`, which can exceed the Windows path-length limit in deeper checkouts.

The wrapper now also propagates the Python driver's exit status explicitly.

## Validation

- The exact change was exercised by ctk-next 13.4 Windows AMD64 and ARM64 runbook builds.
- `build_tests.py` passes Python bytecode compilation.
- `pre-commit run --all-files` passes.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
