### PR TITLE
fix(ci): use numba-cuda-mlir wheel-only skips

### DIFF
--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -478,7 +478,13 @@ jobs:
 
       - name: Run numba-cuda-mlir tests
         if: ${{ inputs.test-mode == 'nightly-numba-cuda-mlir' && env.NUMBA_CUDA_MLIR_VER != '' }}
+        env:
+          LOCAL_CTK: ${{ matrix.LOCAL_CTK }}
         run: |
+          if [[ "${LOCAL_CTK}" != 1 ]]; then
+            # Let numba-cuda-mlir skip inputs that require toolkit executables.
+            export NUMBA_CUDA_MLIR_TEST_WHEEL_ONLY=1
+          fi
           pushd numba-cuda-mlir-released
           # Install this tag's test deps (pytest + plugins + ml-dtypes + ...).
           pip install --upgrade "pip>=25.1"
@@ -486,45 +492,9 @@ jobs:
           # Skip tests/benchmarks/ and tests/doc_examples/ — they import the
           # numba package at collection time, which cuSIMT intentionally does
           # not depend on. See NVIDIA/numba-cuda-mlir#136.
-          #
-          # Version-gated deselects: when a newer numba-cuda-mlir release
-          # ships with the referenced fix, the guard evaluates false and the
-          # tests get run automatically. If they still fail on the newer
-          # version we hear about it loudly (rather than silently masking).
-          DESELECTS=()
-          if python -c "from packaging.version import Version; import sys; sys.exit(0 if Version('${NUMBA_CUDA_MLIR_VER}') <= Version('0.4.1') else 1)"; then
-            # NVIDIA/numba-cuda-mlir#135: serial-pytest contamination of
-            # numba_cuda_mlir.cuda.cudadrv from an xfailed test in
-            # test_nrt_comprehensive.py contaminates any later test that
-            # touches cuda.cudadrv.driver. Upstream CI hides it via
-            # `-n auto --dist loadscope`. Which specific tests fail depends
-            # on collection order (we saw different subsets on linux-64 vs
-            # win-64 across runs), so we deselect the union of all tests
-            # #135 lists as vulnerable + test_fortran_contiguous (observed
-            # to hit the same contamination in our runs).
-            #
-            # test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn:
-            # subprocess-invokes `cuobjdump`, not on PATH in the base
-            # ubuntu:24.04 container. (Linux-only; Windows runners ship
-            # cuobjdump with the local CTK. No upstream fix yet — pending
-            # a skip-guard bug to be filed against NVIDIA/numba-cuda-mlir.)
-            DESELECTS+=(
-              --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_default_stream'
-              --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_supplied_stream'
-              --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_sync'
-              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_consume_no_sync'
-              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_consume_sync'
-              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_no_sync'
-              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_sync'
-              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_sync_two_streams'
-              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_fortran_contiguous'
-              --deselect 'tests/numba_cuda_tests/cudadrv/test_nvjitlink.py::TestLinkerDumpAssembly::test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn'
-            )
-          fi
           pytest -rxXs -v \
             --ignore=tests/benchmarks \
             --ignore=tests/doc_examples \
-            "${DESELECTS[@]}" \
             tests/
           popd
 

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -487,11 +487,21 @@ jobs:
           # numba package at collection time, which cuSIMT intentionally does
           # not depend on. See NVIDIA/numba-cuda-mlir#136.
           #
+          DESELECTS=()
+          # Environment-gated deselect: cuobjdump is not on PATH in the base
+          # ubuntu:24.04 container. Keep this independent of the version gate
+          # below so an unrelated upstream fix cannot retire it. See
+          # NVIDIA/numba-cuda-mlir#286.
+          if ! command -v cuobjdump > /dev/null; then
+            DESELECTS+=(
+              --deselect 'tests/numba_cuda_tests/cudadrv/test_nvjitlink.py::TestLinkerDumpAssembly::test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn'
+            )
+          fi
+
           # Version-gated deselects: when a newer numba-cuda-mlir release
           # ships with the referenced fix, the guard evaluates false and the
           # tests get run automatically. If they still fail on the newer
           # version we hear about it loudly (rather than silently masking).
