### PR TITLE
CI: Restrict pixi source-build smoke test to NVIDIA

### DIFF
--- a/.github/workflows/ci-pixi-source-test.yml
+++ b/.github/workflows/ci-pixi-source-test.yml
@@ -67,7 +67,9 @@ jobs:
   # ── PR guard: CPU-only build + import + placement smoke ──
   build-smoke:
     name: "build smoke (cu13, linux-64, CPU)"
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+    if: >-
+      github.repository_owner == 'nvidia' &&
+      (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:


### PR DESCRIPTION
## Description

Follow-on to PRs #2669 and #2671 (this case was overlooked before).

Restrict the pull-request and manually dispatched `build-smoke` job in `ci-pixi-source-test.yml` to the canonical `NVIDIA` organization, consistent with the workflow's existing public-only full-test guard.

Public CUDA Python pull requests continue to exercise the source-build smoke test because pull-request workflows run in the base repository's context. Repositories that inherit this workflow no longer try to combine the public pixi environments with independently generated bindings for a different CUDA Toolkit version.

Internal tracking issue: 529

## Verification

- Fixes ctk-next CI failures observed under PR 552

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
