### PR TITLE
Move `extra_mrs` to not be shared via `self` and skip other new tests

### DIFF
--- a/cuda_core/tests/memory_ipc/test_errors.py
+++ b/cuda_core/tests/memory_ipc/test_errors.py
@@ -125,7 +125,7 @@ class ChildErrorHarness:
         # from PARENT_ACTION.
         self.device = ipc_device
         self.mr = ipc_memory_resource
-        self._extra_mrs = []
+        extra_mrs = []
 
         try:
             # Start a child process to generate error info.
@@ -134,7 +134,7 @@ class ChildErrorHarness:
             process.start()
 
             # Interact.
-            self.PARENT_ACTION(pipe[0])
+            self.PARENT_ACTION(pipe[0], extra_mrs)
 
             # Check the error.
             exc_type, exc_msg = pipe[1].get(timeout=CHILD_TIMEOUT_SEC)
@@ -146,7 +146,7 @@ class ChildErrorHarness:
             assert not survivors, "child did not exit within timeout"
             assert process.exitcode == 0
         finally:
-            for mr in self._extra_mrs:
+            for mr in extra_mrs:
                 mr.close()
 
     def child_main(self, pipe, device, mr):
@@ -166,7 +166,7 @@ class ChildErrorHarness:
 class TestImportOversizedBufferDescriptorSize(ChildErrorHarness):
     """Reject peer-supplied sizes larger than the mapped allocation extent."""
 
-    def PARENT_ACTION(self, queue):
+    def PARENT_ACTION(self, queue, extra_mrs):
         stream = self.device.default_stream
         self.buffer = self.mr.allocate(NBYTES, stream=stream)
         payload, _ = self.buffer.ipc_descriptor.__reduce__()[1]
@@ -187,7 +187,7 @@ class TestImportOversizedBufferDescriptorSize(ChildErrorHarness):
 class TestAllocFromImportedMr(ChildErrorHarness):
     """Error when attempting to allocate from an import memory resource."""
 
-    def PARENT_ACTION(self, queue):
+    def PARENT_ACTION(self, queue, extra_mrs):
         queue.put(self.mr)
 
     def CHILD_ACTION(self, queue):
@@ -202,10 +202,10 @@ class TestAllocFromImportedMr(ChildErrorHarness):
 class TestImportWrongMR(ChildErrorHarness):
     """Error when importing a buffer from the wrong memory resource."""
 
-    def PARENT_ACTION(self, queue):
+    def PARENT_ACTION(self, queue, extra_mrs):
         options = DeviceMemoryResourceOptions(max_size=POOL_SIZE, ipc_enabled=True)
         mr2 = DeviceMemoryResource(self.device, options=options)
-        self._extra_mrs.append(mr2)
+        extra_mrs.append(mr2)
         stream = self.device.default_stream
         self.buffer = mr2.allocate(NBYTES, stream=stream)
         stream.sync()
@@ -223,7 +223,7 @@ class TestImportWrongMR(ChildErrorHarness):
 class TestImportBuffer(ChildErrorHarness):
     """Error when using a buffer as a buffer descriptor."""
 
-    def PARENT_ACTION(self, queue):
+    def PARENT_ACTION(self, queue, extra_mrs):
         # Note: if the buffer is not attached to something to prolong its life,
         # CUDA_ERROR_INVALID_CONTEXT is raised from Buffer.__del__
         stream = self.device.default_stream
@@ -246,10 +246,10 @@ class TestDanglingBuffer(ChildErrorHarness):
     resource.
     """
 
-    def PARENT_ACTION(self, queue):
+    def PARENT_ACTION(self, queue, extra_mrs):
         options = DeviceMemoryResourceOptions(max_size=POOL_SIZE, ipc_enabled=True)
         mr2 = DeviceMemoryResource(self.device, options=options)
-        self._extra_mrs.append(mr2)
+        extra_mrs.append(mr2)
         stream = self.device.default_stream
         self.buffer = mr2.allocate(NBYTES, stream=stream)
         buffer_s = pickle.dumps(self.buffer)

--- a/cuda_core/tests/memory_ipc/test_errors.py
+++ b/cuda_core/tests/memory_ipc/test_errors.py
@@ -267,6 +267,9 @@ class TestDanglingBuffer(ChildErrorHarness):
 
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="CUDA mempool IPC is Linux-only")
+@pytest.mark.thread_unsafe(
+    reason="concurrent IPC mempool export/destroy SEGV in cuMemPoolDestroy under pytest-run-parallel (#2784)"
+)
 @pytest.mark.agent_authored(model="gpt-5.6-sol")
 def test_from_allocation_handle_raw_fd_imports_mapped_pool(ipc_device):
     """from_allocation_handle accepts a raw int fd and constructs an unregistered mapped MR."""
@@ -303,6 +306,9 @@ def test_from_allocation_handle_raw_fd_imports_mapped_pool(ipc_device):
 
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="CUDA mempool IPC is Linux-only")
+@pytest.mark.thread_unsafe(
+    reason="concurrent IPC mempool export/destroy SEGV in cuMemPoolDestroy under pytest-run-parallel (#2784)"
+)
 @pytest.mark.agent_authored(model="gpt-5.6-sol")
 def test_allocation_handle_forking_pickler_roundtrip(ipc_device):
     """ForkingPickler transfers an IPCAllocationHandle by duplicating its fd."""
@@ -328,6 +334,9 @@ def test_allocation_handle_forking_pickler_roundtrip(ipc_device):
 
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="CUDA mempool IPC is Linux-only")
+@pytest.mark.thread_unsafe(
+    reason="concurrent IPC mempool export/destroy SEGV in cuMemPoolDestroy under pytest-run-parallel (#2784)"
+)
 @pytest.mark.agent_authored(model="gpt-5.6-sol")
 def test_ipc_registry_dedups_repeated_imports(ipc_device):
     """from_allocation_handle registers the mapped pool; later imports hit the cache."""


### PR DESCRIPTION
As of now at least, parallel tests share the `self` instance so using it is always  a bit shady (but OK if it not mutated and identical across threads).
`extra_mrs` is not, so let's pull it out.

I want to also see if there is any chance whether concurrent `close()` might have caused bad things as I can't repro any of these crashes locally.

Investigating gh-2784 (possible alternative to gh-2785)

---

I should say that sharing `ipc_device` here is incorrect as such, but not the core issue.  I am also eyeing the registry for thread-safety, but that seems unrelated to any test failures.