### PR TITLE
nvbug 6602863: system_event_set_wait fails on events: resize() on non-owning SystemEventData_v1._data view

### DIFF
--- a/cuda_bindings/cuda/bindings/nvml.pyx
+++ b/cuda_bindings/cuda/bindings/nvml.pyx
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This code was automatically generated across versions from 12.9.1 to 13.3.0. Do not modify it directly.
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=9167da2a3d3194c67c44a0fe8d4d34b3dbd3c0f43061c50b7d238d2044c75509
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=e6b2e2f1456e0ba7ef3201063d4e670ba71db9334bb671005b63224aeecded0a
 
 
 # <<<< PREAMBLE CONTENT >>>>
@@ -28660,7 +28660,7 @@ cpdef object device_get_field_values(intptr_t device, values):
         __status__ = nvmlDeviceGetFieldValues(<Device>device, valuesCount, ptr)
     check_status(__status__)
 
-    values_._data.resize((valuesCount,))
+    values_._data = values_._data[:valuesCount]
     return values_
 
 
@@ -29304,7 +29304,7 @@ cpdef object system_event_set_wait(intptr_t event_set, unsigned int timeout_ms, 
         request[0].dataSize = buffer_size
         __status__ = nvmlSystemEventSetWait(<nvmlSystemEventSetWaitRequest_t*>request)
     check_status(__status__)
-    event_data._data.resize((request[0].numEvent,))
+    event_data._data = event_data._data[:request[0].numEvent]
     return event_data
 
 


### PR DESCRIPTION
A non-owned Numpy array can not be resized, so we have to replace it with a view instead when we truncate it.  (No copy needs to be performed).

Though this comes from the generator, it is actually in hand-written code.

See the nvbug for further details.

This is stubbornly difficult to write a unit test for.  The only system events we can use to test with are BIND/UNBIND.  We could unbind and bind a GPU in another process to generate these events, but that requires `sudo` and an extra idle GPU lying around (which it certainly isn't in the middle of running the tests).  I have tested this locally and SWQA can repeat for us again.  This is just a lesson to move away from hand-written wrapper code so that we can test it (it's easy to test generated code against "mock" API calls -- much harder with our hand-written code at the moment).