### PR TITLE
pathfinder: also find ptxas in the nvidia/cu13/bin wheel layout

### DIFF
--- a/cuda_pathfinder/cuda/pathfinder/_binaries/supported_nvidia_binaries.py
+++ b/cuda_pathfinder/cuda/pathfinder/_binaries/supported_nvidia_binaries.py
@@ -13,6 +13,7 @@ _NSIGHT_COMPUTE_BIN = os.path.join("nvidia", "nsight_compute", "bin")
 SITE_PACKAGES_BINDIRS = {
     # Core compilation tools
     "nvcc": (_CUDA13_BIN, _CUDA_NVCC_BIN),
+    "ptxas": (_CUDA13_BIN, _CUDA_NVCC_BIN),
     "nvdisasm": (_CUDA13_BIN, _CUDA_NVCC_BIN),
     "cuobjdump": (_CUDA13_BIN, _CUDA_NVCC_BIN),
     "nvprune": (_CUDA_NVCC_BIN,),

--- a/cuda_pathfinder/docs/nv-versions.json
+++ b/cuda_pathfinder/docs/nv-versions.json
@@ -4,6 +4,10 @@
         "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/latest/"
     },
     {
+        "version": "1.8.1",
+        "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/1.8.1/"
+    },
+    {
         "version": "1.8.0",
         "url": "https://nvidia.github.io/cuda-python/cuda-pathfinder/1.8.0/"
     },

--- a/cuda_pathfinder/docs/source/release/1.8.1-notes.rst
+++ b/cuda_pathfinder/docs/source/release/1.8.1-notes.rst
@@ -1,0 +1,33 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+.. py:currentmodule:: cuda.pathfinder
+
+``cuda-pathfinder`` 1.8.1 Release notes
+=======================================
+
+Highlights
+----------
+
+* Add ``ptxas`` to ``SUPPORTED_BINARY_UTILITIES``. The
+  :func:`find_nvidia_binary_utility` function can now locate it on Linux and
+  Windows through the existing NVIDIA wheel, Conda, and CUDA Toolkit search
+  pipeline. NVIDIA wheel discovery prefers the CUDA 13 ``nvidia/cu13/bin``
+  layout while retaining the legacy ``nvidia/cuda_nvcc/bin`` fallback.
+  (`PR #2741 <https://github.com/NVIDIA/cuda-python/pull/2741>`_)
+
+Bugfixes
+--------
+
+* Find ``cuobjdump`` in the CUDA 13 ``nvidia/cu13/bin`` NVIDIA wheel layout
+  while retaining discovery from the legacy ``nvidia/cuda_nvcc/bin`` layout.
+  (`PR #2739 <https://github.com/NVIDIA/cuda-python/pull/2739>`_)
+
+Internal maintenance
+--------------------
+
+* Add ``pytest-run-parallel>=0.4.1`` to the normal test dependencies so the
+  existing ``thread_unsafe`` marker and ``thread_unsafe_fixtures``
+  configuration option are registered in standard test environments. This is
+  test-only and does not add a runtime dependency.
+  (`PR #2741 <https://github.com/NVIDIA/cuda-python/pull/2741>`_)

--- a/cuda_pathfinder/pixi.lock
+++ b/cuda_pathfinder/pixi.lock
@@ -98,6 +98,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-randomly-3.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-repeat-0.9.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-run-parallel-0.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -136,6 +137,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-randomly-3.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-repeat-0.9.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-run-parallel-0.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -156,6 +158,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-randomly-3.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-repeat-0.9.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-run-parallel-0.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -214,6 +217,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-randomly-3.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-repeat-0.9.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-run-parallel-0.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -252,6 +256,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-randomly-3.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-repeat-0.9.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-run-parallel-0.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -272,6 +277,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-randomly-3.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-repeat-0.9.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-run-parallel-0.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -330,6 +336,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-randomly-3.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-repeat-0.9.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-run-parallel-0.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -368,6 +375,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-randomly-3.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-repeat-0.9.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-run-parallel-0.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -388,6 +396,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-randomly-3.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-repeat-0.9.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-run-parallel-0.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -4309,6 +4318,17 @@ packages:
   license_family: MOZILLA
   size: 10537
   timestamp: 1744061283541
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-run-parallel-0.10.0-pyhd8ed1ab_0.conda
+  sha256: e69fc1d40c3ad22ad4b664143916ccb2f5d57cdb70879c371b8905e4f51c82bb
+  md5: 79c30c544dd76bd4f81d7e975efaca4b
+  depends:
+  - pytest >=6.2.0
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 24875
+  timestamp: 1785909313088
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
   sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
   md5: 5b8d21249ff20967101ffa321cab24e8

