### PR TITLE
[no-ci] Refreeze enum tables (revert 2383, add comment)

### DIFF
--- a/.github/RELEASE-core.md
+++ b/.github/RELEASE-core.md
@@ -89,21 +89,6 @@ changes, so they are only permitted at a major-version boundary per the
 
 ---
 
-## Refresh frozen fallback explanation tables
-
-When this release adds support for a new CUDA Toolkit version, check
-whether the CTK release added any new `CUresult` or `cudaError_t` codes.
-If so, update the frozen fallback tables so error messages stay
-informative for consumers on older `cuda-bindings` versions:
-
-- `cuda_core/cuda/core/_utils/driver_cu_result_explanations_frozen.py`
-- `cuda_core/cuda/core/_utils/runtime_cuda_error_explanations_frozen.py`
-
-The corresponding tests in `test_utils_enum_explanations_helpers.py`
-will fail if an entry is missing.
-
----
-
 ## Finalize the doc update, including release notes
 
 Review every PR included in the release. For each one, check whether new

--- a/ci/tools/run-tests
+++ b/ci/tools/run-tests
@@ -55,7 +55,11 @@ elif [[ "${test_module}" == "bindings" ]]; then
   if [[ "${LOCAL_CTK}" == 1 ]]; then
     pip install "${CUDA_BINDINGS_ARTIFACTS_DIR}"/*.whl --group test "${TEST_FT_GROUP[@]}"
   else
-    pip install $(ls "${CUDA_BINDINGS_ARTIFACTS_DIR}"/*.whl)[all] --group test "${TEST_FT_GROUP[@]}"
+    TEST_CUDA_MAJOR_MINOR="$(cut -d '.' -f 1-2 <<< "${CUDA_VER}")"
+    # Keep the wheel-installed Toolkit aligned with the matrix-selected minor;
+    # newer minors can grow ABI structs beyond the size compiled into this wheel.
+    pip install $(ls "${CUDA_BINDINGS_ARTIFACTS_DIR}"/*.whl)[all] --group test "${TEST_FT_GROUP[@]}" \
+      "cuda-toolkit==${TEST_CUDA_MAJOR_MINOR}.*"
   fi
   echo "Running bindings tests"
   ${SANITIZER_CMD} pytest -rxXs -v --randomly-dont-reorganize "${PYTEST_PARALLEL_ARGS[@]}" tests/

--- a/cuda_core/cuda/core/_utils/driver_cu_result_explanations_frozen.py
+++ b/cuda_core/cuda/core/_utils/driver_cu_result_explanations_frozen.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# CUDA Toolkit v13.3
+# CUDA Toolkit v13.1.1
 _FALLBACK_EXPLANATIONS = {
     0: (
         "The API call returned with no errors. In the case of query calls, this"
@@ -346,6 +346,5 @@ _FALLBACK_EXPLANATIONS = {
         " stream is in a detached state. This can occur if the green context associated"
         " with the stream has been destroyed, limiting the stream's operational capabilities."
     ),
-    918: "This error indicates that a graph recapture failed and had to be terminated.",
     999: "This indicates that an unknown internal error has occurred.",
 }

--- a/cuda_core/cuda/core/_utils/driver_cu_result_explanations_frozen.py
+++ b/cuda_core/cuda/core/_utils/driver_cu_result_explanations_frozen.py
@@ -1,6 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Like the runtime counterpart, this fallback is a deliberately frozen
+# compatibility snapshot, not a release-maintained mirror of CUDA's enums.
+# Do not update it past CUDA Toolkit v13.1.1. Bindings releases new enough to
+# define later codes provide explanations through enum-member docstrings; if an
+# older binding receives one from a newer driver, it falls through to
+# cuGetErrorString(). Synchronizing this table with later Toolkit releases would
+# restore the duplicate maintenance burden removed by PR #1860.
 # CUDA Toolkit v13.1.1
 _FALLBACK_EXPLANATIONS = {
     0: (

--- a/cuda_core/tests/test_utils_enum_explanations_helpers.py
+++ b/cuda_core/tests/test_utils_enum_explanations_helpers.py
@@ -168,12 +168,3 @@ def test_runtime_explanations_module_skips_fallback_import_when_docstrings_avail
 
     assert "cuda.core._utils.runtime_cuda_error_explanations_frozen" not in sys.modules
     assert isinstance(runtime_explanations.RUNTIME_CUDA_ERROR_EXPLANATIONS, DocstringBackedExplanations)
-
-
-@pytest.mark.human_authored
-def test_frozen_driver_table_covers_all_curesult_members():
-    from cuda.bindings import driver
-    from cuda.core._utils.driver_cu_result_explanations_frozen import _FALLBACK_EXPLANATIONS
-
-    missing = [m.name for m in driver.CUresult if int(m) not in _FALLBACK_EXPLANATIONS]
-    assert not missing, f"Missing frozen fallback explanations for: {missing}"


### PR DESCRIPTION
## Description

The first commit here is merely: `git revert` 3df61150e66e697f6c9ba18a4c1798a77e3b3af1

See comment added in the second commit (e25317320911c27c72c456db4b9a2b30ffd6ca54) for rationale.
___

The equivalent of PR #2796 was included as a 3rd commit (673016be9c74f353edb30f02a327549b414c17cd) here for testing. The CI succeeded:

* https://github.com/NVIDIA/cuda-python/actions/runs/34408009539?pr=2792

PR #2796 was merged into main first, then main was merged here.

Merging this CI with `[no-ci]` based on the previous successful CI.