### PR TITLE
fix(ci): omit .pxd/.pxi so nightly coverage html can run

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,11 +11,12 @@ plugins = Cython.Coverage
 core = ctrace
 branch = False
 relative_files = True
-# Omits specific definition files that causes plugin errors
+# Cython.Coverage cannot build a FileReporter for .pxd/.pxi (not standalone
+# translation units). Pattern in [run], not an enumeration: a new file of
+# either kind otherwise breaks `coverage html`. Must be [run], not [report].
 omit =
-    */windll.pxd
-    */_lib/windll.pxd
-    */_lib/utils.pxd
+    */*.pxd
+    */*.pxi
 
 [report]
 show_missing = true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -542,7 +542,8 @@ jobs:
           echo "=== Combining coverage data ==="
           coverage combine --rcfile=./.coveragerc --keep .coverage.*
 
-          # Generate reports
+      - name: Generate coverage reports
+        run: |
           echo ""
           echo "=== Generating HTML, XML, and text reports ==="
           coverage html --rcfile=./.coveragerc


### PR DESCRIPTION
## Description

closes #2723

Nightly `CI: Coverage` has failed since Aug 15 at `coverage html`: Cython.Coverage cannot build a `FileReporter` for `.pxd` / `.pxi` files (they are not standalone translation units). `coverage combine` itself succeeds; the old mega-step name made that hard to see.

`[run] omit` now uses `*/*.pxd` and `*/*.pxi` instead of listing three `.pxd` files by hand. A new file of either kind would otherwise break `coverage html` again. 