-          DESELECTS=()
           if python -c "from packaging.version import Version; import sys; sys.exit(0 if Version('${NUMBA_CUDA_MLIR_VER}') <= Version('0.4.1') else 1)"; then
             # NVIDIA/numba-cuda-mlir#135: serial-pytest contamination of
             # numba_cuda_mlir.cuda.cudadrv from an xfailed test in
@@ -502,12 +512,6 @@ jobs:
             # win-64 across runs), so we deselect the union of all tests
             # #135 lists as vulnerable + test_fortran_contiguous (observed
             # to hit the same contamination in our runs).
-            #
-            # test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn:
-            # subprocess-invokes `cuobjdump`, not on PATH in the base
-            # ubuntu:24.04 container. (Linux-only; Windows runners ship
-            # cuobjdump with the local CTK. No upstream fix yet — pending
-            # a skip-guard bug to be filed against NVIDIA/numba-cuda-mlir.)
             DESELECTS+=(
               --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_default_stream'
               --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_supplied_stream'
@@ -518,7 +522,6 @@ jobs:
               --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_sync'
               --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_sync_two_streams'
               --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_fortran_contiguous'
-              --deselect 'tests/numba_cuda_tests/cudadrv/test_nvjitlink.py::TestLinkerDumpAssembly::test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn'
             )
           fi
           pytest -rxXs -v \

--- a/.github/workflows/test-wheel-linux.yml
+++ b/.github/workflows/test-wheel-linux.yml
@@ -487,21 +487,11 @@ jobs:
           # numba package at collection time, which cuSIMT intentionally does
           # not depend on. See NVIDIA/numba-cuda-mlir#136.
           #
-          DESELECTS=()
-          # Environment-gated deselect: cuobjdump is not on PATH in the base
-          # ubuntu:24.04 container. Keep this independent of the version gate
-          # below so an unrelated upstream fix cannot retire it. See
-          # NVIDIA/numba-cuda-mlir#286.
-          if ! command -v cuobjdump > /dev/null; then
-            DESELECTS+=(
-              --deselect 'tests/numba_cuda_tests/cudadrv/test_nvjitlink.py::TestLinkerDumpAssembly::test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn'
-            )
-          fi
-
           # Version-gated deselects: when a newer numba-cuda-mlir release
           # ships with the referenced fix, the guard evaluates false and the
           # tests get run automatically. If they still fail on the newer
           # version we hear about it loudly (rather than silently masking).
+          DESELECTS=()
           if python -c "from packaging.version import Version; import sys; sys.exit(0 if Version('${NUMBA_CUDA_MLIR_VER}') <= Version('0.4.1') else 1)"; then
             # NVIDIA/numba-cuda-mlir#135: serial-pytest contamination of
             # numba_cuda_mlir.cuda.cudadrv from an xfailed test in
@@ -512,6 +502,12 @@ jobs:
             # win-64 across runs), so we deselect the union of all tests
             # #135 lists as vulnerable + test_fortran_contiguous (observed
             # to hit the same contamination in our runs).
+            #
+            # test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn:
+            # subprocess-invokes `cuobjdump`, not on PATH in the base
+            # ubuntu:24.04 container. (Linux-only; Windows runners ship
+            # cuobjdump with the local CTK. No upstream fix yet — pending
+            # a skip-guard bug to be filed against NVIDIA/numba-cuda-mlir.)
             DESELECTS+=(
               --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_default_stream'
               --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_supplied_stream'
@@ -522,6 +518,7 @@ jobs:
               --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_sync'
               --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_sync_two_streams'
               --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_fortran_contiguous'
+              --deselect 'tests/numba_cuda_tests/cudadrv/test_nvjitlink.py::TestLinkerDumpAssembly::test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn'
             )
           fi
           pytest -rxXs -v \

--- a/.github/workflows/test-wheel-windows.yml
+++ b/.github/workflows/test-wheel-windows.yml
@@ -462,35 +462,20 @@ jobs:
 
       - name: Run numba-cuda-mlir tests
         if: ${{ inputs.test-mode == 'nightly-numba-cuda-mlir' && env.NUMBA_CUDA_MLIR_VER != '' }}
+        env:
+          LOCAL_CTK: ${{ matrix.LOCAL_CTK }}
         shell: bash --noprofile --norc -xeuo pipefail {0}
         run: |
