### PR TITLE
nit: Avoid hard-coding `AMD64` in pyproject.toml by making platform tag explicit

### DIFF
--- a/ci/tools/env-vars
+++ b/ci/tools/env-vars
@@ -39,15 +39,19 @@ CUDA_CORE_ARTIFACT_BASENAME="cuda-core-python${PYTHON_VERSION_FORMATTED}-${HOST_
 } >> $GITHUB_ENV
 
 if [[ "${1}" == "build" ]]; then
-  # platform is handled by the default value of platform (`auto`) in cibuildwheel
-  # here we only need to specify the python version we want
-  echo "CIBW_BUILD=cp${PYTHON_VERSION_FORMATTED}-*" >> $GITHUB_ENV
-  if [[ "${HOST_PLATFORM}" == "win-arm64" ]]; then
-    # cibuildwheel's `auto` architecture detection resolves to AMD64 on the
-    # windows-11-arm hosted runner (the Actions runner process itself reports
-    # AMD64 via emulation), so the target arch must be forced explicitly.
-    echo "CIBW_ARCHS=ARM64" >> $GITHUB_ENV
+  if [[ "${HOST_PLATFORM}" == "linux-64" ]]; then
+    CIBW_PLATFORM_TAG="manylinux_x86_64"
+  elif [[ "${HOST_PLATFORM}" == "linux-aarch64" ]]; then
+    CIBW_PLATFORM_TAG="manylinux_aarch64"
+  elif [[ "${HOST_PLATFORM}" == "win-64" ]]; then
+    CIBW_PLATFORM_TAG="win_amd64"
+  elif [[ "${HOST_PLATFORM}" == "win-arm64" ]]; then
+    CIBW_PLATFORM_TAG="win_arm64"
+  else
+    echo "Error: unsupported HOST_PLATFORM=${HOST_PLATFORM}" >&2
+    exit 1
   fi
+  echo "CIBW_BUILD=cp${PYTHON_VERSION_FORMATTED}-${CIBW_PLATFORM_TAG}" >> "$GITHUB_ENV"
   BUILD_CUDA_MAJOR="$(cut -d '.' -f 1 <<< ${CUDA_VER})"
   echo "BUILD_CUDA_MAJOR=${BUILD_CUDA_MAJOR}" >> $GITHUB_ENV
   echo "BUILD_PREV_CUDA_MAJOR=$((${BUILD_CUDA_MAJOR} - 1))" >> $GITHUB_ENV

--- a/cuda_bindings/pyproject.toml
+++ b/cuda_bindings/pyproject.toml
@@ -85,7 +85,6 @@ build-verbosity = 1
 archs = "native"
 
 [tool.cibuildwheel.windows]
-archs = "AMD64"
 before-build = "pip install delvewheel"
 repair-wheel-command = "delvewheel repair --namespace-pkg cuda -w {dest_dir} {wheel}"
 

--- a/cuda_core/pyproject.toml
+++ b/cuda_core/pyproject.toml
@@ -154,6 +154,5 @@ build-verbosity = 1
 archs = "native"
 
 [tool.cibuildwheel.windows]
-archs = "AMD64"
 before-build = "pip install delvewheel"
 repair-wheel-command = "delvewheel repair --namespace-pkg cuda --exclude \"torch_cpu.dll;torch_python.dll\" -w {dest_dir} {wheel}"


### PR DESCRIPTION
This aligns with https://github.com/cupy/cupy/pull/10294.