### PR TITLE
Recognize CUDA 13.4 cuRAND library names

### DIFF
--- a/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/descriptor_catalog.py
+++ b/cuda_pathfinder/cuda/pathfinder/_dynamic_libs/descriptor_catalog.py
@@ -185,8 +185,8 @@ DESCRIPTOR_CATALOG: tuple[DescriptorSpec, ...] = (
     DescriptorSpec(
         name="curand",
         packaged_with="ctk",
-        linux_sonames=("libcurand.so.10",),
-        windows_dlls=("curand64_10.dll",),
+        linux_sonames=("libcurand.so.10", "libcurand.so.11"),
+        windows_dlls=("curand64_10.dll", "curand64_11.dll"),
         supported_windows_arch=("x64", "arm64"),
         site_packages_linux=("nvidia/cu13/lib", "nvidia/curand/lib"),
         site_packages_windows=_ctk_windows_wheel_dirs("nvidia/cu13/bin", "nvidia/curand/bin"),


### PR DESCRIPTION
## Description

The public `13.4.x` release line already recognizes the cuRAND library names introduced for CUDA 13.4 through #2437. Bring the same descriptor metadata to `main`, so that they will be included with the next pathfinder release:

- Linux: recognize `libcurand.so.11` alongside `libcurand.so.10`.
- Windows: recognize `curand64_11.dll` alongside `curand64_10.dll`.