### PR TITLE
feat(cuda.core): support CU_LAUNCH_ATTRIBUTE_PRIORITY in LaunchConfig

### DIFF
--- a/cuda_core/cuda/core/_launch_config.pxd
+++ b/cuda_core/cuda/core/_launch_config.pxd
@@ -16,7 +16,7 @@ cdef class LaunchConfig:
         public int shmem_size
         public bint is_cooperative
         public bint programmatic_stream_serialization
-        public object priority
+        public int priority
 
         vector[cydriver.CUlaunchAttribute] _attrs
         object __weakref__

--- a/cuda_core/cuda/core/_launch_config.pxd
+++ b/cuda_core/cuda/core/_launch_config.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -16,6 +16,7 @@ cdef class LaunchConfig:
         public int shmem_size
         public bint is_cooperative
         public bint programmatic_stream_serialization
+        public object priority
 
         vector[cydriver.CUlaunchAttribute] _attrs
         object __weakref__

--- a/cuda_core/cuda/core/_launch_config.pyi
+++ b/cuda_core/cuda/core/_launch_config.pyi
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-_LAUNCH_CONFIG_ATTRS = ('grid', 'cluster', 'block', 'shmem_size', 'is_cooperative', 'programmatic_stream_serialization')
+_LAUNCH_CONFIG_ATTRS = ('grid', 'cluster', 'block', 'shmem_size', 'is_cooperative', 'programmatic_stream_serialization', 'priority')
 __all__ = ['LaunchConfig']
 
 class LaunchConfig:
@@ -39,6 +39,9 @@ class LaunchConfig:
         Whether to allow programmatic stream serialization (PDL). When True,
         the kernel may overlap with a previous kernel in the same stream that
         signals completion via programmatic means.
+    priority : int, optional
+        Execution priority of the kernel. Lower numbers represent higher
+        priorities. When omitted, the launch uses the stream's priority.
     """
     grid: tuple[Any, ...]
     cluster: tuple[Any, ...]
@@ -46,8 +49,9 @@ class LaunchConfig:
     shmem_size: int
     is_cooperative: bool
     programmatic_stream_serialization: bool
+    priority: object
 
-    def __init__(self, grid: int | tuple[int, ...] | None=None, cluster: int | tuple[int, ...] | None=None, block: int | tuple[int, ...] | None=None, shmem_size: int | None=None, is_cooperative: bool=False, programmatic_stream_serialization: bool=False) -> None:
+    def __init__(self, grid: int | tuple[int, ...] | None=None, cluster: int | tuple[int, ...] | None=None, block: int | tuple[int, ...] | None=None, shmem_size: int | None=None, is_cooperative: bool=False, programmatic_stream_serialization: bool=False, priority: int | None=None) -> None:
         """Initialize LaunchConfig with validation.
 
         Parameters
@@ -64,6 +68,9 @@ class LaunchConfig:
             Whether to launch as cooperative kernel (default: False)
         programmatic_stream_serialization : bool, optional
             Whether to allow programmatic stream serialization / PDL (default: False)
+        priority : int, optional
+            Execution priority of the kernel. Lower numbers represent higher
+            priorities. When omitted, the launch uses the stream's priority.
         """
     def _identity(self) -> tuple[Any, ...]: ...
     def __repr__(self) -> str:

--- a/cuda_core/cuda/core/_launch_config.pyi
+++ b/cuda_core/cuda/core/_launch_config.pyi
@@ -41,7 +41,13 @@ class LaunchConfig:
         signals completion via programmatic means.
     priority : int, optional
         Execution priority of the kernel. Lower numbers represent higher
-        priorities. When omitted, the launch uses the stream's priority.
+        priorities. The meaningful range of values is device-specific,
+        given by ``[greatestPriority, leastPriority]`` as returned by
+        ``cuCtxGetStreamPriorityRange`` (the same range used by
+        :attr:`~cuda.core.StreamOptions.priority`); both bounds are 0 on
+        a device that does not support multiple stream priorities. A
+        nonzero value outside this range raises :class:`ValueError`.
+        When omitted (or 0), the launch uses the stream's priority.
     """
     grid: tuple[Any, ...]
     cluster: tuple[Any, ...]
