### PR TITLE
Avoid aggregate graph access descriptor initialization

### DIFF
--- a/cuda_core/cuda/core/graph/_graph_node.pyx
+++ b/cuda_core/cuda/core/graph/_graph_node.pyx
@@ -828,6 +828,7 @@ cdef inline AllocNode GN_alloc(GraphNode self, size_t size, object device,
         num_deps = 1
 
     cdef vector[cydriver.CUmemAccessDesc] access_descs
+    cdef cydriver.CUmemAccessDesc access_desc
     cdef int peer_id
     cdef list peer_ids = []
 
@@ -835,11 +836,10 @@ cdef inline AllocNode GN_alloc(GraphNode self, size_t size, object device,
         for peer_dev in peer_access:
             peer_id = getattr(peer_dev, 'device_id', peer_dev)
             peer_ids.append(peer_id)
-            access_descs.push_back(cydriver.CUmemAccessDesc_st(
-                cumemlocation_from_id(
-                    cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE, peer_id),
-                cydriver.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE,
-            ))
+            access_desc.location = cumemlocation_from_id(
+                cydriver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE, peer_id)
+            access_desc.flags = cydriver.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
+            access_descs.push_back(access_desc)
 
     cdef str memory_type_str = "device" if memory_type is None else str(memory_type)
 


### PR DESCRIPTION
## Description

Follow-up to #2683.

PR #2683 centralizes `CUmemLocation` construction, but the graph allocation path still embeds the returned location in a `CUmemAccessDesc` aggregate constructor. With the CUDA 13.4 generated declaration, that nested aggregate causes Cython to emit an invalid conversion for the added `localized` union arm.

Declare the access descriptor separately and assign its `location` and `flags` fields before adding it to the descriptor vector. This keeps the helper introduced by #2683 and preserves the existing runtime behavior.

Please see ctk-next PR 539 for background on how this escaped attention while validating #2683.

## Validation

- `pre-commit run --all-files`
- The equivalent change is validated against the CUDA 13.4 generated bindings in ctk-next PR 539.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
