### PR TITLE
fix(core): reject mismatched UUID in register() even under -O

### DIFF
--- a/cuda_core/cuda/core/_memory/_ipc.pyx
+++ b/cuda_core/cuda/core/_memory/_ipc.pyx
@@ -269,7 +269,11 @@ cdef _MemPool MP_from_allocation_handle(cls, alloc_handle):
     # Register it.
     if uuid is not None:
         registered = self.register(uuid)
-        assert registered is self
+        if registered is not self:
+            raise RuntimeError(
+                "Internal error: register() returned a different memory "
+                "resource than the one being registered"
+            )
 
     return self
 
@@ -292,7 +296,11 @@ cdef _MemPool MP_register(_MemPool self, uuid):
         return existing
     if not self.is_ipc_enabled:
         raise RuntimeError("Memory resource is not IPC-enabled")
-    assert self.uuid is None or self.uuid == uuid
+    if self.uuid is not None and self.uuid != uuid:
+        raise ValueError(
+            f"Cannot register memory resource with UUID {uuid}: "
+            f"the resource already has UUID {self.uuid}"
+        )
     registry[uuid] = self
     self._ipc_data._alloc_handle._uuid = uuid
     return self

--- a/cuda_core/tests/memory_ipc/test_errors.py
+++ b/cuda_core/tests/memory_ipc/test_errors.py
@@ -72,6 +72,34 @@ def test_register_rejects_non_ipc_memory_resource(mempool_device):
         DeviceMemoryResource.from_registry(key)
 
 
+@pytest.mark.human_authored
+def test_register_rejects_mismatched_uuid(ipc_memory_resource):
+    """register() rejects a UUID that does not match the resource's own.
+
+    The check is an explicit ValueError (not a bare ``assert``) so it remains
+    enforced even when CPython runs with ``-O``, where assertions are removed
+    (see #2697). Registering under a foreign key would otherwise rewrite the
+    resource's UUID and silently corrupt the IPC registry.
+    """
+    mr = ipc_memory_resource
+    assert mr.is_ipc_enabled
+
+    # The resource must already carry its own UUID (assigned on creation).
+    assert mr.uuid is not None
+    other = uuid.uuid4()
+    while other == mr.uuid:
+        other = uuid.uuid4()
+
+    with pytest.raises(ValueError, match="already has UUID"):
+        mr.register(other)
+
+    # A rejected registration must not rewrite the resource's own UUID.
+    assert mr.uuid != other
+
+    # Registering under the resource's own UUID still succeeds.
+    assert mr.register(mr.uuid) is mr
+
+
 @pytest.mark.skipif(os.name == "nt", reason="IPC allocation handles are not supported on Windows")
 @pytest.mark.agent_authored(model="gpt-5.6")
 def test_ipc_allocation_handle_state_tracks_close():


### PR DESCRIPTION
## Description

closes #2697

`DeviceMemoryResource.register()` and `PinnedMemoryResource.register()`
validated the supplied UUID against the resource's own with a bare
`assert` in `MP_register` (`cuda_core/cuda/core/_memory/_ipc.pyx`).
Since CPython strips assertions when run with `-O`, the check silently
disappears in optimized interpreters: the resource is registered under
a foreign key **and** its own UUID is rewritten to the attacker-
controlled value (`mr.uuid` reports the new value from then on).

### Changes

- `_ipc.pyx` `MP_register`: replace `assert self.uuid is None or
  self.uuid == uuid` with an explicit `ValueError` when the supplied
  UUID does not match the resource's own.
- `_ipc.pyx` `MP_from_allocation_handle`: convert the internal
  `assert registered is self` to an explicit `RuntimeError`, matching
  the maintainer direction to remove bare asserts from the library
  (they are behavioral no-ops under `-O`).
- `cuda_core/tests/memory_ipc/test_errors.py`: add
  `test_register_rejects_mismatched_uuid` covering the rejection and
  verifying the resource's UUID is not rewritten on failure.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.