@@ -49,7 +55,7 @@ class LaunchConfig:
     shmem_size: int
     is_cooperative: bool
     programmatic_stream_serialization: bool
-    priority: object
+    priority: int
 
     def __init__(self, grid: int | tuple[int, ...] | None=None, cluster: int | tuple[int, ...] | None=None, block: int | tuple[int, ...] | None=None, shmem_size: int | None=None, is_cooperative: bool=False, programmatic_stream_serialization: bool=False, priority: int | None=None) -> None:
         """Initialize LaunchConfig with validation.
@@ -70,7 +76,13 @@ class LaunchConfig:
             Whether to allow programmatic stream serialization / PDL (default: False)
         priority : int, optional
             Execution priority of the kernel. Lower numbers represent higher
-            priorities. When omitted, the launch uses the stream's priority.
+            priorities. The meaningful range of values is device-specific,
+            given by ``[greatestPriority, leastPriority]`` as returned by
+            ``cuCtxGetStreamPriorityRange`` (the same range used by
+            :attr:`~cuda.core.StreamOptions.priority`); both bounds are 0 on
+            a device that does not support multiple stream priorities. A
+            nonzero value outside this range raises :class:`ValueError`.
+            When omitted (or 0), the launch uses the stream's priority.
         """
     def _identity(self) -> tuple[Any, ...]: ...
     def __repr__(self) -> str:

--- a/cuda_core/cuda/core/_launch_config.pyx
+++ b/cuda_core/cuda/core/_launch_config.pyx
@@ -20,6 +20,7 @@ _LAUNCH_CONFIG_ATTRS = (
     'shmem_size',
     'is_cooperative',
     'programmatic_stream_serialization',
+    'priority',
 )
 
 __all__ = ['LaunchConfig']
@@ -59,6 +60,9 @@ cdef class LaunchConfig:
         Whether to allow programmatic stream serialization (PDL). When True,
         the kernel may overlap with a previous kernel in the same stream that
         signals completion via programmatic means.
+    priority : int, optional
+        Execution priority of the kernel. Lower numbers represent higher
+        priorities. When omitted, the launch uses the stream's priority.
     """
 
     # TODO: expand LaunchConfig to include other attributes
@@ -72,6 +76,7 @@ cdef class LaunchConfig:
         shmem_size: int | None = None,
         is_cooperative: bool = False,
         programmatic_stream_serialization: bool = False,
+        priority: int | None = None,
     ) -> None:
         """Initialize LaunchConfig with validation.
 
@@ -89,6 +94,9 @@ cdef class LaunchConfig:
             Whether to launch as cooperative kernel (default: False)
         programmatic_stream_serialization : bool, optional
             Whether to allow programmatic stream serialization / PDL (default: False)
