### PR TITLE
fix(cuda.core): xfail cuda-gdb test when GPU debugging is unavailable

### DIFF
--- a/cuda_core/tests/test_program.py
+++ b/cuda_core/tests/test_program.py
@@ -1121,8 +1121,9 @@ def test_cuda_gdb_shows_nvrtc_debug_source_lines(init_cuda):
         timeout=120,
     )
     output = (proc.stdout or "") + (proc.stderr or "")
-    if "Operation not permitted" in output or "ptrace" in output.lower():
-        pytest.skip("cuda-gdb cannot trace this process")
+    lowered = output.lower()
+    if "operation not permitted" in lowered or "ptrace" in lowered or "debugging is not possible" in lowered:
+        pytest.xfail("cuda-gdb is not usable for debugging on this machine: " + output)
     assert re.search(r"cuda_gdb_src_kernel_\w+\.cu", output), output
     assert "ISSUE_2422_SOURCE_LINE" in output, output
     assert "No such file or directory" not in output, output


### PR DESCRIPTION
A nightly test machine has cuda-gdb but no libcudadebugger.so.1, so break_on_launch never fires and `list` has no device frame showing the NVRTC temp .cu.

## Description

closes #2711 (sub-issue of #2693)
`test_cuda_gdb_shows_nvrtc_debug_source_lines`, added in #2679, fails on the a nightly machine. `cuda-gdb` is on `PATH` so the existing guard passes, but the debugger back-end is missing:
```
[Inferior 1 (process 718707) exited normally]
Could not find CUDA Debugger back-end (libcudadebugger.so.1). Debugging is not possible
```

This widens the guard to recognize `Debugging is not possible` and reports `xfail` instead of `skip`.

Not a regression in #2679: the three `test_nvrtc_debug_*` tests pass in the same run, so source materialization works on that board. 


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

