### PR TITLE
BUG: Fix wrapping of nvrtcBundledHeadersInfo

### DIFF
--- a/cuda_bindings/cuda/bindings/nvrtc.pxd
+++ b/cuda_bindings/cuda/bindings/nvrtc.pxd
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # This code was automatically generated with version 13.3.0. Do not modify it directly.
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=06a058e3c626563f034714cce129fd58b33dd80c0e4a954723e92d0ae61c7c58
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=ee485e830fdb8037d58a70b73a413f3ce362819576fd86e91d55ce14ba3f9149
 cimport cuda.bindings.cynvrtc as cynvrtc
 
 include "_lib/utils.pxd"
@@ -21,69 +21,35 @@ cdef class nvrtcProgram:
     cdef cynvrtc.nvrtcProgram  _pvt_val
     cdef cynvrtc.nvrtcProgram* _pvt_ptr
 
-cdef class anon_struct0:
+cdef class nvrtcBundledHeadersInfo:
     """
+    Structure containing information about bundled headers.
+
     Attributes
     ----------
 
     available : int
-
-
-
-    compressedSize : size_t
-
-
-
-    uncompressedSize : size_t
-
-
-
-    cudaVersionMajor : int
-
-
-
-    cudaVersionMinor : int
-
-
-
-    numFiles : unsigned int
-
-
-
-    Methods
-    -------
-    getPtr()
-        Get memory address of class instance
-    """
-    cdef cynvrtc.nvrtcBundledHeadersInfo* _pvt_ptr
-
-cdef class nvrtcBundledHeadersInfo(anon_struct0):
-    """
-    Attributes
-    ----------
-
-    available : int
-
+        Non-zero if bundled headers are available
 
 
     compressedSize : size_t
-
+        Size of compressed archive in bytes
 
 
     uncompressedSize : size_t
-
+        Estimated size when extracted in bytes
 
 
     cudaVersionMajor : int
-
+        CUDA major version of bundled headers
 
 
     cudaVersionMinor : int
-
+        CUDA minor version of bundled headers
 
 
     numFiles : unsigned int
-
+        Number of header files in the bundle
 
 
     Methods
@@ -92,3 +58,4 @@ cdef class nvrtcBundledHeadersInfo(anon_struct0):
         Get memory address of class instance
     """
     cdef cynvrtc.nvrtcBundledHeadersInfo _pvt_val
+    cdef cynvrtc.nvrtcBundledHeadersInfo* _pvt_ptr

--- a/cuda_bindings/cuda/bindings/nvrtc.pyx
+++ b/cuda_bindings/cuda/bindings/nvrtc.pyx
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # This code was automatically generated with version 13.3.0. Do not modify it directly.
-# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=5d36f91a9f04660caaf0a8a7afa443d43899bc6eb70e61a26415485d9a39475a
+# CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=9c30b7a3d79561c6721e7df7b758eaee6afdd2763d9692ff638815abb64417e0
 from typing import Any, Optional
 import cython
 import ctypes
@@ -141,33 +141,35 @@ cdef class nvrtcProgram:
     def getPtr(self):
         return <void_ptr>self._pvt_ptr
 
-cdef class anon_struct0:
+cdef class nvrtcBundledHeadersInfo:
     """
+    Structure containing information about bundled headers.
+
     Attributes
     ----------
 
     available : int
-
+        Non-zero if bundled headers are available
 
 
     compressedSize : size_t
-
+        Size of compressed archive in bytes
 
 
     uncompressedSize : size_t
-
+        Estimated size when extracted in bytes
 
 
     cudaVersionMajor : int
-
+        CUDA major version of bundled headers
 
 
     cudaVersionMinor : int
-
+        CUDA minor version of bundled headers
 
 
     numFiles : unsigned int
-
+        Number of header files in the bundle
 
 
     Methods
@@ -175,10 +177,12 @@ cdef class anon_struct0:
     getPtr()
         Get memory address of class instance
     """
-    def __cinit__(self, void_ptr _ptr):
-        self._pvt_ptr = <cynvrtc.nvrtcBundledHeadersInfo *>_ptr
-
-    def __init__(self, void_ptr _ptr):
+    def __cinit__(self, void_ptr _ptr = 0):
+        if _ptr == 0:
+            self._pvt_ptr = &self._pvt_val
+        else:
+            self._pvt_ptr = <cynvrtc.nvrtcBundledHeadersInfo *>_ptr
+    def __init__(self, void_ptr _ptr = 0):
         pass
     def __dealloc__(self):
         pass
@@ -274,49 +278,6 @@ cdef class anon_struct0:
     def numFiles(self, unsigned int numFiles):
         self._pvt_ptr[0].numFiles = numFiles
 