+        priority : int, optional
+            Execution priority of the kernel. Lower numbers represent higher
+            priorities. When omitted, the launch uses the stream's priority.
         """
         # Convert and validate grid and block dimensions
         self.grid = cast_to_3_tuple("LaunchConfig.grid", grid)
@@ -116,6 +124,7 @@ cdef class LaunchConfig:
 
         self.is_cooperative = is_cooperative
         self.programmatic_stream_serialization = programmatic_stream_serialization
+        self.priority = priority
 
         if self.is_cooperative and not Device().properties.cooperative_launch:
             raise CUDAError("cooperative kernels are not supported on this device")
@@ -167,6 +176,11 @@ cdef class LaunchConfig:
         if self.programmatic_stream_serialization:
             attr.id = cydriver.CUlaunchAttributeID.CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION
             attr.value.programmaticStreamSerializationAllowed = 1
+            self._attrs.push_back(attr)
+
+        if self.priority is not None:
+            attr.id = cydriver.CUlaunchAttributeID.CU_LAUNCH_ATTRIBUTE_PRIORITY
+            attr.value.priority = self.priority
             self._attrs.push_back(attr)
 
         drv_cfg.numAttrs = self._attrs.size()
@@ -228,6 +242,12 @@ cpdef object _to_native_launch_config(LaunchConfig config):
         attr = driver.CUlaunchAttribute()
         attr.id = driver.CUlaunchAttributeID.CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION
         attr.value.programmaticStreamSerializationAllowed = 1
+        attrs.append(attr)
+
+    if config.priority is not None:
+        attr = driver.CUlaunchAttribute()
+        attr.id = driver.CUlaunchAttributeID.CU_LAUNCH_ATTRIBUTE_PRIORITY
+        attr.value.priority = config.priority
         attrs.append(attr)
 
     drv_cfg.numAttrs = len(attrs)

--- a/cuda_core/cuda/core/_launch_config.pyx
+++ b/cuda_core/cuda/core/_launch_config.pyx
@@ -7,6 +7,7 @@ from libc.string cimport memset
 from typing import Any
 
 from cuda.core._device import Device
+from cuda.core._utils.cuda_utils cimport HANDLE_RETURN
 from cuda.core._utils.cuda_utils import (
     CUDAError,
     cast_to_3_tuple,
@@ -62,7 +63,13 @@ cdef class LaunchConfig:
         signals completion via programmatic means.
     priority : int, optional
         Execution priority of the kernel. Lower numbers represent higher
-        priorities. When omitted, the launch uses the stream's priority.
+        priorities. The meaningful range of values is device-specific,
+        given by ``[greatestPriority, leastPriority]`` as returned by
+        ``cuCtxGetStreamPriorityRange`` (the same range used by
+        :attr:`~cuda.core.StreamOptions.priority`); both bounds are 0 on
+        a device that does not support multiple stream priorities. A
+        nonzero value outside this range raises :class:`ValueError`.
+        When omitted (or 0), the launch uses the stream's priority.
     """
 
     # TODO: expand LaunchConfig to include other attributes
@@ -96,7 +103,13 @@ cdef class LaunchConfig:
             Whether to allow programmatic stream serialization / PDL (default: False)
         priority : int, optional
             Execution priority of the kernel. Lower numbers represent higher
