### PR TITLE
CI: constrain bindings test Toolkit to the matrix CUDA minor

### DIFF
--- a/ci/tools/run-tests
+++ b/ci/tools/run-tests
@@ -55,7 +55,11 @@ elif [[ "${test_module}" == "bindings" ]]; then
   if [[ "${LOCAL_CTK}" == 1 ]]; then
     pip install "${CUDA_BINDINGS_ARTIFACTS_DIR}"/*.whl --group test "${TEST_FT_GROUP[@]}"
   else
-    pip install $(ls "${CUDA_BINDINGS_ARTIFACTS_DIR}"/*.whl)[all] --group test "${TEST_FT_GROUP[@]}"
+    TEST_CUDA_MAJOR_MINOR="$(cut -d '.' -f 1-2 <<< "${CUDA_VER}")"
+    # Keep the wheel-installed Toolkit aligned with the matrix-selected minor;
+    # newer minors can grow ABI structs beyond the size compiled into this wheel.
+    pip install $(ls "${CUDA_BINDINGS_ARTIFACTS_DIR}"/*.whl)[all] --group test "${TEST_FT_GROUP[@]}" \
+      "cuda-toolkit==${TEST_CUDA_MAJOR_MINOR}.*"
   fi
   echo "Running bindings tests"
   ${SANITIZER_CMD} pytest -rxXs -v --randomly-dont-reorganize "${PYTEST_PARALLEL_ARGS[@]}" tests/


### PR DESCRIPTION
## Description

Follow-up to #2792 and related to #2794.

When bindings tests use wheel-installed CUDA components, the `cuda-bindings`
wheel's `cuda-toolkit==13.*` dependency can resolve a newer CUDA minor than the
version selected by the CI matrix. After CTK 13.4.1 became available, CUDA 13.3
wheel jobs installed CUDA 13.4 cuFile, exposing an ABI incompatibility and
aborting the bindings tests.

Constrain `cuda-toolkit` to `${TEST_CUDA_MAJOR_MINOR}.*` in the same pip
transaction so wheel-mode bindings tests use the matrix-selected CUDA minor.
Local-Toolkit jobs are unchanged.

This is CI-only containment; it does not resolve the user-facing cuda-bindings
13.3 / CUDA 13.4 cuFile incompatibility tracked in #2794.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes. No documentation changes are needed.
