### PR TITLE
Run nightly CI only in the public repository

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -49,6 +49,7 @@ jobs:
           python -m pytest -v --noconftest ci/tools/tests
 
   find-wheels:
+    if: ${{ github.repository_owner == 'nvidia' }}
     runs-on: ubuntu-latest
     outputs:
       RUN_ID: ${{ steps.find.outputs.run_id }}
@@ -309,7 +310,7 @@ jobs:
 
   checks:
     name: Nightly check status
-    if: always()
+    if: ${{ always() && github.repository_owner == 'nvidia' }}
     runs-on: ubuntu-latest
     needs:
       - test-ci-tools-for-release


### PR DESCRIPTION
## Description
Skip artifact discovery and aggregate status outside the `NVIDIA` github organization, matching the existing public-only guards on the nightly test jobs.

This resolves distracting CI failures in the internal repository.

Internal tracking issue: 529