-
-cdef class nvrtcBundledHeadersInfo(anon_struct0):
-    """
-    Attributes
-    ----------
-
-    available : int
-
-
-
-    compressedSize : size_t
-
-
-
-    uncompressedSize : size_t
-
-
-
-    cudaVersionMajor : int
-
-
-
-    cudaVersionMinor : int
-
-
-
-    numFiles : unsigned int
-
-
-
-    Methods
-    -------
-    getPtr()
-        Get memory address of class instance
-    """
-    def __cinit__(self, void_ptr _ptr = 0):
-        if _ptr == 0:
-            self._pvt_ptr = <cynvrtc.nvrtcBundledHeadersInfo *>&self._pvt_val
-        else:
-            self._pvt_ptr = <cynvrtc.nvrtcBundledHeadersInfo *>_ptr
-
-    def __init__(self, void_ptr _ptr = 0):
-        pass
 
 @cython.embedsignature(True)
 def nvrtcGetErrorString(result not None : nvrtcResult):

--- a/cuda_bindings/docs/source/module/nvrtc.rst
+++ b/cuda_bindings/docs/source/module/nvrtc.rst
@@ -3,7 +3,7 @@
 
 .. This code was automatically generated with version 13.3.0. Do not modify it directly.
 
-.. CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=c324889e2f86a6302cc610b49d290d545483f3fc0fa05d62ee47eb8aed781ae1
+.. CYTHON-BINDINGS-GENERATED-DO-NOT-MODIFY-THIS-FILE: format=1; content-sha256=c0aad81d1be715fcef6b97fc6fa560c100a9c66fd9a67306e78653884618047c
 -----
 nvrtc
 -----
@@ -122,6 +122,7 @@ Bundled Headers Installation
 
 NVRTC defines the following types and functions for bundled headers installation and management.
 
+.. autoclass:: cuda.bindings.nvrtc.nvrtcBundledHeadersInfo
 .. autoclass:: cuda.bindings.nvrtc.nvrtcBundledHeadersInfo
 .. autofunction:: cuda.bindings.nvrtc.nvrtcInstallBundledHeaders
 .. autofunction:: cuda.bindings.nvrtc.nvrtcGetBundledHeadersInfo

--- a/cuda_bindings/tests/legacy_api/test_legacy_nvrtc.py
+++ b/cuda_bindings/tests/legacy_api/test_legacy_nvrtc.py
@@ -35,3 +35,21 @@ def test_nvrtcGetLoweredName_failure():
     err, name = nvrtc.nvrtcGetLoweredName(0, b"I'm another elevated name!")
     assert err == nvrtc.nvrtcResult.NVRTC_ERROR_INVALID_PROGRAM
     assert name is None
+
+
+@pytest.mark.agent_authored(model="claude-sonnet-5")
+@pytest.mark.skipif(nvrtcVersionLessThan(13, 3), reason="When nvrtcGetBundledHeadersInfo was introduced")
+def test_nvrtcGetBundledHeadersInfo():
+    info = nvrtc.nvrtcBundledHeadersInfo()
+    assert isinstance(info, nvrtc.nvrtcBundledHeadersInfo)
+
+    err, info, errorLog = nvrtc.nvrtcGetBundledHeadersInfo()
+    ASSERT_DRV(err)
+    assert isinstance(info, nvrtc.nvrtcBundledHeadersInfo)
+    assert info.available in (0, 1)
+    assert info.compressedSize >= 0
+    assert info.uncompressedSize >= 0
+    assert info.cudaVersionMajor >= 0
+    assert info.cudaVersionMinor >= 0
+    assert info.numFiles >= 0
+    assert errorLog is None

--- a/cuda_bindings/tests/test_nvrtc.py
+++ b/cuda_bindings/tests/test_nvrtc.py
@@ -23,3 +23,20 @@ def test_get_lowered_name_failure():
         nvrtc.get_lowered_name(0, b"I'm an elevated name!")
     with pytest.raises(nvrtc.InvalidProgramError):
         nvrtc.get_lowered_name(0, b"I'm another elevated name!")
+
+
+@pytest.mark.agent_authored(model="claude-sonnet-5")
+@pytest.mark.skipif(nvrtc_version_less_than(13, 3), reason="When nvrtcGetBundledHeadersInfo was introduced")
+def test_get_bundled_headers_info():
+    info = nvrtc.BundledHeadersInfo()
+    assert isinstance(info, nvrtc.BundledHeadersInfo)
+
+    info, error_log = nvrtc.get_bundled_headers_info()
+    assert isinstance(info, nvrtc.BundledHeadersInfo)
+    assert info.available in (0, 1)
+    assert info.compressed_size >= 0
+    assert info.uncompressed_size >= 0
+    assert info.cuda_version_major >= 0
+    assert info.cuda_version_minor >= 0
+    assert info.num_files >= 0
+    assert error_log is None


### PR DESCRIPTION
Due to how the `nvrtcBundledHeadersInfo` struct was spelled in the header, this caused our legacy generator to generate an unnecessary anonymous class and a class that it inherits from that can't be instantiated with its own memory.

This uses a small fix in the generator to generate the right thing, and then adds some regression tests.

This was discovered while looking at the new bundled header APIs as part of #2363, but it is not required for that work -- the implementation there doesn't actually need to use these APIs directly anyway.  This is just a latent bug for any users who want to use these new APIs directly from cuda-bindings.