### PR TITLE
CI: build Windows ARM64 wheels for stable CUDA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,18 @@ jobs:
           cuda_build_channel=$(yq '.cuda.build.channel // "stable"' ci/versions.yml)
           echo "cuda_build_channel=$cuda_build_channel" >> $GITHUB_OUTPUT
 
-          windows_arm64_supported=$(yq '.cuda.build.windows_arm64 // false' ci/versions.yml)
+          if [[ "$cuda_build_ver" =~ ^([0-9]+)\.([0-9]+)(\.|$) ]]; then
+            cuda_build_major="${BASH_REMATCH[1]}"
+            cuda_build_minor="${BASH_REMATCH[2]}"
+          else
+            echo "Invalid CUDA build version: $cuda_build_ver" >&2
+            exit 1
+          fi
+          if (( cuda_build_major > 13 || (cuda_build_major == 13 && cuda_build_minor >= 4) )); then
+            windows_arm64_supported=true
+          else
+            windows_arm64_supported=false
+          fi
           echo "windows_arm64_supported=$windows_arm64_supported" >> $GITHUB_OUTPUT
 
           cuda_prev_build_ver=$(yq '.cuda.prev_build.version' ci/versions.yml)
@@ -327,14 +338,14 @@ jobs:
       cuda-channel: ${{ needs.ci-vars.outputs.CUDA_BUILD_CHANNEL }}
       prev-cuda-version: ${{ needs.ci-vars.outputs.CUDA_PREV_BUILD_VER }}
 
-  # Windows ARM64 supports only the current CUDA major because the platform is
-  # new in CUDA 13.4; no prior-major toolkit or wheel artifacts exist.
+  # Windows ARM64 is available starting with CUDA 13.4. Build only the current
+  # CUDA major because no prior-major toolkit or wheel artifacts exist.
   build-windows-arm64:
     needs:
       - ci-vars
       - should-skip
     name: Build win-arm64, CUDA ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
-    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.skip) && !fromJSON(needs.should-skip.outputs.doc-only) && fromJSON(needs.ci-vars.outputs.WINDOWS_ARM64_SUPPORTED) }}
+    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.skip) && !fromJSON(needs.should-skip.outputs.doc-only) && needs.ci-vars.outputs.WINDOWS_ARM64_SUPPORTED == 'true' }}
     secrets: inherit
     uses: ./.github/workflows/build-wheel.yml
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
     outputs:
       CUDA_BUILD_VER: ${{ steps.get-vars.outputs.cuda_build_ver }}
       CUDA_BUILD_CHANNEL: ${{ steps.get-vars.outputs.cuda_build_channel }}
+      WINDOWS_ARM64_SUPPORTED: ${{ steps.get-vars.outputs.windows_arm64_supported }}
       CUDA_PREV_BUILD_VER: ${{ steps.get-vars.outputs.cuda_prev_build_ver }}
     steps:
       - name: Checkout repository
@@ -46,6 +47,9 @@ jobs:
 
           cuda_build_channel=$(yq '.cuda.build.channel // "stable"' ci/versions.yml)
           echo "cuda_build_channel=$cuda_build_channel" >> $GITHUB_OUTPUT
+
+          windows_arm64_supported=$(yq '.cuda.build.windows_arm64 // false' ci/versions.yml)
+          echo "windows_arm64_supported=$windows_arm64_supported" >> $GITHUB_OUTPUT
 
           cuda_prev_build_ver=$(yq '.cuda.prev_build.version' ci/versions.yml)
           echo "cuda_prev_build_ver=$cuda_prev_build_ver" >> $GITHUB_OUTPUT
@@ -330,7 +334,7 @@ jobs:
       - ci-vars
       - should-skip
     name: Build win-arm64, CUDA ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
-    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.skip) && !fromJSON(needs.should-skip.outputs.doc-only) && needs.ci-vars.outputs.CUDA_BUILD_CHANNEL == 'prerelease' }}
+    if: ${{ github.repository_owner == 'nvidia' && !fromJSON(needs.should-skip.outputs.skip) && !fromJSON(needs.should-skip.outputs.doc-only) && fromJSON(needs.ci-vars.outputs.WINDOWS_ARM64_SUPPORTED) }}
     secrets: inherit
     uses: ./.github/workflows/build-wheel.yml
     with:
@@ -504,6 +508,7 @@ jobs:
 
           doc_only="${{ needs.should-skip.outputs.doc-only }}"
           cuda_build_channel="${{ needs.ci-vars.outputs.CUDA_BUILD_CHANNEL }}"
+          windows_arm64_supported="${{ needs.ci-vars.outputs.WINDOWS_ARM64_SUPPORTED }}"
           status="success"
           check_result() {
             name=$1; expected=$2; result=$3
@@ -520,8 +525,8 @@ jobs:
           check_result "detect-changes" "success" "${{ needs.detect-changes.result }}"
           check_result "doc"            "success" "${{ needs.doc.result }}"
 
-          # [doc-only] skips all builds and tests. Windows preview wheel builds
-          # run, but GPU tests remain skipped until suitable runners are available.
+          # [doc-only] skips all builds and tests. Windows GPU tests remain
+          # skipped for prerelease CUDA until suitable runners are available.
           if [[ "$doc_only" == "true" ]]; then
             linux_expected="skipped"
             windows_build_expected="skipped"
@@ -533,11 +538,14 @@ jobs:
             windows_build_expected="success"
             windows_sdist_expected="success"
             if [[ "$cuda_build_channel" == "prerelease" ]]; then
-              windows_arm_build_expected="success"
               windows_test_expected="skipped"
             else
-              windows_arm_build_expected="skipped"
               windows_test_expected="success"
+            fi
+            if [[ "$windows_arm64_supported" == "true" ]]; then
+              windows_arm_build_expected="success"
+            else
+              windows_arm_build_expected="skipped"
             fi
           fi
           check_result "build-windows"      "$windows_build_expected" "${{ needs.build-windows.result }}"

--- a/ci/versions.yml
+++ b/ci/versions.yml
@@ -7,6 +7,5 @@ cuda:
   build:
     version: "13.4.0"
     channel: "prerelease"
-    windows_arm64: true  # Windows ARM64 toolkit support starts with CUDA 13.4
   prev_build:
     version: "12.9.1"

--- a/ci/versions.yml
+++ b/ci/versions.yml
@@ -7,5 +7,6 @@ cuda:
   build:
     version: "13.4.0"
     channel: "prerelease"
+    windows_arm64: true  # Windows ARM64 toolkit support starts with CUDA 13.4
   prev_build:
     version: "12.9.1"


### PR DESCRIPTION
## Description

Closes #2616

Enable Windows ARM64 wheel builds for CUDA 13.4 and newer instead of
restricting them to the prerelease channel. The CI variables job derives
Windows ARM64 support from the configured CUDA major and minor version, so
unsupported older CUDA versions continue to skip the build.

Update the final CI status check to evaluate Windows ARM64 support independently
from the prerelease-only Windows GPU test skip.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
