### PR TITLE
docs(cuda.core): document PinnedMemoryResource.allocate parameters

### DIFF
--- a/cuda_core/cuda/core/_memory/_pinned_memory_resource.pyi
+++ b/cuda_core/cuda/core/_memory/_pinned_memory_resource.pyi
@@ -84,7 +84,30 @@ class PinnedMemoryResource(_MemPool):
     """
     def __init__(self, options: PinnedMemoryResourceOptions | None=None) -> None: ...
     def allocate(self, size: int, *, stream: Stream | GraphBuilder) -> Buffer:
-        """Allocate a host-pinned buffer asynchronously on the supplied stream."""
+        """Allocate a host-pinned buffer asynchronously on the supplied stream.
+
+        Parameters
+        ----------
+        size : int
+            The size of the buffer to allocate, in bytes.
+        stream : :obj:`~_stream.Stream` | :obj:`~graph.GraphBuilder`
+            Keyword-only. The stream on which to perform the allocation
+            asynchronously. Must be passed explicitly; pass
+            ``device.default_stream`` to use the default stream.
+
+        Returns
+        -------
+        Buffer
+            The allocated buffer object, which is accessible from the host and
+            from the device that the stream belongs to.
+
+        Raises
+        ------
+        RuntimeError
+            If the stream's device does not support the requested host memory
+            pool. Use :class:`LegacyPinnedMemoryResource` when stream-ordered
+            allocation is not required.
+        """
     def __reduce__(self) -> tuple[object, ...]: ...
     @staticmethod
     def from_registry(uuid: uuid.UUID) -> PinnedMemoryResource:

--- a/cuda_core/cuda/core/_memory/_pinned_memory_resource.pyx
+++ b/cuda_core/cuda/core/_memory/_pinned_memory_resource.pyx
@@ -113,7 +113,30 @@ cdef class PinnedMemoryResource(_MemPool):
         _PMR_init(self, options)
 
     def allocate(self, size_t size, *, stream: Stream | GraphBuilder) -> Buffer:
-        """Allocate a host-pinned buffer asynchronously on the supplied stream."""
+        """Allocate a host-pinned buffer asynchronously on the supplied stream.
+
+        Parameters
+        ----------
+        size : int
+            The size of the buffer to allocate, in bytes.
+        stream : :obj:`~_stream.Stream` | :obj:`~graph.GraphBuilder`
+            Keyword-only. The stream on which to perform the allocation
+            asynchronously. Must be passed explicitly; pass
+            ``device.default_stream`` to use the default stream.
+
+        Returns
+        -------
+        Buffer
+            The allocated buffer object, which is accessible from the host and
+            from the device that the stream belongs to.
+
+        Raises
+        ------
+        RuntimeError
+            If the stream's device does not support the requested host memory
+            pool. Use :class:`LegacyPinnedMemoryResource` when stream-ordered
+            allocation is not required.
+        """
         MP_check_open(self)
         if self.is_mapped:
             raise TypeError("Cannot allocate from a mapped IPC-enabled memory resource")


### PR DESCRIPTION
## Description

closes #2712

`PinnedMemoryResource.allocate` overrides the inherited method with a one-line docstring, and that one line is all autodoc has to render, so the generated page for the public class documented neither the required keyword-only `stream` argument nor the return value, and never mentioned the `RuntimeError` raised when the device does not support the requested host memory pool. This gives the override the full numpydoc body, including a `Raises` section for that error. The `.pyi` stub is regenerated by the `stubgen-pyx-cuda-core` pre-commit hook rather than hand-edited.

Docstring-only change, so there is no new test. What the class now renders, and the existing suite:

```
$ python check.py
'stream :' in rendered docstring: True
'Returns' in rendered docstring: True
'Raises' in rendered docstring: True

$ python -m pytest tests/test_memory.py -q -p no:randomly
256 passed, 15 skipped in 10.65s
```

No release note: the one-line docstring landed in #2487, after the `cuda-core-v1.1.1` tag, so nothing user-visible changed since the last release.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
