### PR TITLE
test(cuda.bindings): restore thread_unsafe marker for cuFile stats level

### DIFF
--- a/cuda_bindings/tests/test_cufile.py
+++ b/cuda_bindings/tests/test_cufile.py
@@ -1520,6 +1520,7 @@ def stats(driver):
     cufileVersionLessThan(1150), reason="cuFile parameter APIs require cuFile library version 13.0 or later"
 )
 @pytest.mark.usefixtures("stats")
+@pytest.mark.thread_unsafe(reason="cuFile stats level is process-global")
 def test_set_stats_level():
     """Test cuFile statistics level configuration."""
     # Test setting different statistics levels

--- a/cuda_pathfinder/tests/local_helpers.py
+++ b/cuda_pathfinder/tests/local_helpers.py
@@ -1,16 +1,20 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import functools
 import importlib.metadata
 import re
 
+from packaging.version import Version
+
 
 @functools.cache
-def have_distribution(name_pattern: str) -> bool:
+def have_distribution(name_pattern: str, *, minimum_version: str | None = None) -> bool:
     re_name_pattern = re.compile(name_pattern)
+    parsed_minimum_version = Version(minimum_version) if minimum_version is not None else None
     return any(
         re_name_pattern.match(dist.metadata["Name"])
+        and (parsed_minimum_version is None or Version(dist.version) >= parsed_minimum_version)
         for dist in importlib.metadata.distributions()
         if "Name" in dist.metadata
     )

--- a/cuda_pathfinder/tests/test_load_nvidia_dynamic_lib.py
+++ b/cuda_pathfinder/tests/test_load_nvidia_dynamic_lib.py
@@ -4,6 +4,7 @@
 import os
 import platform
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from child_load_nvidia_dynamic_lib_helper import (
@@ -123,10 +124,37 @@ IMPORTLIB_METADATA_DISTRIBUTIONS_NAMES = {
 def _is_expected_load_nvidia_dynamic_lib_failure(libname):
     if libname == "nvpl_fftw" and platform.machine().lower() != "aarch64":
         return True
+    if libname == "cutensorMg":
+        # cuTENSOR 2.8 removed cuTENSORMg in favor of cuTENSORMp.
+        return have_distribution(r"^cutensor-cu(?:12|13)$", minimum_version="2.8")
     dist_name_pattern = IMPORTLIB_METADATA_DISTRIBUTIONS_NAMES.get(libname)
     if dist_name_pattern is not None:
         return not have_distribution(dist_name_pattern)
     return False
+
+
+@pytest.mark.parametrize(
+    ("installed_distributions", "expected"),
+    [
+        ([], False),
+        ([SimpleNamespace(metadata={"Name": "cutensor-cu13"}, version="2.7.0")], False),
+        ([SimpleNamespace(metadata={"Name": "cutensor-cu12"}, version="2.8.0")], True),
+        ([SimpleNamespace(metadata={"Name": "cutensor-cu13"}, version="2.9.0")], True),
+        ([SimpleNamespace(metadata={"Name": "unrelated-package"}, version="2.8.0")], False),
+    ],
+)
+@pytest.mark.agent_authored(model="gpt-5.6-sol")
+def test_cutensor_mg_expected_failure_follows_installed_cutensor_version(
+    mocker,
+    installed_distributions,
+    expected,
+):
+    mocker.patch("local_helpers.importlib.metadata.distributions", return_value=installed_distributions)
+    have_distribution.cache_clear()
+    try:
+        assert _is_expected_load_nvidia_dynamic_lib_failure("cutensorMg") is expected
+    finally:
+        have_distribution.cache_clear()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Restore `@pytest.mark.thread_unsafe(reason="cuFile stats level is process-global")` on `test_set_stats_level`.

#2782 added the marker because cuFile's stats level is process-global, but it was unintentionally dropped while reconciling the 13.4.x release branch into `main` in #2789. Without it, this test can race with other cuFile stats tests under parallel execution.

This restores the exact marker from #2782; no production code changes.

To keep CI viable while #2809 is awaiting merge, this branch also cherry-picks its exact cuTENSOR 2.8 test fix. Once #2809 lands, updating this branch from `main` will absorb those changes.

## Testing

- Targeted pre-commit checks for the marker change: passed.
- #2809's original head is fully green.
- pytest not run locally, per request; full CI will exercise the combined branch.

## Checklist

- [x] New or existing tests cover these changes. This change restores test scheduling metadata and includes #2809's focused coverage.
- [x] The documentation is up to date with these changes. No documentation changes are needed.
