### PR TITLE
Prepare cuda.core v1.2.0 release

### DIFF
--- a/cuda_core/docs/nv-versions.json
+++ b/cuda_core/docs/nv-versions.json
@@ -4,6 +4,14 @@
         "url": "https://nvidia.github.io/cuda-python/cuda-core/latest/"
     },
     {
+        "version": "1.2.0",
+        "url": "https://nvidia.github.io/cuda-python/cuda-core/1.2.0/"
+    },
+    {
+        "version": "1.1.1",
+        "url": "https://nvidia.github.io/cuda-python/cuda-core/1.1.1/"
+    },
+    {
         "version": "1.1.0",
         "url": "https://nvidia.github.io/cuda-python/cuda-core/1.1.0/"
     },

--- a/cuda_core/docs/source/release/1.2.0-notes.rst
+++ b/cuda_core/docs/source/release/1.2.0-notes.rst
@@ -239,13 +239,6 @@ Fixes and enhancements
   ``ValueError`` before the query runs.
   (`#2488 <https://github.com/NVIDIA/cuda-python/pull/2488>`__)
 
-- ``import cuda.core`` no longer raises ``ValueError`` when
-  ``CUDA_CORE_DONT_FIX_TAB_COMPLETION`` is set to a non-integer value such
-  as an empty string, ``true``, or ``yes``. Any non-empty, non-integer
-  value is honored as an opt-out. See :doc:`environment_variables` for
-  details.
-  (`#2535 <https://github.com/NVIDIA/cuda-python/pull/2535>`__)
-
 - The frozen fallback ``CUresult`` explanation table, used when the
   driver's ``cuGetErrorName`` / ``cuGetErrorString`` are unavailable, is
   refreshed for CUDA 13.3 and now recognizes

--- a/cuda_core/docs/source/release/1.2.0-notes.rst
+++ b/cuda_core/docs/source/release/1.2.0-notes.rst
@@ -37,6 +37,22 @@ New features
   (`#2456 <https://github.com/NVIDIA/cuda-python/pull/2456>`__,
   `#1334 <https://github.com/NVIDIA/cuda-python/issues/1334>`__)
 
+- Added :attr:`ProgramOptions.use_bundled_headers`, which lets NVRTC
+  resolve the CUDA and CCCL headers from the toolkit bundled with NVRTC
+  itself, installed into a per-user cache directory, instead of requiring
+  a full CUDA Toolkit installation on the compile host. NVRTC backend
+  only; requires NVRTC 13.3 or newer.
+  (`#2753 <https://github.com/NVIDIA/cuda-python/pull/2753>`__,
+  closes `#2363 <https://github.com/NVIDIA/cuda-python/issues/2363>`__)
+
+- When a :class:`Program` is compiled with ``debug`` or ``lineinfo``,
+  the NVRTC input source is now materialized as a temporary ``.cu`` file
+  so ``cuda-gdb`` can list the original source while stepping through
+  JIT-compiled kernels. ``#include "..."`` search still resolves against
+  the original source directory.
+  (`#2678 <https://github.com/NVIDIA/cuda-python/pull/2678>`__,
+  `#2679 <https://github.com/NVIDIA/cuda-python/pull/2679>`__)
+
 Fixes and enhancements
 ----------------------
 
@@ -195,6 +211,46 @@ Fixes and enhancements
   NVML system-device count. This prevents non-CUDA accelerators, such as an NPU,
   from being treated as CUDA devices by :meth:`Device.get_all_devices`, examples,
   and tests.
+
+- :class:`PinnedMemoryResource` now rejects unsupported host memory pools
+  at construction with ``RuntimeError``, instead of letting a later
+  allocation or copy fail with ``CUDA_ERROR_INVALID_VALUE``.
+  (`#2487 <https://github.com/NVIDIA/cuda-python/pull/2487>`__)
+
+- :attr:`VirtualMemoryResource.is_host_accessible`, and by extension
+  :attr:`Buffer.is_host_accessible`, now correctly return ``True`` for a
+  resource configured with ``location_type="host_numa"`` or
+  ``"host_numa_current"``. Previously both properties reported ``False``
+  on those NUMA-located variants.
+  (`#2503 <https://github.com/NVIDIA/cuda-python/pull/2503>`__)
+
+- Graph predecessor and successor queries no longer truncate their results
+  on large graphs.
+  (`#2587 <https://github.com/NVIDIA/cuda-python/pull/2587>`__)
+
+- Per-domain clock queries in :mod:`cuda.core.system` treat each domain
+  (minimum, maximum, and current) as independently optional, so an
+  unsupported domain no longer fails the whole clock query for a device.
+  (`#2651 <https://github.com/NVIDIA/cuda-python/pull/2651>`__)
+
+- Temperature threshold checks in :mod:`cuda.core.system` are now
+  forward-compatible with GPU architectures newer than the generated
+  ``DeviceArch`` enum. An unrecognized architecture no longer raises
+  ``ValueError`` before the query runs.
+  (`#2488 <https://github.com/NVIDIA/cuda-python/pull/2488>`__)
+
+- ``import cuda.core`` no longer raises ``ValueError`` when
+  ``CUDA_CORE_DONT_FIX_TAB_COMPLETION`` is set to a non-integer value such
+  as an empty string, ``true``, or ``yes``. Any non-empty, non-integer
+  value is honored as an opt-out. See :doc:`environment_variables` for
+  details.
+  (`#2535 <https://github.com/NVIDIA/cuda-python/pull/2535>`__)
+
+- The frozen fallback ``CUresult`` explanation table, used when the
+  driver's ``cuGetErrorName`` / ``cuGetErrorString`` are unavailable, is
+  refreshed for CUDA 13.3 and now recognizes
+  ``CUDA_ERROR_GRAPH_RECAPTURE_FAILURE``.
+  (`#2383 <https://github.com/NVIDIA/cuda-python/pull/2383>`__)
 
 Deprecation Notices
 -------------------


### PR DESCRIPTION
## Description

Doc-only prep for tagging `cuda-core-v1.2.0`. Version comes from the git tag via `setuptools-scm`, so no `pyproject.toml` bump.

**Release notes (`1.2.0-notes.rst`)** — fills user-visible entries that landed since v1.1.1 but were not yet drafted:

- New features: `ProgramOptions.use_bundled_headers` for NVRTC 13.3+ (#2753 closes #2363), cuda-gdb source display for JIT-compiled kernels (#2678, #2679).
- Fixes and enhancements: pinned-pool validation (#2487), NUMA VMM `is_host_accessible` (#2503), graph query truncation (#2587), per-domain clocks (#2651), temperature threshold forward-compat (#2488), `import cuda.core` non-integer opt-out crash (#2535), `CUresult` table refresh for CUDA 13.3 (#2383).

**Version switcher (`nv-versions.json`)** — adds `1.2.0` (this release) and `1.1.1` (missed after that tag) above `1.1.0`.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

-- Leo's bot