+          if [[ "${LOCAL_CTK}" != 1 ]]; then
+            # Let numba-cuda-mlir skip inputs that require toolkit executables.
+            export NUMBA_CUDA_MLIR_TEST_WHEEL_ONLY=1
+          fi
           pushd numba-cuda-mlir-released
           pip install --upgrade "pip>=25.1"
           pip install --group test
-          # Version-gated deselects — dropped automatically when newer
-          # cuSIMT release ships. See linux step for full rationale.
-          # NVIDIA/numba-cuda-mlir#135 poisons a subset of tests that
-          # varies across runs based on collection order, so we deselect
-          # the full union rather than trying to enumerate what happened
-          # to fail on the most recent nightly.
-          DESELECTS=()
-          if python -c "from packaging.version import Version; import sys; sys.exit(0 if Version('${NUMBA_CUDA_MLIR_VER}') <= Version('0.4.1') else 1)"; then
-            DESELECTS+=(
-              --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_default_stream'
-              --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_no_sync_supplied_stream'
-              --deselect 'tests/numba_cuda_tests/cudadrv/test_cuda_array_slicing.py::CudaArraySetting::test_sync'
-              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_consume_no_sync'
-              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_consume_sync'
-              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_no_sync'
-              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_sync'
-              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_launch_sync_two_streams'
-              --deselect 'tests/numba_cuda_tests/cudapy/test_cuda_array_interface.py::TestCudaArrayInterface::test_fortran_contiguous'
-            )
-          fi
           pytest -rxXs -v \
             --ignore=tests/benchmarks \
             --ignore=tests/doc_examples \
-            "${DESELECTS[@]}" \
             tests/
           popd
 


### PR DESCRIPTION
## Description

closes #2726

## Explanation of the failure reported in #2726

The numba-cuda-mlir nightly jobs install the latest compatible release and then check out that release's matching test suite. The failing nightly resolved numba-cuda-mlir v0.5.0.

All ten numba-cuda-mlir `--deselect` entries were guarded by `NUMBA_CUDA_MLIR_VER <= 0.4.1`. Because v0.5.0 did not satisfy that condition, none of the deselects were passed to pytest. That was correct for nine of the entries, which worked around an old-version bug, but the remaining entry addressed a wheel-only environment constraint instead of a version-specific failure.

`test_nvjitlink_jit_with_linkable_code_lto_dump_assembly_warn` exercises some linkable inputs that require `cuobjdump`. The wheel-only Linux runner does not provide that executable. CUDA Python also did not set `NUMBA_CUDA_MLIR_TEST_WHEEL_ONLY`, so the test's existing wheel-only skip guard was not activated. The affected inputs therefore attempted to invoke the missing executable and failed.

## Why none of the `--deselect` entries are needed anymore

The ten entries fall into two classes:

### Nine version-gated deselects

Nine array-slicing and CUDA Array Interface tests were deselected to work around NVIDIA/numba-cuda-mlir#135 in numba-cuda-mlir v0.4.1 and earlier. The fix shipped in v0.4.2.

Current CI installs the latest compatible numba-cuda-mlir release, currently v0.5.0, and no configured nightly row resolves v0.4.1 or earlier. These nine deselects therefore no longer protect any supported CI configuration.

### One `cuobjdump`-related deselect

The remaining entry deselected the complete nvJitLink test to avoid requiring `cuobjdump`. The test already calls `self.skipTest()` for only the linkable inputs in `require_cuobjdump` when `NUMBA_CUDA_MLIR_TEST_WHEEL_ONLY` is set.

This PR sets `NUMBA_CUDA_MLIR_TEST_WHEEL_ONLY=1` for wheel-only (`LOCAL_CTK != 1`) numba-cuda-mlir jobs on Linux and Windows, matching numba-cuda-mlir's own wheel-test contract. The `fatbin` and object-file inputs that require `cuobjdump` are skipped, while the archive, cubin, and PTX inputs continue to run. The whole-test deselect is therefore unnecessary.

The existing benchmark and documentation-example collection ignores remain unchanged because they address unrelated imports of the `numba` package.

## Testing

- `pre-commit run --all-files`

## Checklist

- [x] Existing upstream tests cover these changes.
- [x] Documentation is not affected by this CI-only change.