### PR TITLE
test(cuda.core): skip generic HOST pool regression before CUDA 13

### DIFF
--- a/cuda_core/tests/test_memory.py
+++ b/cuda_core/tests/test_memory.py
@@ -55,6 +55,7 @@ from cuda.core._dlpack import DLDeviceType
 from cuda.core._memory._ipc import IPCBufferDescriptor
 from cuda.core._stream import default_stream
 from cuda.core._utils.cuda_utils import CUDAError, handle_return
+from cuda.core._utils.version import driver_version
 from cuda.core.typing import (
     ManagedMemoryLocationType,
     VirtualMemoryAccessType,
@@ -1197,6 +1198,9 @@ def test_pinned_memory_resource_initialization(init_cuda):
 @pytest.mark.agent_authored(model="cursor-grok-4.5")
 def test_pinned_memory_resource_rejects_unsupported_host_pool(init_cuda):
     """allocate() must fail on devices without host memory pool support (see #2486)."""
+    if driver_version() < (13, 0, 0):
+        pytest.skip("Generic HOST memory pools require CUDA 13.0 or later")
+
     device = init_cuda
     if device.properties.host_memory_pools_supported:
         pytest.skip("Device supports host memory pools")


### PR DESCRIPTION
## Description

This is to fix internal bug 6746398. Test case  test_pinned_memory_resource_rejects_unsupported_host_pool failed when using CUDA Toolkit 12.9.2 and r575 driver with error CUDA_ERROR_INVALID_VALUE.

`cuda/core/_memory/_pinned_memory_resource.pyx:115:
    in cuda.core._memory._pinned_memory_resource.PinnedMemoryResource.__init__
cuda/core/_memory/_pinned_memory_resource.pyx:276:
    in cuda.core._memory._pinned_memory_resource._PMR_init
cuda/core/_memory/_memory_pool.pyx:267:
    in cuda.core._memory._memory_pool.MP_init_create_pool
cuda/core/_utils/cuda_utils.pxd:23:
    in cuda.core._utils.cuda_utils.HANDLE_RETURN

E   cuda.core._utils.cuda_utils.CUDAError:
E   CUDA_ERROR_INVALID_VALUE: This indicates that one or more of the
E   parameters passed to the API call is not within an acceptable range
E   of values`

The root cause is that generic HOST pools (CU_MEM_LOCATION_TYPE_HOST, no numa_id) are not a CUDA 12 API. [CUDA 12.9 cuMemPoolCreate](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-driver-api/group__CUDA__MALLOC__ASYNC.html#group__CUDA__MALLOC__ASYNC_1g8aa4c143dbc20293659cd883232b95f2) documents that location as CUDA_ERROR_INVALID_VALUE. [CUDA 13.0](https://docs.nvidia.com/cuda/archive/13.0.0/cuda-driver-api/group__CUDA__MALLOC__ASYNC.html#group__CUDA__MALLOC__ASYNC_1g8aa4c143dbc20293659cd883232b95f2) is the first version that describes how to create that pool. 

The fix is to skip test_pinned_memory_resource_rejects_unsupported_host_pool when driver_version() < (13, 0, 0).