### PR TITLE
test(cuda.core): serialize thread-unsafe IPC error tests

### DIFF
--- a/cuda_core/tests/memory_ipc/test_errors.py
+++ b/cuda_core/tests/memory_ipc/test_errors.py
@@ -118,6 +118,12 @@ class ChildErrorHarness:
     """Test harness for checking errors in child processes. Subclasses override
     PARENT_ACTION, CHILD_ACTION, and ASSERT (see below for examples)."""
 
+    @pytest.mark.thread_unsafe(
+        reason=(
+            "pytest-run-parallel reuses the same instance and ipc fixtures across "
+            "workers; Process(target=self.child_main) pickles that shared state (#2784)"
+        )
+    )
     @pytest.mark.flaky(reruns=2)
     def test_main(self, ipc_device, ipc_memory_resource):
         """Parent process that checks child errors."""
@@ -267,6 +273,9 @@ class TestDanglingBuffer(ChildErrorHarness):
 
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="CUDA mempool IPC is Linux-only")
+@pytest.mark.thread_unsafe(
+    reason="serialize the affected IPC mempool import/destroy path under pytest-run-parallel (#2784)"
+)
 @pytest.mark.agent_authored(model="gpt-5.6-sol")
 def test_from_allocation_handle_raw_fd_imports_mapped_pool(ipc_device):
     """from_allocation_handle accepts a raw int fd and constructs an unregistered mapped MR."""
@@ -303,6 +312,9 @@ def test_from_allocation_handle_raw_fd_imports_mapped_pool(ipc_device):
 
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="CUDA mempool IPC is Linux-only")
+@pytest.mark.thread_unsafe(
+    reason="concurrent IPC mempool export/destroy SEGV in cuMemPoolDestroy under pytest-run-parallel (#2784)"
+)
 @pytest.mark.agent_authored(model="gpt-5.6-sol")
 def test_allocation_handle_forking_pickler_roundtrip(ipc_device):
     """ForkingPickler transfers an IPCAllocationHandle by duplicating its fd."""
@@ -328,6 +340,9 @@ def test_allocation_handle_forking_pickler_roundtrip(ipc_device):
 
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="CUDA mempool IPC is Linux-only")
+@pytest.mark.thread_unsafe(
+    reason="concurrent IPC mempool import/destroy SEGV in cuMemPoolDestroy under pytest-run-parallel (#2784)"
+)
 @pytest.mark.agent_authored(model="gpt-5.6-sol")
 def test_ipc_registry_dedups_repeated_imports(ipc_device):
     """from_allocation_handle registers the mapped pool; later imports hit the cache."""


### PR DESCRIPTION
## Description

This is to fix part of #2784. The `cuMemPoolDestroy` SEGV root cause is not fixed here; those tests are only serialized.

`memory_ipc/test_errors.py` is not safe under pytest-run-parallel on free-threaded Python (3.14t). This PR only serializes the tests that hit the two CI failure modes; it does not change cuda.core or the driver.

- Mark `ChildErrorHarness.test_main` `thread_unsafe`. pytest-run-parallel reuses one instance and the same `ipc_*` fixtures across workers, and `Process(target=self.child_main)` pickles that shared state (the `DeviceMemoryResource has been closed` pickle failure).
- Mark the IPC pool import/export/destroy tests `thread_unsafe`: `test_allocation_handle_forking_pickler_roundtrip` , plus `test_ipc_registry_dedups_repeated_imports` and `test_from_allocation_handle_raw_fd_imports_mapped_pool`. 

## Checklist
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
