### PR TITLE
Avoid aggregate `CUmemLocation` initialization

### DIFF
--- a/cuda_core/cuda/core/_memory/_device_memory_resource.pyx
+++ b/cuda_core/cuda/core/_memory/_device_memory_resource.pyx
@@ -321,10 +321,9 @@ cpdef str DMR_mempool_get_access(DeviceMemoryResource dmr, int device_id):
 
     cdef int dev_id = Device(device_id).device_id
     cdef cydriver.CUmemAccess_flags flags
-    cdef cydriver.CUmemLocation location = cydriver.CUmemLocation(
-        type=cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE,
-        id=dev_id,
-    )
+    cdef cydriver.CUmemLocation location
+    location.type = cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+    location.id = dev_id
 
     with nogil:
         HANDLE_RETURN(cydriver.cuMemPoolGetAccess(&flags, as_cu(dmr._h_pool), &location))

--- a/cuda_core/cuda/core/_memory/_location.pxd
+++ b/cuda_core/cuda/core/_memory/_location.pxd
@@ -15,24 +15,22 @@ from cuda.bindings cimport cydriver
 
 IF CUDA_CORE_BUILD_MAJOR >= 13:
     cdef inline cydriver.CUmemLocation to_cumemlocation(str kind, int loc_id):
+        cdef cydriver.CUmemLocation cu_loc
         if kind == "device":
-            return cydriver.CUmemLocation(
-                type=cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE,
-                id=loc_id)
+            cu_loc.type = cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+            cu_loc.id = loc_id
         elif kind == "host":
-            return cydriver.CUmemLocation(
-                type=cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_HOST,
-                id=0)
+            cu_loc.type = cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_HOST
+            cu_loc.id = 0
         elif kind == "host_numa":
-            return cydriver.CUmemLocation(
-                type=cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_HOST_NUMA,
-                id=loc_id)
+            cu_loc.type = cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_HOST_NUMA
+            cu_loc.id = loc_id
         elif kind == "host_numa_current":
-            return cydriver.CUmemLocation(
-                type=cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_HOST_NUMA_CURRENT,
-                id=0)
+            cu_loc.type = cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_HOST_NUMA_CURRENT
+            cu_loc.id = 0
         else:
             raise ValueError(f"unknown location kind: {kind!r}")
