### PR TITLE
Don't block on API changes vs. the merge base of a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -697,8 +697,8 @@ jobs:
           if [[ "$run_core_api_check" == "true" ]]; then expected="success"; fi
           check_result "api-check-core-vs-release" "$expected"
 
-          expected="skipped"
-          if [[ "$is_pr" == "true" && "$run_core_api_check" == "true" ]]; then expected="success"; fi
-          check_result "api-check-core-vs-base" "$expected"
+          # API compatibility checks against the merge base (api-check-core-vs-base)
+          # are purely informational, since it is fine for API to drift during development
+          # when it hasn't been released yet.
 
           [[ "$status" == "success" ]]


### PR DESCRIPTION
The original design of the API checks is that the comparison against the merge base of the PR is purely informational and should not block CI.  The reason for this is that it is perfectly fine and reasonable to iterate on an API design during development before it has been released.  The informational notes are useful just to prevent doing something like that by accident.

(The API comparisons against the latest release of cuda-core remain blocking, however).