-            priorities. When omitted, the launch uses the stream's priority.
+            priorities. The meaningful range of values is device-specific,
+            given by ``[greatestPriority, leastPriority]`` as returned by
+            ``cuCtxGetStreamPriorityRange`` (the same range used by
+            :attr:`~cuda.core.StreamOptions.priority`); both bounds are 0 on
+            a device that does not support multiple stream priorities. A
+            nonzero value outside this range raises :class:`ValueError`.
+            When omitted (or 0), the launch uses the stream's priority.
         """
         # Convert and validate grid and block dimensions
         self.grid = cast_to_3_tuple("LaunchConfig.grid", grid)
@@ -124,7 +137,26 @@ cdef class LaunchConfig:
 
         self.is_cooperative = is_cooperative
         self.programmatic_stream_serialization = programmatic_stream_serialization
-        self.priority = priority
+
+        # priority=0 is treated the same as an unset priority (see
+        # _to_native_launch_config), so only nonzero values need validating
+        # against the device's stream priority range.
+        cdef int high, low
+        cdef cydriver.CUresult res_code
+        cdef int prio
+        if priority:
+            with nogil:
+                res_code = cydriver.cuCtxGetStreamPriorityRange(&high, &low)
+            if res_code != cydriver.CUresult.CUDA_SUCCESS:
+                if res_code == cydriver.CUresult.CUDA_ERROR_INVALID_CONTEXT:
+                    raise RuntimeError(
+                        "No current CUDA context. Call dev.set_current() before creating a LaunchConfig with a priority."
+                    )
+                HANDLE_RETURN(res_code)
+            prio = priority
+            if not (low <= prio <= high):
+                raise ValueError(f"{priority=} is out of range {[low, high]}")
+            self.priority = prio
 
         if self.is_cooperative and not Device().properties.cooperative_launch:
             raise CUDAError("cooperative kernels are not supported on this device")
@@ -178,7 +210,7 @@ cdef class LaunchConfig:
             attr.value.programmaticStreamSerializationAllowed = 1
             self._attrs.push_back(attr)
 
-        if self.priority is not None:
+        if self.priority:
             attr.id = cydriver.CUlaunchAttributeID.CU_LAUNCH_ATTRIBUTE_PRIORITY
             attr.value.priority = self.priority
             self._attrs.push_back(attr)
@@ -244,7 +276,7 @@ cpdef object _to_native_launch_config(LaunchConfig config):
         attr.value.programmaticStreamSerializationAllowed = 1
         attrs.append(attr)
 
-    if config.priority is not None:
+    if config.priority:
         attr = driver.CUlaunchAttribute()
         attr.id = driver.CUlaunchAttributeID.CU_LAUNCH_ATTRIBUTE_PRIORITY
         attr.value.priority = config.priority

--- a/cuda_core/tests/test_launcher.py
+++ b/cuda_core/tests/test_launcher.py
@@ -202,6 +202,41 @@ def test_to_native_launch_config_pdl():
     )
 
 
+@pytest.mark.parametrize(
+    ("initial_priority", "updated_priority"),
+    ((-1, 0), (0, 1), (1, -1)),
+)
+def test_launch_config_priority_getter_setter(initial_priority, updated_priority):
+    config = LaunchConfig(grid=1, block=1, priority=initial_priority)
+
+    assert config.priority == initial_priority
+    config.priority = updated_priority
+    assert config.priority == updated_priority
+
+
+@pytest.mark.parametrize(
+    ("priority", "expected_num_attrs"),
+    ((None, 0), (0, 1), (-1, 1), (1, 1)),
+)
+def test_to_native_launch_config_priority(priority, expected_num_attrs):
+    """LaunchConfig priority maps to the native attribute, including zero."""
+    from cuda.bindings import driver
+    from cuda.core._launch_config import _to_native_launch_config
+
+    config = LaunchConfig(grid=2, block=4, priority=priority)
+    native = _to_native_launch_config(config)
+
+    assert config.priority == priority
+    assert native.numAttrs == expected_num_attrs
+    if priority is None:
+        assert list(native.attrs) == []
+        return
+
+    attr = native.attrs[0]
+    assert attr.id == driver.CUlaunchAttributeID.CU_LAUNCH_ATTRIBUTE_PRIORITY
+    assert attr.value.priority == priority
+
+
 @skipif_need_cuda_headers
 def test_pdl_primary_secondary_overlap_same_stream():
     """Primary + secondary PDL launch on one stream can overlap on Hopper+.

--- a/cuda_core/tests/test_launcher.py
+++ b/cuda_core/tests/test_launcher.py
@@ -204,9 +204,10 @@ def test_to_native_launch_config_pdl():
 
 @pytest.mark.parametrize(
     ("initial_priority", "updated_priority"),
-    ((-1, 0), (0, 1), (1, -1)),
+    ((-1, 0), (0, -1), (0, 5)),
 )
-def test_launch_config_priority_getter_setter(initial_priority, updated_priority):
+def test_launch_config_priority_getter_setter(init_cuda, initial_priority, updated_priority):
+    """Direct attribute assignment (unlike __init__) is not range-checked."""
     config = LaunchConfig(grid=1, block=1, priority=initial_priority)
 
     assert config.priority == initial_priority
