### PR TITLE
[no-ci] ignore more virtual environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,7 +142,7 @@ celerybeat.pid
 
 # Environments
 .env
-.venv
+.venv*
 env/
 venv/
 ENV/


### PR DESCRIPTION
For users using multiple virtual environments `.venv-cp311`, `.venv-cp312` etc.