--- a/cuda_pathfinder/pixi.toml
+++ b/cuda_pathfinder/pixi.toml
@@ -15,6 +15,7 @@ pytest = ">=6.2.4"
 pytest-mock = "*"
 pytest-repeat = "*"
 pytest-randomly = "*"
+pytest-run-parallel = ">=0.4.1"
 
 # Keep this dependency set aligned with cuda_python/docs/environment-docs.yml.
 [feature.docs.dependencies]

--- a/cuda_pathfinder/pyproject.toml
+++ b/cuda_pathfinder/pyproject.toml
@@ -16,6 +16,7 @@ test = [
     "pytest-mock==3.15.1",
     "pytest-repeat==0.9.4",
     "pytest-randomly==4.1.0",
+    "pytest-run-parallel>=0.4.1",
 ]
 # Internal organization of test dependencies.
 cu12 = [

--- a/cuda_pathfinder/tests/test_find_nvidia_binaries.py
+++ b/cuda_pathfinder/tests/test_find_nvidia_binaries.py
@@ -16,7 +16,7 @@ from cuda.pathfinder._binaries.supported_nvidia_binaries import (
 )
 
 CUDA13_WHEEL_BINARIES = frozenset(
-    ("nvcc", "nvdisasm", "cuobjdump", "fatbinary", "bin2c", "nvlink", "compute-sanitizer")
+    ("nvcc", "ptxas", "nvdisasm", "cuobjdump", "fatbinary", "bin2c", "nvlink", "compute-sanitizer")
 )
 
 
@@ -40,7 +40,7 @@ def test_supported_binaries_consistency():
 
 @pytest.mark.agent_authored(model="claude-opus-5")
 def test_cuda13_wheel_layout_is_declared_and_preferred():
-    """Every utility shipped in nvidia/cu13/bin must declare that layout first.
+    """Every supported utility shipped in nvidia/cu13/bin must declare that layout first.
 
     Omitting it makes the site-packages search step skip an installed CUDA 13
     wheel entirely, which is only visible on hosts without a local CTK to fall


### PR DESCRIPTION
## Description

Triggered by #2739.

`ptxas` was not present in Pathfinder's supported binary utility registry. This PR adds it to `SUPPORTED_BINARY_UTILITIES`, enabling `find_nvidia_binary_utility("ptxas")` on Linux and Windows through the existing NVIDIA wheel, Conda, and CUDA Toolkit search pipeline.

For NVIDIA wheels, discovery prefers the CUDA 13 `nvidia/cu13/bin` location while retaining `nvidia/cuda_nvcc/bin` as a fallback. The CUDA 13 wheel-layout consistency test now covers `ptxas` as well.

The PR also adds the `cuda-pathfinder` 1.8.1 release notes, covering this change and the `cuobjdump` CUDA 13 wheel-layout fix from #2739, and registers 1.8.1 in the documentation version switcher.

### Unrelated test dependency

This PR also adds `pytest-run-parallel>=0.4.1` to Pathfinder's normal test dependencies. This is unrelated to `ptxas` discovery. Pathfinder already uses the plugin's `thread_unsafe` marker and `thread_unsafe_fixtures` configuration option, so installing the plugin prevents unknown-marker and unknown-config warnings in standard test environments.

Version `0.4.1` is the minimum compatible with the current pytest dependency; leaving the upper bound open allows normal ecosystem updates. The Pixi lockfile currently resolves `pytest-run-parallel` 0.10.0.

## Testing

- Installed the `test-cu13` dependency group and confirmed that Pathfinder resolves `ptxas` to the file supplied by `nvidia-cuda-nvcc` 13.3.73 under `site-packages/nvidia/cu13/bin`, rather than `/usr/local/cuda-13.3/bin`.
- Pathfinder test suite: `1610 passed, 5 skipped`.
- Built the Pathfinder 1.8.1 documentation with Sphinx warnings treated as errors.
- `pre-commit run --all-files`.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
