### PR TITLE
Fix primary context cleanup during Python shutdown

### DIFF
--- a/cuda_core/cuda/core/_cpp/resource_handles.cpp
+++ b/cuda_core/cuda/core/_cpp/resource_handles.cpp
@@ -625,8 +625,14 @@ ContextHandle get_primary_context(int device_id) {
         new ContextBox{ctx, {}},
         [device_id](const ContextBox* b) {
             context_registry.unregister_handle(b->resource);
-            GILReleaseGuard gil;
-            p_cuDevicePrimaryCtxRelease(device_id);
+            // The driver function pointer targets a Cython __pyx_capi__
+            // wrapper, which touches the Python runtime even though the
+            // underlying CUDA call does not. During interpreter shutdown,
+            // leave primary-context cleanup to process teardown.
+            if (Py_IsInitialized() && !py_is_finalizing()) {
+                GILReleaseGuard gil;
+                p_cuDevicePrimaryCtxRelease(device_id);
+            }
             delete b;
         }
     );

--- a/cuda_core/tests/test_device.py
+++ b/cuda_core/tests/test_device.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib
+import subprocess
+import sys
 
 import pytest
 
@@ -52,6 +54,19 @@ def test_device_set_current(deinit_cuda):
     device = Device()
     device.set_current()
     assert handle_return(driver.cuCtxGetCurrent()) is not None
+
+
+@pytest.mark.agent_authored(model="gpt-5.6-sol")
+def test_primary_context_cleanup_is_safe_during_python_shutdown(init_cuda, tmp_path):
+    result = subprocess.run(
+        [sys.executable, "-c", "from cuda.core import Device; Device().set_current()"],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        # Avoid shadowing the installed package with cuda_core/cuda/core.
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 def test_device_repr(deinit_cuda):


### PR DESCRIPTION
## Summary

- avoid calling the CUDA Bindings Cython wrapper from the primary-context TLS destructor after CPython has finalized
- preserve `cuDevicePrimaryCtxRelease` during normal thread cleanup while leaving process-exit cleanup to CUDA/the OS
- add a subprocess regression test covering `Device().set_current()` followed by interpreter shutdown

Fixes #2743.

## Root cause

`get_primary_context()` caches a `ContextHandle` in thread-local storage. When the main thread's TLS destructors run after `Py_Finalize()`, the handle deleter calls `p_cuDevicePrimaryCtxRelease`. That pointer targets `cuda.bindings.cydriver.__pyx_capi__["cuDevicePrimaryCtxRelease"]`, whose generated Cython entry path touches Python thread state. The result is a post-`atexit` segfault in `PyThreadState_New`.

The existing `GILReleaseGuard` avoids manipulating the GIL after finalization, but the Cython driver wrapper invoked immediately afterward has the same Python-runtime requirement. The new guard skips that wrapper only when Python is no longer usable.

## Testing

- `pixi run --manifest-path cuda_core -e cu12 python -m pytest cuda_core/tests/test_device.py -q`
  - 166 passed, 2 skipped
- minimal shutdown probe exits 0:
  - `python -c 'from cuda.core import Device; Device().set_current(); print("initialized")'`
- repository pre-commit hooks pass
