### PR TITLE
TST: mark test_set_stats_level as thread_unsafe

### DIFF
--- a/cuda_bindings/tests/test_cufile.py
+++ b/cuda_bindings/tests/test_cufile.py
@@ -1520,6 +1520,7 @@ def stats(driver):
     cufileVersionLessThan(1150), reason="cuFile parameter APIs require cuFile library version 13.0 or later"
 )
 @pytest.mark.usefixtures("stats")
+@pytest.mark.thread_unsafe(reason="cuFile stats level is process-global")
 def test_set_stats_level():
     """Test cuFile statistics level configuration."""
     # Test setting different statistics levels


### PR DESCRIPTION
## Summary

`test_set_stats_level` was missing the `@pytest.mark.thread_unsafe` marker, causing a flaky race condition when tests run in parallel. See [CI log](https://github.com/NVIDIA/cuda-python/actions/runs/33934947394/job/101221833613?pr=2266)

## Root Cause

cuFile's stats level is a **process-global C library variable** accessed via `cufile.set_stats_level()` / `cufile.get_stats_level()`. When `test_set_stats_level` runs concurrently with `test_stats_start_stop` (which explicitly calls `set_stats_level(1)`), the following race can occur:

```
test_set_stats_level        |  test_stats_start_stop
----------------------------|----------------------------
set_stats_level(0)          |
                            |  set_stats_level(1)   ← overwrites
get_stats_level() → 1       |
assert 1 == 0  ← FAILS      |
```

## Fix

Add `@pytest.mark.thread_unsafe(reason="cuFile stats level is process-global")` to `test_set_stats_level`.

All other cuFile stats tests (`test_stats_start_stop`, `test_get_stats_l1`, `test_get_stats_l2`, `test_get_stats_l3`) were already marked `thread_unsafe`. This was an oversight introduced when those markers were added in #2218.