### PR TITLE
Guard unsupported NVML clock-domain queries in tests

### DIFF
--- a/cuda_core/tests/system/test_system_device.py
+++ b/cuda_core/tests/system/test_system_device.py
@@ -590,7 +590,10 @@ def test_clock(subtests):
                 with unsupported_before(device, None):
                     pstate = device.performance_state
 
-                min_, max_ = clock.get_min_max_clock_of_pstate_mhz(pstate)
+                # Individual queries may be unsupported for a clock domain even
+                # on newer devices.
+                with unsupported_before(device, None):
+                    min_, max_ = clock.get_min_max_clock_of_pstate_mhz(pstate)
                 assert isinstance(min_, int)
                 assert min_ >= 0
                 assert isinstance(max_, int)
@@ -601,7 +604,7 @@ def test_clock(subtests):
                 assert isinstance(max_mhz, int)
                 assert max_mhz >= 0
 
-                with unsupported_before(device, DeviceArch.KEPLER):
+                with unsupported_before(device, None):
                     current_mhz = clock.get_current_mhz()
                 assert isinstance(current_mhz, int)
                 assert current_mhz >= 0


### PR DESCRIPTION
## Description

Extracted from ctk-next 13.4 developments (PRs 523, 525) after broader platform testing exposed clock domains for which individual NVML queries are unsupported.

Guard the per-domain minimum/maximum and current-clock queries independently with the existing `unsupported_before` helper. GPU architecture generation alone is not sufficient to predict support for every clock-domain query.

## Validation

- Focused `test_clock` run: `2 passed`, `2 skipped`, and `3 subtests passed`.
- The exact change also passed broader ctk-next 13.4 Linux and Windows validation on AMD64 and ARM64.
- `pre-commit run --all-files` passes.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
