### PR TITLE
[DO NOT MERGE] ci: validate selective core-test workplan

### DIFF
--- a/cuda_core/tests/test_typing_imports.py
+++ b/cuda_core/tests/test_typing_imports.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for cuda.core.typing public type aliases and protocols."""
+"""Tests for public type aliases and protocols exported by cuda.core.typing."""
 
 
 def test_typing_module_imports():


### PR DESCRIPTION
## Description

Related to #2467.

> [!WARNING]
> This is a temporary, validation-only draft PR. **Do not merge.** It targets
> `NVIDIA/cuda-python:pull-request/2467`, not `main`, and will be closed after
> the validation result is recorded on #2467.

The only delta is a nonfunctional module-docstring clarification in
`cuda_core/tests/test_typing_imports.py`. It exercises the `cuda_core`
test-only classification introduced by #2467 against the successful artifact
baseline at `1516ca87491ed5409ad50862d815c9a96c6b4900` (CI run
`33340094633`).

Expected workplan:

- reuse the complete artifacts from successful baseline run `33340094633`
- rebuild no package wheels
- test only `cuda_core`
- select the Linux and Windows test platforms
- skip sdist tests
- skip both `cuda_core` API checks
- pass the strict final job-status gate with intentional skips

The PR will be closed without merging after these expectations are verified.

## Checklist

- [x] New or existing tests cover these changes. The dependent CI run is the validation.
- [x] The documentation is up to date with these changes. This PR changes no product or user-facing behavior.