+        return cu_loc
 ELSE:
     cdef inline cydriver.CUmemLocation to_cumemlocation(str kind, int loc_id):
         raise NotImplementedError(

--- a/cuda_core/cuda/core/_memory/_managed_memory_ops.pyx
+++ b/cuda_core/cuda/core/_memory/_managed_memory_ops.pyx
@@ -193,9 +193,8 @@ cdef void _do_single_advise(Buffer buf, object advice_value, object loc, bint al
             # Driver ignores location for read_mostly / unset_preferred_location
             # advice values but still validates the CUmemLocation; pass a
             # host placeholder.
-            cu_loc = cydriver.CUmemLocation(
-                type=cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_HOST,
-                id=0)
+            cu_loc.type = cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_HOST
+            cu_loc.id = 0
         else:
             cu_loc = to_cumemlocation(loc.kind, loc.id)
         with nogil:

--- a/cuda_core/cuda/core/_memory/_memory_pool.pyx
+++ b/cuda_core/cuda/core/_memory/_memory_pool.pyx
@@ -279,8 +279,9 @@ cdef int MP_init_current_pool(
     """
     IF CUDA_CORE_BUILD_MAJOR >= 13:
         cdef cydriver.CUmemoryPool pool
-        cdef cydriver.CUmemLocation loc = cydriver.CUmemLocation(
-            type=loc_type, id=loc_id)
+        cdef cydriver.CUmemLocation loc
+        loc.type = loc_type
+        loc.id = loc_id
         with nogil:
             HANDLE_RETURN(cydriver.cuMemGetMemPool(&pool, &loc, alloc_type))
         self._h_pool = create_mempool_handle_ref(pool)

--- a/cuda_core/cuda/core/_memory/_peer_access_utils.pyx
+++ b/cuda_core/cuda/core/_memory/_peer_access_utils.pyx
@@ -113,10 +113,9 @@ cdef inline tuple _query_peer_access_ids(DeviceMemoryResource mr):
 cdef inline bint _peer_access_includes(DeviceMemoryResource mr, int dev_id):
     """Return True if peer access from ``dev_id`` is currently granted."""
     cdef cydriver.CUmemAccess_flags flags
-    cdef cydriver.CUmemLocation location = cydriver.CUmemLocation(
-        type=cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE,
-        id=dev_id,
-    )
+    cdef cydriver.CUmemLocation location
+    location.type = cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+    location.id = dev_id
     with nogil:
         HANDLE_RETURN(cydriver.cuMemPoolGetAccess(&flags, as_cu(mr._h_pool), &location))
     return flags == cydriver.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE

--- a/cuda_core/cuda/core/graph/_graph_node.pyx
+++ b/cuda_core/cuda/core/graph/_graph_node.pyx
@@ -827,6 +827,7 @@ cdef inline AllocNode GN_alloc(GraphNode self, size_t size, object device,
         num_deps = 1
 
     cdef vector[cydriver.CUmemAccessDesc] access_descs
+    cdef cydriver.CUmemAccessDesc access_desc
     cdef int peer_id
     cdef list peer_ids = []
 
@@ -834,13 +835,10 @@ cdef inline AllocNode GN_alloc(GraphNode self, size_t size, object device,
         for peer_dev in peer_access:
             peer_id = getattr(peer_dev, 'device_id', peer_dev)
             peer_ids.append(peer_id)
-            access_descs.push_back(cydriver.CUmemAccessDesc_st(
-                cydriver.CUmemLocation_st(
-                    cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE,
-                    peer_id
-                ),
-                cydriver.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
-            ))
+            access_desc.location.type = cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+            access_desc.location.id = peer_id
+            access_desc.flags = cydriver.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
+            access_descs.push_back(access_desc)
 
     cdef str memory_type_str = "device" if memory_type is None else str(memory_type)
 


### PR DESCRIPTION
## Summary

Initialize `CUmemLocation` structures by declaring them and assigning the active `type` and `id` fields instead of using Cython aggregate constructors. Apply the same pattern when constructing the nested `CUmemLocation` inside `CUmemAccessDesc`.

This preserves the existing behavior while keeping the source compatible with both the older two-member generated declaration and the newer CUDA 13.4 declaration.

## Rationale

This issue surfaced while building #2641. Public main's `cuda.core` source used aggregate initializers such as:

```cython
cydriver.CUmemLocation(type=..., id=...)
```

The older generated declaration exposed only `type` and `id`, making that initializer complete. CUDA 13.4 adds the `localized` arm to the anonymous location union, so the generated Cython declaration exposes `type`, `id`, and `localized`. With that declaration, Cython reports:

```text
Not all members given for struct 'CUmemLocation'
```

All affected paths currently construct location kinds whose active payload is `id`: `DEVICE`, `HOST`, `HOST_NUMA`, or `HOST_NUMA_CURRENT`. They do not construct `DEVICE_LOCALITY_DOMAIN`, which uses the `localized` arm. Declaring the structure and assigning only its active fields therefore expresses the intended union use directly and compiles against both generated layouts.

This is a source-compatibility change only; it does not alter the selected location types, IDs, access flags, or runtime control flow.

## Note for completeness

The aggregate initialization style entered through #2434 and was valid for the generated binding declaration available at that time. Public PR #2593 later centralized one of the location conversions in `_memory/_location.pxd`, so this patch updates that shared helper as well as the original call sites. This is a narrow compatibility follow-up that preserves the broader refactoring in those PRs.