### PR TITLE
cuda.core: reject a mismatched UUID in register()

### DIFF
--- a/cuda_core/cuda/core/_memory/_ipc.pyx
+++ b/cuda_core/cuda/core/_memory/_ipc.pyx
@@ -292,7 +292,8 @@ cdef _MemPool MP_register(_MemPool self, uuid):
         return existing
     if not self.is_ipc_enabled:
         raise RuntimeError("Memory resource is not IPC-enabled")
-    assert self.uuid is None or self.uuid == uuid
+    if self.uuid is not None and self.uuid != uuid:
+        raise ValueError(f"Memory resource is registered as {self.uuid}, cannot register it as {uuid}")
     registry[uuid] = self
     self._ipc_data._alloc_handle._uuid = uuid
     return self

--- a/cuda_core/docs/source/release/1.2.0-notes.rst
+++ b/cuda_core/docs/source/release/1.2.0-notes.rst
@@ -142,6 +142,13 @@ Fixes and enhancements
   leaves an entry in the memory resource registry.
   (`#2568 <https://github.com/NVIDIA/cuda-python/issues/2568>`__)
 
+- :meth:`DeviceMemoryResource.register` and
+  :meth:`PinnedMemoryResource.register` now raise ``ValueError`` when the UUID
+  does not match the resource's own. The check was previously an ``assert``, so
+  under ``python -O`` the mismatched key was accepted and the resource's UUID
+  was rewritten.
+  (`#2697 <https://github.com/NVIDIA/cuda-python/issues/2697>`__)
+
 - Starting with CUDA 13.4, unconstrained SM-resource discovery through
   :meth:`SMResource.split` with ``SMResourceOptions(count=None)`` may return
   every available SM, even when that count is not divisible by the device's

--- a/cuda_core/tests/memory_ipc/test_errors.py
+++ b/cuda_core/tests/memory_ipc/test_errors.py
@@ -72,6 +72,23 @@ def test_register_rejects_non_ipc_memory_resource(mempool_device):
         DeviceMemoryResource.from_registry(key)
 
 
+@pytest.mark.human_authored
+def test_register_rejects_mismatched_uuid(ipc_memory_resource):
+    """A UUID that is not the resource's own is rejected even when CPython runs with -O."""
+    mr = ipc_memory_resource
+    own = mr.uuid
+    assert own is not None
+
+    other = uuid.UUID("00000000-0000-0000-0000-000000000001")
+    with pytest.raises(ValueError, match="cannot register it as"):
+        mr.register(other)
+
+    # The resource must keep its own identity rather than silently taking on the new key.
+    assert mr.uuid == own
+    with pytest.raises(RuntimeError, match=r"Memory resource [a-z0-9-]+ was not found"):
+        type(mr).from_registry(other)
+
+
 @pytest.mark.skipif(os.name == "nt", reason="IPC allocation handles are not supported on Windows")
 @pytest.mark.agent_authored(model="gpt-5.6")
 def test_ipc_allocation_handle_state_tracks_close():


### PR DESCRIPTION
`MP_register` checked the caller's UUID against the resource's own with a bare `assert`, which is removed under `python -O`. This raises `ValueError` instead, before the registry insertion, and adds a regression test over both IPC-enabled resource types.

```
tests/memory_ipc/test_errors.py::test_register_rejects_non_ipc_memory_resource PASSED [ 33%]
tests/memory_ipc/test_errors.py::test_register_rejects_mismatched_uuid[DeviceMR] PASSED [ 66%]
tests/memory_ipc/test_errors.py::test_register_rejects_mismatched_uuid[PinnedMR] PASSED [100%]
================= 3 passed, 17 deselected, 1 warning in 1.70s ==================
```
