### PR TITLE
Fix the lychee precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,6 +97,7 @@ repos:
     hooks:
       - id: lychee
         args:
+          - LYCHEE_VERSION=0.24.2  # Must match the pinned rev above
           - --cache
           - --max-concurrency=4
           - --max-retries=3


### PR DESCRIPTION
The lychee precommit hook (which is independently released from lychee itself) recently changed behavior where it needs an actual lychee version, but it converts the hash to a rev using /our/ tags rather than it's own.

Fortunately, we can override this behavior with an environment variable, so the workaround is not to bad and does not reduce the security benefits of hash-pinning.