### PR TITLE
Establish CI customization variable convention

### DIFF
--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -31,8 +31,11 @@ permissions:
 jobs:
   security-suite:
     name: Security Suite
-    # Pulse needs nv-gha-runners + Vault/nvcr vars; skip on forks.
-    if: github.repository == 'NVIDIA/cuda-python'
+    # Repository-specific workflow opt-ins use CI_CUSTOMIZATIONS_* Actions variables;
+    # see ci/README.md. Enable this only after the security-suite prerequisites exist.
+    if: >-
+      github.repository == 'NVIDIA/cuda-python' ||
+      vars.CI_CUSTOMIZATIONS_SECURITY_SUITE_ENABLED == 'true'
     uses: NVIDIA/security-workflows/.github/workflows/security-suite.yml@711025b090f2aa728da576700750b195d1e816dc  # v0.3.0
     with:
       enable-secret-scan: true

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,24 @@
+# Continuous Integration
+
+## Repository Customizations
+
+The workflows in this repository use the `CI_CUSTOMIZATIONS_*` namespace for
+GitHub Actions configuration variables that opt an alternative synchronized
+repository into repository-specific CI behavior. This keeps the workflow logic
+shared without hard-coding the names of private repositories into the public
+source tree.
+
+These variables are non-secret strings configured under
+**Settings > Secrets and variables > Actions > Variables**.
+An unset variable, or any value other than the literal string `true`, leaves
+the customization disabled. Do not store credentials or other secret values in
+these variables.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `CI_CUSTOMIZATIONS_SECURITY_SUITE_ENABLED` | Disabled | Enables the NVIDIA Security Suite after its runner, Actions variables, and OIDC/Vault authorization have been provisioned for the repository. |
+
+The canonical `NVIDIA/cuda-python` repository does not need this variable
+because its standard workflow behavior is enabled directly. Before enabling a
+customization elsewhere, document the repository-specific prerequisites and
+verification procedure in that repository's own documentation.


### PR DESCRIPTION
## Description

Establish a `CI_CUSTOMIZATIONS_*` GitHub Actions variable convention for repository-specific workflow behavior. This lets an alternative synchronized repository opt into the shared NVIDIA Security Suite after its prerequisites are provisioned, without hard-coding private repository names in the public workflow.

The canonical `NVIDIA/cuda-python` behavior is unchanged. The new `ci/README.md` documents the namespace, fail-closed default, and current Security Suite opt-in.

xrefs:
* ctk-next issue 529
* ctk-next PR 550

## Checklist

- [x] New or existing tests cover these changes. The workflow was exercised in the synchronized repository, and actionlint validates the final workflow.
- [x] The documentation is up to date with these changes.
