### PR TITLE
Fix cuPointerGetAttribute(s) returning 0 for CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL

### DIFF
--- a/cuda_bindings/cuda/bindings/_lib/utils.pxi
+++ b/cuda_bindings/cuda/bindings/_lib/utils.pxi
@@ -308,11 +308,12 @@ cdef class _HelperCUpointer_attribute:
         if self._attr in (cydriver.CUpointer_attribute_enum.CU_POINTER_ATTRIBUTE_CONTEXT,):
             return self._ctx
         elif self._attr in (cydriver.CUpointer_attribute_enum.CU_POINTER_ATTRIBUTE_MEMORY_TYPE,
-                            cydriver.CUpointer_attribute_enum.CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,
                             cydriver.CUpointer_attribute_enum.CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES,
                             cydriver.CUpointer_attribute_enum.CU_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE,
                             cydriver.CUpointer_attribute_enum.CU_POINTER_ATTRIBUTE_ACCESS_FLAGS,):
             return self._uint
+        elif self._attr in (cydriver.CUpointer_attribute_enum.CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,):
+            return self._int
         elif self._attr in (cydriver.CUpointer_attribute_enum.CU_POINTER_ATTRIBUTE_DEVICE_POINTER,
                             cydriver.CUpointer_attribute_enum.CU_POINTER_ATTRIBUTE_RANGE_START_ADDR,):
             return self._devptr

--- a/cuda_bindings/tests/test_cuda.py
+++ b/cuda_bindings/tests/test_cuda.py
@@ -1335,3 +1335,35 @@ def test_dealloc_clears_array_field_in_external_struct():
         f"external struct still holds a dangling pointer ({attrs_after:#x}) "
         "where attrs was, after the aliasing wrapper was destroyed"
     )
+
+
+def test_pointer_device_ordinal_matches_allocation_device():
+    # Regression test for cuPointerGetAttribute(s)(DEVICE_ORDINAL): the binding
+    # must report the real device the pointer was allocated on, not always 0.
+    # Needs >= 2 GPUs: on device 0 a wrong 0 is indistinguishable from correct.
+    err, ndev = cudart.cudaGetDeviceCount()
+    assert err == cudart.cudaError_t.cudaSuccess
+    if ndev < 2:
+        pytest.skip("needs >= 2 GPUs to distinguish a wrong 0 from the correct ordinal")
+
+    ord_attr = cuda.CUpointer_attribute.CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL
+    for dev in range(ndev):
+        (err,) = cudart.cudaSetDevice(dev)
+        assert err == cudart.cudaError_t.cudaSuccess
+        err, ptr = cudart.cudaMalloc(256)
+        assert err == cudart.cudaError_t.cudaSuccess
+        try:
+            err, attrs = cudart.cudaPointerGetAttributes(ptr)
+            assert err == cudart.cudaError_t.cudaSuccess
+            expected = attrs.device
+
+            err, singular = cuda.cuPointerGetAttribute(ord_attr, cuda.CUdeviceptr(ptr))
+            assert err == cuda.CUresult.CUDA_SUCCESS
+            assert singular == expected, f"singular ordinal {singular} != {expected} on device {dev}"
+
+            err, plural = cuda.cuPointerGetAttributes(1, [ord_attr], cuda.CUdeviceptr(ptr))
+            assert err == cuda.CUresult.CUDA_SUCCESS
+            assert plural[0] == expected, f"plural ordinal {plural[0]} != {expected} on device {dev}"
+        finally:
+            (err,) = cudart.cudaFree(ptr)
+            assert err == cudart.cudaError_t.cudaSuccess


### PR DESCRIPTION
`cuPointerGetAttribute` and `cuPointerGetAttributes` always return `0` for `CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL`, regardless of which device the pointer was actually allocated on. 
The root cause is I think a write/read field mismatch in
`_HelperCUpointer_attribute` (`cuda_bindings/cuda/bindings/_lib/utils.pxi`):
- `__cinit__` allocates storage for `DEVICE_ORDINAL` in the **signed** `_int`
  member and points `_cptr` at it, so the driver writes the ordinal there.
- `pyObj()` reads `DEVICE_ORDINAL` back from the **unsigned** `_uint` member,
  which is never written and stays `0`.
Because the value is read from the wrong member, the ordinal is always `0`.

## Fix
Read `DEVICE_ORDINAL` from `_int` in `pyObj()` so the read path matches the write path in `__cinit__`.

## Test
Adds a regression test that allocates on each visible GPU and asserts the
ordinal reported by both the singular and plural bindings matches the
allocation device (ground truth from `cudaPointerGetAttributes`).
Existing tests missed this because they only asserted call success / that
singular and plural agree (both share the buggy read path and both returned 0).
The test needs >= 2 GPUs and skips otherwise, since on device 0 a wrong `0` is
indistinguishable from the correct value.

Below are also minimal reproducers in c and python . the c one works correctly , the python does not and motivated this MR.
```c
/*
 * nvcc -o minimal minimal.c -lcuda
 * ./minimal
 */

#include <cuda.h>
#include <cuda_runtime_api.h>
#include <stdio.h>

int main(void) {
    cuInit(0);

    int ndev = 0;
    cudaGetDeviceCount(&ndev);
    printf("visible GPUs: %d\n", ndev);

    for (int dev = 0; dev < ndev; ++dev) {
        cudaSetDevice(dev);

        void *ptr = NULL;
        cudaMalloc(&ptr, 256);

        /* runtime */
        struct cudaPointerAttributes attr;
        cudaPointerGetAttributes(&attr, ptr);
        int rt = attr.device;

        /* driver, singular */
        int singular = -1;
        cuPointerGetAttribute(&singular, CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,
                              (CUdeviceptr)ptr);

        /* driver, plural */
        int plural = -1;
        CUpointer_attribute attrs[1] = {CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL};
        void *data[1] = {&plural};
        cuPointerGetAttributes(1, attrs, data, (CUdeviceptr)ptr);

        printf("device %d: rt=%d singular=%d plural=%d\n", dev, rt, singular, plural);

        cudaFree(ptr);
    }
    return 0;
}
```

```py
from cuda.bindings import runtime as cbr
from cuda.bindings import driver as cbd

ORD = cbd.CUpointer_attribute.CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL
_, ndev = cbr.cudaGetDeviceCount()
for dev in range(ndev):
    cbr.cudaSetDevice(dev)
    _, ptr = cbr.cudaMalloc(256)
    rt = cbr.cudaPointerGetAttributes(ptr)[1].device
    singular = cbd.cuPointerGetAttribute(ORD, cbd.CUdeviceptr(ptr))[1]
    plural = cbd.cuPointerGetAttributes(1, [ORD], cbd.CUdeviceptr(ptr))[1][0]
    print(f"device {dev}: rt={rt} singular={singular} plural={plural}")
    cbr.cudaFree(ptr)
```

when i run these, **before the fix of this MR**, I get:
```
bin/nvcc -o exe minimal.c -lcuda && ./exe
visible GPUs: 4
device 0: rt=0 singular=0 plural=0
device 1: rt=1 singular=1 plural=1
device 2: rt=2 singular=2 plural=2
device 3: rt=3 singular=3 plural=3
```
and 
```
python minimal.py
device 0: rt=0 singular=0 plural=0
device 1: rt=1 singular=0 plural=0
device 2: rt=2 singular=0 plural=0
device 3: rt=3 singular=0 plural=0
```

