### PR TITLE
Restore clock-event enum coverage with older bindings

### DIFF
--- a/cuda_core/tests/test_enum_coverage.py
+++ b/cuda_core/tests/test_enum_coverage.py
@@ -128,6 +128,15 @@ if system.CUDA_BINDINGS_NVML_IS_COMPATIBLE:
 
     _MODULES.append(system_typing)
 
+    _CLOCKS_EVENT_REASONS_STR_UNMAPPED = {
+        core_member
+        for binding_member, core_member in (
+            ("EVENT_REASON_BOARD_LIMIT", "BOARD_LIMIT"),
+            ("EVENT_REASON_RELIABILITY", "RELIABILITY"),
+        )
+        if binding_member not in nvml.ClocksEventReasons.__members__
+    }
+
     _CASES.extend(
         [
             (
@@ -160,7 +169,7 @@ if system.CUDA_BINDINGS_NVML_IS_COMPATIBLE:
                 system_typing.ClocksEventReasons,
                 _device._CLOCKS_EVENT_REASONS_MAPPING,
                 set(),
-                set(),
+                _CLOCKS_EVENT_REASONS_STR_UNMAPPED,
             ),
             (
                 nvml.EventType,


### PR DESCRIPTION
@mdboom, could you please advise on the intended long-term solution? Given the compatibility matrix we currently run, the narrow dynamic allowance seems appropriate, but I do not want to undo the earlier removal (see History) without understanding its intent.
___

## Summary

Restore a narrowly scoped compatibility allowance in `test_enum_coverage.py` for `ClocksEventReasons.BOARD_LIMIT` and `ClocksEventReasons.RELIABILITY` when the installed `cuda.bindings` version predates the corresponding NVML enum names.

The allowance is computed dynamically. When the binding names exist, the set is empty and the ordinary full-coverage check still applies. This changes only the coverage test; it does not change runtime behavior.

## Why this is needed

This surfaced while validating #2641. That branch exposes the two newer `cuda.core` clock-event members, while its compatibility matrix also tests against older CUDA 12.9 and 13.3 `cuda.bindings` packages. All 11 failing Linux ARM64 jobs reached the same enum-coverage case: the wrapper had `BOARD_LIMIT` and `RELIABILITY`, but those older bindings did not yet have `EVENT_REASON_BOARD_LIMIT` and `EVENT_REASON_RELIABILITY`.

The production mapping intentionally supports this package-version combination by using the stable numeric NVML values when the names are absent. The coverage test's member-count check did not model that exception and therefore rejected a combination that the runtime mapping handles deliberately. Commit df5356dddd204f0611abac7e19b9ddaa7543630b on #2641 restored this dynamic allowance so the older-bindings rows could continue checking every member they actually provide.

## History

The history is less straightforward than the resulting change:

- The same targeted allowance entered public [PR 2437](https://github.com/NVIDIA/cuda-python/pull/2437) through commit c8c60dbf1c59ddd73e6d9b19126566fbfe0d8806.
- It was then removed it in commit aa10ee9879973c3518de844922cf7681fb046265 (`Fix enum handling`) before PR 2437 was merged.
- Public [PR 2451](https://github.com/NVIDIA/cuda-python/pull/2451) subsequently changed the generic coverage test to tolerate the opposite version skew: newer bindings may contain members that an older `cuda.core` wrapper does not yet expose.
- The PR 2451 behavior does not cover the case seen in [PR 2641](https://github.com/NVIDIA/cuda-python/pull/2641), where the wrapper is newer than the installed bindings. The targeted allowance was therefore reintroduced there.