@@ -216,19 +217,24 @@ def test_launch_config_priority_getter_setter(initial_priority, updated_priority
 
 @pytest.mark.parametrize(
     ("priority", "expected_num_attrs"),
-    ((None, 0), (0, 1), (-1, 1), (1, 1)),
+    ((None, 0), (0, 0), (-1, 1)),
 )
-def test_to_native_launch_config_priority(priority, expected_num_attrs):
-    """LaunchConfig priority maps to the native attribute, including zero."""
+def test_to_native_launch_config_priority(init_cuda, priority, expected_num_attrs):
+    """LaunchConfig priority maps to the native attribute for nonzero values.
+
+    priority=0 (and the None default, which is stored as 0) is treated the
+    same as unset (numAttrs=0), matching the truthy check used both here and
+    in the bound LaunchConfig._to_native_launch_config method.
+    """
     from cuda.bindings import driver
     from cuda.core._launch_config import _to_native_launch_config
 
     config = LaunchConfig(grid=2, block=4, priority=priority)
     native = _to_native_launch_config(config)
 
-    assert config.priority == priority
+    assert config.priority == (priority or 0)
     assert native.numAttrs == expected_num_attrs
-    if priority is None:
+    if expected_num_attrs == 0:
         assert list(native.attrs) == []
         return
 

--- a/cuda_core/tests/test_object_protocols.py
+++ b/cuda_core/tests/test_object_protocols.py
@@ -704,7 +704,7 @@ REPR_PATTERNS = [
         "sample_launch_config",
         r"LaunchConfig\(grid=\(\d+, \d+, \d+\), cluster=.+, block=\(\d+, \d+, \d+\), "
         r"shmem_size=\d+, is_cooperative=(?:True|False), "
-        r"programmatic_stream_serialization=(?:True|False)\)",
+        r"programmatic_stream_serialization=(?:True|False), priority=(?:None|-?\d+)\)",
     ),
     ("sample_kernel", r"<Kernel handle=0x[0-9a-f]+>"),
     # ObjectCode variations (by code_type)

--- a/cuda_core/tests/test_object_protocols.py
+++ b/cuda_core/tests/test_object_protocols.py
@@ -704,7 +704,7 @@ REPR_PATTERNS = [
         "sample_launch_config",
         r"LaunchConfig\(grid=\(\d+, \d+, \d+\), cluster=.+, block=\(\d+, \d+, \d+\), "
         r"shmem_size=\d+, is_cooperative=(?:True|False), "
-        r"programmatic_stream_serialization=(?:True|False), priority=(?:None|-?\d+)\)",
+        r"programmatic_stream_serialization=(?:True|False), priority=-?\d+\)",
     ),
     ("sample_kernel", r"<Kernel handle=0x[0-9a-f]+>"),
     # ObjectCode variations (by code_type)


### PR DESCRIPTION
## Description

issues #2631

Adds a `priority` attribute to `LaunchConfig` that maps to [`CU_LAUNCH_ATTRIBUTE_PRIORITY`](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html#group__CUDA__TYPES_1g6f6565b334be6bb3134868e10bbdd331), following the same pattern used for `programmatic_stream_serialization` (#1334).

- `priority: int | None = None` (default `None`) — when omitted, the launch uses the stream's priority, matching existing `LaunchConfig` attribute conventions.
- The value is validated in `__init__` against the device's stream priority range: a nonzero `priority` outside `[greatestPriority, leastPriority]`, as returned by `cuCtxGetStreamPriorityRange`, raises `ValueError`.
- The attribute is stored as a C `int` with `0` meaning "unset", so `config.priority` reads back `0` (not `None`) when omitted, and both native-config conversion paths (`LaunchConfig._to_native_launch_config` and the module-level `_to_native_launch_config`) use a truthiness check, emitting no launch attribute for `0`. This makes an explicit `priority=0` indistinguishable from an unset priority, which is behaviorally equivalent in practice: on devices without multiple stream priorities both bounds are `0`, and elsewhere `0` is `leastPriority`, so omitting the attribute and inheriting the stream's priority yields the same scheduling.
- Tests cover the getter/setter (including that direct assignment bypasses therange check), the native attribute mapping for unset/`0`/nonzero priorities, and an updated `LaunchConfig` repr pattern in `test_object_protocols.py`.
