### PR TITLE
[no-ci] toolshed: require all LICENSE files to match the repository license

### DIFF
--- a/cuda_pathfinder/LICENSE
+++ b/cuda_pathfinder/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
                                  Apache License
                            Version 2.0, January 2004

--- a/toolshed/check_spdx.py
+++ b/toolshed/check_spdx.py
@@ -36,6 +36,19 @@ TOP_LEVEL_DIRS_LICENSE_IDENTIFIERS = {
 }
 
 SPDX_IGNORE_FILENAME = ".spdx-ignore"
+REPOSITORY_LICENSE_CONTENTS = Path("LICENSE").read_bytes()
+
+
+def license_files_match_repository(filepaths):
+    licenses_match = True
+    for filepath in filepaths:
+        license_path = Path(filepath)
+        if license_path.name != "LICENSE":
+            continue
+        if license_path.read_bytes() != REPOSITORY_LICENSE_CONTENTS:
+            print(f"PACKAGE LICENSE {filepath!r} does not match repository LICENSE")
+            licenses_match = False
+    return licenses_match
 
 
 def load_spdx_ignore():
@@ -203,9 +216,12 @@ def main(args):
     else:
         fix = False
 
+    returncode = 0
+    if not license_files_match_repository(args):
+        returncode = 1
+
     ignore_spec = load_spdx_ignore()
 
-    returncode = 0
     for filepath in args:
         if ignore_spec.match_file(filepath):
             continue


### PR DESCRIPTION
## Description

No linked issue; this was found while working on #2737.

Make the `check-spdx` hook compare every `LICENSE` file it receives with the repository-level `LICENSE`. This removes the hard-coded package-license list, automatically covers future package roots, and reports a mismatch only in the pre-commit batch containing that file instead of repeating it for every batch.

Normalize `cuda_pathfinder/LICENSE` so all currently tracked `LICENSE` files are byte-identical. CI runs pre-commit with `--all-files`, enforcing the repository-wide invariant downstream.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
