### PR TITLE
fix: clear bindings dir before adding prior wheel

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -587,12 +587,14 @@ jobs:
           OLD_BRANCH=$(yq '.backport_branch' ci/versions.yml)
           OLD_BASENAME="cuda-bindings-python${PYTHON_VERSION_FORMATTED}-cuda*-${{ inputs.host-platform }}*"
           LATEST_PRIOR_RUN_ID=$(./ci/tools/lookup-run-id --branch "${OLD_BRANCH}" NVIDIA/cuda-python "CI")
-          PREV_BINDINGS_DIR="cuda_bindings/dist-prev"
+          PREV_BINDINGS_DIR="${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}"
 
           gh run download $LATEST_PRIOR_RUN_ID -p ${OLD_BASENAME} -R NVIDIA/cuda-python
           rm -rf ${OLD_BASENAME}-tests  # exclude cython test artifacts
           ls -al $OLD_BASENAME
           mkdir -p "${PREV_BINDINGS_DIR}"
+          # Clear any current-CUDA wheel so only the prior wheel is staged.
+          rm -f "${PREV_BINDINGS_DIR}"/*.whl
           mv $OLD_BASENAME/*.whl "${PREV_BINDINGS_DIR}"
           rmdir $OLD_BASENAME
 
@@ -600,7 +602,7 @@ jobs:
         if: ${{ inputs.build-core }}
         run: |
           pathfinder_wheels=(cuda_pathfinder/cuda_pathfinder-*.whl)
-          bindings_wheels=(cuda_bindings/dist-prev/cuda_bindings-"${BUILD_PREV_CUDA_MAJOR}".*.whl)
+          bindings_wheels=("${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}"/cuda_bindings-"${BUILD_PREV_CUDA_MAJOR}".*.whl)
           test "${#pathfinder_wheels[@]}" -eq 1
           test "${#bindings_wheels[@]}" -eq 1
           test -f "${pathfinder_wheels[0]}"
@@ -617,6 +619,20 @@ jobs:
             printf 'cuda-pathfinder @ %s\n' "${pathfinder_uri}"
             printf 'cuda-bindings @ %s\n' "${bindings_uri}"
           } | tee wheel-constraints/cuda-core-prev.txt
+
+      - name: Verify prior cuda.bindings staging
+        if: ${{ inputs.build-core }}
+        run: |
+          # Ensure the staging directory contains exactly one wheel so pip cannot
+          # accidentally resolve a different cuda.bindings version.
+          shopt -s nullglob
+          whl_files=("${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}"/*.whl)
+          shopt -u nullglob
+          if [[ "${#whl_files[@]}" -ne 1 ]]; then
+            echo "Expected exactly one wheel in ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}, found ${#whl_files[@]}:"
+            ls -la "${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}"
+            exit 1
+          fi
 
       - name: Build cuda.core wheel
         if: ${{ inputs.build-core }}


### PR DESCRIPTION
This PR addresses the following issue in `.github/workflows/build-wheel.yml`: clear bindings dir before adding prior wheel.

## Changes
- `.github/workflows/build-wheel.yml`: clear bindings dir before adding prior wheel.

## Details
```diff
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -1,15 +1,17 @@
-          OLD_BRANCH=$(yq '.backport_branch' ci/versions.yml)
-          OLD_BASENAME="cuda-bindings-python${PYTHON_VERSION_FORMATTED}-cuda*-${{ inputs.host-platform }}*"
-          LATEST_PRIOR_RUN_ID=$(./ci/tools/lookup-run-id --branch "${OLD_BRANCH}" NVIDIA/cuda-python "CI")
-          PREV_BINDINGS_DIR="cuda_bindings/dist-prev"
-
-          gh run download $LATEST_PRIOR_RUN_ID -p ${OLD_BASENAME} -R NVIDIA/cuda-python
-          rm -rf ${OLD_BASENAME}-tests  # exclude cython test artifacts
-          ls -al $OLD_BASENAME
-          mkdir -p "${PREV_BINDINGS_DIR}"
-          mv $OLD_BASENAME/*.whl "${PREV_BINDINGS_DIR}"
-          rmdir $OLD_BASENAME
-...
-      - name: Constrain previous cuda.core to the downloaded cuda.bindings wheel
-        ...
-          bindings_wheels=(cuda_bindings/dist-prev/cuda_bindings-"${BUILD_PREV_CUDA_MAJOR}".*.whl)
+          OLD_BRANCH=$(yq '.backport_branch' ci/versions.yml)
+          OLD_BASENAME="cuda-bindings-python${PYTHON_VERSION_FORMATTED}-cuda*-${{ inputs.host-platform }}*"
+          LATEST_PRIOR_RUN_ID=$(./ci/tools/lookup-run-id --branch "${OLD_BRANCH}" NVIDIA/cuda-python "CI")
+          PREV_BINDINGS_DIR="${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}"
+
+          gh run download $LATEST_PRIOR_RUN_ID -p ${OLD_BASENAME} -R NVIDIA/cuda-python
+          rm -rf ${OLD_BASENAME}-tests  # exclude cython test artifacts
+          ls -al $OLD_BASENAME
+          mkdir -p "${PREV_BINDINGS_DIR}"
+          # Clear any current-CUDA wheel so only the prior wheel is staged.
+          rm -f "${PREV_BINDINGS_DIR}"/*.whl
+          mv $OLD_BASENAME/*.whl "${PREV_BINDINGS_DIR}"
+          rmdir $OLD_BASENAME
+...
+      - name: Constrain previous cuda.core to the downloaded cuda.bindings wheel
+        ...
+          bindings_wheels=("${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}"/cuda_bindings-"${BUILD_PREV_CUDA_MAJOR}".*.whl)
```

## Tests
- `.github/workflows/build-wheel.yml`

```diff
--- .github/workflows/build-wheel.yml
+++ .github/workflows/build-wheel.yml
@@ -540,6 +540,17 @@
             printf 'cuda-bindings @ %s\n' "${bindings_uri}"
           } | tee wheel-constraints/cuda-core-prev.txt
 
+      - name: Verify prior cuda.bindings staging
+        if: ${{ inputs.build-core }}
+        run: |
+          # Ensure the staging directory contains exactly one wheel so pip cannot
+          # accidentally resolve a different cuda.bindings version.
+          shopt -s nullglob
+          whl_files=("${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}"/*.whl)
+          shopt -u nullglob
+          if [[ "${#whl_files[@]}" -ne 1 ]]; then
+            echo "Expected exactly one wheel in ${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}, found ${#whl_files[@]}:"
+            ls -la "${{ env.CUDA_BINDINGS_ARTIFACTS_DIR }}"
+            exit 1
+          fi
+
       - name: Build cuda.core wheel
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).