### PR TITLE
[doc-only] "Prerelease feature" -> "Preview feature"

### DIFF
--- a/cuda_bindings/docs/source/release/13.4.0-notes.rst
+++ b/cuda_bindings/docs/source/release/13.4.0-notes.rst
@@ -59,8 +59,8 @@ Deprecation Notices
   removed in a future version.  Python 3.10 reaches end of life in October 2026
   per the `CPython support cycle <https://devguide.python.org/versions/>`_.
 
-Prerelease feature
-------------------
+Preview feature
+---------------
 
 A new version of the ``nvrtc`` API is available as ``cuda.bindings._v2.nvrtc``.  The
 primary improvements are: (1) raising exceptions rather than returning error

--- a/cuda_bindings/docs/source/release/13.4.0b1-notes.rst
+++ b/cuda_bindings/docs/source/release/13.4.0b1-notes.rst
@@ -59,8 +59,8 @@ Deprecation Notices
   removed in a future version.  Python 3.10 reaches end of life in October 2026
   per the `CPython support cycle <https://devguide.python.org/versions/>`_.
 
-Prerelease feature
-------------------
+Preview feature
+---------------
 
 A new version of the ``nvrtc`` API is available as ``cuda.bindings._v2.nvrtc``.  The
 primary improvements are: (1) raising exceptions rather than returning error

--- a/cuda_bindings/docs/source/release/13.4.1-notes.rst
+++ b/cuda_bindings/docs/source/release/13.4.1-notes.rst
@@ -83,8 +83,8 @@ Deprecation Notices
   removed in a future version.  Python 3.10 reaches end of life in October 2026
   per the `CPython support cycle <https://devguide.python.org/versions/>`_.
 
-Prerelease feature
-------------------
+Preview feature
+---------------
 
 A new version of the ``nvrtc`` API is available as ``cuda.bindings._v2.nvrtc``.  The
 primary improvements are: (1) raising exceptions rather than returning error

--- a/cuda_bindings/docs/source/release/13.4.1a0-notes.rst
+++ b/cuda_bindings/docs/source/release/13.4.1a0-notes.rst
@@ -83,8 +83,8 @@ Deprecation Notices
   removed in a future version.  Python 3.10 reaches end of life in October 2026
   per the `CPython support cycle <https://devguide.python.org/versions/>`_.
 
-Prerelease feature
-------------------
+Preview feature
+---------------
 
 A new version of the ``nvrtc`` API is available as ``cuda.bindings._v2.nvrtc``.  The
 primary improvements are: (1) raising exceptions rather than returning error


### PR DESCRIPTION
It was noted that the word "prerelease" was confusing here.
