### PR TITLE
Fix NVML CUDA device-order test early return

### DIFF
--- a/cuda_bindings/tests/nvml/test_cuda.py
+++ b/cuda_bindings/tests/nvml/test_cuda.py
@@ -61,7 +61,6 @@ def test_cuda_device_order():
     for kind in ("Orin", "Thor"):
         if any(kind in device["name"] for device in nvml_devices):
             pytest.skip(f"Skipping test on {kind}, which has non-standard device naming")
-        return
 
     if "CUDA_VISIBLE_DEVICES" not in os.environ:
         # If that environment variable isn't set, the device lists should match exactly


### PR DESCRIPTION
## Description

Follow-up to #2742.

Remove an accidentally retained `return` from `test_cuda_device_order()`. It currently exits after the first device-kind check on every supported system, so it never checks Thor and never compares the CUDA and NVML device lists.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes. No documentation changes are needed.
