### PR TITLE
Update cuda-core and cuda-pathfinder dependency versions automatically in cuda-python

### DIFF
--- a/cuda_python/setup.py
+++ b/cuda_python/setup.py
@@ -8,34 +8,41 @@ from packaging.version import Version
 from setuptools import setup
 from setuptools_scm import get_version
 
-version = get_version(
-    root="..",
-    relative_to=__file__,
-    # Preserve a/b pre-release suffixes, but intentionally strip rc suffixes.
-    tag_regex="^(?P<version>v\\d+\\.\\d+\\.\\d+(?:[ab]\\d+)?)",
-    git_describe_command=["git", "describe", "--dirty", "--tags", "--long", "--match", "v*[0-9]*"],
-)
+
+def get_version_for_module(module_name: str | None = None) -> str:
+    if module_name is None:
+        module_name = ""
+    else:
+        module_name = f"{module_name}-"
+    return get_version(
+        root="..",
+        relative_to=__file__,
+        # Preserve a/b pre-release suffixes, but intentionally strip rc suffixes.
+        tag_regex=f"^{module_name}(?P<version>v\\d+\\.\\d+\\.\\d+(?:[ab]\\d+)?)",
+        git_describe_command=["git", "describe", "--dirty", "--tags", "--long", "--match", f"{module_name}v*[0-9]*"],
+        version_scheme="post-release",
+    )
 
 
-base_version = Version(version).base_version
+install_requires: list[str] = []
+extras_require: dict[str, list[str]] = {}
 
+for module in ["cuda-bindings", "cuda-core", "cuda-pathfinder"]:
+    if module == "cuda-bindings":
+        module_prefix = None
+    else:
+        module_prefix = module
+    version = get_version_for_module(module_prefix)
+    base_version: str = Version(version).base_version
 
-if base_version == version:
-    # Tagged release
-    matcher = "~="
-else:
-    # Pre-release version
-    matcher = "=="
+    install_requires.append(f"{module}~={base_version}")
+
+    if module == "cuda-bindings":
+        extras_require["all"] = [f"{module}[all]~={base_version}"]
 
 
 setup(
     version=version,
-    install_requires=[
-        f"cuda-bindings{matcher}{version}",
-        "cuda-core~=1.0.0",
-        "cuda-pathfinder~=1.1",
-    ],
-    extras_require={
-        "all": [f"cuda-bindings[all]{matcher}{version}"],
-    },
+    install_requires=install_requires,
+    extras_require=extras_require,
 )

--- a/cuda_python/setup.py
+++ b/cuda_python/setup.py
@@ -19,7 +19,7 @@ def get_version_for_module(module_name: str | None = None) -> str:
         relative_to=__file__,
         # Preserve a/b pre-release suffixes, but intentionally strip rc suffixes.
         tag_regex=f"^{module_name}(?P<version>v\\d+\\.\\d+\\.\\d+(?:[ab]\\d+)?)",
-        git_describe_command=["git", "describe", "--dirty", "--tags", "--long", "--match", f"{module_name}v*[0-9]*"],
+        git_describe_command=["git", "describe", "--dirty", "--tags", "--long", "--match", f"{module_name}v[0-9]*"],
         version_scheme="post-release",
     )
 

--- a/cuda_python/setup.py
+++ b/cuda_python/setup.py
@@ -35,6 +35,9 @@ for module in ["cuda-bindings", "cuda-core", "cuda-pathfinder"]:
     version = get_version_for_module(module_prefix)
     base_version: str = Version(version).base_version
 
+    if module == "cuda-pathfinder":
+        base_version = base_version.rsplit(".", 1)[0]
+
     install_requires.append(f"{module}~={base_version}")
 
     if module == "cuda-bindings":


### PR DESCRIPTION
We currently determine the cuda-bindings version automatically to be the latest release whenever we build cuda-python.  We don't currently determine the cuda-core or cuda-pathfinder versions automatically, which means we they need to be updated by hand during the release.  This just automates out that one extra step.  This isn't theoretically -- the cuda-core dependency is still specified as `1.0.0` here, even though `1.1.1` has been out for weeks.

This specifies the dependencies so that patch releases of the same version are considered equivalent.  For cuda-pathfinder, it is looser and even minor release changes are considered equivalent.  (This matches current behavior).

As an additional bugfix, this will no longer generate a cuda-python package that depends on a non-tagged git commit of any package (which we will never release, so doesn't make much sense).

(There is a larger question about whether we should be so tight with our cuda-python dependencies, which leads to other issues downstream of this, but this is just to automate a part of making a release while keeping status quo behavior.)