### PR TITLE
test(pathfinder): handle cuTENSORMg removal in cuTENSOR 2.8

### DIFF
--- a/cuda_pathfinder/tests/local_helpers.py
+++ b/cuda_pathfinder/tests/local_helpers.py
@@ -1,16 +1,20 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import functools
 import importlib.metadata
 import re
 
+from packaging.version import Version
+
 
 @functools.cache
-def have_distribution(name_pattern: str) -> bool:
+def have_distribution(name_pattern: str, *, minimum_version: str | None = None) -> bool:
     re_name_pattern = re.compile(name_pattern)
+    parsed_minimum_version = Version(minimum_version) if minimum_version is not None else None
     return any(
         re_name_pattern.match(dist.metadata["Name"])
+        and (parsed_minimum_version is None or Version(dist.version) >= parsed_minimum_version)
         for dist in importlib.metadata.distributions()
         if "Name" in dist.metadata
     )

--- a/cuda_pathfinder/tests/test_load_nvidia_dynamic_lib.py
+++ b/cuda_pathfinder/tests/test_load_nvidia_dynamic_lib.py
@@ -4,6 +4,7 @@
 import os
 import platform
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from child_load_nvidia_dynamic_lib_helper import (
@@ -123,10 +124,37 @@ IMPORTLIB_METADATA_DISTRIBUTIONS_NAMES = {
 def _is_expected_load_nvidia_dynamic_lib_failure(libname):
     if libname == "nvpl_fftw" and platform.machine().lower() != "aarch64":
         return True
+    if libname == "cutensorMg":
+        # cuTENSOR 2.8 removed cuTENSORMg in favor of cuTENSORMp.
+        return have_distribution(r"^cutensor-cu(?:12|13)$", minimum_version="2.8")
     dist_name_pattern = IMPORTLIB_METADATA_DISTRIBUTIONS_NAMES.get(libname)
     if dist_name_pattern is not None:
         return not have_distribution(dist_name_pattern)
     return False
+
+
+@pytest.mark.parametrize(
+    ("installed_distributions", "expected"),
+    [
+        ([], False),
+        ([SimpleNamespace(metadata={"Name": "cutensor-cu13"}, version="2.7.0")], False),
+        ([SimpleNamespace(metadata={"Name": "cutensor-cu12"}, version="2.8.0")], True),
+        ([SimpleNamespace(metadata={"Name": "cutensor-cu13"}, version="2.9.0")], True),
+        ([SimpleNamespace(metadata={"Name": "unrelated-package"}, version="2.8.0")], False),
+    ],
+)
+@pytest.mark.agent_authored(model="gpt-5.6-sol")
+def test_cutensor_mg_expected_failure_follows_installed_cutensor_version(
+    mocker,
+    installed_distributions,
+    expected,
+):
+    mocker.patch("local_helpers.importlib.metadata.distributions", return_value=installed_distributions)
+    have_distribution.cache_clear()
+    try:
+        assert _is_expected_load_nvidia_dynamic_lib_failure("cutensorMg") is expected
+    finally:
+        have_distribution.cache_clear()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

cuTENSOR 2.8 removed cuTENSORMg in favor of cuTENSORMp, so the strict
real-library coverage now sees an expected missing library when an unpinned
`cutensor-cu12` or `cutensor-cu13` wheel resolves to 2.8 or newer.

Treat a missing `cutensorMg` as expected only for those newer installed wheel
versions. Keep the catalog descriptor unchanged so cuTENSORMg remains
discoverable with cuTENSOR 2.7 and older, and add focused version-boundary
coverage.

This addresses the failure in the [CUDA Python workflow rerun](https://github.com/NVIDIA/cuda-python/actions/runs/34520880743/job/103075839727).
See the [cuTENSOR 2.8 release notes](https://docs.nvidia.com/cuda/cutensor/latest/release_notes.html#cutensor-v2-8-0).

## Testing

- Full CUDA 13.4 Linux build and test runbook: passed
- `TestVenv/bin/python -m pytest -ra -vv cuda_pathfinder/tests/test_load_nvidia_dynamic_lib.py -k cutensor_mg`: 5 passed
- `/usr/bin/pre-commit run --all-files`: passed

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
